### PR TITLE
fix(docker): fix build context, DB URL absolute path, and stale repo references

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # repowise — multi-stage Docker build (backend + frontend)
 # =============================================================================
 # Usage:
-#   docker build -t repowise .
+#   docker build -t repowise -f docker/Dockerfile .
 #   docker run -p 7337:7337 -p 3000:3000 -v /path/to/repo/.repowise:/data -e GEMINI_API_KEY=... repowise
 # =============================================================================
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,8 @@ Run the full repowise stack (API + Web UI) in a single container.
 ## Quick Start
 
 ```bash
-docker build -t repowise .
+# Run from the project root
+docker build -t repowise -f docker/Dockerfile .
 
 # Run with a mounted .repowise directory
 docker run -p 7337:7337 -p 3000:3000 \
@@ -36,7 +37,7 @@ docker compose up
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `REPOWISE_DB_URL` | `sqlite+aiosqlite:///data/wiki.db` | Database URL |
+| `REPOWISE_DB_URL` | `sqlite+aiosqlite:////data/wiki.db` | Database URL |
 | `REPOWISE_EMBEDDER` | `mock` | Embedder: `gemini`, `openai`, `mock` |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key (for chat) |
 | `OPENAI_API_KEY` | — | OpenAI API key (for chat) |

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   repowise:
-    build: .
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     ports:
       - "7337:7337"   # API
       - "3000:3000"   # Web UI
@@ -8,7 +10,7 @@ services:
       # Mount the .repowise directory from your indexed repo
       - ${REPOWISE_DATA:-./data}:/data
     environment:
-      - REPOWISE_DB_URL=sqlite+aiosqlite:///data/wiki.db
+      - REPOWISE_DB_URL=sqlite+aiosqlite:////data/wiki.db
       - REPOWISE_EMBEDDER=${REPOWISE_EMBEDDER:-mock}
       # Set your LLM provider API key
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -110,7 +110,9 @@ To skip the web UI and only run the API: `repowise serve --no-ui`
 ### With Docker (no Node.js needed)
 
 ```bash
-docker build -t repowise https://github.com/RaghavChamadiya/repowise.git
+git clone https://github.com/repowise-dev/repowise.git
+cd repowise
+docker build -t repowise -f docker/Dockerfile .
 
 docker run -p 7337:7337 -p 3000:3000 \
   -v /path/to/your-repo/.repowise:/data \

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -565,8 +565,11 @@ On first run, the pre-built frontend is downloaded (~50 MB) and cached in `~/.re
 ### Docker (no Node.js needed)
 
 ```bash
+git clone https://github.com/repowise-dev/repowise.git
+cd repowise
+
 # Build the image (one-time)
-docker build -t repowise https://github.com/RaghavChamadiya/repowise.git
+docker build -t repowise -f docker/Dockerfile .
 
 # Run with your indexed repo's .repowise directory
 docker run -p 7337:7337 -p 3000:3000 \
@@ -579,11 +582,11 @@ docker run -p 7337:7337 -p 3000:3000 \
 Or with docker compose:
 
 ```bash
-git clone https://github.com/RaghavChamadiya/repowise.git
+git clone https://github.com/repowise-dev/repowise.git
 cd repowise
 export REPOWISE_DATA=/path/to/your-repo/.repowise
 export GEMINI_API_KEY=your-key
-docker compose up
+docker compose -f docker/docker-compose.yml up
 ```
 
 Open **http://localhost:3000** for the Web UI, **http://localhost:7337** for the API.


### PR DESCRIPTION
## Summary

- **`docker/Dockerfile`**: Fix header comment build command to use `-f docker/Dockerfile`
- **`docker/docker-compose.yml`**: Fix build context to project root (`context: ..`, `dockerfile: docker/Dockerfile`) so `COPY packages/` paths resolve correctly; fix `REPOWISE_DB_URL` from `///` (relative) to `////` (absolute `/data/wiki.db`)
- **`docker/README.md`**: Update build command and fix default DB URL in env vars table
- **`docs/QUICKSTART.md`**, **`docs/USER_GUIDE.md`**: Replace remote-URL `docker build` with local clone + build; update stale repo URL from `RaghavChamadiya/repowise` → `repowise-dev/repowise`; add `-f docker/docker-compose.yml` to `docker compose` command

## Root causes

These issues appear to be oversights from #14 (moving `Dockerfile` and `docker-compose.yml` into the `docker/` subdirectory) — the build context paths and documentation were not updated to reflect the new file locations.

1. `docker-compose.yml` had `build: .` — when run from the `docker/` directory, the build context was `docker/`, making `COPY packages/...` fail silently or at build time.
2. `sqlite+aiosqlite:///data/wiki.db` (3 slashes) is a relative path resolved from the process CWD, not the intended absolute `/data/wiki.db` volume mount.

## Test plan

- [x] `docker build -t repowise -f docker/Dockerfile .` from project root succeeds
- [x] `docker compose -f docker/docker-compose.yml up` resolves `packages/` paths correctly
- [x] Container writes DB to `/data/wiki.db` (the mounted volume), not a relative path