### PR TITLE
fix: make api_key optional with env var fallback in Anthropic/OpenAI providers

### DIFF
--- a/packages/core/src/repowise/core/providers/llm/anthropic.py
+++ b/packages/core/src/repowise/core/providers/llm/anthropic.py
@@ -12,6 +12,8 @@ Recommended models (as of 2026):
 
 from __future__ import annotations
 
+import os
+
 import structlog
 from anthropic import AsyncAnthropic
 from anthropic import RateLimitError as _AnthropicRateLimitError
@@ -48,7 +50,7 @@ class AnthropicProvider(BaseProvider):
     """Anthropic Claude provider with automatic prompt caching.
 
     Args:
-        api_key:      Anthropic API key. Reads ANTHROPIC_API_KEY env var if not set.
+        api_key:      Anthropic API key. Falls back to ANTHROPIC_API_KEY env var.
         model:        Model identifier. Defaults to claude-sonnet-4-6.
         rate_limiter: Optional pre-configured RateLimiter. If None, no rate limiting
                       is applied (useful when the caller manages concurrency via semaphore).
@@ -56,11 +58,17 @@ class AnthropicProvider(BaseProvider):
 
     def __init__(
         self,
-        api_key: str,
+        api_key: str | None = None,
         model: str = "claude-sonnet-4-6",
         rate_limiter: RateLimiter | None = None,
     ) -> None:
-        self._client = AsyncAnthropic(api_key=api_key)
+        resolved_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not resolved_key:
+            raise ProviderError(
+                "anthropic",
+                "No API key provided. Pass api_key= or set ANTHROPIC_API_KEY.",
+            )
+        self._client = AsyncAnthropic(api_key=resolved_key)
         self._model = model
         self._rate_limiter = rate_limiter
 

--- a/packages/core/src/repowise/core/providers/llm/openai.py
+++ b/packages/core/src/repowise/core/providers/llm/openai.py
@@ -12,6 +12,8 @@ Recommended models (as of 2026):
 
 from __future__ import annotations
 
+import os
+
 import structlog
 from openai import AsyncOpenAI
 from openai import RateLimitError as _OpenAIRateLimitError
@@ -47,7 +49,7 @@ class OpenAIProvider(BaseProvider):
     """OpenAI Chat Completions provider.
 
     Args:
-        api_key:   OpenAI API key. Reads OPENAI_API_KEY env var if not set.
+        api_key:   OpenAI API key. Falls back to OPENAI_API_KEY env var.
         model:     Model identifier. Defaults to gpt-4o.
         base_url:  Optional custom base URL for OpenAI-compatible endpoints.
         rate_limiter: Optional RateLimiter instance.
@@ -55,12 +57,18 @@ class OpenAIProvider(BaseProvider):
 
     def __init__(
         self,
-        api_key: str,
+        api_key: str | None = None,
         model: str = "gpt-5.4-nano",
         base_url: str | None = None,
         rate_limiter: RateLimiter | None = None,
     ) -> None:
-        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        resolved_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not resolved_key:
+            raise ProviderError(
+                "openai",
+                "No API key provided. Pass api_key= or set OPENAI_API_KEY.",
+            )
+        self._client = AsyncOpenAI(api_key=resolved_key, base_url=base_url)
         self._model = model
         self._rate_limiter = rate_limiter
 

--- a/tests/unit/test_providers/test_anthropic_provider.py
+++ b/tests/unit/test_providers/test_anthropic_provider.py
@@ -29,6 +29,18 @@ def test_default_model():
     assert p.model_name == "claude-sonnet-4-6"
 
 
+def test_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env")
+    p = AnthropicProvider()
+    assert p.provider_name == "anthropic"
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with pytest.raises(ProviderError):
+        AnthropicProvider()
+
+
 def test_opus_model():
     p = AnthropicProvider(api_key="sk-ant-test", model="claude-opus-4-6")
     assert p.model_name == "claude-opus-4-6"

--- a/tests/unit/test_providers/test_openai_provider.py
+++ b/tests/unit/test_providers/test_openai_provider.py
@@ -29,6 +29,18 @@ def test_default_model_is_nano():
     assert p.model_name == "gpt-5.4-nano"
 
 
+def test_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-test")
+    p = OpenAIProvider()
+    assert p.provider_name == "openai"
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(ProviderError):
+        OpenAIProvider()
+
+
 def test_custom_model():
     p = OpenAIProvider(api_key="sk-test", model="gpt-5.4-mini")
     assert p.model_name == "gpt-5.4-mini"


### PR DESCRIPTION
## Summary

- `AnthropicProvider` and `OpenAIProvider` require `api_key` as a positional argument, but `resolve_provider()` in `helpers.py` only passes `model` in kwargs when the provider is selected interactively
- The CLI correctly sets the API key via `os.environ["ANTHROPIC_API_KEY"]` during the interactive prompt, but the provider constructors don't check the env var — they crash with `TypeError: AnthropicProvider.__init__() missing 1 required positional argument: 'api_key'`
- This makes the Anthropic and OpenAI providers **completely unusable** through the interactive `repowise init` flow

## Fix

Make `api_key` optional (`str | None = None`) with env var fallback, matching the existing `GeminiProvider` pattern. Raise `ProviderError` with a clear message when neither `api_key` nor the env var is set.

**Files changed:**
- `packages/core/src/repowise/core/providers/llm/anthropic.py` — `api_key: str` → `api_key: str | None = None`, falls back to `ANTHROPIC_API_KEY`
- `packages/core/src/repowise/core/providers/llm/openai.py` — same pattern, falls back to `OPENAI_API_KEY`
- `tests/unit/test_providers/test_anthropic_provider.py` — added `test_api_key_from_env` and `test_missing_api_key_raises`
- `tests/unit/test_providers/test_openai_provider.py` — same two tests

## Reproducer

```
pipx install repowise
repowise init  # select anthropic, paste API key, confirm
# → TypeError: AnthropicProvider.__init__() missing 1 required positional argument: 'api_key'
```

## Test plan

- [x] All 50 provider unit tests pass (`pytest tests/unit/test_providers/ -v`)
- [x] All 15 registry tests pass (`pytest tests/providers/test_registry.py -v`)
- [x] New tests verify env var fallback and missing-key error for both providers
- [x] Existing tests that pass `api_key=` explicitly still work (backward compatible)