### PR TITLE
fix(workspace): show contract summary when contracts exist but no cross-repo links

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/_enrichment.py
+++ b/packages/server/src/repowise/server/mcp_server/_enrichment.py
@@ -191,8 +191,8 @@ class CrossRepoEnricher:
 
     @property
     def has_contract_data(self) -> bool:
-        """True if contract links are available."""
-        return bool(self._contract_links)
+        """True if contracts or contract links are available."""
+        return bool(self._contracts or self._contract_links)
 
     def get_cross_repo_partners(
         self, repo_alias: str, file_path: str


### PR DESCRIPTION
## Summary

\`CrossRepoEnricher.has_contract_data\` returns True only when \`_contract_links\` is non-empty. That gates the workspace summary endpoint (\`/api/workspace.contract_summary\`) — so for any workspace where the link extractor can't match providers to consumers, the API returns \`null\` and the dashboard widget renders 0 even though contracts were extracted successfully.

This is the common case for any Go-heavy workspace: the HTTP client-side extractor doesn't currently recognize Go HTTP client patterns (\`http.NewRequest\`, \`net/http\`, etc.), so a workspace with both Go HTTP servers and Go HTTP clients gets \`total_contracts: 50\`, \`total_links: 0\`, and a UI tile that says \"Contracts Detected: 0\".

The 0 is misleading: it tells the user that contract extraction failed, when in reality only the cross-repo MATCHING failed. The detected contracts are still useful — they show up in per-repo views and are queryable via \`/api/workspace/contracts\`.

## Repro

```bash
mkdir my-workspace && cd my-workspace
# add 2+ git repos with HTTP-style code (e.g., Go gateway + Go CLI)
repowise init . --index-only --yes
curl -s http://localhost:7337/api/workspace | jq '.contract_summary'
# null  ← bug
curl -s http://localhost:7337/api/workspace/contracts | jq '.total_contracts'
# 50    ← but contracts ARE there
```

## Fix

```python
@property
def has_contract_data(self) -> bool:
    return bool(self._contracts or self._contract_links)  # was: bool(self._contract_links)
```

After this, \`/api/workspace.contract_summary\` is populated whenever any contracts exist, and the dashboard tile shows the real count. \`CONTRACT LINKS\` (a separate tile) correctly continues to show 0 when there are no cross-repo matches.

## Verification

3-repo workspace (operator + operator-cli + genui-schema), 50 HTTP + 12 gRPC contracts indexed, 0 cross-repo links. Before: dashboard shows \"0 detected\". After: \"62 detected · 50 http, 12 grpc\" with the type breakdown shown as subtitle.

## Diff

+2 / -2, single property body. No tests added — there's no existing test covering \`has_contract_data\`'s gating logic, and adding one would mean stubbing the whole enricher. Happy to add one if you'd like.