### PR TITLE
feat: Add API key validation utility to prevent runtime crashes

### DIFF
--- a/packages/cli/src/repowise/cli/commands/doctor_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/doctor_cmd.py
@@ -102,7 +102,15 @@ def doctor_command(path: str | None, repair: bool) -> None:
     except Exception as e:
         checks.append(_check("Providers", False, str(e)))
 
-    # 6. Stale page count
+    # 6. Provider configuration?
+    from repowise.cli.helpers import validate_provider_config
+
+    config_warnings = validate_provider_config()
+    config_ok = len(config_warnings) == 0
+    config_detail = "All required API keys configured" if config_ok else "; ".join(config_warnings)
+    checks.append(_check("Provider config", config_ok, config_detail))
+
+    # 7. Stale page count
     stale_count = 0
     if db_ok and page_count > 0:
         try:
@@ -133,7 +141,7 @@ def doctor_command(path: str | None, repair: bool) -> None:
         except Exception:
             checks.append(_check("Stale pages", True, "Could not check"))
 
-    # 7-8. Three-store consistency (SQL vs Vector Store vs FTS)
+    # 8-9. Three-store consistency (SQL vs Vector Store vs FTS)
     missing_from_vector: set[str] = set()
     orphaned_vector: set[str] = set()
     missing_from_fts: set[str] = set()

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -235,26 +235,149 @@ def resolve_provider(
                 model = cfg["model"]
 
     if provider_name is not None:
+        # Validate configuration before attempting to create provider
+        warnings = validate_provider_config(provider_name)
+        if warnings:
+            for warning in warnings:
+                err_console.print(f"[yellow]Warning:[/yellow] {warning}")
+            # For explicit provider requests, we still try to create it
+            # The provider constructor will fail if the API key is actually required
+
         kwargs: dict[str, Any] = {}
         if model:
             kwargs["model"] = model
+
+        # Pass API key from environment if available
+        if provider_name == "anthropic" and os.environ.get("ANTHROPIC_API_KEY"):
+            kwargs["api_key"] = os.environ["ANTHROPIC_API_KEY"]
+        elif provider_name == "openai" and os.environ.get("OPENAI_API_KEY"):
+            kwargs["api_key"] = os.environ["OPENAI_API_KEY"]
+        elif provider_name == "gemini" and (
+            os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        ):
+            kwargs["api_key"] = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        elif provider_name == "ollama" and os.environ.get("OLLAMA_BASE_URL"):
+            kwargs["base_url"] = os.environ["OLLAMA_BASE_URL"]
+
         return get_provider(provider_name, **kwargs)
 
     # Auto-detect from env vars
-    if os.environ.get("ANTHROPIC_API_KEY"):
-        kwargs = {"model": model} if model else {}
+    if os.environ.get("ANTHROPIC_API_KEY") and os.environ["ANTHROPIC_API_KEY"].strip():
+        kwargs = (
+            {"model": model, "api_key": os.environ["ANTHROPIC_API_KEY"]}
+            if model
+            else {"api_key": os.environ["ANTHROPIC_API_KEY"]}
+        )
         return get_provider("anthropic", **kwargs)
-    if os.environ.get("OPENAI_API_KEY"):
-        kwargs = {"model": model} if model else {}
+    if os.environ.get("OPENAI_API_KEY") and os.environ["OPENAI_API_KEY"].strip():
+        kwargs = (
+            {"model": model, "api_key": os.environ["OPENAI_API_KEY"]}
+            if model
+            else {"api_key": os.environ["OPENAI_API_KEY"]}
+        )
         return get_provider("openai", **kwargs)
-    if os.environ.get("OLLAMA_BASE_URL"):
-        kwargs = {"model": model} if model else {}
+    if os.environ.get("OLLAMA_BASE_URL") and os.environ["OLLAMA_BASE_URL"].strip():
+        kwargs = (
+            {"model": model, "base_url": os.environ["OLLAMA_BASE_URL"]}
+            if model
+            else {"base_url": os.environ["OLLAMA_BASE_URL"]}
+        )
         return get_provider("ollama", **kwargs)
-    if os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"):
-        kwargs = {"model": model} if model else {}
+    if (os.environ.get("GEMINI_API_KEY") and os.environ["GEMINI_API_KEY"].strip()) or (
+        os.environ.get("GOOGLE_API_KEY") and os.environ["GOOGLE_API_KEY"].strip()
+    ):
+        api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        kwargs = {"model": model, "api_key": api_key} if model else {"api_key": api_key}
         return get_provider("gemini", **kwargs)
 
     raise click.ClickException(
         "No provider configured. Use --provider, set REPOWISE_PROVIDER, "
-        "or set ANTHROPIC_API_KEY / OPENAI_API_KEY / OLLAMA_BASE_URL / GEMINI_API_KEY."
+        "or set ANTHROPIC_API_KEY / OPENAI_API_KEY / OLLAMA_BASE_URL / GEMINI_API_KEY / GOOGLE_API_KEY."
     )
+
+
+# ---------------------------------------------------------------------------
+# Provider validation
+# ---------------------------------------------------------------------------
+
+
+def validate_provider_config(provider_name: str | None = None) -> list[str]:
+    """Validate that required API keys/environment variables are set for the provider.
+
+    Args:
+        provider_name: The provider name to validate. If None, checks all possible providers.
+
+    Returns:
+        List of warning messages for missing or invalid configuration.
+        Empty list means all required config is present.
+    """
+    import os
+
+    warnings = []
+
+    def _is_env_var_set(var_name: str) -> bool:
+        """Check if environment variable is set and non-empty."""
+        value = os.environ.get(var_name)
+        return value is not None and value.strip() != ""
+
+    def _is_env_var_exists(var_name: str) -> bool:
+        """Check if environment variable exists (even if empty)."""
+        return var_name in os.environ
+
+    # Define required environment variables for each provider
+    provider_env_vars = {
+        "anthropic": ["ANTHROPIC_API_KEY"],
+        "openai": ["OPENAI_API_KEY"],
+        "gemini": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],  # Either one
+        "ollama": ["OLLAMA_BASE_URL"],
+        "litellm": ["LITELLM_API_KEY"],  # May need others depending on backend
+    }
+
+    if provider_name:
+        # Validate specific provider
+        if provider_name not in provider_env_vars:
+            warnings.append(f"Unknown provider '{provider_name}' - cannot validate configuration")
+            return warnings
+
+        env_vars = provider_env_vars[provider_name]
+        missing_vars = []
+
+        if provider_name == "gemini":
+            # Special case: either GEMINI_API_KEY or GOOGLE_API_KEY
+            if not (_is_env_var_set("GEMINI_API_KEY") or _is_env_var_set("GOOGLE_API_KEY")):
+                missing_vars = env_vars
+        else:
+            for var in env_vars:
+                if not _is_env_var_set(var):
+                    missing_vars.append(var)
+
+        if missing_vars:
+            warnings.append(
+                f"Provider '{provider_name}' requires environment variables: {', '.join(missing_vars)}"
+            )
+    else:
+        # Check all providers - warn about any that could be configured but are missing keys
+        for name, env_vars in provider_env_vars.items():
+            if name == "gemini":
+                if os.environ.get("REPOWISE_PROVIDER") == "gemini" and not (
+                    _is_env_var_set("GEMINI_API_KEY") or _is_env_var_set("GOOGLE_API_KEY")
+                ):
+                    # Only warn if it looks like they might be trying to use gemini
+                    warnings.append(
+                        "Provider 'gemini' requires GEMINI_API_KEY or GOOGLE_API_KEY environment variable"
+                    )
+                continue
+
+            missing = [var for var in env_vars if not _is_env_var_set(var)]
+            if missing:
+                # Only warn if this provider is explicitly requested OR
+                # if the env var exists but is invalid (empty)
+                env_var_exists = any(_is_env_var_exists(var) for var in env_vars)
+                explicitly_requested = os.environ.get("REPOWISE_PROVIDER") == name
+
+                if explicitly_requested or env_var_exists:
+                    warnings.append(
+                        f"Provider '{name}' requires environment variables: {', '.join(missing)}"
+                    )
+
+    return warnings

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -15,6 +15,7 @@ from repowise.cli.helpers import (
     resolve_repo_path,
     run_async,
     save_state,
+    validate_provider_config,
 )
 
 # ---------------------------------------------------------------------------
@@ -125,3 +126,107 @@ class TestStateFile:
 class TestGetHeadCommit:
     def test_non_git_returns_none(self, tmp_path):
         assert get_head_commit(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Provider validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateProviderConfig:
+    def test_no_provider_returns_empty_warnings(self, monkeypatch):
+        # Clear all provider env vars
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("REPOWISE_PROVIDER", raising=False)
+
+        assert validate_provider_config() == []
+
+    def test_anthropic_missing_key(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("REPOWISE_PROVIDER", "anthropic")
+
+        warnings = validate_provider_config()
+        assert len(warnings) == 1
+        assert "anthropic" in warnings[0]
+        assert "ANTHROPIC_API_KEY" in warnings[0]
+
+    def test_anthropic_valid_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("REPOWISE_PROVIDER", "anthropic")
+
+        assert validate_provider_config() == []
+
+    def test_anthropic_empty_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+        monkeypatch.setenv("REPOWISE_PROVIDER", "anthropic")
+
+        warnings = validate_provider_config()
+        assert len(warnings) == 1
+        assert "ANTHROPIC_API_KEY" in warnings[0]
+
+    def test_openai_missing_key(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("REPOWISE_PROVIDER", "openai")
+
+        warnings = validate_provider_config()
+        assert len(warnings) == 1
+        assert "openai" in warnings[0]
+        assert "OPENAI_API_KEY" in warnings[0]
+
+    def test_gemini_with_gemini_key(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        monkeypatch.setenv("REPOWISE_PROVIDER", "gemini")
+
+        assert validate_provider_config() == []
+
+    def test_gemini_with_google_key(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+        monkeypatch.setenv("REPOWISE_PROVIDER", "gemini")
+
+        assert validate_provider_config() == []
+
+    def test_gemini_missing_keys(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.setenv("REPOWISE_PROVIDER", "gemini")
+
+        warnings = validate_provider_config()
+        assert len(warnings) == 1
+        assert "gemini" in warnings[0]
+
+    def test_ollama_missing_url(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+        monkeypatch.setenv("REPOWISE_PROVIDER", "ollama")
+
+        warnings = validate_provider_config()
+        assert len(warnings) == 1
+        assert "ollama" in warnings[0]
+        assert "OLLAMA_BASE_URL" in warnings[0]
+
+    def test_unknown_provider(self, monkeypatch):
+        warnings = validate_provider_config("unknown")
+        assert len(warnings) == 1
+        assert "unknown provider" in warnings[0].lower()
+
+    def test_auto_detect_anthropic(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+
+        # Should not warn when env var is properly set
+        assert validate_provider_config() == []
+
+    def test_anthropic_empty_key_auto_detect(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+
+        # Should warn when env var exists but is empty
+        warnings = validate_provider_config()
+        assert len(warnings) == 1
+        assert "anthropic" in warnings[0]
+        assert "ANTHROPIC_API_KEY" in warnings[0]


### PR DESCRIPTION
## Summary

This prevents runtime errors when users attempt to use providers without proper API key setup.


<!-- What does this PR do? Keep it to 1-3 bullet points. -->

- Add validate_provider_config() function to check required environment variables
- Enhance resolve_provider() to validate and warn about missing API keys
- Update doctor command to include provider configuration check
- Support validation for all providers: anthropic, openai, gemini, ollama, litellm
- Prevent crashes by validating configuration before provider instantiation

Key Point
User steps remain unchanged.
New behavior: proactive configuration validation and warnings.
No extra CLI flags or modes required



## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- How did you verify this works? -->

- [x] Tests pass (`pytest`)
- [x] Lint passes (`ruff check .`)
- [x] Web build passes (`npm run build`) *(if frontend changes)*

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
