### PR TITLE
fix(update): persist LLM costs to llm_costs table during incremental updates

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd.py
@@ -287,6 +287,36 @@ def update_command(
 
     provider = resolve_provider(provider_name, model, repo_path=repo_path)
 
+    # Attach a DB-backed CostTracker so every LLM call made during this update
+    # (decision rescan + page regeneration) is persisted to the `llm_costs`
+    # table — matching what `repowise init` already does. Without this,
+    # `repowise costs` only ever reflects the initial index and shows $0 for
+    # all subsequent updates.
+    from repowise.cli.helpers import get_db_url_for_repo
+    from repowise.core.generation.cost_tracker import CostTracker
+    from repowise.core.persistence import (
+        create_engine,
+        create_session_factory,
+        get_session,
+        init_db,
+        upsert_repository,
+    )
+
+    async def _make_cost_tracker() -> CostTracker:
+        url = get_db_url_for_repo(repo_path)
+        engine = create_engine(url)
+        await init_db(engine)
+        sf = create_session_factory(engine)
+        async with get_session(sf) as session:
+            repo = await upsert_repository(session, name=repo_path.name, local_path=str(repo_path))
+            return CostTracker(session_factory=sf, repo_id=repo.id)
+
+    try:
+        cost_tracker = run_async(_make_cost_tracker())
+    except Exception:
+        cost_tracker = CostTracker()
+    provider._cost_tracker = cost_tracker
+
     # Run partial dead code analysis on affected files
     dead_code_report = None
     try:


### PR DESCRIPTION
## Summary

`repowise update` resolves an LLM provider via `resolve_provider(...)` but never attaches a `CostTracker` to it. Because `CostTracker._persist()` is gated on `session_factory is not None and repo_id is not None`, every LLM call made during an update silently bypasses persistence — no error, no warning. As a result, the `llm_costs` table (and therefore `repowise costs`) only ever reflects the initial `repowise init` run.

For long-lived projects driven by CI-style updates, this is invisible until you go looking: the wiki keeps growing, but `repowise costs` reports \$0.00 indefinitely.

## Repro

1. `repowise init` a project — costs land in `llm_costs` ✅
2. Make a commit, run `repowise update` — wiki pages regenerate, but `llm_costs` gets no new rows ❌
3. `repowise costs` — only the init run shows up

You can confirm this in 0.3.1 / 0.4.0 with:

```bash
sqlite3 .repowise/wiki.db "SELECT COUNT(*), MIN(ts), MAX(ts) FROM llm_costs;"
# rows only from your init timestamp; updates contribute nothing
```

## Fix

Mirror the wiring `init_cmd.py` already does (`provider._cost_tracker = cost_tracker` at lines 385 and 1289) inside `update_cmd.py`, right after `resolve_provider(...)`. Falls back to an in-memory `CostTracker()` if DB initialization fails, preserving the prior no-crash behavior.

The block is intentionally identical in shape to `init`'s `_make_cost_tracker()` so the two stay in sync.

## Diff size

+30 / -0, all in one function. No tests added — there is no existing CostTracker-attachment test covering `init`'s wiring either, and the change is structurally identical to that already-working code path. Happy to add one if you'd like.

## Verification

- `make test-fast` — green (15/15 in `tests/unit/cli/test_commands.py`)
- `ruff check` — no new lint errors introduced (10 pre-existing → 10 post-change)
- `ruff format --check` — added block is format-clean