### PR TITLE
refactor(build): auto-discover subpackages with setuptools find

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,45 +119,17 @@ Issues = "https://github.com/repowise-dev/repowise/issues"
 Documentation = "https://github.com/repowise-dev/repowise/blob/main/docs/USER_GUIDE.md"
 
 # ---------------------------------------------------------------------------
-# setuptools — explicit package-dir mapping across three src/ directories
+# setuptools — auto-discover packages across three src/ roots
 # ---------------------------------------------------------------------------
 [tool.setuptools.package-dir]
 "repowise.core" = "packages/core/src/repowise/core"
 "repowise.cli" = "packages/cli/src/repowise/cli"
 "repowise.server" = "packages/server/src/repowise/server"
 
-[tool.setuptools]
-packages = [
-    # core
-    "repowise.core",
-    "repowise.core.analysis",
-    "repowise.core.analysis.dead_code",
-    "repowise.core.generation",
-    "repowise.core.generation.editor_files",
-    "repowise.core.ingestion",
-    "repowise.core.ingestion.dynamic_hints",
-    "repowise.core.ingestion.extractors",
-    "repowise.core.ingestion.extractors.bindings",
-    "repowise.core.ingestion.extractors.heritage",
-    "repowise.core.ingestion.languages",
-    "repowise.core.ingestion.resolvers",
-    "repowise.core.ingestion.resolvers.dotnet",
-    "repowise.core.pipeline",
-    "repowise.core.persistence",
-    "repowise.core.providers",
-    "repowise.core.providers.llm",
-    "repowise.core.providers.embedding",
-    "repowise.core.workspace",
-    "repowise.core.workspace.extractors",
-    # cli
-    "repowise.cli",
-    "repowise.cli.commands",
-    # server
-    "repowise.server",
-    "repowise.server.routers",
-    "repowise.server.mcp_server",
-    "repowise.server.services",
-]
+[tool.setuptools.packages.find]
+where = ["packages/core/src", "packages/cli/src", "packages/server/src"]
+include = ["repowise*"]
+namespaces = true
 
 [tool.setuptools.package-data]
 "repowise.core.ingestion" = ["queries/*.scm"]


### PR DESCRIPTION
## Summary

Follow-up to #110 (and previously #97). Switches `[tool.setuptools]` from a hand-maintained explicit packages list to `[tool.setuptools.packages.find]`, scanning the three `packages/*/src` roots. New subpackages now ship in the wheel automatically — no more drift.

## What changed

`pyproject.toml`:

- Removed the 26-entry explicit `[tool.setuptools] packages = [...]` list.
- Added `[tool.setuptools.packages.find]` with `where = ["packages/core/src", "packages/cli/src", "packages/server/src"]`, `include = ["repowise*"]`, `namespaces = true` (top-level `repowise` is a PEP 420 namespace package across the three src roots).
- Existing `[tool.setuptools.package-dir]` mapping and `[tool.setuptools.package-data]` entries are unchanged.

Net diff: +5/-33 lines.

## Verification

Built the wheel before and after the edit on the same `origin/main` (0.4.1) base and diffed the package list inside the wheel. Identical contents, both manifests have 26 packages, all 15 `.scm` query files and 12 `.j2` template files are still bundled.

```
$ uv build --wheel
Successfully built dist/repowise-0.4.1-py3-none-any.whl

$ python -c "import zipfile; z = zipfile.ZipFile('dist/repowise-0.4.1-py3-none-any.whl'); \
    pkgs = sorted(set('/'.join(n.split('/')[:-1]) for n in z.namelist() if n.endswith('__init__.py'))); \
    print(len(pkgs), 'packages')"
26 packages

$ diff baseline_packages.txt after_packages.txt
(empty)
```

Spot-check on package-data:

```
.scm files: 15
.j2 files: 12
First 3 .scm: ['repowise/core/ingestion/queries/c.scm', 'repowise/core/ingestion/queries/cpp.scm', 'repowise/core/ingestion/queries/csharp.scm']
First 3 .j2: ['repowise/core/generation/templates/api_contract.j2', 'repowise/core/generation/templates/architecture_diagram.j2', 'repowise/core/generation/templates/claude_md.j2']
```

## Open questions / risks

- `namespaces = true` is required because no `repowise/__init__.py` exists in any of the three src roots; the top-level `repowise` is a PEP 420 namespace package. Verified by `find packages -path "*/repowise/__init__.py"` returning nothing.
- The `package-dir` mapping is kept as-is — it's consistent with what `find` discovers and removing it would be an orthogonal cleanup.

## Test plan

- [x] `uv build --wheel` succeeds on the new config
- [x] Built wheel package set is byte-for-byte identical to the 0.4.1 wheel built from `origin/main`
- [x] `.scm` and `.j2` package-data files still ship
- [x] CI green