### PR TITLE
fix: prefer local repo build over stale cached frontend

### DIFF
--- a/packages/cli/src/repowise/cli/commands/serve_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/serve_cmd.py
@@ -260,20 +260,10 @@ def _start_frontend(node: str, backend_port: int, frontend_port: int) -> subproc
         "PORT": str(frontend_port),
     }
 
-    # Option 1: Cached download
-    cached_server = _WEB_CACHE_DIR / "server.js"
-    if cached_server.exists():
-        return subprocess.Popen(
-            [node, str(cached_server)],
-            cwd=str(_WEB_CACHE_DIR),
-            env=env,
-        )
-
-    # Option 2: Local repo build
+    # Option 1: Local repo build (preferred — uses latest source)
     local_web = _find_local_web()
     if local_web:
         standalone_dir = local_web / ".next" / "standalone"
-        # Next.js standalone in monorepos nests server under the package path
         server_js = standalone_dir / "packages" / "web" / "server.js"
         if server_js.exists():
             # Copy static files into standalone (Next.js requirement)
@@ -291,6 +281,15 @@ def _start_frontend(node: str, backend_port: int, frontend_port: int) -> subproc
                 cwd=str(standalone_dir / "packages" / "web"),
                 env=env,
             )
+
+    # Option 2: Cached download (fallback for pip-installed users)
+    cached_server = _WEB_CACHE_DIR / "server.js"
+    if cached_server.exists():
+        return subprocess.Popen(
+            [node, str(cached_server)],
+            cwd=str(_WEB_CACHE_DIR),
+            env=env,
+        )
 
     return None
 


### PR DESCRIPTION
## Summary
- `_start_frontend()` checked the cached download (`~/.repowise/web/`) before the local repo build, so a stale cached version was always served even when a newer local build existed
- Swaps the priority: local repo builds are now preferred, with the cached download as a fallback for pip-installed users

## Test plan
- [ ] Run `repowise serve` from a repo checkout that has a local `.next/standalone` build
- [ ] Verify the local build is served (not the cached `~/.repowise/web/` version)
- [ ] Verify pip-installed users without a local build still get the cached download