### PR TITLE
fix: README logo spacing, stars badge, and docs formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <div align="center">
 
 <img src=".github/assets/logo.png" width="280" alt="repowise" />
-
 **Codebase intelligence for AI-assisted engineering teams.**
 
 Four intelligence layers. Eight MCP tools. One `pip install`.

--- a/website/index.md
+++ b/website/index.md
@@ -40,15 +40,8 @@ pip install repowise
 
 ## Get started
 
-<div class="d-flex flex-wrap gap-3 mt-4">
-
-**[60-second quickstart →](getting-started)**
-The fastest path to a working setup.
-
-**[Core concepts →](concepts)**
-Understand the four layers before diving in.
-
-**[CLI reference →](cli-reference)**
-Every command, flag, and option.
-
-</div>
+| | |
+|---|---|
+| [**60-second quickstart →**](getting-started) | The fastest path to a working setup. |
+| [**Core concepts →**](concepts) | Understand the four layers before diving in. |
+| [**CLI reference →**](cli-reference) | Every command, flag, and option. |


### PR DESCRIPTION
## Summary
- Fix stars badge pointing to wrong repo (`repowise/repowise` → `repowise-dev/repowise`)
- Remove extra blank line between logo and tagline in README header
- Fix docs homepage "Get started" section — replaced unsupported Bootstrap utility div with a markdown table