### PR TITLE
fix: stars badge repo and logo spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 <img src=".github/assets/logo.png" width="280" alt="repowise" />
 
-<br /><br />
-
 **Codebase intelligence for AI-assisted engineering teams.**
 
 Four intelligence layers. Eight MCP tools. One `pip install`.


### PR DESCRIPTION
## Summary
- Fix stars badge pointing to wrong repo (`repowise/repowise` → `repowise-dev/repowise`)
- Remove extra `<br /><br />` spacing between logo and tagline in README header