### PR TITLE
Release v0.4.1

### DIFF
--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -6,4 +6,4 @@ git signals, dead code detection, architectural decisions, and
 AI-generated documentation.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.4.0"
+version = "0.4.1"
 description = "Codebase intelligence for developers and AI — generates and maintains a structured wiki for any codebase"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
@
## Summary

Patch release bumping `0.4.0` to `0.4.1` across all four version files. Cuts the release that ships the #110 fix for the missing setuptools subpackages so pipx installs of 0.4.0 (#109) are unblocked.

## What changed

Version bump only, no source changes:

- `pyproject.toml`
- `packages/core/src/repowise/core/__init__.py`
- `packages/cli/src/repowise/cli/__init__.py`
- `packages/server/src/repowise/server/__init__.py`

## What is in this release

The only behavioural change vs 0.4.0 is #110: four subpackages (`core.analysis.dead_code`, `core.ingestion.extractors.bindings`, `core.ingestion.extractors.heritage`, `core.ingestion.resolvers.dotnet`) are now actually shipped in the wheel. Fixes the `ModuleNotFoundError: No module named repowise.core.ingestion.resolvers.dotnet` from #109 that crashed `repowise init` immediately on any pipx install of 0.4.0.

Verified the `[tool.setuptools].packages` list is now in sync with disk (26 entries, 26 subpackages). Diff is clean.

## Release flow

Once this merges to main, tag `v0.4.1` will be pushed against the merge commit. That triggers `publish.yml` end to end: web build, Python wheel build, GitHub release with both artifacts, PyPI upload via trusted publisher.

Closes #109.
@