### PR TITLE
fix: fall back to env vars for OpenAI and Anthropic API keys

### DIFF
--- a/packages/core/src/repowise/core/providers/llm/anthropic.py
+++ b/packages/core/src/repowise/core/providers/llm/anthropic.py
@@ -12,6 +12,8 @@ Recommended models (as of 2026):
 
 from __future__ import annotations
 
+import os
+
 import structlog
 from anthropic import AsyncAnthropic
 from anthropic import RateLimitError as _AnthropicRateLimitError
@@ -56,11 +58,17 @@ class AnthropicProvider(BaseProvider):
 
     def __init__(
         self,
-        api_key: str,
+        api_key: str | None = None,
         model: str = "claude-sonnet-4-6",
         rate_limiter: RateLimiter | None = None,
     ) -> None:
-        self._client = AsyncAnthropic(api_key=api_key)
+        resolved_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not resolved_key:
+            raise ProviderError(
+                "anthropic",
+                "No API key found. Pass api_key= or set the ANTHROPIC_API_KEY env var.",
+            )
+        self._client = AsyncAnthropic(api_key=resolved_key)
         self._model = model
         self._rate_limiter = rate_limiter
 

--- a/packages/core/src/repowise/core/providers/llm/openai.py
+++ b/packages/core/src/repowise/core/providers/llm/openai.py
@@ -12,6 +12,8 @@ Recommended models (as of 2026):
 
 from __future__ import annotations
 
+import os
+
 import structlog
 from openai import AsyncOpenAI
 from openai import RateLimitError as _OpenAIRateLimitError
@@ -55,12 +57,18 @@ class OpenAIProvider(BaseProvider):
 
     def __init__(
         self,
-        api_key: str,
+        api_key: str | None = None,
         model: str = "gpt-5.4-nano",
         base_url: str | None = None,
         rate_limiter: RateLimiter | None = None,
     ) -> None:
-        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        resolved_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not resolved_key:
+            raise ProviderError(
+                "openai",
+                "No API key found. Pass api_key= or set the OPENAI_API_KEY env var.",
+            )
+        self._client = AsyncOpenAI(api_key=resolved_key, base_url=base_url)
         self._model = model
         self._rate_limiter = rate_limiter
 


### PR DESCRIPTION
OpenAIProvider and AnthropicProvider required api_key as a mandatory positional argument, but resolve_provider never passed it — causing a TypeError on every invocation. Make api_key optional and resolve from OPENAI_API_KEY / ANTHROPIC_API_KEY env vars, matching the pattern already used by GeminiProvider.

---
## Summary

- OpenAIProvider and AnthropicProvider now fall back to reading `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from environment variables when `api_key` is not explicitly passed, fixing a `TypeError` that made both providers unusable via the CLI.
- Aligns OpenAI and Anthropic providers with the env-var resolution pattern already used by GeminiProvider.

## Related Issues

## Test Plan

- [x] Tests pass (`pytest`) — 56/56 provider tests pass
- [ ] Lint passes (`ruff check .`) — `ruff` not installed in environment; IDE linter shows no errors
- [ ] Web build passes (`npm run build`) — N/A, no frontend changes
- [x] Manually verified: `export OPENAI_API_KEY=sk-...` then `repowise init` no longer raises `TypeError: missing 1 required positional argument: 'api_key'`
- [x] Verified that omitting both `api_key` argument and env var raises a clear `ProviderError` with guidance

## Checklist

- [x] My code follows the project's code style
- [ ] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed — no doc changes needed; the docstrings already stated env-var fallback behavior, the code now matches