### PR TITLE
security: harden defaults for network-exposed deployments

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,13 +28,15 @@ RUN npm run build
 # ---------------------------------------------------------------------------
 FROM python:3.12-slim AS runtime
 
-# Install git (required by gitpython) and Node.js (required for Next.js server)
+# Install git (required by gitpython)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
-    curl \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
+
+# Copy Node.js from the official image instead of piping curl|bash
+COPY --from=frontend-builder /usr/local/bin/node /usr/local/bin/node
+COPY --from=frontend-builder /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
 
 WORKDIR /app
 
@@ -66,5 +68,10 @@ EXPOSE 7337 3000
 # Startup script
 COPY docker/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
+
+# Run as non-root user (mitigates container escape → root escalation)
+RUN groupadd -r repowise && useradd -r -g repowise -d /app -s /sbin/nologin repowise \
+    && chown -R repowise:repowise /app /data
+USER repowise
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,14 +2,22 @@ services:
   repowise:
     build: .
     ports:
-      - "7337:7337"   # API
-      - "3000:3000"   # Web UI
+      - "127.0.0.1:7337:7337"   # API — loopback only by default
+      - "127.0.0.1:3000:3000"   # Web UI — loopback only by default
     volumes:
       # Mount the .repowise directory from your indexed repo
       - ${REPOWISE_DATA:-./data}:/data
+      # Mount repo directory as read-only to prevent write-based attacks
+      - type: bind
+        source: ${REPO_PATH:?Set REPO_PATH to your repository directory}
+        target: /repos
+        read_only: true
     environment:
       - REPOWISE_DB_URL=sqlite+aiosqlite:///data/wiki.db
       - REPOWISE_EMBEDDER=${REPOWISE_EMBEDDER:-mock}
+      - REPOWISE_HOST=0.0.0.0
+      # SECURITY: Set this to enable API authentication (required for non-loopback)
+      - REPOWISE_API_KEY=${REPOWISE_API_KEY:?Set REPOWISE_API_KEY for Docker deployments}
       # Set your LLM provider API key
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}

--- a/packages/server/src/repowise/server/deps.py
+++ b/packages/server/src/repowise/server/deps.py
@@ -9,6 +9,8 @@ Provides Depends() callables for:
 
 from __future__ import annotations
 
+import hmac
+import logging
 import os
 from collections.abc import AsyncGenerator
 
@@ -18,8 +20,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from repowise.core.persistence.database import get_session
 
+logger = logging.getLogger(__name__)
+
 _API_KEY = os.environ.get("REPOWISE_API_KEY")
+_REPOWISE_HOST = os.environ.get("REPOWISE_HOST", "127.0.0.1")
 _header_scheme = APIKeyHeader(name="Authorization", auto_error=False)
+
+# Warn at import time if server is network-exposed without authentication
+if _API_KEY is None and _REPOWISE_HOST in ("0.0.0.0", "::"):
+    logger.warning(
+        "SECURITY WARNING: Server is binding to %s without REPOWISE_API_KEY set. "
+        "All endpoints are unauthenticated and network-accessible. "
+        "Set REPOWISE_API_KEY or bind to 127.0.0.1.",
+        _REPOWISE_HOST,
+    )
 
 
 async def get_db_session(request: Request) -> AsyncGenerator[AsyncSession, None]:
@@ -42,14 +56,22 @@ async def get_fts(request: Request):
 async def verify_api_key(
     auth: str | None = Security(_header_scheme),
 ) -> None:
-    """Optional API key verification.
+    """API key verification.
 
-    When REPOWISE_API_KEY is not set, this is a no-op (fully open).
+    When REPOWISE_API_KEY is not set and server binds to loopback, this is a
+    no-op (local-only access). When binding to a non-loopback address without
+    a key, requests are rejected (fail-closed for network-exposed deployments).
     When set, requests must include ``Authorization: Bearer <key>``.
     """
     if _API_KEY is None:
+        if _REPOWISE_HOST in ("0.0.0.0", "::"):
+            raise HTTPException(
+                status_code=503,
+                detail="Server is network-exposed but REPOWISE_API_KEY is not set. "
+                "Set REPOWISE_API_KEY or bind to 127.0.0.1.",
+            )
         return
     if not auth or not auth.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing API key")
-    if auth[7:] != _API_KEY:
+    if not hmac.compare_digest(auth[7:], _API_KEY):
         raise HTTPException(status_code=401, detail="Invalid API key")

--- a/packages/server/src/repowise/server/mcp_server/tool_why.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_why.py
@@ -464,7 +464,11 @@ async def _run_git_log(
     import subprocess
 
     def _sync_git_log() -> list[dict]:
+        import re
+
         results: list[dict] = []
+        # Sanitize stem to prevent argument injection via --grep
+        safe_stem = re.sub(r"[^a-zA-Z0-9_\-.]", "", stem) if stem else ""
         try:
             proc = subprocess.run(
                 ["git", "log", "--follow", "--format=%H\t%an\t%ai\t%s", "-20", "--", file_path],
@@ -487,9 +491,14 @@ async def _run_git_log(
                             }
                         )
 
-            if stem and len(stem) >= 3:
+            if safe_stem and len(safe_stem) >= 3:
                 proc2 = subprocess.run(
-                    ["git", "log", "--all", "--grep", stem, "--format=%H\t%an\t%ai\t%s", "-10"],
+                    [
+                        "git", "log", "--all",
+                        "--grep", safe_stem,
+                        "--format=%H\t%an\t%ai\t%s", "-10",
+                        "--",  # end of options — prevent argument injection
+                    ],
                     cwd=repo_path,
                     capture_output=True,
                     text=True,

--- a/packages/server/src/repowise/server/schemas.py
+++ b/packages/server/src/repowise/server/schemas.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # ---------------------------------------------------------------------------
 # Repository
@@ -18,6 +19,18 @@ class RepoCreate(BaseModel):
     url: str = ""
     default_branch: str = "main"
     settings: dict | None = None
+
+    @field_validator("local_path")
+    @classmethod
+    def validate_local_path(cls, v: str) -> str:
+        resolved = Path(v).resolve()
+        if ".." in Path(v).parts:
+            raise ValueError("local_path must not contain '..' segments")
+        if not resolved.is_dir():
+            raise ValueError(f"local_path does not exist or is not a directory: {resolved}")
+        if not (resolved / ".git").exists():
+            raise ValueError(f"local_path is not a git repository (no .git found): {resolved}")
+        return str(resolved)
 
 
 class RepoUpdate(BaseModel):


### PR DESCRIPTION
## Summary

Addresses a chain of vulnerabilities that combine into **unauthenticated root RCE** when repowise is deployed via Docker with default settings (the "Skeleton Key" kill chain: no auth → unrestricted `local_path` → command injection → root container).

This was identified through a comprehensive security audit with multi-model adversarial validation.

### Changes

- **`deps.py`** — Fail-closed authentication when `REPOWISE_HOST=0.0.0.0` and no API key is set (returns 503). Uses `hmac.compare_digest()` for constant-time key comparison. Logs a startup warning when network-exposed without auth. Localhost deployments remain open (no UX change).
- **`schemas.py`** — Pydantic `field_validator` on `RepoCreate.local_path`: rejects `..` path segments, requires directory to exist and contain `.git`. Returns resolved absolute path.
- **`tool_why.py`** — Sanitizes `stem` to `[a-zA-Z0-9_\-.]` before passing to `git log --grep`. Adds `--` separator to prevent argument injection.
- **`Dockerfile`** — Runs as non-root `repowise` user. Copies Node.js from the builder stage instead of piping `curl | bash` (eliminates supply chain risk).
- **`docker-compose.yml`** — Binds ports to `127.0.0.1` (loopback only). Requires `REPOWISE_API_KEY` and `REPO_PATH` env vars (docker-compose fails fast if unset). Mounts repos read-only.

### Security Model

The fix adopts a **dual-mode security model**:
- **Local CLI** (`repowise serve`): binds `127.0.0.1`, no auth required — unchanged developer experience
- **Docker/network**: binds `0.0.0.0`, requires API key, non-root container, read-only repo mount

### Kill Chains Addressed

| Chain | Findings | Status |
|-------|----------|--------|
| Unauthenticated root RCE | No auth + path traversal + cmd injection + root Docker | **Blocked** (4 independent mitigations) |
| Credential theft via browser | CORS + plaintext keys | Partially mitigated (auth required for network) |
| Webhook abuse | No webhook auth | Not addressed (separate PR) |

## Test plan

- [ ] `repowise serve` on localhost still works without API key
- [ ] Docker build succeeds and container runs as non-root (`docker exec <id> whoami` → `repowise`)
- [ ] `docker-compose up` fails if `REPOWISE_API_KEY` or `REPO_PATH` not set
- [ ] `POST /api/repos` with `local_path=/etc` returns 422 validation error
- [ ] `POST /api/repos` with `local_path=/tmp/valid-repo` (with `.git`) succeeds
- [ ] API returns 503 when `REPOWISE_HOST=0.0.0.0` and no key set
- [ ] API returns 401 on bad key, 200 on correct key with `REPOWISE_API_KEY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)