### PR TITLE
fix(init): always honour the CLAUDE.md opt-out

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd.py
@@ -877,6 +877,7 @@ def init_command(
         build_contextual_next_steps,
         format_elapsed,
         interactive_advanced_config,
+        interactive_claude_md_prompt,
         interactive_mode_select,
         interactive_provider_select,
         load_dotenv,
@@ -974,9 +975,15 @@ def init_command(
             test_run = adv["test_run"]
             embedder_name = adv.get("embedder") or embedder_name
             include_submodules = adv.get("include_submodules", include_submodules)
-            no_claude_md = adv.get("no_claude_md", no_claude_md)
         else:
             provider_name, model = interactive_provider_select(console, model, repo_path=repo_path)
+
+        # Ask about CLAUDE.md once, after mode selection, so full and advanced
+        # modes both honour the user's choice (issue #81). Skip when --no-claude-md
+        # was already passed on the CLI (the user has already opted out) and when
+        # the user picked index-only mode (no LLM generation runs anyway).
+        if not no_claude_md and not index_only:
+            no_claude_md = interactive_claude_md_prompt(console)
 
     # Merge exclude_patterns from config.yaml and --exclude/-x flags
     config = load_config(repo_path)

--- a/packages/cli/src/repowise/cli/ui.py
+++ b/packages/cli/src/repowise/cli/ui.py
@@ -553,7 +553,11 @@ def interactive_advanced_config(
     Returns a dict with keys matching init_command kwargs:
     ``commit_limit``, ``follow_renames``, ``skip_tests``, ``skip_infra``,
     ``concurrency``, ``exclude``, ``test_run``, ``embedder``,
-    ``include_submodules``, ``no_claude_md``.
+    ``include_submodules``.
+
+    The CLAUDE.md prompt is intentionally not asked here so that full and
+    advanced modes stay aligned: the caller asks once via
+    :func:`interactive_claude_md_prompt` after mode selection.
     """
     console.print()
     console.print(
@@ -681,16 +685,6 @@ def interactive_advanced_config(
         default=False,
     )
 
-    # ── Editor Integration ────────────────────────────────────────────────
-    console.print()
-    console.print(f"  [{BRAND}]Editor Integration[/]")
-    console.print()
-
-    result["no_claude_md"] = not click.confirm(
-        "  Generate .claude/CLAUDE.md?",
-        default=True,
-    )
-
     # ── Summary ───────────────────────────────────────────────────────────
     console.print()
     summary = Table(box=None, padding=(0, 2), show_header=False)
@@ -707,7 +701,6 @@ def interactive_advanced_config(
     if patterns:
         summary.add_row("Exclude", ", ".join(patterns))
     summary.add_row("Test run", "yes" if result["test_run"] else "no")
-    summary.add_row("CLAUDE.md", "no" if result["no_claude_md"] else "yes")
 
     console.print(
         Panel(
@@ -719,6 +712,23 @@ def interactive_advanced_config(
     )
     console.print()
     return result
+
+
+def interactive_claude_md_prompt(console: Console) -> bool:
+    """Ask the user whether to generate ``.claude/CLAUDE.md``.
+
+    Returns ``True`` when the user opts out (i.e. the value to assign to
+    ``no_claude_md``). Asked once after mode selection so that full mode and
+    advanced mode behave the same way and a user who answers ``n`` always has
+    that answer honoured (issue #81).
+    """
+    console.print()
+    console.print(f"  [{BRAND}]Editor Integration[/]")
+    console.print()
+    return not click.confirm(
+        "  Generate .claude/CLAUDE.md?",
+        default=True,
+    )
 
 
 def _resolve_embedder_from_env() -> str:

--- a/tests/unit/cli/test_claude_md_prompt.py
+++ b/tests/unit/cli/test_claude_md_prompt.py
@@ -1,0 +1,85 @@
+"""Regression tests for issue #81.
+
+The CLAUDE.md opt-out prompt used to live inside ``interactive_advanced_config``
+and was therefore skipped entirely in full mode, and the answer was not always
+threaded back to the writer in every code path. These tests pin the new
+behaviour: the dedicated ``interactive_claude_md_prompt`` helper returns
+``True`` (i.e. ``no_claude_md=True``) when the user answers ``n`` and ``False``
+when they answer ``y`` or accept the default, and the writer's gating function
+honours that answer by early-returning before any file is written.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+from rich.console import Console
+
+from repowise.cli.commands.init_cmd import _maybe_generate_claude_md
+from repowise.cli.ui import interactive_claude_md_prompt
+
+
+def _silent_console() -> Console:
+    return Console(file=StringIO(), force_terminal=False)
+
+
+def test_prompt_returns_true_when_user_says_no() -> None:
+    runner = CliRunner()
+    with runner.isolation(input="n\n"):
+        assert interactive_claude_md_prompt(_silent_console()) is True
+
+
+def test_prompt_returns_false_when_user_says_yes() -> None:
+    runner = CliRunner()
+    with runner.isolation(input="y\n"):
+        assert interactive_claude_md_prompt(_silent_console()) is False
+
+
+def test_prompt_returns_false_on_default_enter() -> None:
+    runner = CliRunner()
+    with runner.isolation(input="\n"):
+        # default is "Yes", so empty input should produce no_claude_md=False
+        assert interactive_claude_md_prompt(_silent_console()) is False
+
+
+def test_maybe_generate_skips_write_when_user_opted_out(tmp_path: Path) -> None:
+    """When ``no_claude_md=True`` the gating function must not touch the
+    .claude directory and must persist the opt-out to config.yaml so future
+    ``repowise update`` invocations stay opted out as well."""
+
+    (tmp_path / ".repowise").mkdir()
+    claude_dir = tmp_path / ".claude"
+
+    _maybe_generate_claude_md(_silent_console(), tmp_path, no_claude_md=True)
+
+    # No .claude directory and no CLAUDE.md should have been created.
+    assert not claude_dir.exists()
+    assert not (claude_dir / "CLAUDE.md").exists()
+
+    # Opt-out must be persisted to .repowise/config.yaml so that subsequent
+    # commands (e.g. `repowise update`) also skip CLAUDE.md generation.
+    cfg_path = tmp_path / ".repowise" / "config.yaml"
+    assert cfg_path.exists()
+    contents = cfg_path.read_text(encoding="utf-8")
+    assert "claude_md: false" in contents
+
+
+def test_maybe_generate_skips_write_when_config_disabled(tmp_path: Path) -> None:
+    """If the persisted opt-out is already in config.yaml from a previous run,
+    the writer must respect it even when ``no_claude_md`` is False."""
+
+    (tmp_path / ".repowise").mkdir()
+    cfg_path = tmp_path / ".repowise" / "config.yaml"
+    cfg_path.write_text("editor_files:\n  claude_md: false\n", encoding="utf-8")
+
+    # Patch the writer to detect any unexpected call.
+    with patch(
+        "repowise.cli.commands.init_cmd._write_claude_md_async"
+    ) as fake_write:
+        _maybe_generate_claude_md(_silent_console(), tmp_path, no_claude_md=False)
+
+    fake_write.assert_not_called()
+    assert not (tmp_path / ".claude" / "CLAUDE.md").exists()


### PR DESCRIPTION
Closes #81.

## Summary

The "Generate .claude/CLAUDE.md? [Y/n]" prompt was nested inside `interactive_advanced_config`, so users in full mode were never asked and the writer fell through to its default of generating the file. Even in advanced mode the answer was easy to lose, because it travelled inside the `adv` dict alongside ten other settings.

## What changed

- Move the prompt out into a small `interactive_claude_md_prompt(console)` helper.
- Ask it once after mode selection, in both full and advanced flows.
- Skip the prompt when `--no-claude-md` was already passed on the CLI (the user has already opted out) and when the user picked index-only mode (no LLM generation runs at all).

The downstream gating in `_maybe_generate_claude_md` is unchanged — it already early-returns when either the explicit flag is true or the persisted opt-out is in `config.yaml`.

## Tests

Five regression tests in `tests/unit/cli/test_claude_md_prompt.py`:

- Prompt returns `True` (i.e. `no_claude_md=True`) when the user types `n`.
- Prompt returns `False` when the user types `y`.
- Prompt returns `False` on the default Enter response.
- Writer's gate creates no file and persists `editor_files.claude_md: false` when the user opts out in this run.
- Writer's gate also respects the persisted opt-out from a previous run, even when the explicit flag is false.