### PR TITLE
Release v0.1.29

### DIFF
--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -6,4 +6,4 @@ git signals, dead code detection, architectural decisions, and
 AI-generated documentation.
 """
 
-__version__ = "0.1.25"
+__version__ = "0.1.29"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.1.24"
+__version__ = "0.1.29"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.1.24"
+__version__ = "0.1.29"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.1.25"
+version = "0.1.29"
 description = "Codebase intelligence for developers and AI — generates and maintains a structured wiki for any codebase"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -194,7 +194,7 @@ known-first-party = ["repowise"]
 # mypy — strict type checking
 # ---------------------------------------------------------------------------
 [tool.mypy]
-python_version = "3.11"
+python_version = "0.1.29"
 warn_unused_configs = true
 show_error_codes = true
 namespace_packages = true


### PR DESCRIPTION
Bumps version to 0.1.29 across all 4 version files.

**What's in this release:**
- Fix: api_key optional with env var fallback in Anthropic/OpenAI providers (fixes crash on repowise init)
- Fix: CI test failures — co-changes key mismatch, integration DB path isolation, ruff format/lint