### PR TITLE
chore(uv): document uv workflow and migrate to dependency-groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ These become structured decision records, queryable by Claude Code via `get_why(
 pip install repowise
 ```
 
+Or install the CLI into an isolated, uv-managed environment:
+
+```bash
+uv tool install repowise
+```
+
 ### Single repo
 
 ```bash
@@ -594,8 +600,22 @@ Full configuration reference: [docs/CONFIG.md](docs/CONFIG.md)
 ```bash
 git clone https://github.com/repowise-dev/repowise
 cd repowise
-pip install -e "packages/core[dev]"
-pytest tests/unit/
+uv sync --all-packages
+uv run repowise --version
+uv run pytest tests/unit/
+```
+
+Run commands through uv without activating the environment:
+
+```bash
+uv run repowise --help
+```
+
+Or activate the local environment created by `uv sync`:
+
+```bash
+source .venv/bin/activate
+repowise --help
 ```
 
 Full guide including how to add languages and LLM providers: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -71,6 +71,17 @@ repowise --version
 repowise --help
 ```
 
+### From Source with uv
+
+For local development, use the workspace lockfile from the repository root:
+
+```bash
+git clone https://github.com/repowise-dev/repowise.git
+cd repowise
+uv sync --all-packages
+uv run repowise --version
+```
+
 ---
 
 ## Getting Started

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,8 +169,8 @@ members = [
     "packages/server",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8,<9",
     "pytest-asyncio>=0.23,<1",
     "pytest-snapshot>=0.9,<1",


### PR DESCRIPTION
Supersedes #90 by @Leeaandrob. Picking up the surviving pieces of that PR (the docs additions and the dev-dependency-group migration) now that #97 has independently fixed the setuptools `packages = [...]` list.

Full credit to @Leeaandrob for the original work and for documenting the uv flow.

## What this changes

- README quickstart documents `uv tool install repowise` alongside `pip install repowise`.
- README contributing section switches from `pip install -e "packages/core[dev]"` to `uv sync --all-packages` plus `uv run`, and shows both the activate-the-venv and the `uv run` flows.
- USER_GUIDE adds a "From Source with uv" subsection.
- `pyproject.toml`: replace the deprecated `[tool.uv] dev-dependencies` table with the PEP 735 `[dependency-groups] dev` form. This silences the `tool.uv.dev-dependencies is deprecated` warning every `uv pip install` was emitting.

## What was dropped from #90

- The `packages = [...]` change (already landed via #97 with the correct `extractors`/`languages`/`resolvers` list).
- `.python-version = 3.13`. The project supports Python `>=3.11`, so pinning to the newest version excludes 3.11/3.12 contributors.

## Verification

- `uv pip install -e . --dry-run` resolves cleanly with no deprecation warning.