### PR TITLE
fix: unify repo-local DB resolution for init and MCP

### DIFF
--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -11,6 +11,8 @@ from typing import Any, TypeVar
 import click
 from rich.console import Console
 
+from repowise.core.persistence.database import resolve_db_url
+
 CONFIG_FILENAME = "config.yaml"
 
 T = TypeVar("T")
@@ -69,16 +71,10 @@ def ensure_repowise_dir(repo_path: Path) -> Path:
 def get_db_url_for_repo(repo_path: Path) -> str:
     """Return a database URL for this repo.
 
-    If ``REPOWISE_DB_URL`` is set in the environment that URL is used.
-    Otherwise defaults to the global ``~/.repowise/wiki.db`` so all repos
-    are visible in one ``repowise serve`` regardless of working directory.
+    Prefers ``REPOWISE_DB_URL``, then the legacy ``REPOWISE_DATABASE_URL``.
+    Otherwise defaults to the repo-local ``<repo>/.repowise/wiki.db``.
     """
-    env_url = os.environ.get("REPOWISE_DB_URL")
-    if env_url:
-        return env_url
-    db_path = Path.home() / REPOWISE_DIR / DB_FILENAME
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    return f"sqlite+aiosqlite:///{db_path}"
+    return resolve_db_url(repo_path)
 
 
 async def _ensure_db_async(repo_path: Path) -> tuple[Any, Any]:
@@ -220,7 +216,6 @@ def resolve_provider(
       3. ``.repowise/config.yaml`` (written by ``repowise init``)
       4. Auto-detect from API key env vars
     """
-    import os
 
     from repowise.core.providers import get_provider
 
@@ -311,7 +306,6 @@ def validate_provider_config(provider_name: str | None = None) -> list[str]:
         List of warning messages for missing or invalid configuration.
         Empty list means all required config is present.
     """
-    import os
 
     warnings = []
 

--- a/packages/core/src/repowise/core/persistence/__init__.py
+++ b/packages/core/src/repowise/core/persistence/__init__.py
@@ -68,9 +68,12 @@ from .database import (
     async_sessionmaker,
     create_engine,
     create_session_factory,
+    get_configured_db_url,
     get_db_url,
+    get_repo_db_path,
     get_session,
     init_db,
+    resolve_db_url,
 )
 from .models import (
     Base,
@@ -143,6 +146,7 @@ __all__ = [
     "delete_decision",
     # git metadata crud
     "get_all_git_metadata",
+    "get_configured_db_url",
     "get_conversation",
     "get_db_url",
     # dead code crud
@@ -155,6 +159,7 @@ __all__ = [
     "get_git_metadata_bulk",
     "get_page",
     "get_page_versions",
+    "get_repo_db_path",
     "get_repository",
     "get_repository_by_path",
     "get_session",
@@ -167,6 +172,7 @@ __all__ = [
     "list_pages",
     "mark_webhook_processed",
     "recompute_decision_staleness",
+    "resolve_db_url",
     "save_dead_code_findings",
     "store_webhook_event",
     "touch_conversation",

--- a/packages/core/src/repowise/core/persistence/database.py
+++ b/packages/core/src/repowise/core/persistence/database.py
@@ -11,8 +11,10 @@ Call init_db() once at startup to create all tables and the FTS index.
 
 from __future__ import annotations
 
+import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
@@ -31,19 +33,43 @@ __all__ = [
     "async_sessionmaker",
     "create_engine",
     "create_session_factory",
+    "get_configured_db_url",
     "get_db_url",
+    "get_repo_db_path",
     "get_session",
     "init_db",
+    "resolve_db_url",
 ]
 
+DB_FILENAME = "wiki.db"
+REPOWISE_DIRNAME = ".repowise"
+DB_ENV_VARS = ("REPOWISE_DB_URL", "REPOWISE_DATABASE_URL")
 
-def _default_db_url() -> str:
-    """Global SQLite DB at ~/.repowise/wiki.db — shared across all repos."""
-    from pathlib import Path
 
-    db_path = Path.home() / ".repowise" / "wiki.db"
-    db_path.parent.mkdir(parents=True, exist_ok=True)
+def get_repo_db_path(repo_path: str | Path) -> Path:
+    """Return the repo-local database path ``<repo>/.repowise/wiki.db``."""
+    return Path(repo_path).resolve() / REPOWISE_DIRNAME / DB_FILENAME
+
+
+def _default_db_url(repo_path: str | Path | None = None, *, create_parent: bool = True) -> str:
+    """Return the default SQLite URL for a repo-local or global wiki database."""
+    if repo_path is not None:
+        db_path = get_repo_db_path(repo_path)
+    else:
+        db_path = Path.home() / REPOWISE_DIRNAME / DB_FILENAME
+
+    if create_parent:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
     return f"sqlite+aiosqlite:///{db_path}"
+
+
+def get_configured_db_url() -> str | None:
+    """Return the configured DB URL from supported env vars, if present."""
+    for env_name in DB_ENV_VARS:
+        env_url = os.environ.get(env_name)
+        if env_url:
+            return get_db_url(env_url)
+    return None
 
 
 def get_db_url(raw_url: str | None = None) -> str:
@@ -67,6 +93,25 @@ def get_db_url(raw_url: str | None = None) -> str:
         return url.replace("://", "+asyncpg://", 1)
 
     return url
+
+
+def resolve_db_url(
+    repo_path: str | Path | None = None,
+    *,
+    create_parent: bool = True,
+) -> str:
+    """Resolve the active DB URL from env vars or the default filesystem path.
+
+    Resolution order:
+    1. ``REPOWISE_DB_URL``
+    2. ``REPOWISE_DATABASE_URL`` (legacy compatibility)
+    3. ``<repo>/.repowise/wiki.db`` when ``repo_path`` is provided
+    4. ``~/.repowise/wiki.db`` otherwise
+    """
+    configured = get_configured_db_url()
+    if configured is not None:
+        return configured
+    return _default_db_url(repo_path, create_parent=create_parent)
 
 
 def create_engine(

--- a/packages/server/src/repowise/server/app.py
+++ b/packages/server/src/repowise/server/app.py
@@ -20,6 +20,7 @@ from repowise.core.persistence.database import (
     create_engine,
     create_session_factory,
     init_db,
+    resolve_db_url,
 )
 from repowise.core.persistence.search import FullTextSearch
 from repowise.core.persistence.vector_store import InMemoryVectorStore
@@ -75,7 +76,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     Shutdown: dispose engine, stop scheduler, close vector store.
     """
     # Database
-    db_url = os.environ.get("REPOWISE_DB_URL")
+    db_url = resolve_db_url()
     engine = create_engine(db_url)
     await init_db(engine)
     session_factory = create_session_factory(engine)

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -11,7 +11,12 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from repowise.core.persistence.database import init_db
+from repowise.core.persistence.database import (
+    get_configured_db_url,
+    get_repo_db_path,
+    init_db,
+    resolve_db_url,
+)
 from repowise.core.persistence.search import FullTextSearch
 from repowise.core.persistence.vector_store import InMemoryVectorStore
 from repowise.core.providers.embedding.base import MockEmbedder
@@ -127,27 +132,24 @@ async def _lifespan(server: FastMCP):
 
     _log = _logging.getLogger("repowise.mcp")
 
-    db_url = os.environ.get("REPOWISE_DATABASE_URL", "sqlite+aiosqlite:///repowise.db")
+    configured_db_url = get_configured_db_url()
+    db_url = resolve_db_url(_state._repo_path, create_parent=False)
 
-    # If a repo path was configured, try .repowise/wiki.db
-    if _state._repo_path:
-        from pathlib import Path
-
-        repowise_dir = Path(_state._repo_path) / ".repowise"
+    # If a repo path was configured, prefer <repo>/.repowise/wiki.db unless an env
+    # override was provided explicitly.
+    if _state._repo_path and configured_db_url is None:
+        db_path = get_repo_db_path(_state._repo_path)
+        repowise_dir = db_path.parent
         if not repowise_dir.exists():
             _log.warning(
                 "No .repowise directory at %s — run 'repowise init' first",
                 _state._repo_path,
             )
-        elif not (repowise_dir / "wiki.db").exists():
+        elif not db_path.exists():
             _log.warning(
                 "No wiki.db in %s — run 'repowise init' to generate the wiki",
                 repowise_dir,
             )
-        if repowise_dir.exists():
-            db_path = repowise_dir / "wiki.db"
-            if db_path.exists():
-                db_url = f"sqlite+aiosqlite:///{db_path.as_posix()}"
 
     connect_args: dict = {}
     if db_url.startswith("sqlite"):

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -59,6 +59,29 @@ class TestInitFullMock:
         assert "init complete" in result.output
 
 
+class TestInitDefaultDbLocation:
+    def test_creates_repo_local_db_without_env_override(
+        self,
+        runner,
+        tmp_path,
+        sample_repo_path,
+        monkeypatch,
+    ):
+        work_repo = tmp_path / "repo"
+        shutil.copytree(sample_repo_path, work_repo)
+        monkeypatch.delenv("REPOWISE_DB_URL", raising=False)
+        monkeypatch.delenv("REPOWISE_DATABASE_URL", raising=False)
+
+        result = runner.invoke(
+            cli,
+            ["init", str(work_repo), "--provider", "mock", "--yes"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (work_repo / ".repowise" / "wiki.db").exists()
+
+
 class TestInitIdempotent:
     def test_running_init_twice(self, runner, work_repo):
         args = ["init", str(work_repo), "--provider", "mock", "--yes"]

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -90,10 +90,10 @@ class TestrepowiseDir:
 
 
 class TestDbUrl:
-    def test_sqlite_url(self, tmp_path):
+    def test_defaults_to_repo_local_database(self, tmp_path):
         url = get_db_url_for_repo(tmp_path)
-        assert url.startswith("sqlite+aiosqlite:///")
-        assert "wiki.db" in url
+        assert url == f"sqlite+aiosqlite:///{tmp_path / '.repowise' / 'wiki.db'}"
+        assert (tmp_path / ".repowise").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/test_mcp.py
+++ b/tests/unit/server/test_mcp.py
@@ -74,6 +74,69 @@ async def vector_store():
     await vs.close()
 
 
+async def test_mcp_lifespan_uses_cli_database_env_var(monkeypatch):
+    import repowise.server.mcp_server._server as mcp_server
+    from repowise.server.mcp_server import _state
+
+    captured: dict[str, str] = {}
+
+    class DummyEngine:
+        async def dispose(self) -> None:
+            return None
+
+    class DummyFts:
+        def __init__(self, engine) -> None:
+            self.engine = engine
+
+        async def ensure_index(self) -> None:
+            return None
+
+    class DummyVectorStore:
+        def __init__(self, *, embedder) -> None:
+            self.embedder = embedder
+
+        async def close(self) -> None:
+            return None
+
+    async def fake_init_db(engine) -> None:
+        return None
+
+    async def fake_load_vector_stores(repo_path: str | None) -> None:
+        return None
+
+    def fake_create_async_engine(url: str, connect_args: dict | None = None) -> DummyEngine:
+        captured["url"] = url
+        return DummyEngine()
+
+    monkeypatch.setenv("REPOWISE_DB_URL", "sqlite:///tmp/from-cli.db")
+    monkeypatch.delenv("REPOWISE_DATABASE_URL", raising=False)
+    monkeypatch.setattr(mcp_server, "create_async_engine", fake_create_async_engine)
+    monkeypatch.setattr(mcp_server, "init_db", fake_init_db)
+    monkeypatch.setattr(mcp_server, "FullTextSearch", DummyFts)
+    monkeypatch.setattr(mcp_server, "InMemoryVectorStore", DummyVectorStore)
+    monkeypatch.setattr(mcp_server, "async_sessionmaker", lambda *args, **kwargs: object())
+    monkeypatch.setattr(mcp_server, "_load_vector_stores", fake_load_vector_stores)
+
+    original_repo_path = _state._repo_path
+    original_vector_store = _state._vector_store
+    original_decision_store = _state._decision_store
+    original_ready = _state._vector_store_ready
+
+    _state._repo_path = None
+    _state._vector_store = None
+    _state._decision_store = None
+    _state._vector_store_ready = None
+
+    try:
+        async with mcp_server._lifespan(mcp_server.mcp):
+            assert captured["url"] == "sqlite+aiosqlite:///tmp/from-cli.db"
+    finally:
+        _state._repo_path = original_repo_path
+        _state._vector_store = original_vector_store
+        _state._decision_store = original_decision_store
+        _state._vector_store_ready = original_ready
+
+
 @pytest.fixture
 async def repo_id(session: AsyncSession) -> str:
     """Create a test repository and return its ID."""


### PR DESCRIPTION
Fixes #28.

## Summary
- make repo-aware DB resolution default to `<repo>/.repowise/wiki.db`
- let server code honor both `REPOWISE_DB_URL` and legacy `REPOWISE_DATABASE_URL`
- reuse the shared resolver in the CLI helper, FastAPI app, and MCP lifespan
- add unit and integration regression coverage for the init/MCP mismatch

## Verification
- `uv run ruff check packages/core/src/repowise/core/persistence/database.py packages/core/src/repowise/core/persistence/__init__.py packages/cli/src/repowise/cli/helpers.py packages/server/src/repowise/server/app.py packages/server/src/repowise/server/mcp_server/_server.py tests/unit/cli/test_helpers.py tests/unit/server/test_mcp.py tests/integration/test_cli.py`
- `uv run pytest tests/unit/cli/test_helpers.py::TestDbUrl::test_defaults_to_repo_local_database tests/unit/server/test_mcp.py::test_mcp_lifespan_uses_cli_database_env_var tests/integration/test_cli.py::TestInitDefaultDbLocation::test_creates_repo_local_db_without_env_override`