### PR TITLE
feat: add ClaudeCode provider and Ollama embedder for zero-cost indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,7 +142,8 @@ provider_config.json
 .mcp.json
 frontend/
 integrations/
-providers/
+# Only ignore a top-level /providers/ dir (legacy closed-source dir), not nested ones in packages/
+/providers/
 
 # Private release notes
 docs/PYPI_RELEASE.md
@@ -165,7 +166,7 @@ run_ingest.py
 run_test.ps1
 smoke_test.py
 integrations/
-providers/
+/providers/
 demo_init.py
 fastapi/
 openclaw/

--- a/packages/cli/src/repowise/cli/commands/init_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd.py
@@ -41,6 +41,8 @@ def _resolve_embedder(embedder_flag: str | None) -> str:
         return "gemini"
     if os.environ.get("OPENAI_API_KEY"):
         return "openai"
+    if os.environ.get("OLLAMA_BASE_URL"):
+        return "ollama"
     return "mock"
 
 
@@ -259,15 +261,15 @@ async def _persist_result(
     "--provider",
     "provider_name",
     default=None,
-    help="LLM provider name (anthropic, openai, gemini, ollama, mock).",
+    help="LLM provider name (anthropic, openai, gemini, ollama, claudecode, mock).",
 )
 @click.option("--model", default=None, help="Model identifier override.")
 @click.option(
     "--embedder",
     "embedder_name",
     default=None,
-    type=click.Choice(["gemini", "openai", "mock"]),
-    help="Embedder for RAG: gemini | openai | mock (default: auto-detect).",
+    type=click.Choice(["gemini", "openai", "ollama", "mock"]),
+    help="Embedder for RAG: gemini | openai | ollama | mock (default: auto-detect).",
 )
 @click.option("--skip-tests", is_flag=True, default=False, help="Skip test files.")
 @click.option("--skip-infra", is_flag=True, default=False, help="Skip infrastructure files.")
@@ -576,6 +578,13 @@ def init_command(
                 from repowise.core.providers.embedding.openai import OpenAIEmbedder
 
                 embedder_impl = OpenAIEmbedder()
+            except Exception:
+                embedder_impl = MockEmbedder()
+        elif embedder_name_resolved == "ollama":
+            try:
+                from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+                embedder_impl = OllamaEmbedder()
             except Exception:
                 embedder_impl = MockEmbedder()
         else:

--- a/packages/cli/src/repowise/cli/commands/reindex_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/reindex_cmd.py
@@ -18,7 +18,7 @@ from repowise.cli.helpers import (
 @click.argument("path", required=False, default=None)
 @click.option(
     "--embedder",
-    type=click.Choice(["gemini", "openai", "auto"]),
+    type=click.Choice(["gemini", "openai", "ollama", "auto"]),
     default="auto",
     help="Embedder to use. 'auto' detects from env vars / config.",
 )
@@ -66,9 +66,15 @@ async def _reindex(repo_path, embedder_name: str, batch_size: int) -> None:
 
         embedder_impl = OpenAIEmbedder()
         console.print("[green]Using OpenAI embedder[/green]")
+    elif embedder_name == "ollama":
+        from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+        embedder_impl = OllamaEmbedder()
+        console.print("[green]Using Ollama embedder (local)[/green]")
     else:
         console.print(
-            "[red]No real embedder available. Set GEMINI_API_KEY or OPENAI_API_KEY.[/red]"
+            "[red]No real embedder available. Set GEMINI_API_KEY, OPENAI_API_KEY, "
+            "or use --embedder ollama (requires local Ollama server).[/red]"
         )
         raise click.Abort()
 

--- a/packages/cli/src/repowise/cli/commands/search_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/search_cmd.py
@@ -79,6 +79,10 @@ def _search_semantic(repo_path, query: str, limit: int) -> None:
                     from repowise.core.providers.embedding.openai import OpenAIEmbedder
 
                     embedder = OpenAIEmbedder()
+                elif embedder_name == "ollama":
+                    from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+                    embedder = OllamaEmbedder()
                 else:
                     embedder = MockEmbedder()
                 store = LanceDBVectorStore(str(lance_dir), embedder=embedder)

--- a/packages/cli/src/repowise/cli/commands/serve_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/serve_cmd.py
@@ -17,6 +17,17 @@ from repowise.cli.helpers import console, load_config
 _GLOBAL_CONFIG_DIR = Path.home() / ".repowise"
 
 
+def _ollama_reachable(base_url: str = "http://localhost:11434") -> bool:
+    """Return True if an Ollama server is responding at *base_url*."""
+    try:
+        import urllib.request
+
+        with urllib.request.urlopen(f"{base_url}/api/tags", timeout=1) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
+
+
 def _setup_embedder() -> None:
     """Ensure REPOWISE_EMBEDDER is set before the server starts.
 
@@ -38,9 +49,10 @@ def _setup_embedder() -> None:
             _set_api_key_env(saved_embedder, cfg["embedder_api_key"])
         return
 
-    # Detect which providers already have keys in the environment.
+    # Detect which providers already have keys / are available in the environment.
     has_gemini = bool(os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"))
     has_openai = bool(os.environ.get("OPENAI_API_KEY"))
+    has_ollama = bool(os.environ.get("OLLAMA_BASE_URL") or _ollama_reachable())
 
     console.print(
         "\n[bold]Chat & search require an embedder.[/bold] "
@@ -51,24 +63,32 @@ def _setup_embedder() -> None:
     labels = []
     if has_gemini:
         options.append("gemini")
-        labels.append("[1] gemini  [green]✓ key set[/green]")
+        labels.append(f"[{len(options)}] gemini  [green]✓ key set[/green]")
     else:
         options.append("gemini")
-        labels.append("[1] gemini  [dim]needs GEMINI_API_KEY / GOOGLE_API_KEY[/dim]")
+        labels.append(f"[{len(options)}] gemini  [dim]needs GEMINI_API_KEY / GOOGLE_API_KEY[/dim]")
     if has_openai:
         options.append("openai")
-        labels.append("[2] openai  [green]✓ key set[/green]")
+        labels.append(f"[{len(options)}] openai  [green]✓ key set[/green]")
     else:
         options.append("openai")
-        labels.append("[2] openai  [dim]needs OPENAI_API_KEY[/dim]")
+        labels.append(f"[{len(options)}] openai  [dim]needs OPENAI_API_KEY[/dim]")
+    if has_ollama:
+        options.append("ollama")
+        labels.append(f"[{len(options)}] ollama  [green]✓ local server detected[/green]")
+    else:
+        options.append("ollama")
+        labels.append(
+            f"[{len(options)}] ollama  [dim]local, no key needed — start with: ollama serve[/dim]"
+        )
     options.append("skip")
-    labels.append("[3] skip    [dim]no chat/search[/dim]")
+    labels.append(f"[{len(options)}] skip    [dim]no chat/search[/dim]")
 
     for label in labels:
         console.print(f"  {label}")
     console.print()
 
-    default = "1" if (has_gemini or has_openai) else "3"
+    default = "1" if (has_gemini or has_openai or has_ollama) else str(len(options))
     raw = click.prompt("  Select", default=default).strip()
 
     # Map number or name to option.
@@ -83,6 +103,14 @@ def _setup_embedder() -> None:
         return
 
     os.environ["REPOWISE_EMBEDDER"] = choice
+
+    if choice == "ollama":
+        # Ollama needs no API key — just ensure OLLAMA_BASE_URL is set
+        base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+        os.environ.setdefault("OLLAMA_BASE_URL", base_url)
+        _save_global_embedder(choice, "")
+        console.print()
+        return
 
     # Ensure the API key is present; prompt if missing.
     api_key = _get_or_prompt_api_key(choice)

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -258,8 +258,9 @@ def resolve_provider(
             kwargs["api_key"] = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
         elif provider_name == "ollama" and os.environ.get("OLLAMA_BASE_URL"):
             kwargs["base_url"] = os.environ["OLLAMA_BASE_URL"]
+        # claudecode needs no API key — uses the active Claude Code session
 
-        return get_provider(provider_name, **kwargs)
+        return get_provider(provider_name, with_rate_limiter=provider_name != "claudecode", **kwargs)
 
     # Auto-detect from env vars
     if os.environ.get("ANTHROPIC_API_KEY") and os.environ["ANTHROPIC_API_KEY"].strip():
@@ -324,6 +325,9 @@ def validate_provider_config(provider_name: str | None = None) -> list[str]:
         """Check if environment variable exists (even if empty)."""
         return var_name in os.environ
 
+    # Providers that require no API key or env var whatsoever
+    _no_key_providers = {"claudecode", "mock"}
+
     # Define required environment variables for each provider
     provider_env_vars = {
         "anthropic": ["ANTHROPIC_API_KEY"],
@@ -331,9 +335,14 @@ def validate_provider_config(provider_name: str | None = None) -> list[str]:
         "gemini": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],  # Either one
         "ollama": ["OLLAMA_BASE_URL"],
         "litellm": ["LITELLM_API_KEY"],  # May need others depending on backend
+        # claudecode / mock need no env vars — always "valid"
     }
 
     if provider_name:
+        # Providers with no key requirements are always valid
+        if provider_name in _no_key_providers:
+            return warnings
+
         # Validate specific provider
         if provider_name not in provider_env_vars:
             warnings.append(f"Unknown provider '{provider_name}' - cannot validate configuration")

--- a/packages/cli/src/repowise/cli/ui.py
+++ b/packages/cli/src/repowise/cli/ui.py
@@ -82,13 +82,17 @@ _PROVIDER_DEFAULTS: dict[str, str] = {
     "anthropic": "claude-sonnet-4-6",
     "ollama": "llama3.2",
     "litellm": "groq/llama-3.1-70b-versatile",
+    "claudecode": "haiku",
 }
 
+# Providers with no required env var have an empty string value.
+# _detect_provider_status handles the no-key-needed case separately.
 _PROVIDER_ENV: dict[str, str] = {
     "gemini": "GEMINI_API_KEY",
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
     "ollama": "OLLAMA_BASE_URL",
+    "claudecode": "",  # No env var required — uses active claude CLI session
 }
 
 _PROVIDER_SIGNUP: dict[str, str] = {
@@ -96,7 +100,11 @@ _PROVIDER_SIGNUP: dict[str, str] = {
     "openai": "https://platform.openai.com/api-keys",
     "anthropic": "https://console.anthropic.com/settings/keys",
     "ollama": "https://ollama.com/download",
+    "claudecode": "https://claude.ai/code",
 }
+
+# Providers that require no API key at all
+_NO_KEY_PROVIDERS: frozenset[str] = frozenset({"ollama", "claudecode"})
 
 
 # ---------------------------------------------------------------------------
@@ -220,13 +228,16 @@ def interactive_mode_select(console: Console) -> str:
 
 
 def _detect_provider_status() -> dict[str, str]:
-    """Return {provider: env_var_name} for providers whose key is set."""
+    """Return {provider: env_var_name} for providers whose key is set (or not required)."""
     status: dict[str, str] = {}
     for prov, env_var in _PROVIDER_ENV.items():
-        if prov == "gemini":
+        if prov in _NO_KEY_PROVIDERS:
+            # Always "configured" — no key needed
+            status[prov] = env_var
+        elif prov == "gemini":
             if os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"):
                 status[prov] = env_var
-        elif os.environ.get(env_var):
+        elif env_var and os.environ.get(env_var):
             status[prov] = env_var
     return status
 
@@ -258,7 +269,12 @@ def interactive_provider_select(
     table.add_column("Default Model", style="dim")
 
     for idx, prov in enumerate(providers, 1):
-        status_text = f"[{OK}]✓ API key set[/]" if prov in detected else "[dim]✗ no key[/dim]"
+        if prov in _NO_KEY_PROVIDERS:
+            status_text = f"[{OK}]✓ no key needed[/]"
+        elif prov in detected:
+            status_text = f"[{OK}]✓ API key set[/]"
+        else:
+            status_text = "[dim]✗ no key[/dim]"
         default_model = _PROVIDER_DEFAULTS.get(prov, "")
         # Mark gemini as recommended
         label = prov
@@ -287,8 +303,8 @@ def interactive_provider_select(
     )
     chosen = providers[int(chosen_idx) - 1]
 
-    # --- inline API key entry if missing ---
-    if chosen not in detected:
+    # --- inline API key entry if missing (skip for no-key providers) ---
+    if chosen not in detected and chosen not in _NO_KEY_PROVIDERS:
         env_var = _PROVIDER_ENV[chosen]
         signup_url = _PROVIDER_SIGNUP.get(chosen, "")
         console.print()

--- a/packages/core/src/repowise/core/providers/embedding/ollama.py
+++ b/packages/core/src/repowise/core/providers/embedding/ollama.py
@@ -1,0 +1,111 @@
+"""Ollama embedding support for repowise semantic search.
+
+Uses Ollama's OpenAI-compatible /v1/embeddings endpoint.
+Runs the synchronous SDK call in a thread pool to avoid blocking asyncio.
+
+Installation:
+    pip install openai  # already a dependency
+
+Usage:
+    import asyncio
+    from repowise.core.providers.embedding.ollama import OllamaEmbedder
+    from repowise.core.persistence.vector_store import InMemoryVectorStore
+
+    embedder = OllamaEmbedder()
+    store = InMemoryVectorStore(embedder)
+    await store.embed_and_upsert("page-1", "Some wiki content...", {})
+    results = await store.search("auth service", limit=5)
+
+Recommended models:
+    nomic-embed-text  → 768 dims  (pull with: ollama pull nomic-embed-text)
+    mxbai-embed-large → 1024 dims (pull with: ollama pull mxbai-embed-large)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+
+
+class OllamaEmbedder:
+    """Ollama embedding model adapter implementing the repowise Embedder protocol.
+
+    Args:
+        model:    Ollama embedding model name. Default: "nomic-embed-text".
+        base_url: Ollama API base URL. Falls back to OLLAMA_BASE_URL env var,
+                  then "http://localhost:11434".
+        dimensions: Override the output dimension. Auto-detected from known
+                    models; falls back to 768 for unknown models.
+    """
+
+    _DIMS: dict[str, int] = {
+        "nomic-embed-text": 768,
+        "mxbai-embed-large": 1024,
+        "all-minilm": 384,
+        "snowflake-arctic-embed": 1024,
+        "bge-m3": 1024,
+    }
+
+    _DEFAULT_TIMEOUT: float = 30.0
+
+    def __init__(
+        self,
+        model: str = "nomic-embed-text",
+        base_url: str | None = None,
+        dimensions: int | None = None,
+        timeout: float = _DEFAULT_TIMEOUT,
+    ) -> None:
+        env_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+        raw_url = base_url or env_url
+        # Ensure we use the /v1 path for OpenAI-compatible endpoint
+        self._base_url = raw_url.rstrip("/")
+        if not self._base_url.endswith("/v1"):
+            self._base_url = self._base_url + "/v1"
+        self._model = model
+        self._timeout = timeout
+        self._dims = dimensions or self._DIMS.get(model, 768)
+        self._client: object | None = None
+
+    @property
+    def dimensions(self) -> int:
+        return self._dims
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts using Ollama.
+
+        Args:
+            texts: Non-empty list of strings to embed.
+
+        Returns:
+            List of L2-normalized float vectors.
+        """
+        if not texts:
+            return []
+
+        model = self._model
+        base_url = self._base_url
+        timeout = self._timeout
+
+        def _embed_sync() -> list[list[float]]:
+            import openai  # type: ignore[import-untyped]
+
+            if self._client is None:
+                self._client = openai.OpenAI(
+                    api_key="ollama",  # Ollama doesn't check the key
+                    base_url=base_url,
+                    timeout=timeout,
+                )
+            response = self._client.embeddings.create(model=model, input=texts)  # type: ignore[union-attr]
+            raw_vectors = [list(item.embedding) for item in response.data]
+            return [_l2_normalize(v) for v in raw_vectors]
+
+        return await asyncio.to_thread(_embed_sync)
+
+
+def _l2_normalize(vec: list[float]) -> list[float]:
+    """L2-normalize a vector to unit length (cosine similarity = dot product)."""
+    norm = math.sqrt(sum(x * x for x in vec))
+    if norm == 0.0:
+        norm = 1.0
+    return [x / norm for x in vec]

--- a/packages/core/src/repowise/core/providers/embedding/registry.py
+++ b/packages/core/src/repowise/core/providers/embedding/registry.py
@@ -23,9 +23,10 @@ from typing import Any, Callable
 from repowise.core.providers.embedding.base import Embedder
 
 _BUILTIN_EMBEDDERS: dict[str, tuple[str, str]] = {
-    "openai": ("repowise.core.providers.embedding.openai", "OpenAIEmbedder"),
-    "gemini": ("repowise.core.providers.embedding.gemini", "GeminiEmbedder"),
-    "mock":   ("repowise.core.providers.embedding.base",   "MockEmbedder"),
+    "openai":  ("repowise.core.providers.embedding.openai",  "OpenAIEmbedder"),
+    "gemini":  ("repowise.core.providers.embedding.gemini",  "GeminiEmbedder"),
+    "ollama":  ("repowise.core.providers.embedding.ollama",  "OllamaEmbedder"),
+    "mock":    ("repowise.core.providers.embedding.base",    "MockEmbedder"),
 }
 
 _custom_embedders: dict[str, Callable[..., Embedder]] = {}

--- a/packages/core/src/repowise/core/providers/llm/claudecode.py
+++ b/packages/core/src/repowise/core/providers/llm/claudecode.py
@@ -1,0 +1,245 @@
+"""Claude Code provider for repowise — uses `claude -p` subprocess.
+
+Generates documentation by shelling out to the Claude Code CLI instead of
+calling the Anthropic API directly. No API key required — uses the active
+Claude Code session.
+
+Usage:
+    repowise init --provider claudecode --model haiku
+
+Environment:
+    No API key needed. Requires `claude` CLI to be installed and authenticated.
+
+Supported models (via --model flag):
+    haiku    → claude-haiku-4-5 (fast, cheap, good for docs)
+    sonnet   → claude-sonnet-4-6 (better quality)
+    opus     → claude-opus-4-6 (best quality)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json as _json
+import time
+from typing import Any, AsyncIterator
+
+from repowise.core.providers.llm.base import (
+    BaseProvider,
+    ChatStreamEvent,
+    ChatToolCall,
+    GeneratedResponse,
+    ProviderError,
+)
+
+
+class ClaudeCodeProvider(BaseProvider):
+    """LLM provider that shells out to `claude -p` (Claude Code CLI).
+
+    Implements both BaseProvider (for doc generation) and the ChatProvider
+    protocol (for dashboard streaming chat), with no Anthropic API key required.
+
+    Args:
+        model:      Model alias passed to --model flag. Default: "haiku".
+        timeout:    Subprocess timeout in seconds. Default: 120.
+    """
+
+    def __init__(
+        self,
+        model: str = "haiku",
+        timeout: float = 120.0,
+        **kwargs: Any,
+    ) -> None:
+        self._model = model
+        self._timeout = timeout
+
+    @property
+    def provider_name(self) -> str:
+        return "claudecode"
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    async def generate(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+        request_id: str | None = None,
+    ) -> GeneratedResponse:
+        """Generate documentation via `claude -p` subprocess.
+
+        Uses asyncio.create_subprocess_exec for true async concurrency —
+        multiple pages can be generated in parallel without blocking.
+        """
+        start = time.monotonic()
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "claude", "-p", system_prompt, "--model", self._model,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:
+            raise ProviderError(
+                "claudecode",
+                "claude CLI not found. Is Claude Code installed and in PATH?",
+            ) from exc
+
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(input=user_prompt.encode()),
+                timeout=self._timeout,
+            )
+        except asyncio.TimeoutError as exc:
+            proc.kill()
+            raise ProviderError(
+                "claudecode",
+                f"claude -p timed out after {self._timeout}s",
+            ) from exc
+
+        if proc.returncode != 0:
+            raise ProviderError(
+                "claudecode",
+                f"claude -p exited with code {proc.returncode}: {stderr.decode().strip()}",
+            )
+
+        content = stdout.decode().strip()
+        elapsed = time.monotonic() - start
+
+        # Estimate token counts (no exact count available from CLI)
+        input_tokens = len(system_prompt + user_prompt) // 4
+        output_tokens = len(content) // 4
+
+        return GeneratedResponse(
+            content=content,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_tokens=0,
+            usage={"elapsed_seconds": elapsed, "model": self._model},
+        )
+
+    # --- ChatProvider protocol implementation ---
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        system_prompt: str,
+        max_tokens: int = 8192,
+        temperature: float = 0.7,
+        request_id: str | None = None,
+        tool_executor: Any | None = None,
+    ) -> AsyncIterator[ChatStreamEvent]:
+        """Stream a chat response via `claude -p --output-format stream-json --verbose`.
+
+        Parses the NDJSON event stream emitted by Claude Code CLI and converts
+        each event to a ChatStreamEvent. Tool use is not supported via the CLI
+        streaming interface — tools parameter is accepted but ignored.
+
+        The full conversation context is passed as the user prompt (formatted
+        as a markdown conversation transcript), with the system_prompt as the
+        CLI system argument.
+        """
+        # Build a flat conversation transcript from the messages list
+        transcript_parts = []
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                # Extract text from content blocks
+                content = " ".join(
+                    block.get("text", "") for block in content if isinstance(block, dict)
+                )
+            if role == "system":
+                continue
+            transcript_parts.append(f"**{role.upper()}**: {content}")
+
+        user_prompt = "\n\n".join(transcript_parts)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "claude",
+                "-p", system_prompt,
+                "--model", self._model,
+                "--output-format", "stream-json",
+                "--verbose",
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:
+            raise ProviderError(
+                "claudecode",
+                "claude CLI not found. Is Claude Code installed and in PATH?",
+            ) from exc
+
+        # Write user prompt and close stdin
+        if proc.stdin:
+            proc.stdin.write(user_prompt.encode())
+            await proc.stdin.drain()
+            proc.stdin.close()
+
+        # Stream and parse NDJSON lines from stdout
+        input_tokens = 0
+        output_tokens = 0
+
+        try:
+            while True:
+                try:
+                    line = await asyncio.wait_for(
+                        proc.stdout.readline(),
+                        timeout=self._timeout,
+                    )
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    raise ProviderError(
+                        "claudecode",
+                        f"claude streaming timed out after {self._timeout}s",
+                    )
+
+                if not line:
+                    break
+
+                line_str = line.decode().strip()
+                if not line_str:
+                    continue
+
+                try:
+                    event = _json.loads(line_str)
+                except _json.JSONDecodeError:
+                    continue
+
+                event_type = event.get("type", "")
+
+                # assistant message with text content
+                if event_type == "assistant":
+                    message = event.get("message", {})
+                    for block in message.get("content", []):
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text", "")
+                            if text:
+                                yield ChatStreamEvent(type="text_delta", text=text)
+
+                # result event carries final usage stats
+                elif event_type == "result":
+                    usage = event.get("usage", {})
+                    input_tokens = usage.get("input_tokens", 0)
+                    output_tokens = usage.get("output_tokens", 0)
+                    if input_tokens or output_tokens:
+                        yield ChatStreamEvent(
+                            type="usage",
+                            input_tokens=input_tokens,
+                            output_tokens=output_tokens,
+                        )
+
+        finally:
+            # Ensure process is cleaned up
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                proc.kill()
+
+        yield ChatStreamEvent(type="stop", stop_reason="end_turn")

--- a/packages/core/src/repowise/core/providers/llm/registry.py
+++ b/packages/core/src/repowise/core/providers/llm/registry.py
@@ -34,12 +34,13 @@ from repowise.core.rate_limiter import PROVIDER_DEFAULTS, RateLimitConfig, RateL
 # This means `pip install repowise-core` without anthropic installed still works —
 # you just can't use the anthropic provider.
 _BUILTIN_PROVIDERS: dict[str, tuple[str, str]] = {
-    "anthropic": ("repowise.core.providers.llm.anthropic", "AnthropicProvider"),
-    "openai": ("repowise.core.providers.llm.openai", "OpenAIProvider"),
-    "gemini": ("repowise.core.providers.llm.gemini", "GeminiProvider"),
-    "ollama": ("repowise.core.providers.llm.ollama", "OllamaProvider"),
-    "litellm": ("repowise.core.providers.llm.litellm", "LiteLLMProvider"),
-    "mock": ("repowise.core.providers.llm.mock", "MockProvider"),
+    "anthropic":   ("repowise.core.providers.llm.anthropic",   "AnthropicProvider"),
+    "openai":      ("repowise.core.providers.llm.openai",      "OpenAIProvider"),
+    "gemini":      ("repowise.core.providers.llm.gemini",      "GeminiProvider"),
+    "ollama":      ("repowise.core.providers.llm.ollama",      "OllamaProvider"),
+    "litellm":     ("repowise.core.providers.llm.litellm",     "LiteLLMProvider"),
+    "claudecode":  ("repowise.core.providers.llm.claudecode",  "ClaudeCodeProvider"),
+    "mock":        ("repowise.core.providers.llm.mock",        "MockProvider"),
 }
 
 # Runtime-registered custom providers (factory callables)

--- a/packages/server/src/repowise/server/app.py
+++ b/packages/server/src/repowise/server/app.py
@@ -53,6 +53,7 @@ def _build_embedder():
         mock    — deterministic 8-dim SHA-256 embedder (default, no API key needed)
         gemini  — GeminiEmbedder via GEMINI_API_KEY / GOOGLE_API_KEY env var
         openai  — OpenAIEmbedder via OPENAI_API_KEY env var
+        ollama  — OllamaEmbedder via OLLAMA_BASE_URL env var (local, no key needed)
     """
     name = os.environ.get("REPOWISE_EMBEDDER", "mock").lower()
     if name == "gemini":
@@ -65,7 +66,15 @@ def _build_embedder():
 
         model = os.environ.get("REPOWISE_EMBEDDING_MODEL", "text-embedding-3-small")
         return OpenAIEmbedder(model=model)
-    logger.warning("embedder.mock_active — set REPOWISE_EMBEDDER=gemini or openai for real RAG")
+    if name == "ollama":
+        from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+        model = os.environ.get("REPOWISE_EMBEDDING_MODEL", "nomic-embed-text")
+        base_url = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+        return OllamaEmbedder(model=model, base_url=base_url)
+    logger.warning(
+        "embedder.mock_active — set REPOWISE_EMBEDDER=gemini, openai, or ollama for real RAG"
+    )
     return MockEmbedder()
 
 

--- a/packages/server/src/repowise/server/provider_config.py
+++ b/packages/server/src/repowise/server/provider_config.py
@@ -63,6 +63,14 @@ PROVIDER_CATALOG: list[dict[str, Any]] = [
         "env_keys": [],
         "requires_key": True,
     },
+    {
+        "id": "claudecode",
+        "name": "Claude Code (local CLI)",
+        "default_model": "haiku",
+        "models": ["haiku", "sonnet", "opus"],
+        "env_keys": [],
+        "requires_key": False,
+    },
 ]
 
 _CATALOG_BY_ID = {p["id"]: p for p in PROVIDER_CATALOG}


### PR DESCRIPTION
## Summary

- **New `ClaudeCodeProvider`** (`--provider claudecode`): generates wiki pages by shelling out to `claude -p` — no Anthropic API key required, uses the active Claude Code CLI session. Also implements `ChatProvider.stream_chat()` via `claude -p --output-format stream-json --verbose` so the dashboard chat works without an API key.
- **New `OllamaEmbedder`** (`--embedder ollama`): local semantic embeddings via Ollama's OpenAI-compatible `/v1/embeddings` endpoint. Defaults to `nomic-embed-text` (768 dims). L2-normalizes vectors for cosine similarity in LanceDB. No API key needed.
- **Full dashboard integration**: `app.py`, `serve_cmd.py`, `provider_config.py`, `reindex_cmd.py`, `search_cmd.py`, `helpers.py`, and `ui.py` all updated to recognize `claudecode` and `ollama` as zero-key options.
- **`.gitignore` fix**: `providers/` rule was unanchored, accidentally ignoring the `packages/*/providers/` source tree. Changed to `/providers/` to scope it to the repo root.

## Motivation

Users with a Claude Code subscription or a local Ollama install can now run a complete repowise workflow — index, search, and dashboard chat — at $0.00 in API costs.

```bash
# Full zero-cost setup
repowise init --provider claudecode --embedder ollama
REPOWISE_EMBEDDER=ollama repowise serve
```

## Test plan

- [ ] `repowise init --provider claudecode --embedder ollama` completes without API errors
- [ ] `repowise reindex --embedder ollama` rebuilds vector index using local Ollama
- [ ] `repowise search "auth flow" --mode semantic` returns results via Ollama embedder
- [ ] `repowise serve` interactive menu shows ollama as "✓ local server detected" when Ollama is running
- [ ] Dashboard chat streams responses via `claude -p --output-format stream-json --verbose`
- [ ] `validate_provider_config("claudecode")` returns no warnings
- [ ] Existing providers (anthropic, openai, gemini, ollama LLM) unaffected

🤖 Generated with [Claude Code](https://claude.ai/code)