### PR TITLE
Release v0.1.31

### DIFF
--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -6,4 +6,4 @@ git signals, dead code detection, architectural decisions, and
 AI-generated documentation.
 """
 
-__version__ = "0.1.30"
+__version__ = "0.1.31"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.1.30"
+__version__ = "0.1.31"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.1.30"
+__version__ = "0.1.31"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.1.30"
+version = "0.1.31"
 description = "Codebase intelligence for developers and AI — generates and maintains a structured wiki for any codebase"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Bump version to v0.1.31 across all 4 version files (pyproject.toml,
core, cli, server init.py)
Related Issues

Part of the v0.1.31 release cycle. Follows https://github.com/repowise-dev/repowise/pull/38 (overview dashboard,
background pipeline execution, and shared persistence layer).

Test Plan

Tests pass (pytest)
Lint passes (ruff check .)
Web build passes (npm run build)
repowise --version reports 0.1.31 after install
Checklist

My code follows the project's code style
I have added tests for new functionality
All existing tests still pass
I have updated documentation if needed