### PR TITLE
feat: add wiki ZIP export endpoint and download buttons

### DIFF
--- a/packages/server/src/repowise/server/routers/repos.py
+++ b/packages/server/src/repowise/server/routers/repos.py
@@ -256,7 +256,7 @@ async def export_wiki(
     if repo is None:
         raise HTTPException(status_code=404, detail="Repository not found")
 
-    pages = await crud.list_pages(session, repo_id, limit=10000)
+    pages = (await session.execute(select(Page).where(Page.repository_id == repo_id))).scalars().all()
     if not pages:
         raise HTTPException(status_code=404, detail="No pages to export")
 

--- a/packages/server/src/repowise/server/routers/repos.py
+++ b/packages/server/src/repowise/server/routers/repos.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import logging
+import zipfile
+from pathlib import PurePosixPath
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
 from repowise.core.persistence import crud
 from repowise.core.persistence.models import (
     DeadCodeFinding,
@@ -240,3 +244,42 @@ def _launch_job_task(request: Request, job_id: str) -> None:
             logger.error("background_job_failed", exc_info=t.exception())
 
     task.add_done_callback(_on_done)
+
+
+@router.get("/{repo_id}/export")
+async def export_wiki(
+    repo_id: str,
+    session: AsyncSession = Depends(get_db_session),  # noqa: B008
+) -> StreamingResponse:
+    """Export all wiki pages as a ZIP of markdown files with folder structure."""
+    repo = await crud.get_repository(session, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=404, detail="Repository not found")
+
+    pages = await crud.list_pages(session, repo_id, limit=10000)
+    if not pages:
+        raise HTTPException(status_code=404, detail="No pages to export")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for page in pages:
+            target = page.target_path or page.id
+            safe = (
+                target.replace("::", "/")
+                .replace("->", "--")
+                .replace("\\", "/")
+            )
+            path = PurePosixPath("wiki") / page.page_type / safe
+            if path.suffix != ".md":
+                path = path.with_suffix(path.suffix + ".md")
+
+            content = f"# {page.title}\n\n{page.content}"
+            zf.writestr(str(path), content)
+
+    buf.seek(0)
+    filename = f"{repo.name}-wiki.zip"
+    return StreamingResponse(
+        buf,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/packages/web/src/app/repos/[id]/docs/page.tsx
+++ b/packages/web/src/app/repos/[id]/docs/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { use, useState } from "react";
-import { Download, Loader2 } from "lucide-react";
+import { Download, FolderArchive, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DocsExplorer } from "@/components/docs/docs-explorer";
 import { listAllPages } from "@/lib/api/pages";
@@ -41,20 +41,27 @@ export default function DocsPage({
             Browse AI-generated documentation for every file, module, and symbol.
           </p>
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleExportAll}
-          disabled={isExporting}
-          className="shrink-0"
-        >
-          {isExporting ? (
-            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-          ) : (
-            <Download className="h-3.5 w-3.5 mr-1.5" />
-          )}
-          Export All
-        </Button>
+        <div className="flex gap-2 shrink-0">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleExportAll}
+            disabled={isExporting}
+          >
+            {isExporting ? (
+              <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+            ) : (
+              <Download className="h-3.5 w-3.5 mr-1.5" />
+            )}
+            Export All
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <a href={`/api/repos/${repoId}/export`} download>
+              <FolderArchive className="h-3.5 w-3.5 mr-1.5" />
+              Download ZIP
+            </a>
+          </Button>
+        </div>
       </div>
 
       {/* Explorer */}

--- a/packages/web/src/components/repos/operations-panel.tsx
+++ b/packages/web/src/components/repos/operations-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
-import { RefreshCw, Zap, ChevronDown, ChevronUp, AlertTriangle } from "lucide-react";
+import { RefreshCw, Zap, ChevronDown, ChevronUp, AlertTriangle, Download } from "lucide-react";
 import { syncRepo, fullResyncRepo } from "@/lib/api/repos";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -124,6 +124,16 @@ export function OperationsPanel({ repoId, repoName }: Props) {
               >
                 <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
                 {loading === "resync" ? "Starting…" : "Full Resync"}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                asChild
+              >
+                <a href={`/api/repos/${repoId}/export`} download>
+                  <Download className="h-3.5 w-3.5 mr-1.5" />
+                  Export
+                </a>
               </Button>
             </div>
           )}

--- a/tests/unit/server/test_repos.py
+++ b/tests/unit/server/test_repos.py
@@ -125,3 +125,33 @@ async def test_full_resync_duplicate_returns_409(client: AsyncClient) -> None:
 
         resp2 = await client.post(f"/api/repos/{repo['id']}/full-resync")
         assert resp2.status_code == 409
+
+
+
+@pytest.mark.asyncio
+async def test_export_wiki_not_found(client: AsyncClient) -> None:
+    resp = await client.get("/api/repos/nonexistent/export")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_export_wiki_returns_zip(client: AsyncClient, session) -> None:
+    import zipfile
+    from io import BytesIO
+
+    from repowise.core.persistence.crud import upsert_page, upsert_repository
+    from tests.unit.persistence.helpers import make_page_kwargs
+
+    repo = await upsert_repository(session, name="export-test", local_path="/tmp/export-test")
+    await upsert_page(session, **make_page_kwargs(repo.id))
+    await session.commit()
+
+    resp = await client.get(f"/api/repos/{repo.id}/export")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/zip"
+
+    zf = zipfile.ZipFile(BytesIO(resp.content))
+    names = zf.namelist()
+    assert len(names) == 1
+    assert names[0].startswith("wiki/")
+    assert names[0].endswith(".md")


### PR DESCRIPTION
## Summary
- Add `GET /api/repos/{repo_id}/export` endpoint that returns a ZIP archive with pages organized as `wiki/{page_type}/{target_path}.md`
- Add "Download ZIP" button next to "Export All" on the docs page
- Add "Export" button in the operations panel on the settings page

The docs page already had a markdown "Export All" button; this adds a structured ZIP alternative that preserves folder hierarchy.

## Test plan
- [x] Unit tests for export endpoint (success + 404)
- [x] Manual: click "Download ZIP" on docs page, verify ZIP contains organized markdown files
- [x] Manual: click "Export" in operations panel, verify same ZIP download