### PR TITLE
docs + UI/UX audit fixes + jobs reliability pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ docs/multi-repo/
 
 # Local-only language work tracker (not for git)
 docs/LANGUAGE_REMAINING_WORK.md
+
+# Local UI/UX audit notes
+AUDIT_UI_UX.md

--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,20 @@ docs/LANGUAGE_REMAINING_WORK.md
 
 # Local UI/UX audit notes
 AUDIT_UI_UX.md
+
+# Local scratch / sibling tools (not for distribution)
+GitNexus/
+graphify/
+test-repos/
+
+# Office temp / lock files
+~$*
+*.zip
+
+# Local hosted-product planning (not for OSS distribution)
+docs/IXOPAY_FEATURES.md
+docs/IXOPAY_FEATURES.docx
+docs/HOSTED_PRODUCT_UPGRADE_PLAN.md
+docs/HOSTED_IMPLEMENTATION_GUIDE.md
+docs/HOSTED_PROGRESS.md
+scripts/md_to_docx.py

--- a/packages/core/src/repowise/core/persistence/database.py
+++ b/packages/core/src/repowise/core/persistence/database.py
@@ -33,7 +33,11 @@ from .models import Base
 # busy_timeout gives that block a bounded retry window before giving up.
 # Foreign keys are off by default in SQLite for legacy reasons; we want them on
 # everywhere so our FK-driven cascades behave the same in tests and production.
-_SQLITE_BUSY_TIMEOUT_MS = 5000
+# 30s gives heavy bulk writes (e.g. persisting tens of thousands of graph
+# edges in one transaction) enough headroom to finish before a concurrent
+# progress-callback write raises "database is locked". 5s was too tight
+# for large repos. SQLite blocks (doesn't busy-loop) so this is cheap.
+_SQLITE_BUSY_TIMEOUT_MS = 30000
 
 _SQLITE_PRAGMAS: tuple[tuple[str, str], ...] = (
     ("journal_mode", "WAL"),

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -10,7 +10,7 @@ FastAPI REST API, webhook handlers, MCP server, and background job scheduler for
 
 | Component | Description |
 |-----------|-------------|
-| **REST API** | FastAPI application with full CRUD for repos, pages (with version history), symbols, jobs, git analytics, dead code, decisions, graph intelligence |
+| **REST API** | FastAPI application with full CRUD for repos, pages (with version history), symbols, jobs, git analytics, dead code, decisions, graph intelligence, blast radius, costs, knowledge map, security findings, providers, chat, CLAUDE.md generation, and multi-repo workspace |
 | **MCP Server** | 16 MCP tools for AI coding assistants (Claude Code, Cursor, Cline) |
 | **Webhooks** | GitHub and GitLab push event handlers — trigger sync jobs automatically on push |
 | **Scheduler** | APScheduler background jobs — polling fallback (auto-syncs diverged repos), stale page detection |
@@ -156,6 +156,64 @@ Job progress events (`JobProgressEvent`) carry: `event` type, `file` currently b
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/api/search` | Search wiki pages. Body: `{"query": "...", "repo_id": "...", "mode": "fts|semantic|hybrid"}` |
+
+### Blast Radius
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/repos/{repo_id}/blast-radius` | Estimate PR impact for a list of changed files — returns overall risk score, direct/transitive risks, co-change warnings, recommended reviewers, and test gaps |
+
+### Costs
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/repos/{repo_id}/costs/summary` | All-time totals: cost (USD), call count, input/output token counts |
+| `GET` | `/api/repos/{repo_id}/costs` | Per-group breakdown of LLM usage with `by=day|model|operation` |
+
+### Knowledge Map
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/repos/{repo_id}/knowledge-map` | Bus-factor / silo / freshness intelligence — files owned by single contributors, knowledge concentration risk |
+
+### Security
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/repos/{repo_id}/security` | List security findings (filterable by kind/severity) |
+
+### Chat
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/repos/{repo_id}/chat/messages` | Send a chat message; SSE streams the assistant reply with tool calls and source citations |
+| `GET`  | `/api/repos/{repo_id}/chat/conversations` | List saved conversations for a repo |
+| `GET`  | `/api/repos/{repo_id}/chat/conversations/{conversation_id}` | Fetch a full conversation with its messages |
+| `DELETE` | `/api/repos/{repo_id}/chat/conversations/{conversation_id}` | Delete a conversation |
+
+### CLAUDE.md Generation
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET`  | `/api/repos/{repo_id}/claude-md` | Fetch the latest generated CLAUDE.md content for the repo |
+| `POST` | `/api/repos/{repo_id}/claude-md/generate` | Trigger a fresh CLAUDE.md generation job (returns 202 with job id) |
+
+### Providers
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET`    | `/api/providers` | List available LLM providers and which one is active |
+| `PATCH`  | `/api/providers/active` | Switch the active provider |
+| `POST`   | `/api/providers/{provider_id}/key` | Store an encrypted API key for the provider |
+| `DELETE` | `/api/providers/{provider_id}/key` | Remove the stored API key |
+
+### Workspace (Multi-Repo)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/workspace` | Workspace summary — registered repos with per-repo stats, cross-repo and contract summaries |
+| `GET` | `/api/workspace/co-changes` | Cross-repo co-change pairs (files in different repos that frequently change together) |
+| `GET` | `/api/workspace/contracts` | Detected API contracts (HTTP/gRPC/topic) and their provider/consumer file links |
 
 ### Webhooks
 

--- a/packages/server/src/repowise/server/app.py
+++ b/packages/server/src/repowise/server/app.py
@@ -113,8 +113,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await init_db(engine)
     session_factory = create_session_factory(engine)
 
-    # Reset any jobs left in "running" state from a previous server instance
-    # (crash or restart) — they can never complete now.
+    # Reset any jobs left in "running" or "pending" state from a previous
+    # server instance (crash, restart, or cancellation between row-insert and
+    # background-task launch) — they can never complete now and would block
+    # new syncs via the active-job guard in the repos router.
     # Note: with multi-worker deployments this is a best-effort race; the
     # try/except prevents a SQLite lock error from crashing startup.
     try:
@@ -125,7 +127,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         async with get_session(session_factory) as session:
             stale_result = await session.execute(
                 sa_update(GenerationJob)
-                .where(GenerationJob.status == "running")
+                .where(GenerationJob.status.in_(["running", "pending"]))
                 .values(
                     status="failed",
                     error_message="Server restarted — job interrupted",

--- a/packages/server/src/repowise/server/job_executor.py
+++ b/packages/server/src/repowise/server/job_executor.py
@@ -127,7 +127,11 @@ class JobProgressCallback:
             logger.debug("progress_update_failed", job_id=self._job_id, exc_info=True)
 
 
-async def execute_job(job_id: str, app_state: Any) -> None:
+async def execute_job(
+    job_id: str,
+    app_state: Any,
+    session_factory_override: Any = None,
+) -> None:
     """Execute a pending pipeline job in the background.
 
     This is the single entry point called by the endpoint via
@@ -138,6 +142,13 @@ async def execute_job(job_id: str, app_state: Any) -> None:
     3. Runs ``run_pipeline()``
     4. Persists all results via ``persist_pipeline_result()``
     5. Marks the job as ``completed`` (or ``failed`` on error)
+
+    In workspace mode, each repo has its own ``wiki.db`` and the route
+    handler that created this job committed it to a per-repo session
+    factory (``app_state.workspace_sessions[repo_id]``), not the primary
+    one. The caller must pass that same factory in
+    ``session_factory_override`` so we read from the same database — else
+    we'd see "job_not_found" and the row would stay pending forever.
     """
     start = time.monotonic()
     progress: JobProgressCallback | None = None
@@ -148,7 +159,7 @@ async def execute_job(job_id: str, app_state: Any) -> None:
         # missing attribute (e.g., partially-initialised app_state during
         # development hot-reload) gets recorded as a job failure instead of
         # leaving the row stuck in 'pending' forever.
-        session_factory = app_state.session_factory
+        session_factory = session_factory_override or app_state.session_factory
         fts = app_state.fts
         vector_store = app_state.vector_store
 

--- a/packages/server/src/repowise/server/job_executor.py
+++ b/packages/server/src/repowise/server/job_executor.py
@@ -58,6 +58,14 @@ class JobProgressCallback:
         self._pending_tasks: set[asyncio.Task] = set()  # type: ignore[type-arg]
         # Batch DB writes: flush every N items to avoid per-item overhead
         self._flush_interval = 5
+        # Time-based throttling: hold off issuing a new write while one is
+        # already in flight or one fired in the last second. Without this,
+        # a tight phase (e.g. 1000 fast items) would create N concurrent
+        # writes that all contend with the main pipeline's bulk persist
+        # transaction, producing "database is locked" errors.
+        self._min_write_interval_s = 1.0
+        self._last_write_at: float = 0.0
+        self._inflight: bool = False
 
     def on_phase_start(self, phase: str, total: int | None) -> None:
         self._phase = phase
@@ -65,7 +73,9 @@ class JobProgressCallback:
         self._completed = 0
         self._total = total
         self._pending_flush = 0
-        self._sync_job_status()  # Flush immediately so the label updates
+        # Force a write at phase boundaries so the UI label updates promptly
+        # even if a throttled write was just issued.
+        self._sync_job_status(force=True)
         logger.info("job_phase_start", job_id=self._job_id, phase=phase, total=total)
 
     def on_item_done(self, phase: str) -> None:
@@ -80,19 +90,36 @@ class JobProgressCallback:
             text, job_id=self._job_id, phase=self._phase
         )
 
-    def _sync_job_status(self) -> None:
+    def _sync_job_status(self, *, force: bool = False) -> None:
         """Fire-and-forget progress update in the current event loop.
 
         Tracks task references to allow cancellation before final status.
+        Throttled: skipped if another write is already in flight, or if the
+        last write was less than ``_min_write_interval_s`` ago — unless
+        ``force=True`` (used at phase boundaries).
         """
         if self._stopped:
             return
 
+        if not force:
+            if self._inflight:
+                return
+            now = time.monotonic()
+            if now - self._last_write_at < self._min_write_interval_s:
+                return
+
         try:
             loop = asyncio.get_running_loop()
+            self._inflight = True
+            self._last_write_at = time.monotonic()
             t = loop.create_task(self._async_update())
             self._pending_tasks.add(t)
-            t.add_done_callback(self._pending_tasks.discard)
+
+            def _on_done(task: asyncio.Task) -> None:
+                self._pending_tasks.discard(task)
+                self._inflight = False
+
+            t.add_done_callback(_on_done)
         except RuntimeError:
             pass  # No event loop — skip the update
 
@@ -123,8 +150,19 @@ class JobProgressCallback:
                     total_pages=self._total,
                     current_level=_PHASE_LEVELS.get(self._phase, 0),
                 )
-        except Exception:
-            logger.debug("progress_update_failed", job_id=self._job_id, exc_info=True)
+        except Exception as exc:
+            # Lock contention with the main pipeline transaction is recoverable —
+            # the next throttled write will pick up the latest counts. Log a
+            # brief one-liner instead of a multi-page traceback.
+            msg = str(exc)
+            if "database is locked" in msg or "OperationalError" in type(exc).__name__:
+                logger.debug(
+                    "progress_update_skipped_locked",
+                    job_id=self._job_id,
+                    phase=self._phase,
+                )
+            else:
+                logger.debug("progress_update_failed", job_id=self._job_id, exc_info=True)
 
 
 async def execute_job(

--- a/packages/server/src/repowise/server/job_executor.py
+++ b/packages/server/src/repowise/server/job_executor.py
@@ -139,13 +139,19 @@ async def execute_job(job_id: str, app_state: Any) -> None:
     4. Persists all results via ``persist_pipeline_result()``
     5. Marks the job as ``completed`` (or ``failed`` on error)
     """
-    session_factory = app_state.session_factory
-    fts = app_state.fts
-    vector_store = app_state.vector_store
     start = time.monotonic()
     progress: JobProgressCallback | None = None
+    session_factory = None
 
     try:
+        # Resolve required app_state attributes inside the try block so a
+        # missing attribute (e.g., partially-initialised app_state during
+        # development hot-reload) gets recorded as a job failure instead of
+        # leaving the row stuck in 'pending' forever.
+        session_factory = app_state.session_factory
+        fts = app_state.fts
+        vector_store = app_state.vector_store
+
         # ---- Fetch job + repo metadata ------------------------------------
         async with get_session(session_factory) as session:
             job = await get_generation_job(session, job_id)
@@ -306,16 +312,22 @@ async def execute_job(job_id: str, app_state: Any) -> None:
                 await progress.drain_and_stop()
             except Exception:
                 logger.debug("drain_failed_on_error_path", job_id=job_id, exc_info=True)
-        try:
-            async with get_session(session_factory) as session:
-                await update_job_status(
-                    session,
-                    job_id,
-                    "failed",
-                    error_message=str(exc)[:500],
-                )
-        except Exception:
-            logger.exception("job_status_update_failed", job_id=job_id)
+        # If we failed before resolving session_factory, fall back to the one
+        # on app_state (best-effort) so the row never stays stuck in pending.
+        recovery_factory = session_factory or getattr(app_state, "session_factory", None)
+        if recovery_factory is not None:
+            try:
+                async with get_session(recovery_factory) as session:
+                    await update_job_status(
+                        session,
+                        job_id,
+                        "failed",
+                        error_message=str(exc)[:500],
+                    )
+            except Exception:
+                logger.exception("job_status_update_failed", job_id=job_id)
+        else:
+            logger.error("job_status_update_skipped_no_session", job_id=job_id)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/server/src/repowise/server/routers/jobs.py
+++ b/packages/server/src/repowise/server/routers/jobs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime, UTC
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -53,6 +54,39 @@ async def get_job(
     job = await crud.get_generation_job(session, job_id)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
+    return JobResponse.from_orm(job)
+
+
+@router.post("/{job_id}/cancel", response_model=JobResponse)
+async def cancel_job(
+    job_id: str,
+    session: AsyncSession = Depends(get_db_session),  # noqa: B008
+) -> JobResponse:
+    """Cancel a pending or running generation job.
+
+    Marks the job as ``failed`` with a cancellation message. The background
+    task itself is not interrupted — but in practice this unblocks the
+    active-job guard in /repos/{id}/sync so the user can start a new sync
+    immediately. Useful when a job is stuck in ``pending`` because the
+    background task crashed before it could record a failure.
+    """
+    job = await crud.get_generation_job(session, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job.status not in ("pending", "running"):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot cancel a job in '{job.status}' state",
+        )
+    await crud.update_job_status(
+        session,
+        job_id,
+        "failed",
+        error_message="Cancelled by user",
+    )
+    job = await crud.get_generation_job(session, job_id)
+    assert job is not None  # we just updated it
+    # Pydantic v1 from_orm; matches the rest of this file.
     return JobResponse.from_orm(job)
 
 

--- a/packages/server/src/repowise/server/routers/jobs.py
+++ b/packages/server/src/repowise/server/routers/jobs.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import datetime, UTC
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,6 +21,34 @@ router = APIRouter(
     tags=["jobs"],
     dependencies=[Depends(verify_api_key)],
 )
+
+
+async def _find_job_factory(app_state, job_id: str):
+    """Locate the session_factory whose database contains ``job_id``.
+
+    In workspace mode each repo has its own ``wiki.db``. The /api/jobs/*
+    endpoints don't take repo_id in the path, so we must scan: primary
+    first, then all per-repo factories. Returns ``(factory, job)`` or
+    ``(None, None)`` if no DB has the row.
+    """
+    candidates = [app_state.session_factory]
+    ws = getattr(app_state, "workspace_sessions", None)
+    if ws:
+        candidates.extend(ws.values())
+    seen: set[int] = set()
+    for factory in candidates:
+        if id(factory) in seen:
+            continue
+        seen.add(id(factory))
+        try:
+            async with get_session(factory) as session:
+                job = await crud.get_generation_job(session, job_id)
+            if job is not None:
+                return factory, job
+        except Exception:
+            # Don't let one bad DB poison the lookup; try the rest.
+            continue
+    return None, None
 
 
 @router.get("", response_model=list[JobResponse])
@@ -46,22 +73,16 @@ async def list_jobs(
 
 
 @router.get("/{job_id}", response_model=JobResponse)
-async def get_job(
-    job_id: str,
-    session: AsyncSession = Depends(get_db_session),  # noqa: B008
-) -> JobResponse:
+async def get_job(job_id: str, request: Request) -> JobResponse:
     """Get a single generation job by ID."""
-    job = await crud.get_generation_job(session, job_id)
+    _, job = await _find_job_factory(request.app.state, job_id)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
     return JobResponse.from_orm(job)
 
 
 @router.post("/{job_id}/cancel", response_model=JobResponse)
-async def cancel_job(
-    job_id: str,
-    session: AsyncSession = Depends(get_db_session),  # noqa: B008
-) -> JobResponse:
+async def cancel_job(job_id: str, request: Request) -> JobResponse:
     """Cancel a pending or running generation job.
 
     Marks the job as ``failed`` with a cancellation message. The background
@@ -70,23 +91,23 @@ async def cancel_job(
     immediately. Useful when a job is stuck in ``pending`` because the
     background task crashed before it could record a failure.
     """
-    job = await crud.get_generation_job(session, job_id)
-    if job is None:
+    factory, job = await _find_job_factory(request.app.state, job_id)
+    if job is None or factory is None:
         raise HTTPException(status_code=404, detail="Job not found")
     if job.status not in ("pending", "running"):
         raise HTTPException(
             status_code=409,
             detail=f"Cannot cancel a job in '{job.status}' state",
         )
-    await crud.update_job_status(
-        session,
-        job_id,
-        "failed",
-        error_message="Cancelled by user",
-    )
-    job = await crud.get_generation_job(session, job_id)
+    async with get_session(factory) as session:
+        await crud.update_job_status(
+            session,
+            job_id,
+            "failed",
+            error_message="Cancelled by user",
+        )
+        job = await crud.get_generation_job(session, job_id)
     assert job is not None  # we just updated it
-    # Pydantic v1 from_orm; matches the rest of this file.
     return JobResponse.from_orm(job)
 
 
@@ -97,7 +118,11 @@ async def stream_job(job_id: str, request: Request) -> StreamingResponse:
     Emits ``event: progress`` every second until the job completes or fails,
     then emits ``event: done`` and closes.
     """
-    factory = request.app.state.session_factory
+    factory, _ = await _find_job_factory(request.app.state, job_id)
+    if factory is None:
+        # Fall back to the primary so we still emit a structured "not found"
+        # event instead of a connection error.
+        factory = request.app.state.session_factory
 
     async def event_generator():
         while True:

--- a/packages/server/src/repowise/server/routers/repos.py
+++ b/packages/server/src/repowise/server/routers/repos.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from repowise.core.persistence import crud
+from repowise.core.persistence.database import get_session
 from repowise.core.persistence.models import (
     DeadCodeFinding,
     GenerationJob,
@@ -275,15 +276,51 @@ def _launch_job_task(request: Request, job_id: str) -> None:
     Stores a strong reference in ``app.state.background_tasks`` to prevent
     garbage collection, and removes it when the task finishes.  Exceptions
     are logged instead of silently swallowed.
+
+    If task creation itself fails (or the task ends with an unhandled
+    exception that ``execute_job`` couldn't record), we mark the job as
+    failed via a fallback path so the active-job guard never gets stuck.
     """
-    task = asyncio.create_task(execute_job(job_id, request.app.state), name=f"job-{job_id}")
-    bg_tasks: set[asyncio.Task] = request.app.state.background_tasks  # type: ignore[assignment]
+    app_state = request.app.state
+
+    async def _mark_failed(reason: str) -> None:
+        try:
+            from repowise.core.persistence.crud import update_job_status
+
+            async with get_session(app_state.session_factory) as session:
+                await update_job_status(
+                    session,
+                    job_id,
+                    "failed",
+                    error_message=reason[:500],
+                )
+        except Exception:
+            logger.exception("fallback_job_failure_record_failed", extra={"job_id": job_id})
+
+    try:
+        task = asyncio.create_task(execute_job(job_id, app_state), name=f"job-{job_id}")
+    except Exception as exc:
+        logger.exception("create_task_failed", extra={"job_id": job_id})
+        # Schedule the failure-marking on the running loop; we're already in
+        # an async request handler so a fresh task is fine.
+        asyncio.create_task(_mark_failed(f"Failed to launch background task: {exc}"))
+        return
+
+    bg_tasks: set[asyncio.Task] = app_state.background_tasks  # type: ignore[assignment]
     bg_tasks.add(task)
 
     def _on_done(t: asyncio.Task) -> None:
         bg_tasks.discard(t)
-        if not t.cancelled() and t.exception() is not None:
-            logger.error("background_job_failed", exc_info=t.exception())
+        if t.cancelled():
+            asyncio.create_task(_mark_failed("Job task was cancelled"))
+            return
+        exc = t.exception()
+        if exc is not None:
+            logger.error("background_job_failed", exc_info=exc)
+            # execute_job already tries to mark failed in its except block,
+            # but if that itself raised we must still ensure the row is
+            # not left in pending/running.
+            asyncio.create_task(_mark_failed(f"Background task crashed: {exc}"))
 
     task.add_done_callback(_on_done)
 

--- a/packages/server/src/repowise/server/routers/repos.py
+++ b/packages/server/src/repowise/server/routers/repos.py
@@ -228,7 +228,7 @@ async def sync_repo(
     # see the job row.  SQLite WAL isolation hides uncommitted rows from
     # other connections, so flush() alone is not sufficient.
     await session.commit()
-    _launch_job_task(request, job.id)
+    _launch_job_task(request, job.id, repo_id)
     return {"job_id": job.id, "status": "accepted"}
 
 
@@ -266,11 +266,24 @@ async def full_resync(
     # Commit (not just flush) so the background task's separate session can
     # see the job row.  See sync_repo comment for rationale.
     await session.commit()
-    _launch_job_task(request, job.id)
+    _launch_job_task(request, job.id, repo_id)
     return {"job_id": job.id, "status": "accepted"}
 
 
-def _launch_job_task(request: Request, job_id: str) -> None:
+def _resolve_repo_session_factory(app_state, repo_id: str):
+    """Return the session_factory whose database contains this repo's row.
+
+    In workspace mode each repo has its own ``wiki.db`` registered under
+    ``app_state.workspace_sessions[repo_id]``. The primary session_factory
+    (``app_state.session_factory``) does NOT see those rows.
+    """
+    ws_sessions = getattr(app_state, "workspace_sessions", None)
+    if ws_sessions and repo_id in ws_sessions:
+        return ws_sessions[repo_id]
+    return app_state.session_factory
+
+
+def _launch_job_task(request: Request, job_id: str, repo_id: str) -> None:
     """Launch a background job task with proper lifecycle management.
 
     Stores a strong reference in ``app.state.background_tasks`` to prevent
@@ -280,14 +293,19 @@ def _launch_job_task(request: Request, job_id: str) -> None:
     If task creation itself fails (or the task ends with an unhandled
     exception that ``execute_job`` couldn't record), we mark the job as
     failed via a fallback path so the active-job guard never gets stuck.
+
+    ``repo_id`` is required so we can resolve the per-repo session factory
+    in workspace mode — that's the same DB the route handler just wrote
+    the job to.
     """
     app_state = request.app.state
+    session_factory = _resolve_repo_session_factory(app_state, repo_id)
 
     async def _mark_failed(reason: str) -> None:
         try:
             from repowise.core.persistence.crud import update_job_status
 
-            async with get_session(app_state.session_factory) as session:
+            async with get_session(session_factory) as session:
                 await update_job_status(
                     session,
                     job_id,
@@ -298,7 +316,10 @@ def _launch_job_task(request: Request, job_id: str) -> None:
             logger.exception("fallback_job_failure_record_failed", extra={"job_id": job_id})
 
     try:
-        task = asyncio.create_task(execute_job(job_id, app_state), name=f"job-{job_id}")
+        task = asyncio.create_task(
+            execute_job(job_id, app_state, session_factory_override=session_factory),
+            name=f"job-{job_id}",
+        )
     except Exception as exc:
         logger.exception("create_task_failed", extra={"job_id": job_id})
         # Schedule the failure-marking on the running loop; we're already in

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -30,6 +30,10 @@ The home page. Shows aggregate stats across all registered repositories (total f
 
 Landing page for a single repo. Displays health score, git insights (commit activity, churn distribution, bus factor), documentation coverage, and quick links to all sub-pages. Includes a **Graph Intelligence** section with expandable architecture communities (cohesion scores, member lists, neighboring communities) and execution flows panel (entry point scoring, BFS call traces, cross-community classification). Operations panel for triggering sync and full-resync jobs.
 
+### Repository Overview — Standalone (`/repos/[id]/overview`)
+
+Dedicated overview surface separate from the repo landing page. Aggregates 15 parallel data fetches and degrades gracefully on any failure. Sections include the key metrics strip, attention panel (auto-derived issues), language donut, ownership treemap, hotspots mini-leaderboard, decisions timeline, module minimap, dependency heatmap, community summary grid, execution flows panel, and Git Insights row (churn histogram, commit-category donut + sparkline, bus-factor panel).
+
 ### Wiki Pages (`/repos/[id]/wiki/[...slug]`)
 
 The core documentation viewer. Renders AI-generated wiki pages as MDX with:
@@ -94,6 +98,26 @@ Split-pane documentation browser (VS Code-style). Left panel is a searchable fil
 
 Lists extracted architectural decision records with health metrics. Each decision has a detail page (`/repos/[id]/decisions/[decisionId]`) showing context, rationale, alternatives, and consequences rendered as markdown, with Confirm/Dismiss/Deprecate actions.
 
+### Blast Radius (`/repos/[id]/blast-radius`)
+
+Pre-PR impact estimator. Paste a list of changed file paths (one per line) — or click hotspot suggestion chips to prefill — and get an overall risk score (0–10), breakdown of direct risks (per-file risk score, temporal hotspot, centrality), transitive affected files with depth, co-change warnings (files that historically change together but aren't in the diff), recommended reviewers ranked by ownership, and test gaps for code paths without coverage.
+
+### Cost Tracking (`/repos/[id]/costs`)
+
+LLM token usage and spend dashboard. Shows total cost, total calls, input/output token counts (all-time), a daily-spend bar chart, and a breakdown table grouped by day, model, or operation.
+
+### Workspace Dashboard (`/workspace`)
+
+Multi-repo workspace surface. Aggregates totals (files, symbols, average doc coverage, hotspot count, page count) across all registered repos, renders a RepoCard grid with per-repo stats, surfaces cross-repo intelligence (workspace-wide co-change summary, API contract counts by type with provider/consumer split), and shows a top cross-repo co-changes table with deep links into the full views.
+
+### Cross-Repo Co-Changes (`/workspace/co-changes`)
+
+Full browser for files across repositories that change together based on git history. Filterable by source/target repo with summary stats (total pairs, distinct repo pairs).
+
+### API Contracts (`/workspace/contracts`)
+
+All detected API contracts (HTTP, gRPC, topic) and the provider/consumer file links between repos. Filter by contract type, repo, or role. Surfaces unmatched contracts (providers without consumers, or vice versa).
+
 ### Settings (`/settings` and `/repos/[id]/settings`)
 
 Global settings page with sections for API connection, LLM provider/model selection, webhook configuration, and MCP integration. Per-repo settings available under each repository.
@@ -154,7 +178,13 @@ components/
   git/          Churn bars, contributor charts, hotspot/ownership tables
   symbols/      Symbol table, symbol drawer, symbol graph panel (metrics + callers)
   dashboard/    Health ring, attention panel, quick actions, language donut,
-                ownership treemap, community summary grid, execution flows panel
+                ownership treemap, community summary grid, execution flows panel,
+                module minimap, dependency heatmap, hotspots mini, decisions timeline
+  chat/         Streaming chat interface, message bubbles, model selector,
+                tool-call blocks, source citations, conversation history, artifact panel
+  workspace/    Repo cards, cross-repo summary, co-change table,
+                contract links table, contract type / role badges
+  settings/     Connection, MCP integration, webhook, provider sections
   shared/       Stat cards, empty states
 ```
 

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -46,13 +46,19 @@ export default async function RootLayout({
       className={`${GeistSans.variable} ${GeistMono.variable} dark`}
     >
       <body className="bg-[var(--color-bg-root)] text-[var(--color-text-primary)] antialiased">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-[var(--color-bg-elevated)] focus:px-3 focus:py-2 focus:text-sm focus:text-[var(--color-text-primary)] focus:outline focus:outline-2 focus:outline-[var(--color-accent-primary)]"
+        >
+          Skip to content
+        </a>
         <NuqsAdapter>
         <TooltipProvider delayDuration={300}>
           <div className="flex h-screen overflow-hidden">
             <Sidebar repos={repos} workspace={workspace} />
             <div className="flex flex-1 flex-col min-w-0 overflow-hidden">
               <MobileNav repos={repos} workspace={workspace} />
-              <main className="flex-1 overflow-auto min-w-0">
+              <main id="main-content" className="flex-1 overflow-auto min-w-0">
                 {children}
               </main>
             </div>

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -198,10 +198,11 @@ export default async function DashboardPage() {
             ) : (
               <ul className="divide-y divide-[var(--color-border-default)]">
                 {jobList.map((job) => (
-                  <li
-                    key={job.id}
-                    className="flex items-center gap-3 px-6 py-3"
-                  >
+                  <li key={job.id}>
+                    <Link
+                      href={`/repos/${job.repository_id}/overview`}
+                      className="flex items-center gap-3 px-6 py-3 hover:bg-[var(--color-bg-elevated)] transition-colors"
+                    >
                     <JobStatusIcon status={job.status} />
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
@@ -232,6 +233,7 @@ export default async function DashboardPage() {
                         {job.model_name} · {formatRelativeTime(job.updated_at)}
                       </p>
                     </div>
+                    </Link>
                   </li>
                 ))}
               </ul>

--- a/packages/web/src/app/repos/[id]/blast-radius/page.tsx
+++ b/packages/web/src/app/repos/[id]/blast-radius/page.tsx
@@ -6,6 +6,7 @@ import { useParams } from "next/navigation";
 import { Radar, Plus, Flame } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils/cn";
 import {
   analyzeBlastRadius,
@@ -244,7 +245,7 @@ export default function BlastRadiusPage() {
 
   // Suggestions: top 8 hotspots so users can prefill with one click instead
   // of remembering paths. Falls back gracefully if the call fails.
-  const { data: hotspotSuggestions } = useSWR(
+  const { data: hotspotSuggestions, isLoading: hotspotSuggestionsLoading } = useSWR(
     repoId ? ["blast-radius-suggestions", repoId] : null,
     () => getHotspots(repoId, 8),
   );
@@ -325,6 +326,14 @@ export default function BlastRadiusPage() {
             </button>
             .
           </p>
+
+          {hotspotSuggestionsLoading && !hotspotSuggestions && (
+            <div className="flex flex-wrap gap-2">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton key={i} className="h-7 w-32 rounded-full" />
+              ))}
+            </div>
+          )}
 
           {hotspotSuggestions && hotspotSuggestions.length > 0 && (
             <div className="flex flex-wrap gap-2">

--- a/packages/web/src/app/repos/[id]/blast-radius/page.tsx
+++ b/packages/web/src/app/repos/[id]/blast-radius/page.tsx
@@ -98,9 +98,14 @@ function Td({ children, className }: { children: React.ReactNode; className?: st
 // ---------------------------------------------------------------------------
 
 function DirectRisksTable({ rows }: { rows: DirectRiskEntry[] }) {
+  // Risk scores from the API are 0–1; render as 0–10 to match the gauge.
+  const fmt10 = (v: number) => (v * 10).toFixed(2);
+  // Centrality is small; render as percentage with 2 decimals.
+  const fmtPct = (v: number) => `${(v * 100).toFixed(2)}%`;
   return (
     <div className="overflow-x-auto">
       <table className="w-full">
+        <caption className="sr-only">Direct risks for the changed files</caption>
         <thead>
           <tr>
             <Th>File</Th>
@@ -113,11 +118,11 @@ function DirectRisksTable({ rows }: { rows: DirectRiskEntry[] }) {
           {rows.map((r) => (
             <tr key={r.path} className="border-t border-[var(--color-border-default)]">
               <Td>
-                <span className="font-mono break-all">{r.path}</span>
+                <span className="font-mono break-all" title={r.path}>{r.path}</span>
               </Td>
-              <Td>{r.risk_score.toFixed(4)}</Td>
-              <Td>{r.temporal_hotspot.toFixed(4)}</Td>
-              <Td>{r.centrality.toFixed(6)}</Td>
+              <Td className="text-right tabular-nums">{fmt10(r.risk_score)}</Td>
+              <Td className="text-right tabular-nums">{fmt10(r.temporal_hotspot)}</Td>
+              <Td className="text-right tabular-nums">{fmtPct(r.centrality)}</Td>
             </tr>
           ))}
         </tbody>
@@ -130,6 +135,7 @@ function TransitiveTable({ rows }: { rows: TransitiveEntry[] }) {
   return (
     <div className="overflow-x-auto">
       <table className="w-full">
+        <caption className="sr-only">Transitively affected files</caption>
         <thead>
           <tr>
             <Th>File</Th>
@@ -140,9 +146,9 @@ function TransitiveTable({ rows }: { rows: TransitiveEntry[] }) {
           {rows.map((r) => (
             <tr key={r.path} className="border-t border-[var(--color-border-default)]">
               <Td>
-                <span className="font-mono break-all">{r.path}</span>
+                <span className="font-mono break-all" title={r.path}>{r.path}</span>
               </Td>
-              <Td>{r.depth}</Td>
+              <Td className="text-right tabular-nums">{r.depth}</Td>
             </tr>
           ))}
         </tbody>
@@ -155,6 +161,7 @@ function CochangeTable({ rows }: { rows: CochangeWarning[] }) {
   return (
     <div className="overflow-x-auto">
       <table className="w-full">
+        <caption className="sr-only">Co-change warnings</caption>
         <thead>
           <tr>
             <Th>Changed File</Th>
@@ -164,14 +171,17 @@ function CochangeTable({ rows }: { rows: CochangeWarning[] }) {
         </thead>
         <tbody>
           {rows.map((r, i) => (
-            <tr key={i} className="border-t border-[var(--color-border-default)]">
+            <tr
+              key={`${r.changed}|${r.missing_partner}|${i}`}
+              className="border-t border-[var(--color-border-default)]"
+            >
               <Td>
-                <span className="font-mono break-all">{r.changed}</span>
+                <span className="font-mono break-all" title={r.changed}>{r.changed}</span>
               </Td>
               <Td>
-                <span className="font-mono break-all">{r.missing_partner}</span>
+                <span className="font-mono break-all" title={r.missing_partner}>{r.missing_partner}</span>
               </Td>
-              <Td>{r.score}</Td>
+              <Td className="text-right tabular-nums">{r.score}</Td>
             </tr>
           ))}
         </tbody>
@@ -184,6 +194,7 @@ function ReviewersTable({ rows }: { rows: ReviewerEntry[] }) {
   return (
     <div className="overflow-x-auto">
       <table className="w-full">
+        <caption className="sr-only">Recommended reviewers</caption>
         <thead>
           <tr>
             <Th>Email</Th>
@@ -195,8 +206,8 @@ function ReviewersTable({ rows }: { rows: ReviewerEntry[] }) {
           {rows.map((r) => (
             <tr key={r.email} className="border-t border-[var(--color-border-default)]">
               <Td>{r.email}</Td>
-              <Td>{r.files}</Td>
-              <Td>{(r.ownership_pct * 100).toFixed(1)}%</Td>
+              <Td className="text-right tabular-nums">{r.files}</Td>
+              <Td className="text-right tabular-nums">{(r.ownership_pct * 100).toFixed(1)}%</Td>
             </tr>
           ))}
         </tbody>
@@ -323,7 +334,8 @@ export default function BlastRadiusPage() {
                   type="button"
                   onClick={() => addSuggestion(h.file_path)}
                   className="inline-flex items-center gap-1 rounded-full border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2.5 py-1 text-[11px] font-mono text-[var(--color-text-secondary)] hover:border-[var(--color-accent-primary)] hover:text-[var(--color-text-primary)] transition-colors"
-                  title={`Add ${h.file_path}`}
+                  title={h.file_path}
+                  aria-label={`Add ${h.file_path} to changed files`}
                 >
                   <Flame className="h-3 w-3 text-orange-500" />
                   <span className="truncate max-w-[260px]">{h.file_path}</span>
@@ -333,11 +345,16 @@ export default function BlastRadiusPage() {
             </div>
           )}
 
+          <label htmlFor="blast-radius-changed-files" className="sr-only">
+            Changed file paths, one per line
+          </label>
           <textarea
+            id="blast-radius-changed-files"
             className="w-full rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2 text-xs font-mono text-[var(--color-text-primary)] placeholder:text-[var(--color-text-tertiary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent-primary)] resize-y min-h-[120px]"
             placeholder={"src/auth/login.py\nsrc/models/user.py\n..."}
             value={files}
             onChange={(e) => setFiles(e.target.value)}
+            aria-label="Changed file paths, one per line"
           />
           <div className="flex items-center gap-4 flex-wrap">
             <label className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)]">
@@ -349,6 +366,7 @@ export default function BlastRadiusPage() {
                 value={maxDepth}
                 onChange={(e) => setMaxDepth(Math.max(1, Math.min(10, Number(e.target.value))))}
                 className="w-16 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2 py-1 text-xs text-[var(--color-text-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent-primary)]"
+                aria-label="Maximum dependency depth (1–10)"
               />
             </label>
             <Button onClick={handleAnalyze} disabled={loading} size="sm">

--- a/packages/web/src/app/repos/[id]/costs/page.tsx
+++ b/packages/web/src/app/repos/[id]/costs/page.tsx
@@ -125,9 +125,16 @@ export default function CostsPage() {
                 >
                   <XAxis
                     dataKey="group"
-                    tick={{ fill: "var(--color-text-tertiary)", fontSize: 10 }}
+                    tick={{ fill: "var(--color-text-tertiary)", fontSize: 11 }}
                     axisLine={false}
                     tickLine={false}
+                    interval="preserveStartEnd"
+                    minTickGap={24}
+                    tickFormatter={(v: string) => {
+                      // ISO date "YYYY-MM-DD" → "M/D"
+                      const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(v);
+                      return m ? `${Number(m[2])}/${Number(m[3])}` : v;
+                    }}
                   />
                   <YAxis
                     tick={{ fill: "var(--color-text-tertiary)", fontSize: 10 }}
@@ -204,8 +211,8 @@ export default function CostsPage() {
                       key={row.group}
                       className="hover:bg-[var(--color-bg-elevated)] transition-colors"
                     >
-                      <td className="py-2 pr-4 text-[var(--color-text-primary)] font-mono text-xs">
-                        {row.group}
+                      <td className="py-2 pr-4 text-[var(--color-text-primary)] font-mono text-xs max-w-[280px]">
+                        <span className="block truncate" title={row.group}>{row.group}</span>
                       </td>
                       <td className="py-2 pr-4 text-right text-[var(--color-text-secondary)] tabular-nums">
                         {formatNumber(row.calls)}

--- a/packages/web/src/app/repos/[id]/dead-code/page.tsx
+++ b/packages/web/src/app/repos/[id]/dead-code/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import useSWR from "swr";
 import { useParams } from "next/navigation";
 import { Trash2 } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { SummaryBar } from "@/components/dead-code/summary-bar";
 import { FindingsTable } from "@/components/dead-code/findings-table";
@@ -15,9 +16,8 @@ export default function DeadCodePage() {
   const params = useParams<{ id: string }>();
   const id = params.id;
   const [analyzing, setAnalyzing] = useState(false);
-  const [analyzeMsg, setAnalyzeMsg] = useState("");
 
-  const { data: summary, isLoading: loadingSummary } = useSWR<DeadCodeSummaryResponse>(
+  const { data: summary, isLoading: loadingSummary, error: summaryError, mutate: mutateSummary } = useSWR<DeadCodeSummaryResponse>(
     `dead-code-summary:${id}`,
     () => getDeadCodeSummary(id),
     { revalidateOnFocus: false },
@@ -25,12 +25,13 @@ export default function DeadCodePage() {
 
   const handleAnalyze = async () => {
     setAnalyzing(true);
-    setAnalyzeMsg("");
     try {
       await analyzeDeadCode(id);
-      setAnalyzeMsg("Analysis started — results will appear shortly.");
-    } catch {
-      setAnalyzeMsg("Failed to start analysis.");
+      toast.success("Analysis started — results will appear shortly.");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? `Couldn't start analysis: ${err.message}` : "Couldn't start analysis",
+      );
     } finally {
       setAnalyzing(false);
     }
@@ -49,9 +50,6 @@ export default function DeadCodePage() {
           </p>
         </div>
         <div className="flex items-center gap-3">
-          {analyzeMsg && (
-            <span className="text-xs text-green-500">{analyzeMsg}</span>
-          )}
           <Button
             size="sm"
             variant="outline"
@@ -71,6 +69,13 @@ export default function DeadCodePage() {
         </div>
       ) : summary ? (
         <SummaryBar summary={summary} />
+      ) : summaryError ? (
+        <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4 text-sm text-[var(--color-text-secondary)] flex items-center justify-between gap-2">
+          <span>Couldn&apos;t load summary.</span>
+          <Button size="sm" variant="outline" onClick={() => mutateSummary()}>
+            Retry
+          </Button>
+        </div>
       ) : null}
 
       <FindingsTable repoId={id} />

--- a/packages/web/src/app/repos/[id]/decisions/page.tsx
+++ b/packages/web/src/app/repos/[id]/decisions/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { listDecisions } from "@/lib/api/decisions";
+import { ApiClientError } from "@/lib/api/client";
 import { DecisionsTable } from "@/components/decisions/decisions-table";
 
 export const revalidate = 30;
@@ -14,8 +15,12 @@ export default async function DecisionsPage({ params }: Props) {
   let decisions;
   try {
     decisions = await listDecisions(repoId, { include_proposed: true, limit: 100 });
-  } catch {
-    notFound();
+  } catch (err) {
+    if (err instanceof ApiClientError && err.status === 404) {
+      notFound();
+    }
+    // Re-throw so the nearest error.tsx boundary can surface a retry UI
+    throw err;
   }
 
   return (

--- a/packages/web/src/app/repos/[id]/hotspots/page.tsx
+++ b/packages/web/src/app/repos/[id]/hotspots/page.tsx
@@ -22,13 +22,15 @@ export default async function HotspotsPage({
   let hotspots: Awaited<ReturnType<typeof getHotspots>> = [];
   let summary: Awaited<ReturnType<typeof getGitSummary>> | null = null;
 
+  let loadError: Error | null = null;
   try {
     [hotspots, summary] = await Promise.all([
       getHotspots(id, 100),
       getGitSummary(id),
     ]);
-  } catch {
-    // API unavailable
+  } catch (err) {
+    loadError = err instanceof Error ? err : new Error("Couldn't load hotspots");
+    console.error("[hotspots] load failed:", err);
   }
 
   // Aggregate commit categories across all hotspot files
@@ -52,6 +54,12 @@ export default async function HotspotsPage({
           High-churn files — where the most risky code lives.
         </p>
       </div>
+
+      {loadError && hotspots.length === 0 && (
+        <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4 text-sm text-[var(--color-text-secondary)]">
+          Couldn&apos;t load hotspots. The data may not be ready yet — try running a sync first.
+        </div>
+      )}
 
       {/* Summary cards */}
       {summary && (

--- a/packages/web/src/app/repos/[id]/hotspots/page.tsx
+++ b/packages/web/src/app/repos/[id]/hotspots/page.tsx
@@ -142,7 +142,12 @@ export default async function HotspotsPage({
               <div className="mt-3 space-y-1.5">
                 {summary.top_owners.slice(0, 5).map((o, i) => (
                   <div key={o.email || `owner-${i}`} className="flex items-center justify-between text-xs">
-                    <span className="text-[var(--color-text-secondary)] truncate">{o.name}</span>
+                    <span
+                      className="text-[var(--color-text-secondary)] truncate"
+                      title={o.email ? `${o.name} <${o.email}>` : o.name}
+                    >
+                      {o.name}
+                    </span>
                     <span className="text-[var(--color-text-tertiary)] tabular-nums ml-2">
                       {formatNumber(o.file_count)} files ({Math.round(o.pct * 100)}%)
                     </span>

--- a/packages/web/src/app/repos/[id]/not-found.tsx
+++ b/packages/web/src/app/repos/[id]/not-found.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { Home, ChevronLeft } from "lucide-react";
+
+export default function RepoNotFound() {
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center gap-4 px-6 text-center">
+      <div className="rounded-full bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] p-4">
+        <Home className="h-8 w-8 text-[var(--color-text-tertiary)]" />
+      </div>
+      <div className="space-y-1">
+        <h1 className="text-lg font-semibold text-[var(--color-text-primary)]">
+          Page not found
+        </h1>
+        <p className="max-w-md text-sm text-[var(--color-text-secondary)]">
+          The page or resource you requested doesn&apos;t exist for this repository. It may
+          have been moved or never existed.
+        </p>
+      </div>
+      <Link
+        href="/"
+        className="inline-flex items-center gap-1 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)] transition-colors"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back to dashboard
+      </Link>
+    </div>
+  );
+}

--- a/packages/web/src/app/repos/[id]/search/page.tsx
+++ b/packages/web/src/app/repos/[id]/search/page.tsx
@@ -17,7 +17,7 @@ export default function SearchPage() {
   const [query, setQuery] = useState("");
   const [searchType, setSearchType] = useState<SearchType>("semantic");
 
-  const { results, isLoading, isTyping } = useSearch(query, {
+  const { results, isLoading, isTyping, error } = useSearch(query, {
     search_type: searchType,
     limit: 20,
   });
@@ -43,6 +43,12 @@ export default function SearchPage() {
         searchType={searchType}
         onSearchTypeChange={setSearchType}
       />
+
+      {showResults && error && (
+        <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4 text-sm text-[var(--color-outdated)]">
+          Couldn&apos;t run search: {error instanceof Error ? error.message : "unknown error"}
+        </div>
+      )}
 
       {!showResults ? (
         <EmptyState

--- a/packages/web/src/app/repos/[id]/wiki/[...slug]/page.tsx
+++ b/packages/web/src/app/repos/[id]/wiki/[...slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { ApiClientError } from "@/lib/api/client";
 import { getRepo } from "@/lib/api/repos";
 import { getPageById, getPageVersions } from "@/lib/api/pages";
 import { getGitMetadata } from "@/lib/api/git";
@@ -40,8 +41,11 @@ export default async function WikiPageRoute({ params }: Props) {
   let page;
   try {
     page = await getPageById(pageId);
-  } catch {
-    notFound();
+  } catch (err) {
+    if (err instanceof ApiClientError && err.status === 404) {
+      notFound();
+    }
+    throw err;
   }
 
   const [repo, versions, gitMeta, graphMetricsResult] = await Promise.allSettled([

--- a/packages/web/src/app/workspace/page.tsx
+++ b/packages/web/src/app/workspace/page.tsx
@@ -68,7 +68,10 @@ export default async function WorkspaceDashboardPage() {
         <p className="text-sm text-[var(--color-text-secondary)]">
           {workspace?.repos.length ?? 0} repositories
           {workspace?.workspace_root && (
-            <span className="text-[var(--color-text-tertiary)]">
+            <span
+              className="text-[var(--color-text-tertiary)] font-mono break-all"
+              title={workspace.workspace_root}
+            >
               {" "}&middot; {workspace.workspace_root}
             </span>
           )}

--- a/packages/web/src/components/chat/chat-interface.tsx
+++ b/packages/web/src/components/chat/chat-interface.tsx
@@ -225,6 +225,7 @@ export function ChatInterface({ repoId, repoName }: ChatInterfaceProps) {
                 }
               }}
               placeholder="Ask anything about this codebase..."
+              aria-label="Chat message"
               rows={1}
               className="flex-1 resize-none bg-transparent text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-tertiary)] outline-none leading-6 max-h-36 overflow-y-auto"
               style={{ scrollbarWidth: "none" }}
@@ -234,6 +235,8 @@ export function ChatInterface({ repoId, repoName }: ChatInterfaceProps) {
               className="h-8 w-8 shrink-0 rounded-xl"
               onClick={isStreaming ? reset : handleSubmit}
               disabled={!input.trim() && !isStreaming}
+              aria-label={isStreaming ? "Stop generation" : "Send message"}
+              title={isStreaming ? "Stop generation" : "Send message"}
             >
               {isStreaming ? (
                 <StopCircle className="h-4 w-4" />

--- a/packages/web/src/components/coverage/freshness-table.tsx
+++ b/packages/web/src/components/coverage/freshness-table.tsx
@@ -39,12 +39,14 @@ export function FreshnessTable({ pages }: FreshnessTableProps) {
   return (
     <div className="space-y-4">
       {/* Filter tabs */}
-      <div className="flex items-center gap-1">
+      <div role="tablist" aria-label="Freshness filter" className="flex items-center gap-1">
         {(["all", "fresh", "stale", "outdated"] as Filter[]).map((f) => {
           const count = f === "all" ? pages.length : pages.filter((p) => p.freshness_status === f).length;
           return (
             <button
               key={f}
+              role="tab"
+              aria-selected={filter === f}
               onClick={() => setFilter(f)}
               className={cn(
                 "rounded-md px-3 py-1.5 text-xs font-medium transition-colors",

--- a/packages/web/src/components/coverage/freshness-table.tsx
+++ b/packages/web/src/components/coverage/freshness-table.tsx
@@ -65,24 +65,27 @@ export function FreshnessTable({ pages }: FreshnessTableProps) {
       ) : (
         <div className="rounded-lg border border-[var(--color-border-default)] overflow-x-auto">
           <table className="w-full text-sm">
-            <thead>
+            <caption className="sr-only">Documentation freshness</caption>
+            <thead className="sticky top-0 z-10 bg-[var(--color-bg-elevated)]">
               <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
-                <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+                <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
                   Page
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
+                <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
                   Status
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
+                <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
                   Confidence
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+                <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden md:table-cell">
                   Model
                 </th>
-                <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-28">
+                <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-28 hidden md:table-cell">
                   Updated
                 </th>
-                <th className="px-4 py-2.5 w-24" />
+                <th scope="col" className="px-4 py-2.5 w-24">
+                  <span className="sr-only">Action</span>
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -93,9 +96,9 @@ export function FreshnessTable({ pages }: FreshnessTableProps) {
                     key={page.id}
                     className="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] transition-colors last:border-0"
                   >
-                    <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-primary)]" style={{ maxWidth: 0 }}>
+                    <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-primary)] min-w-[220px] max-w-[480px]">
                       <div className="truncate" title={page.target_path}>{page.target_path}</div>
-                      <div className="text-[var(--color-text-tertiary)]">{page.page_type}</div>
+                      <div className="truncate text-[var(--color-text-tertiary)]" title={page.page_type}>{page.page_type}</div>
                     </td>
                     <td className="px-4 py-2.5">
                       <span
@@ -120,10 +123,13 @@ export function FreshnessTable({ pages }: FreshnessTableProps) {
                         {formatConfidence(page.confidence)}
                       </span>
                     </td>
-                    <td className="px-4 py-2.5 text-xs text-[var(--color-text-tertiary)]">
-                      {page.model_name}
+                    <td className="px-4 py-2.5 text-xs text-[var(--color-text-tertiary)] max-w-[200px] hidden md:table-cell">
+                      <span className="block truncate" title={page.model_name}>{page.model_name}</span>
                     </td>
-                    <td className="px-4 py-2.5 text-xs text-[var(--color-text-tertiary)]">
+                    <td
+                      className="px-4 py-2.5 text-xs text-[var(--color-text-tertiary)] hidden md:table-cell"
+                      title={new Date(page.updated_at).toLocaleString()}
+                    >
                       {formatRelativeTime(page.updated_at)}
                     </td>
                     <td className="px-4 py-2.5">

--- a/packages/web/src/components/dashboard/quick-actions.tsx
+++ b/packages/web/src/components/dashboard/quick-actions.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { RefreshCw, FileText, Trash2, AlertTriangle, Zap } from "lucide-react";
+import { RefreshCw, Trash2, AlertTriangle, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,6 +13,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { syncRepo, fullResyncRepo } from "@/lib/api/repos";
+import { listJobs } from "@/lib/api/jobs";
 import { analyzeDeadCode } from "@/lib/api/dead-code";
 import { GenerationProgress } from "@/components/jobs/generation-progress";
 import { formatNumber, formatCost, formatRelativeTime } from "@/lib/utils/format";
@@ -131,6 +132,30 @@ export function QuickActions({ repoId, repoName, pageCount = 0, modelName = "", 
   const [pendingAction, setPendingAction] = useState<ActionDef | null>(null);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
 
+  // On mount, hydrate from any in-flight job so a page refresh shows live
+  // progress instead of pretending nothing is happening. Without this, a
+  // job stuck in 'pending' is invisible from the UI even though the
+  // sync-blocked guard is still firing on the server.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [running, pending] = await Promise.all([
+          listJobs({ repo_id: repoId, status: "running", limit: 1 }),
+          listJobs({ repo_id: repoId, status: "pending", limit: 1 }),
+        ]);
+        if (cancelled) return;
+        const inflight = running[0] ?? pending[0];
+        if (inflight) setActiveJobId(inflight.id);
+      } catch {
+        // best-effort hydration — don't block the UI
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [repoId]);
+
   // Sync regenerates ~10-15% of pages (only affected by changes).
   // Full resync regenerates all pages.
   const estimate = pageCount > 0 && pendingAction?.key !== "dead-code"
@@ -157,9 +182,26 @@ export function QuickActions({ repoId, repoName, pageCount = 0, modelName = "", 
         toast.info("Dead code analysis started");
       }
     } catch (e) {
-      toast.error(`${action.label} failed`, {
-        description: e instanceof Error ? e.message : "Unknown error",
-      });
+      const msg = e instanceof Error ? e.message : "Unknown error";
+      // If the server already has an in-flight job, surface that one's
+      // progress instead of just showing an opaque 409.
+      if (/already in progress/i.test(msg)) {
+        try {
+          const [running, pending] = await Promise.all([
+            listJobs({ repo_id: repoId, status: "running", limit: 1 }),
+            listJobs({ repo_id: repoId, status: "pending", limit: 1 }),
+          ]);
+          const inflight = running[0] ?? pending[0];
+          if (inflight) {
+            setActiveJobId(inflight.id);
+            toast.info("Showing progress for the in-flight job. Cancel it from the panel to start a new one.");
+            return;
+          }
+        } catch {
+          // fall through to error toast
+        }
+      }
+      toast.error(`${action.label} failed`, { description: msg });
     } finally {
       setLoading(null);
     }

--- a/packages/web/src/components/dead-code/finding-row.tsx
+++ b/packages/web/src/components/dead-code/finding-row.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { truncatePath, formatConfidence } from "@/lib/utils/format";
@@ -30,6 +31,10 @@ export function FindingRow({ finding, selected, onToggle, onUpdate }: FindingRow
     try {
       const updated = await patchDeadCodeFinding(finding.id, { status });
       onUpdate(updated);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? `Couldn't update finding: ${err.message}` : "Couldn't update finding",
+      );
     } finally {
       setPending(false);
     }
@@ -47,13 +52,14 @@ export function FindingRow({ finding, selected, onToggle, onUpdate }: FindingRow
           type="checkbox"
           checked={selected}
           onChange={() => onToggle(finding.id)}
+          aria-label={`Select finding ${finding.file_path}`}
           className="rounded border-[var(--color-border-default)]"
         />
       </td>
-      <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-primary)]" style={{ maxWidth: 0 }}>
+      <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-primary)] min-w-[200px] max-w-[480px]">
         <span className="truncate block" title={finding.file_path}>{finding.file_path}</span>
         {finding.symbol_name && (
-          <span className="text-[var(--color-text-tertiary)]">{finding.symbol_name}</span>
+          <span className="block truncate text-[var(--color-text-tertiary)]" title={finding.symbol_name}>{finding.symbol_name}</span>
         )}
       </td>
       <td className="px-4 py-2.5 text-xs text-[var(--color-text-secondary)] tabular-nums">
@@ -93,15 +99,16 @@ export function FindingRow({ finding, selected, onToggle, onUpdate }: FindingRow
           {finding.status.replace(/_/g, " ")}
         </span>
       </td>
-      <td className="px-4 py-2.5 hidden lg:table-cell">
+      <td className="px-4 py-2.5">
         {finding.status === "open" && (
-          <div className="flex items-center gap-1">
+          <div className="flex items-center gap-1 flex-wrap justify-end">
             <Button
               size="sm"
               variant="ghost"
               disabled={pending}
               onClick={() => patch("resolved")}
               className="h-6 px-2 text-xs text-green-500 hover:text-green-400"
+              aria-label={`Resolve ${finding.file_path}`}
             >
               Resolve
             </Button>
@@ -111,6 +118,7 @@ export function FindingRow({ finding, selected, onToggle, onUpdate }: FindingRow
               disabled={pending}
               onClick={() => patch("acknowledged")}
               className="h-6 px-2 text-xs"
+              aria-label={`Acknowledge ${finding.file_path}`}
             >
               Ack
             </Button>
@@ -120,6 +128,7 @@ export function FindingRow({ finding, selected, onToggle, onUpdate }: FindingRow
               disabled={pending}
               onClick={() => patch("false_positive")}
               className="h-6 px-2 text-xs text-[var(--color-text-tertiary)]"
+              aria-label={`Mark ${finding.file_path} as false positive`}
             >
               FP
             </Button>

--- a/packages/web/src/components/dead-code/finding-row.tsx
+++ b/packages/web/src/components/dead-code/finding-row.tsx
@@ -4,10 +4,32 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { truncatePath, formatConfidence } from "@/lib/utils/format";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { formatConfidence } from "@/lib/utils/format";
 import { patchDeadCodeFinding } from "@/lib/api/dead-code";
 import { cn } from "@/lib/utils/cn";
 import type { DeadCodeFindingResponse } from "@/lib/api/types";
+
+const STATUS_LABELS: Record<string, { title: string; description: string; confirmLabel: string; destructive: boolean }> = {
+  resolved: {
+    title: "Resolve finding?",
+    description: "Mark this finding as resolved. You can undo from the toast.",
+    confirmLabel: "Resolve",
+    destructive: false,
+  },
+  acknowledged: {
+    title: "Acknowledge finding?",
+    description: "Mark this finding as acknowledged.",
+    confirmLabel: "Acknowledge",
+    destructive: false,
+  },
+  false_positive: {
+    title: "Mark as false positive?",
+    description: "This finding will be excluded from future analyses. You can undo from the toast.",
+    confirmLabel: "Mark FP",
+    destructive: true,
+  },
+};
 
 interface FindingRowProps {
   finding: DeadCodeFindingResponse;
@@ -25,12 +47,32 @@ const STATUS_COLORS: Record<string, string> = {
 
 export function FindingRow({ finding, selected, onToggle, onUpdate }: FindingRowProps) {
   const [pending, setPending] = useState(false);
+  const [confirmStatus, setConfirmStatus] = useState<string | null>(null);
 
-  const patch = async (status: string) => {
+  const previousStatus = finding.status;
+
+  const applyPatch = async (status: string) => {
     setPending(true);
     try {
       const updated = await patchDeadCodeFinding(finding.id, { status });
       onUpdate(updated);
+      setConfirmStatus(null);
+      toast.success(`Finding ${status.replace(/_/g, " ")}`, {
+        action: {
+          label: "Undo",
+          onClick: async () => {
+            try {
+              const reverted = await patchDeadCodeFinding(finding.id, { status: previousStatus });
+              onUpdate(reverted);
+            } catch (err) {
+              toast.error(
+                err instanceof Error ? `Couldn't undo: ${err.message}` : "Couldn't undo",
+              );
+            }
+          },
+        },
+        duration: 6000,
+      });
     } catch (err) {
       toast.error(
         err instanceof Error ? `Couldn't update finding: ${err.message}` : "Couldn't update finding",
@@ -39,6 +81,10 @@ export function FindingRow({ finding, selected, onToggle, onUpdate }: FindingRow
       setPending(false);
     }
   };
+
+  const requestPatch = (status: string) => setConfirmStatus(status);
+
+  const confirmConfig = confirmStatus ? STATUS_LABELS[confirmStatus] : null;
 
   return (
     <tr
@@ -106,7 +152,7 @@ export function FindingRow({ finding, selected, onToggle, onUpdate }: FindingRow
               size="sm"
               variant="ghost"
               disabled={pending}
-              onClick={() => patch("resolved")}
+              onClick={() => requestPatch("resolved")}
               className="h-6 px-2 text-xs text-green-500 hover:text-green-400"
               aria-label={`Resolve ${finding.file_path}`}
             >
@@ -116,7 +162,7 @@ export function FindingRow({ finding, selected, onToggle, onUpdate }: FindingRow
               size="sm"
               variant="ghost"
               disabled={pending}
-              onClick={() => patch("acknowledged")}
+              onClick={() => requestPatch("acknowledged")}
               className="h-6 px-2 text-xs"
               aria-label={`Acknowledge ${finding.file_path}`}
             >
@@ -126,7 +172,7 @@ export function FindingRow({ finding, selected, onToggle, onUpdate }: FindingRow
               size="sm"
               variant="ghost"
               disabled={pending}
-              onClick={() => patch("false_positive")}
+              onClick={() => requestPatch("false_positive")}
               className="h-6 px-2 text-xs text-[var(--color-text-tertiary)]"
               aria-label={`Mark ${finding.file_path} as false positive`}
             >
@@ -135,6 +181,18 @@ export function FindingRow({ finding, selected, onToggle, onUpdate }: FindingRow
           </div>
         )}
       </td>
+      {confirmConfig && (
+        <ConfirmDialog
+          open={confirmStatus !== null}
+          onOpenChange={(o) => !o && setConfirmStatus(null)}
+          title={confirmConfig.title}
+          description={confirmConfig.description}
+          confirmLabel={confirmConfig.confirmLabel}
+          destructive={confirmConfig.destructive}
+          loading={pending}
+          onConfirm={() => applyPatch(confirmStatus!)}
+        />
+      )}
     </tr>
   );
 }

--- a/packages/web/src/components/dead-code/findings-table.tsx
+++ b/packages/web/src/components/dead-code/findings-table.tsx
@@ -164,31 +164,39 @@ export function FindingsTable({ repoId }: FindingsTableProps) {
             ) : (
               <div className="rounded-lg border border-[var(--color-border-default)] overflow-x-auto mt-2">
                 <table className="w-full text-sm">
-                  <thead>
+                  <caption className="sr-only">Dead code findings</caption>
+                  <thead className="sticky top-0 z-10 bg-[var(--color-bg-elevated)]">
                     <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
-                      <th className="px-4 py-2.5 w-8">
+                      <th scope="col" className="px-4 py-2.5 w-8">
                         <input
                           type="checkbox"
                           checked={selected.size === current.length && current.length > 0}
                           onChange={toggleSelectAll}
+                          aria-label="Select all findings"
                           className="rounded border-[var(--color-border-default)]"
                         />
                       </th>
-                      <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+                      <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
                         File / Symbol
                       </th>
-                      <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
+                      <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
                         Confidence
                       </th>
-                      <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden md:table-cell">
+                      <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden md:table-cell">
                         Owner
                       </th>
-                      <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-16 hidden md:table-cell">
+                      <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-16 hidden md:table-cell">
                         Lines
                       </th>
-                      <th className="px-4 py-2.5 w-20 hidden sm:table-cell" />
-                      <th className="px-4 py-2.5 w-24 hidden sm:table-cell" />
-                      <th className="px-4 py-2.5 w-36 hidden lg:table-cell" />
+                      <th scope="col" className="px-4 py-2.5 w-20 hidden sm:table-cell">
+                        <span className="sr-only">Safety</span>
+                      </th>
+                      <th scope="col" className="px-4 py-2.5 w-24 hidden sm:table-cell">
+                        <span className="sr-only">Status</span>
+                      </th>
+                      <th scope="col" className="px-4 py-2.5 w-36">
+                        <span className="sr-only">Actions</span>
+                      </th>
                     </tr>
                   </thead>
                   <tbody>

--- a/packages/web/src/components/dead-code/findings-table.tsx
+++ b/packages/web/src/components/dead-code/findings-table.tsx
@@ -2,9 +2,11 @@
 
 import { useState, useEffect } from "react";
 import useSWR from "swr";
+import { toast } from "sonner";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { EmptyState } from "@/components/shared/empty-state";
 import { FindingRow } from "./finding-row";
 import { listDeadCode, patchDeadCodeFinding } from "@/lib/api/dead-code";
@@ -33,6 +35,7 @@ export function FindingsTable({ repoId }: FindingsTableProps) {
     zombie_package: [],
   });
   const [bulkPending, setBulkPending] = useState(false);
+  const [bulkConfirmOpen, setBulkConfirmOpen] = useState(false);
 
   const { data, isLoading } = useSWR(
     `dead-code:${repoId}:${activeTab}:${minConfidence}:${safeOnly}`,
@@ -79,13 +82,28 @@ export function FindingsTable({ repoId }: FindingsTableProps) {
   };
 
   const resolveSelected = async () => {
+    const ids = Array.from(selected);
     setBulkPending(true);
+    let succeeded = 0;
     try {
-      for (const id of selected) {
-        const updated = await patchDeadCodeFinding(id, { status: "resolved" });
-        handleUpdate(updated);
+      for (const id of ids) {
+        try {
+          const updated = await patchDeadCodeFinding(id, { status: "resolved" });
+          handleUpdate(updated);
+          succeeded += 1;
+        } catch {
+          // continue; we'll report partial below
+        }
       }
       setSelected(new Set());
+      setBulkConfirmOpen(false);
+      if (succeeded === ids.length) {
+        toast.success(`Resolved ${succeeded} finding${succeeded === 1 ? "" : "s"}`);
+      } else if (succeeded > 0) {
+        toast.warning(`Resolved ${succeeded} of ${ids.length}; some failed`);
+      } else {
+        toast.error("Couldn't resolve findings");
+      }
     } finally {
       setBulkPending(false);
     }
@@ -98,16 +116,18 @@ export function FindingsTable({ repoId }: FindingsTableProps) {
       {/* Controls */}
       <div className="flex flex-wrap items-center gap-4">
         <div className="flex items-center gap-2">
-          <label className="text-xs text-[var(--color-text-secondary)]">
+          <label htmlFor="min-confidence" className="text-xs text-[var(--color-text-secondary)]">
             Min confidence: {Math.round(minConfidence * 100)}%
           </label>
           <input
+            id="min-confidence"
             type="range"
             min="0.4"
             max="1"
             step="0.05"
             value={minConfidence}
             onChange={(e) => setMinConfidence(Number(e.target.value))}
+            aria-valuetext={`${Math.round(minConfidence * 100)} percent`}
             className="w-28 accent-[var(--color-accent-primary)]"
           />
         </div>
@@ -126,13 +146,22 @@ export function FindingsTable({ repoId }: FindingsTableProps) {
             size="sm"
             variant="outline"
             disabled={bulkPending}
-            onClick={resolveSelected}
+            onClick={() => setBulkConfirmOpen(true)}
             className="text-green-500 border-green-500/30 hover:bg-green-500/10"
           >
             {bulkPending ? "Resolving…" : `Resolve ${selected.size} selected`}
           </Button>
         )}
       </div>
+      <ConfirmDialog
+        open={bulkConfirmOpen}
+        onOpenChange={setBulkConfirmOpen}
+        title={`Resolve ${selected.size} finding${selected.size === 1 ? "" : "s"}?`}
+        description="This will mark each selected finding as resolved."
+        confirmLabel="Resolve all"
+        loading={bulkPending}
+        onConfirm={resolveSelected}
+      />
 
       <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as Kind)}>
         <TabsList>

--- a/packages/web/src/components/decisions/decision-detail.tsx
+++ b/packages/web/src/components/decisions/decision-detail.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { patchDecision } from "@/lib/api/decisions";
 import type { DecisionRecordResponse } from "@/lib/api/types";
@@ -28,6 +29,13 @@ export function DecisionDetail({ decision, repoId }: DecisionDetailProps) {
     try {
       await patchDecision(repoId, decision.id, { status: newStatus });
       setStatus(newStatus as typeof status);
+      toast.success(`Decision marked ${newStatus.replace(/_/g, " ")}`);
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? `Couldn't update decision: ${err.message}`
+          : "Couldn't update decision",
+      );
     } finally {
       setLoading(false);
     }

--- a/packages/web/src/components/decisions/decision-detail.tsx
+++ b/packages/web/src/components/decisions/decision-detail.tsx
@@ -4,7 +4,10 @@ import * as React from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { toast } from "sonner";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { patchDecision } from "@/lib/api/decisions";
 import type { DecisionRecordResponse } from "@/lib/api/types";
 
@@ -20,16 +23,49 @@ interface DecisionDetailProps {
   repoId: string;
 }
 
+const CONFIRM_COPY: Record<string, { title: string; description: string; confirmLabel: string; destructive: boolean }> = {
+  active: {
+    title: "Confirm decision?",
+    description: "Mark this decision as active.",
+    confirmLabel: "Confirm",
+    destructive: false,
+  },
+  deprecated: {
+    title: "Deprecate decision?",
+    description: "This will mark the decision as deprecated. Existing references remain but it will no longer be considered current.",
+    confirmLabel: "Deprecate",
+    destructive: true,
+  },
+};
+
 export function DecisionDetail({ decision, repoId }: DecisionDetailProps) {
   const [status, setStatus] = React.useState(decision.status);
   const [loading, setLoading] = React.useState(false);
+  const [pendingStatus, setPendingStatus] = React.useState<string | null>(null);
 
-  const handleStatusChange = async (newStatus: string) => {
+  const applyStatusChange = async (newStatus: string) => {
+    const previous = status;
     setLoading(true);
     try {
       await patchDecision(repoId, decision.id, { status: newStatus });
       setStatus(newStatus as typeof status);
-      toast.success(`Decision marked ${newStatus.replace(/_/g, " ")}`);
+      setPendingStatus(null);
+      toast.success(`Decision marked ${newStatus.replace(/_/g, " ")}`, {
+        action: {
+          label: "Undo",
+          onClick: async () => {
+            try {
+              await patchDecision(repoId, decision.id, { status: previous });
+              setStatus(previous);
+            } catch (err) {
+              toast.error(
+                err instanceof Error ? `Couldn't undo: ${err.message}` : "Couldn't undo",
+              );
+            }
+          },
+        },
+        duration: 6000,
+      });
     } catch (err) {
       toast.error(
         err instanceof Error
@@ -41,8 +77,25 @@ export function DecisionDetail({ decision, repoId }: DecisionDetailProps) {
     }
   };
 
+  const handleStatusChange = (newStatus: string) => {
+    if (CONFIRM_COPY[newStatus]) {
+      setPendingStatus(newStatus);
+    } else {
+      void applyStatusChange(newStatus);
+    }
+  };
+
+  const confirmConfig = pendingStatus ? CONFIRM_COPY[pendingStatus] : null;
+
   return (
     <div className="space-y-6">
+      <Link
+        href={`/repos/${repoId}/decisions`}
+        className="inline-flex items-center gap-1 text-xs text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)]"
+      >
+        <ChevronLeft className="h-3.5 w-3.5" />
+        All decisions
+      </Link>
       {/* Header */}
       <div className="space-y-2">
         <div className="flex items-center gap-3">
@@ -168,6 +221,18 @@ export function DecisionDetail({ decision, repoId }: DecisionDetailProps) {
           </button>
         )}
       </div>
+      {confirmConfig && (
+        <ConfirmDialog
+          open={pendingStatus !== null}
+          onOpenChange={(o) => !o && setPendingStatus(null)}
+          title={confirmConfig.title}
+          description={confirmConfig.description}
+          confirmLabel={confirmConfig.confirmLabel}
+          destructive={confirmConfig.destructive}
+          loading={loading}
+          onConfirm={() => applyStatusChange(pendingStatus!)}
+        />
+      )}
     </div>
   );
 }

--- a/packages/web/src/components/decisions/decisions-table.tsx
+++ b/packages/web/src/components/decisions/decisions-table.tsx
@@ -30,7 +30,7 @@ export function DecisionsTable({ repoId, initialData }: DecisionsTableProps) {
   const [statusFilter, setStatusFilter] = React.useState<string>("all");
   const [sourceFilter, setSourceFilter] = React.useState<string>("all");
 
-  const { data: decisions } = useSWR(
+  const { data: decisions, error, mutate, isLoading } = useSWR(
     [`/api/repos/${repoId}/decisions`, statusFilter, sourceFilter],
     () =>
       listDecisions(repoId, {
@@ -143,7 +143,20 @@ export function DecisionsTable({ repoId, initialData }: DecisionsTableProps) {
                 </td>
               </tr>
             ))}
-            {!decisions?.length && (
+            {!decisions?.length && error && !isLoading && (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center text-[var(--color-outdated)]">
+                  Couldn&apos;t load decisions.{" "}
+                  <button
+                    onClick={() => mutate()}
+                    className="underline text-[var(--color-accent-primary)] hover:text-[var(--color-text-primary)]"
+                  >
+                    Retry
+                  </button>
+                </td>
+              </tr>
+            )}
+            {!decisions?.length && !error && (
               <tr>
                 <td colSpan={6} className="px-4 py-8 text-center text-[var(--color-text-tertiary)]">
                   No decisions found

--- a/packages/web/src/components/decisions/decisions-table.tsx
+++ b/packages/web/src/components/decisions/decisions-table.tsx
@@ -45,11 +45,12 @@ export function DecisionsTable({ repoId, initialData }: DecisionsTableProps) {
   return (
     <div className="space-y-4">
       {/* Filters */}
-      <div className="flex gap-3">
+      <div className="flex flex-wrap gap-3">
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value)}
-          className="rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
+          aria-label="Filter by status"
+          className="w-full sm:w-auto rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
         >
           <option value="all">All statuses</option>
           <option value="active">Active</option>
@@ -60,7 +61,8 @@ export function DecisionsTable({ repoId, initialData }: DecisionsTableProps) {
         <select
           value={sourceFilter}
           onChange={(e) => setSourceFilter(e.target.value)}
-          className="rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
+          aria-label="Filter by source"
+          className="w-full sm:w-auto rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)]"
         >
           <option value="all">All sources</option>
           <option value="inline_marker">Inline markers</option>
@@ -73,14 +75,15 @@ export function DecisionsTable({ repoId, initialData }: DecisionsTableProps) {
       {/* Table */}
       <div className="overflow-x-auto rounded-lg border border-[var(--color-border-default)]">
         <table className="w-full text-sm">
-          <thead>
+          <caption className="sr-only">Architectural decisions</caption>
+          <thead className="sticky top-0 z-10 bg-[var(--color-bg-elevated)]">
             <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
-              <th className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Title</th>
-              <th className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Status</th>
-              <th className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Source</th>
-              <th className="px-4 py-2.5 text-right font-medium text-[var(--color-text-secondary)]">Confidence</th>
-              <th className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Tags</th>
-              <th className="px-4 py-2.5 text-right font-medium text-[var(--color-text-secondary)]">Staleness</th>
+              <th scope="col" className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Title</th>
+              <th scope="col" className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Status</th>
+              <th scope="col" className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Source</th>
+              <th scope="col" className="px-4 py-2.5 text-right font-medium text-[var(--color-text-secondary)]">Confidence</th>
+              <th scope="col" className="px-4 py-2.5 text-left font-medium text-[var(--color-text-secondary)]">Tags</th>
+              <th scope="col" className="px-4 py-2.5 text-right font-medium text-[var(--color-text-secondary)]">Staleness</th>
             </tr>
           </thead>
           <tbody>
@@ -91,7 +94,7 @@ export function DecisionsTable({ repoId, initialData }: DecisionsTableProps) {
                   d.status === "proposed" ? "border-l-2 border-l-amber-400" : ""
                 }`}
               >
-                <td className="px-4 py-2.5" style={{ maxWidth: 0 }}>
+                <td className="px-4 py-2.5 min-w-[240px] max-w-[520px]">
                   <Link
                     href={`/repos/${repoId}/decisions/${d.id}`}
                     className="font-medium text-[var(--color-accent-primary)] hover:underline block truncate"
@@ -119,15 +122,23 @@ export function DecisionsTable({ repoId, initialData }: DecisionsTableProps) {
                         {tag}
                       </span>
                     ))}
+                    {d.tags.length > 3 && (
+                      <span
+                        className="inline-block rounded bg-[var(--color-bg-elevated)] px-1.5 py-0.5 text-xs text-[var(--color-text-tertiary)]"
+                        title={d.tags.slice(3).join(", ")}
+                      >
+                        +{d.tags.length - 3}
+                      </span>
+                    )}
                   </div>
                 </td>
-                <td className="px-4 py-2.5 text-right tabular-nums">
+                <td className="px-4 py-2.5 text-right tabular-nums" title="0 = fresh, 1 = fully stale">
                   {d.staleness_score > 0.5 ? (
-                    <span className="text-red-500">{d.staleness_score.toFixed(1)}</span>
+                    <span className="text-red-500">{Math.round(d.staleness_score * 100)}%</span>
                   ) : d.staleness_score > 0 ? (
-                    <span className="text-[var(--color-text-tertiary)]">{d.staleness_score.toFixed(1)}</span>
+                    <span className="text-[var(--color-text-tertiary)]">{Math.round(d.staleness_score * 100)}%</span>
                   ) : (
-                    <span className="text-[var(--color-text-tertiary)]">-</span>
+                    <span className="text-[var(--color-text-tertiary)]">—</span>
                   )}
                 </td>
               </tr>

--- a/packages/web/src/components/docs/docs-explorer.tsx
+++ b/packages/web/src/components/docs/docs-explorer.tsx
@@ -17,7 +17,10 @@ interface DocsExplorerProps {
 export function DocsExplorer({ repoId }: DocsExplorerProps) {
   const { pages, isLoading } = usePages(repoId);
   const [selectedPage, setSelectedPage] = useState<PageResponse | null>(null);
-  const [treePanelOpen, setTreePanelOpen] = useState(true);
+  const [treePanelOpen, setTreePanelOpen] = useState(() => {
+    if (typeof window === "undefined") return true;
+    return window.matchMedia("(min-width: 768px)").matches;
+  });
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -42,7 +45,7 @@ export function DocsExplorer({ repoId }: DocsExplorerProps) {
   if (isLoading) {
     return (
       <div className="flex h-full">
-        <div className="w-[300px] border-r border-[var(--color-border-default)] p-3 space-y-2">
+        <div className="w-full md:w-[300px] border-r border-[var(--color-border-default)] p-3 space-y-2">
           <Skeleton className="h-8 w-full rounded-md" />
           <Skeleton className="h-4 w-3/4 rounded" />
           <Skeleton className="h-4 w-1/2 rounded" />
@@ -82,23 +85,30 @@ export function DocsExplorer({ repoId }: DocsExplorerProps) {
       <div
         className={cn(
           "border-r border-[var(--color-border-default)] bg-[var(--color-bg-surface)] transition-all duration-200 shrink-0 relative",
-          treePanelOpen ? "w-[300px]" : "w-0 overflow-hidden border-r-0",
+          treePanelOpen ? "w-full md:w-[300px]" : "w-0 overflow-hidden border-r-0",
         )}
       >
         <DocsTree
           pages={pages}
           selectedPageId={selectedPage?.id ?? null}
-          onSelectPage={handleSelectPage}
+          onSelectPage={(p) => {
+            handleSelectPage(p);
+            if (typeof window !== "undefined" && !window.matchMedia("(min-width: 768px)").matches) {
+              setTreePanelOpen(false);
+            }
+          }}
         />
       </div>
 
       {/* Toggle button */}
       <button
         onClick={() => setTreePanelOpen((o) => !o)}
-        className="absolute left-[300px] top-3 z-20 rounded-r-md border border-l-0 border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-1 text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-elevated)] transition-colors"
-        style={{
-          left: treePanelOpen ? "300px" : "0px",
-        }}
+        aria-label={treePanelOpen ? "Hide pages tree" : "Show pages tree"}
+        aria-expanded={treePanelOpen}
+        className={cn(
+          "absolute top-3 z-20 rounded-r-md border border-l-0 border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-1 text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-bg-elevated)] transition-colors",
+          treePanelOpen ? "hidden md:block left-[300px]" : "left-0",
+        )}
       >
         {treePanelOpen ? (
           <PanelLeftClose className="h-3.5 w-3.5" />
@@ -108,7 +118,7 @@ export function DocsExplorer({ repoId }: DocsExplorerProps) {
       </button>
 
       {/* Viewer */}
-      <div className="flex-1 min-w-0">
+      <div className={cn("flex-1 min-w-0", treePanelOpen ? "hidden md:block" : "block")}>
         <DocsViewer page={selectedPage} repoId={repoId} />
       </div>
     </div>

--- a/packages/web/src/components/git/hotspot-table.tsx
+++ b/packages/web/src/components/git/hotspot-table.tsx
@@ -109,7 +109,7 @@ export function HotspotTable({ hotspots }: HotspotTableProps) {
             className="pl-8 h-8 w-full sm:w-56 text-xs"
           />
         </div>
-        <div className="flex rounded-md border border-[var(--color-border-default)] overflow-hidden text-xs">
+        <div className="flex flex-wrap rounded-md border border-[var(--color-border-default)] overflow-hidden text-xs">
           {filters.map((f) => (
             <button
               key={f.key}
@@ -134,7 +134,7 @@ export function HotspotTable({ hotspots }: HotspotTableProps) {
       ) : (
         <div className="rounded-lg border border-[var(--color-border-default)] overflow-x-auto">
           <table className="w-full text-sm">
-            <thead>
+            <thead className="sticky top-0 z-10 bg-[var(--color-bg-elevated)]">
               <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
                 <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-8">
                   #
@@ -185,7 +185,7 @@ export function HotspotTable({ hotspots }: HotspotTableProps) {
                     <td className="px-3 py-2.5 text-[var(--color-text-tertiary)] tabular-nums text-xs">
                       {i + 1}
                     </td>
-                    <td className="px-3 py-2.5 font-mono text-xs text-[var(--color-text-primary)]" style={{ maxWidth: 0 }}>
+                    <td className="px-3 py-2.5 font-mono text-xs text-[var(--color-text-primary)] min-w-[220px] max-w-[520px]">
                       <span className="block truncate" title={h.file_path}>{h.file_path}</span>
                     </td>
                     <td className="px-3 py-2.5 tabular-nums text-xs">

--- a/packages/web/src/components/git/hotspot-table.tsx
+++ b/packages/web/src/components/git/hotspot-table.tsx
@@ -19,10 +19,15 @@ type SortKey = "trend" | "churn" | "commits";
 type SortDir = "asc" | "desc";
 
 function SortIcon({ column, sortKey, sortDir }: { column: SortKey; sortKey: SortKey; sortDir: SortDir }) {
-  if (column !== sortKey) return <ArrowUpDown className="inline h-3 w-3 ml-1 opacity-40" />;
+  if (column !== sortKey) return <ArrowUpDown className="inline h-3 w-3 ml-1 opacity-60" />;
   return sortDir === "desc"
     ? <ArrowDown className="inline h-3 w-3 ml-1" />
     : <ArrowUp className="inline h-3 w-3 ml-1" />;
+}
+
+function ariaSortFor(column: SortKey, sortKey: SortKey, sortDir: SortDir): "none" | "ascending" | "descending" {
+  if (column !== sortKey) return "none";
+  return sortDir === "asc" ? "ascending" : "descending";
 }
 
 export function HotspotTable({ hotspots }: HotspotTableProps) {
@@ -143,19 +148,25 @@ export function HotspotTable({ hotspots }: HotspotTableProps) {
                   File
                 </th>
                 <th
-                  className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24 cursor-pointer select-none hover:text-[var(--color-text-secondary)]"
+                  scope="col"
+                  aria-sort={ariaSortFor("commits", sortKey, sortDir)}
+                  className="px-3 py-2.5 text-right text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24 cursor-pointer select-none hover:text-[var(--color-text-secondary)]"
                   onClick={() => handleSort("commits")}
                 >
                   Commits 90d<SortIcon column="commits" sortKey={sortKey} sortDir={sortDir} />
                 </th>
                 <th
+                  scope="col"
+                  aria-sort={ariaSortFor("churn", sortKey, sortDir)}
                   className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-32 cursor-pointer select-none hover:text-[var(--color-text-secondary)] hidden lg:table-cell"
                   onClick={() => handleSort("churn")}
                 >
                   Churn<SortIcon column="churn" sortKey={sortKey} sortDir={sortDir} />
                 </th>
                 <th
-                  className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24 cursor-pointer select-none hover:text-[var(--color-text-secondary)]"
+                  scope="col"
+                  aria-sort={ariaSortFor("trend", sortKey, sortDir)}
+                  className="px-3 py-2.5 text-right text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24 cursor-pointer select-none hover:text-[var(--color-text-secondary)]"
                   onClick={() => handleSort("trend")}
                   title="Exponential decay score weighting recent commits more heavily (180-day half-life)"
                 >
@@ -188,8 +199,8 @@ export function HotspotTable({ hotspots }: HotspotTableProps) {
                     <td className="px-3 py-2.5 font-mono text-xs text-[var(--color-text-primary)] min-w-[220px] max-w-[520px]">
                       <span className="block truncate" title={h.file_path}>{h.file_path}</span>
                     </td>
-                    <td className="px-3 py-2.5 tabular-nums text-xs">
-                      <span className="flex items-center gap-1">
+                    <td className="px-3 py-2.5 tabular-nums text-xs text-right">
+                      <span className="inline-flex items-center justify-end gap-1">
                         <span className="text-[var(--color-text-secondary)]">
                           {h.commit_count_90d}
                         </span>
@@ -208,8 +219,8 @@ export function HotspotTable({ hotspots }: HotspotTableProps) {
                         </span>
                       </div>
                     </td>
-                    <td className="px-3 py-2.5 tabular-nums text-xs">
-                      <span className="flex items-center gap-1">
+                    <td className="px-3 py-2.5 tabular-nums text-xs text-right">
+                      <span className="inline-flex items-center justify-end gap-1">
                         {trendScore != null ? (
                           <>
                             <Flame className={cn("h-3 w-3 shrink-0", trendScore >= 5 ? "text-red-500" : trendScore >= 2 ? "text-orange-400" : "text-[var(--color-text-tertiary)]")} />

--- a/packages/web/src/components/git/ownership-table.tsx
+++ b/packages/web/src/components/git/ownership-table.tsx
@@ -59,7 +59,8 @@ export function OwnershipTable({ entries }: OwnershipTableProps) {
             placeholder="Search modules or owners…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="pl-8 h-8 w-56 text-xs"
+            className="pl-8 h-8 w-full sm:w-56 text-xs"
+            aria-label="Search modules or owners"
           />
         </div>
         <div className="flex rounded-md border border-[var(--color-border-default)] overflow-hidden text-xs">
@@ -96,7 +97,7 @@ export function OwnershipTable({ entries }: OwnershipTableProps) {
       ) : (
         <div className="rounded-lg border border-[var(--color-border-default)] overflow-x-auto">
           <table className="w-full text-sm">
-            <thead>
+            <thead className="sticky top-0 z-10 bg-[var(--color-bg-elevated)]">
               <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
                 <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
                   Module / File
@@ -119,11 +120,13 @@ export function OwnershipTable({ entries }: OwnershipTableProps) {
                   key={entry.module_path}
                   className="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] transition-colors last:border-0"
                 >
-                  <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-primary)]" style={{ maxWidth: 0 }}>
+                  <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-primary)] min-w-[200px] max-w-[480px]">
                     <span className="block truncate" title={entry.module_path}>{entry.module_path}</span>
                   </td>
-                  <td className="px-4 py-2.5 text-xs text-[var(--color-text-secondary)]">
-                    {entry.primary_owner ?? "—"}
+                  <td className="px-4 py-2.5 text-xs text-[var(--color-text-secondary)] max-w-[200px]">
+                    <span className="block truncate" title={entry.primary_owner ?? undefined}>
+                      {entry.primary_owner ?? "—"}
+                    </span>
                   </td>
                   <td className="px-4 py-2.5">
                     {entry.owner_pct !== null ? (

--- a/packages/web/src/components/graph/graph-doc-panel.tsx
+++ b/packages/web/src/components/graph/graph-doc-panel.tsx
@@ -35,7 +35,7 @@ export function GraphDocPanel({ repoId, nodeId, onClose }: GraphDocPanelProps) {
   }, [nodeId]);
 
   return (
-    <div className="absolute top-0 right-0 z-20 h-full w-[400px] flex flex-col bg-[var(--color-bg-surface)] border-l border-[var(--color-border-default)] shadow-2xl shadow-black/30">
+    <div className="absolute top-0 right-0 z-20 h-full w-[min(400px,calc(100vw-1.5rem))] flex flex-col bg-[var(--color-bg-surface)] border-l border-[var(--color-border-default)] shadow-2xl shadow-black/30">
       {/* Header */}
       <div className="flex items-center gap-2 px-4 py-3 border-b border-[var(--color-border-default)] shrink-0">
         <FileText className="h-4 w-4 text-[var(--color-accent-primary)] shrink-0" />

--- a/packages/web/src/components/graph/graph-ego-sidebar.tsx
+++ b/packages/web/src/components/graph/graph-ego-sidebar.tsx
@@ -16,7 +16,7 @@ export function GraphEgoSidebar({ graph, onClose, onNavigateToNode }: GraphEgoSi
   const centerNode = graph.nodes.find((n) => n.node_id === graph.center_node_id);
 
   return (
-    <div className="absolute top-3 right-3 z-20 w-72 rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)]/95 backdrop-blur-sm shadow-xl text-xs">
+    <div className="absolute top-3 right-3 z-20 w-[min(18rem,calc(100vw-1.5rem))] rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)]/95 backdrop-blur-sm shadow-xl text-xs">
       {/* Header */}
       <div className="flex items-start justify-between p-3 border-b border-[var(--color-border-default)]">
         <div className="flex-1 min-w-0">

--- a/packages/web/src/components/graph/graph-flow.tsx
+++ b/packages/web/src/components/graph/graph-flow.tsx
@@ -421,8 +421,15 @@ function GraphFlowInner({
   useEffect(() => {
     if (!ctxMenu) return;
     const close = () => setCtxMenu(null);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
     window.addEventListener("click", close);
-    return () => window.removeEventListener("click", close);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("click", close);
+      window.removeEventListener("keydown", onKey);
+    };
   }, [ctxMenu]);
 
   const handlePathFound = useCallback(
@@ -560,7 +567,7 @@ function GraphFlowInner({
 
   return (
     <GraphContext.Provider value={ctxValue}>
-      <div className="relative w-full h-full">
+      <div className="relative w-full h-full" style={{ touchAction: "none" }} aria-label="Dependency graph">
         {isLayouting && (
           <div className="absolute inset-0 z-50 flex items-center justify-center bg-[var(--color-bg-root)]/60 backdrop-blur-sm rounded-lg">
             <div className="flex items-center gap-3 text-sm text-[var(--color-text-secondary)]">
@@ -606,7 +613,7 @@ function GraphFlowInner({
           <MiniMap
             nodeColor={minimapNodeColor}
             maskColor="rgba(0, 0, 0, 0.6)"
-            className="!bg-[var(--color-bg-surface)] !border-[var(--color-border-default)] !shadow-lg !shadow-black/20 !rounded-lg"
+            className="!bg-[var(--color-bg-surface)] !border-[var(--color-border-default)] !shadow-lg !shadow-black/20 !rounded-lg !hidden sm:!block"
             pannable
             zoomable
           />
@@ -684,7 +691,7 @@ function GraphFlowInner({
 
         {/* Execution Flows Panel */}
         {showFlows && executionFlowsData && executionFlowsData.flows.length > 0 && (
-          <div className="absolute top-14 right-3 z-10 w-64">
+          <div className="absolute top-14 right-3 z-10 w-[min(16rem,calc(100vw-1.5rem))]">
             <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/95 backdrop-blur-sm shadow-lg shadow-black/20 p-3">
               <div className="flex items-center justify-between mb-2">
                 <span className="text-[11px] font-medium text-[var(--color-text-primary)]">

--- a/packages/web/src/components/graph/graph-toolbar.tsx
+++ b/packages/web/src/components/graph/graph-toolbar.tsx
@@ -84,6 +84,8 @@ export function GraphToolbar({
                   : "text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-overlay)]"
               }`}
               title={m.label}
+              aria-label={m.label}
+              aria-pressed={isActive}
             >
               <Icon className="w-3 h-3" />
               <span className="hidden lg:inline">{m.label}</span>
@@ -109,6 +111,8 @@ export function GraphToolbar({
                     : "text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-overlay)]"
                 }`}
                 title={m.label}
+                aria-label={m.label}
+                aria-pressed={isActive}
               >
                 <Icon className="w-3 h-3" />
               </button>
@@ -124,6 +128,8 @@ export function GraphToolbar({
             onClick={onTogglePathFinder}
             className={`h-7 w-7 p-0 ${showPathFinder ? "text-[var(--color-accent-graph)]" : "text-[var(--color-text-tertiary)]"}`}
             title="Find dependency path"
+            aria-label="Find dependency path"
+            aria-pressed={showPathFinder}
           >
             <Route className="w-3.5 h-3.5" />
           </Button>
@@ -133,6 +139,8 @@ export function GraphToolbar({
             onClick={onToggleFlows}
             className={`h-7 w-7 p-0 ${showFlows ? "text-[var(--color-accent-graph)]" : "text-[var(--color-text-tertiary)]"}`}
             title="Execution flows"
+            aria-label="Execution flows"
+            aria-pressed={showFlows}
           >
             <Workflow className="w-3.5 h-3.5" />
           </Button>
@@ -142,6 +150,8 @@ export function GraphToolbar({
             onClick={() => onHideTestsChange(!hideTests)}
             className={`h-7 w-7 p-0 ${hideTests ? "text-[var(--color-accent-graph)]" : "text-[var(--color-text-tertiary)]"}`}
             title={hideTests ? "Show test files" : "Hide test files"}
+            aria-label={hideTests ? "Show test files" : "Hide test files"}
+            aria-pressed={hideTests}
           >
             <EyeOff className="w-3.5 h-3.5" />
           </Button>
@@ -151,6 +161,7 @@ export function GraphToolbar({
             onClick={onFitView}
             className="h-7 w-7 p-0 text-[var(--color-text-tertiary)]"
             title="Fit view"
+            aria-label="Fit view"
           >
             <Maximize className="w-3.5 h-3.5" />
           </Button>
@@ -166,10 +177,15 @@ export function GraphToolbar({
             value={searchQuery}
             onChange={(e) => onSearchChange(e.target.value)}
             placeholder="Search nodes…"
+            aria-label="Search graph nodes"
             className="bg-transparent text-[11px] text-[var(--color-text-primary)] placeholder:text-[var(--color-text-tertiary)] outline-none w-28 lg:w-40"
           />
           {searchQuery && (
-            <button onClick={() => onSearchChange("")} className="text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)]">
+            <button
+              onClick={() => onSearchChange("")}
+              aria-label="Clear search"
+              className="text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)]"
+            >
               <X className="w-3 h-3" />
             </button>
           )}

--- a/packages/web/src/components/graph/path-finder-panel.tsx
+++ b/packages/web/src/components/graph/path-finder-panel.tsx
@@ -166,7 +166,7 @@ export function PathFinderPanel({
   }, [onClear]);
 
   return (
-    <div className="rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)]/90 backdrop-blur-md shadow-xl shadow-black/30 p-3 w-[280px] space-y-2">
+    <div className="rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)]/90 backdrop-blur-md shadow-xl shadow-black/30 p-3 w-[min(280px,calc(100vw-1.5rem))] space-y-2">
       {/* Header */}
       <div className="flex items-center gap-2">
         <Route className="w-3.5 h-3.5 text-[var(--color-accent-graph)]" />

--- a/packages/web/src/components/jobs/generation-progress.tsx
+++ b/packages/web/src/components/jobs/generation-progress.tsx
@@ -2,12 +2,14 @@
 
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import { CheckCircle, XCircle, Loader2, RefreshCw } from "lucide-react";
+import { CheckCircle, XCircle, Loader2, AlertTriangle, X } from "lucide-react";
 import { useJob } from "@/lib/hooks/use-job";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { JobLog } from "./job-log";
 import { formatTokens, formatNumber } from "@/lib/utils/format";
+import { cancelJob } from "@/lib/api/jobs";
 import type { JobProgressEvent } from "@/lib/api/types";
 
 interface Props {
@@ -17,11 +19,16 @@ interface Props {
   onDone?: () => void;
 }
 
+// Anything past this without transitioning out of "pending" is almost
+// certainly stuck — the background task crashed before recording running.
+const PENDING_STUCK_THRESHOLD_MS = 30_000;
+
 export function GenerationProgress({ jobId, repoName, onDone }: Props) {
   const { job, sse } = useJob(jobId);
   const [log, setLog] = useState<Array<{ text: string }>>([]);
   const [elapsed, setElapsed] = useState(0);
   const [actualCost, setActualCost] = useState<number | null>(null);
+  const [cancelling, setCancelling] = useState(false);
   const startRef = useRef(Date.now());
   const notifiedRef = useRef(false);
 
@@ -71,19 +78,45 @@ export function GenerationProgress({ jobId, repoName, onDone }: Props) {
     : 0;
 
   const elapsedStr = `${Math.floor(elapsed / 60000)}m ${Math.floor((elapsed % 60000) / 1000)}s`;
-  const isRunning = job?.status === "running" || job?.status === "pending";
+  const isPending = job?.status === "pending";
+  const isRunning = job?.status === "running";
+  const isInflight = isPending || isRunning;
   const isDone = job?.status === "completed";
   const isFailed = job?.status === "failed";
+
+  // Detect a stuck pending job: we've been observing it for >30s and the
+  // server still reports `pending` without `started_at` ever flipping.
+  const stuckPending =
+    isPending &&
+    job?.started_at == null &&
+    elapsed > PENDING_STUCK_THRESHOLD_MS;
+
+  async function handleCancel() {
+    if (!job) return;
+    setCancelling(true);
+    try {
+      await cancelJob(job.id);
+      toast.success("Job cancelled");
+      onDone?.();
+    } catch (e) {
+      toast.error("Couldn't cancel job", {
+        description: e instanceof Error ? e.message : "Unknown error",
+      });
+    } finally {
+      setCancelling(false);
+    }
+  }
 
   return (
     <div className="space-y-3">
       {/* Header */}
       <div className="flex items-center gap-2">
-        {isRunning && <Loader2 className="h-4 w-4 animate-spin text-[var(--color-accent-primary)] shrink-0" />}
+        {isInflight && <Loader2 className="h-4 w-4 animate-spin text-[var(--color-accent-primary)] shrink-0" />}
         {isDone && <CheckCircle className="h-4 w-4 text-[var(--color-fresh)] shrink-0" />}
         {isFailed && <XCircle className="h-4 w-4 text-[var(--color-outdated)] shrink-0" />}
 
         <span className="text-sm font-medium text-[var(--color-text-primary)]">
+          {isPending && "Queued — waiting for worker…"}
           {isRunning && `Generating level ${job?.current_level ?? "?"}…`}
           {isDone && "Generation complete"}
           {isFailed && "Generation failed"}
@@ -92,7 +125,34 @@ export function GenerationProgress({ jobId, repoName, onDone }: Props) {
         <span className="ml-auto text-xs text-[var(--color-text-tertiary)] tabular-nums">
           {elapsedStr}
         </span>
+
+        {isInflight && (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={handleCancel}
+            disabled={cancelling}
+            className="h-7 px-2 text-xs"
+            aria-label="Cancel job"
+          >
+            <X className="h-3.5 w-3.5 mr-1" />
+            {cancelling ? "Cancelling…" : "Cancel"}
+          </Button>
+        )}
       </div>
+
+      {stuckPending && (
+        <div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+          <div className="flex-1">
+            <p className="font-medium">Job hasn&apos;t started after {Math.round(elapsed / 1000)}s.</p>
+            <p className="mt-0.5 opacity-80">
+              The server may have crashed before the worker could pick it up. Cancel
+              this job and try again — if it keeps happening, check the server logs.
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Progress bar */}
       <div className="space-y-1">

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -74,7 +74,23 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
   const isWorkspace = workspace?.is_workspace ?? false;
   const [open, setOpen] = React.useState(false);
   const pathname = usePathname();
-  const [expandedRepos, setExpandedRepos] = React.useState<Set<string>>(new Set());
+  const activeRepoId = React.useMemo(() => {
+    const m = pathname?.match(/^\/repos\/([^/]+)/);
+    return m ? m[1] : undefined;
+  }, [pathname]);
+  const [expandedRepos, setExpandedRepos] = React.useState<Set<string>>(
+    activeRepoId ? new Set([activeRepoId]) : new Set(),
+  );
+  React.useEffect(() => {
+    if (activeRepoId) {
+      setExpandedRepos((prev) => {
+        if (prev.has(activeRepoId)) return prev;
+        const next = new Set(prev);
+        next.add(activeRepoId);
+        return next;
+      });
+    }
+  }, [activeRepoId]);
 
   const toggleRepo = (id: string) => {
     setExpandedRepos((prev) => {
@@ -209,6 +225,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
                         <div key={repo.id}>
                           <button
                             onClick={() => toggleRepo(repo.id)}
+                            aria-expanded={isExpanded}
                             className="flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-sm transition-colors hover:bg-[var(--color-bg-elevated)] text-[var(--color-text-secondary)]"
                           >
                             <Circle className="h-2 w-2 shrink-0 fill-[var(--color-text-tertiary)] text-[var(--color-text-tertiary)]" />

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -91,17 +91,17 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
   }, [pathname]);
 
   return (
-    <div className="flex md:hidden h-14 items-center gap-3 px-4 border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shrink-0">
+    <div className="flex md:hidden min-h-14 items-center gap-3 px-4 border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shrink-0">
       <Button
         variant="ghost"
         size="icon"
         onClick={() => setOpen(true)}
         aria-label="Open navigation menu"
-        className="h-9 w-9"
+        className="h-11 w-11"
       >
         <Menu className="h-5 w-5" />
       </Button>
-      <div className="flex items-center gap-2 min-w-0">
+      <div className="flex items-center gap-2 min-w-0 flex-1">
         <Image
           src="/repowise-logo.png"
           alt="repowise"
@@ -113,9 +113,20 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           repowise
         </span>
       </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => {
+          window.dispatchEvent(new CustomEvent("repowise:open-command-palette"));
+        }}
+        aria-label="Open search"
+        className="h-11 w-11"
+      >
+        <Search className="h-5 w-5" />
+      </Button>
 
       <Sheet open={open} onOpenChange={setOpen}>
-        <SheetContent side="left" className="p-0">
+        <SheetContent side="left" className="w-72 p-0">
           <SheetHeader className="border-b border-[var(--color-border-default)] h-14 flex-row items-center gap-3 py-0 px-4">
             <Image
               src="/repowise-logo.png"

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -81,9 +81,24 @@ interface SidebarProps {
 export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
   const isWorkspace = workspace?.is_workspace ?? false;
   const pathname = usePathname();
+  const derivedActiveRepoId = React.useMemo(() => {
+    if (activeRepoId) return activeRepoId;
+    const m = pathname?.match(/^\/repos\/([^/]+)/);
+    return m ? m[1] : undefined;
+  }, [activeRepoId, pathname]);
   const [expandedRepos, setExpandedRepos] = React.useState<Set<string>>(
-    activeRepoId ? new Set([activeRepoId]) : new Set(),
+    derivedActiveRepoId ? new Set([derivedActiveRepoId]) : new Set(),
   );
+  React.useEffect(() => {
+    if (derivedActiveRepoId) {
+      setExpandedRepos((prev) => {
+        if (prev.has(derivedActiveRepoId)) return prev;
+        const next = new Set(prev);
+        next.add(derivedActiveRepoId);
+        return next;
+      });
+    }
+  }, [derivedActiveRepoId]);
   const [collapsed, setCollapsed] = React.useState(false);
 
   const toggleRepo = (id: string) => {
@@ -120,14 +135,16 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
         )}
         <button
           onClick={() => setCollapsed((c) => !c)}
-          className="ml-auto shrink-0 rounded-md p-1.5 text-[var(--color-text-tertiary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-secondary)] transition-colors"
+          className="ml-auto shrink-0 rounded-md p-2.5 text-[var(--color-text-tertiary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-secondary)] transition-colors"
           aria-label={isIconOnly ? "Expand sidebar" : "Collapse sidebar"}
+          aria-expanded={!isIconOnly}
+          aria-controls="sidebar-nav"
         >
           <PanelLeft className={cn("h-4 w-4 transition-transform", isIconOnly && "rotate-180")} />
         </button>
       </div>
 
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1" id="sidebar-nav">
         <div className={cn("px-3 py-2", isIconOnly && "px-2")}>
           {/* Global nav */}
           <nav className="space-y-1">
@@ -184,7 +201,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
               <div className="space-y-0.5">
                 {repos.map((repo) => {
                   const isExpanded = expandedRepos.has(repo.id);
-                  const isActive = activeRepoId === repo.id;
+                  const isActive = derivedActiveRepoId === repo.id;
                   const navItems = repoNavItems(repo.id);
 
                   if (isIconOnly) {
@@ -211,6 +228,8 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
                     <div key={repo.id}>
                       <button
                         onClick={() => toggleRepo(repo.id)}
+                        aria-expanded={isExpanded}
+                        aria-controls={`sidebar-repo-${repo.id}`}
                         className={cn(
                           "flex w-full items-center gap-2.5 rounded-lg px-2 py-2 text-sm transition-colors hover:bg-[var(--color-bg-elevated)]",
                           isActive
@@ -231,7 +250,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
                         )}
                       </button>
                       {isExpanded && (
-                        <div className="ml-3.5 mt-0.5 space-y-0.5 border-l border-[var(--color-border-default)] pl-3">
+                        <div id={`sidebar-repo-${repo.id}`} className="ml-3.5 mt-0.5 space-y-0.5 border-l border-[var(--color-border-default)] pl-3">
                           {navItems.map((item) => (
                             <SidebarNavItem
                               key={item.href}
@@ -306,7 +325,7 @@ function SidebarNavItem({
                 : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]",
             )}
           >
-            <Icon className="h-4.5 w-4.5 shrink-0" />
+            <Icon className="h-[18px] w-[18px] shrink-0" />
           </Link>
         </TooltipTrigger>
         <TooltipContent side="right">{item.label}</TooltipContent>

--- a/packages/web/src/components/repos/add-repo-dialog.tsx
+++ b/packages/web/src/components/repos/add-repo-dialog.tsx
@@ -80,7 +80,7 @@ export function AddRepoDialog({ variant = "default" }: Props) {
       )}
 
       <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) reset(); }}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="sm:max-w-md w-[calc(100vw-2rem)]">
           <DialogHeader>
             <DialogTitle>Add Repository</DialogTitle>
           </DialogHeader>

--- a/packages/web/src/components/repos/add-repo-dialog.tsx
+++ b/packages/web/src/components/repos/add-repo-dialog.tsx
@@ -63,26 +63,21 @@ export function AddRepoDialog({ variant = "default" }: Props) {
 
   return (
     <>
-      <button
-        onClick={() => setOpen(true)}
-        className={
-          variant === "sidebar"
-            ? "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-[var(--color-text-tertiary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-secondary)] transition-colors"
-            : undefined
-        }
-      >
-        {variant === "sidebar" ? (
-          <>
-            <Plus className="h-3.5 w-3.5 shrink-0" />
-            <span>Add Repository</span>
-          </>
-        ) : (
-          <Button variant="default" size="sm">
-            <Plus className="h-4 w-4 mr-1" />
-            Add Repository
-          </Button>
-        )}
-      </button>
+      {variant === "sidebar" ? (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-[var(--color-text-tertiary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-secondary)] transition-colors"
+        >
+          <Plus className="h-3.5 w-3.5 shrink-0" />
+          <span>Add Repository</span>
+        </button>
+      ) : (
+        <Button variant="default" size="sm" onClick={() => setOpen(true)}>
+          <Plus className="h-4 w-4 mr-1" />
+          Add Repository
+        </Button>
+      )}
 
       <Dialog open={open} onOpenChange={(v) => { setOpen(v); if (!v) reset(); }}>
         <DialogContent className="sm:max-w-md">

--- a/packages/web/src/components/repos/operations-panel.tsx
+++ b/packages/web/src/components/repos/operations-panel.tsx
@@ -79,7 +79,9 @@ export function OperationsPanel({ repoId, repoName }: Props) {
             <CardTitle className="text-sm">Operations</CardTitle>
             <button
               onClick={() => setOpen((v) => !v)}
-              className="flex items-center gap-1 text-xs text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)] transition-colors"
+              aria-expanded={open}
+              aria-controls="operations-panel-content"
+              className="flex items-center gap-1 text-xs text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)] transition-colors cursor-pointer"
             >
               {open ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
               {open ? "Collapse" : "Configure"}
@@ -87,7 +89,7 @@ export function OperationsPanel({ repoId, repoName }: Props) {
           </div>
         </CardHeader>
 
-        <CardContent className="space-y-4">
+        <CardContent id="operations-panel-content" className="space-y-4">
           {/* Active job progress */}
           {activeJobId && (
             <GenerationProgress

--- a/packages/web/src/components/repos/repo-settings-form.tsx
+++ b/packages/web/src/components/repos/repo-settings-form.tsx
@@ -167,6 +167,8 @@ export function RepoSettingsForm({ repo }: RepoSettingsFormProps) {
         {/* Add input */}
         <div className="flex gap-2 max-w-sm">
           <Input
+            id="exclude-pattern"
+            aria-label="New excluded pattern"
             value={newPattern}
             onChange={(e) => setNewPattern(e.target.value)}
             onKeyDown={(e) => {

--- a/packages/web/src/components/repos/run-config-form.tsx
+++ b/packages/web/src/components/repos/run-config-form.tsx
@@ -51,9 +51,9 @@ export function RunConfigForm({ value, onChange }: Props) {
     <div className="space-y-4">
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
-          <Label>Provider</Label>
+          <Label htmlFor="run-provider">Provider</Label>
           <Select value={value.provider} onValueChange={(v) => set("provider", v)}>
-            <SelectTrigger>
+            <SelectTrigger id="run-provider" aria-label="Provider">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -108,12 +108,15 @@ export function RunConfigForm({ value, onChange }: Props) {
 
       <div className="space-y-2">
         <div className="flex items-center justify-between">
-          <Label>Concurrency</Label>
+          <Label htmlFor="run-concurrency">Concurrency</Label>
           <span className="text-sm tabular-nums text-[var(--color-text-secondary)]">
             {value.concurrency}
           </span>
         </div>
         <Slider
+          id="run-concurrency"
+          aria-label="Concurrency"
+          aria-valuetext={`${value.concurrency} parallel`}
           min={1}
           max={10}
           step={1}

--- a/packages/web/src/components/search/command-palette.tsx
+++ b/packages/web/src/components/search/command-palette.tsx
@@ -71,7 +71,7 @@ export function CommandPalette({ repos, workspace }: CommandPaletteProps) {
           </kbd>
         </div>
 
-        <Command.List className="max-h-80 overflow-y-auto py-2">
+        <Command.List className="max-h-[60dvh] overflow-y-auto py-2">
           <Command.Empty className="px-4 py-8 text-center text-sm text-[var(--color-text-tertiary)]">
             {isLoading ? "Searching…" : "No results found."}
           </Command.Empty>

--- a/packages/web/src/components/search/command-palette.tsx
+++ b/packages/web/src/components/search/command-palette.tsx
@@ -28,8 +28,13 @@ export function CommandPalette({ repos, workspace }: CommandPaletteProps) {
         setOpen((o) => !o);
       }
     };
+    const openHandler = () => setOpen(true);
     window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    window.addEventListener("repowise:open-command-palette", openHandler);
+    return () => {
+      window.removeEventListener("keydown", handler);
+      window.removeEventListener("repowise:open-command-palette", openHandler);
+    };
   }, []);
 
   const navigate = useCallback(
@@ -46,7 +51,7 @@ export function CommandPalette({ repos, workspace }: CommandPaletteProps) {
       open={open}
       onOpenChange={setOpen}
       label="Command palette"
-      className="fixed inset-0 z-[calc(var(--z-modal)+1)] flex items-start justify-center pt-[20vh]"
+      className="fixed inset-0 z-[calc(var(--z-modal)+1)] flex items-start justify-center pt-[10vh] sm:pt-[20vh] px-4"
     >
       <div
         className="fixed inset-0 bg-black/60 backdrop-blur-sm"

--- a/packages/web/src/components/search/search-result-card.tsx
+++ b/packages/web/src/components/search/search-result-card.tsx
@@ -37,7 +37,7 @@ export function SearchResultCard({ result, query, repoId }: SearchResultCardProp
       className="block rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-elevated)] transition-colors"
     >
       <div className="flex items-start justify-between gap-2 mb-1.5">
-        <h3 className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+        <h3 className="text-sm font-medium text-[var(--color-text-primary)] truncate" title={result.title}>
           {result.title}
         </h3>
         <div className="flex items-center gap-1.5 shrink-0">
@@ -56,7 +56,7 @@ export function SearchResultCard({ result, query, repoId }: SearchResultCardProp
           </span>
         </div>
       </div>
-      <p className="text-xs font-mono text-[var(--color-text-tertiary)] mb-2">
+      <p className="text-xs font-mono text-[var(--color-text-tertiary)] mb-2" title={result.target_path}>
         {truncatePath(result.target_path, 60)}
       </p>
       {result.snippet && (

--- a/packages/web/src/components/settings/connection-section.tsx
+++ b/packages/web/src/components/settings/connection-section.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { CheckCircle, XCircle, Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { config } from "@/lib/config";
 import { getHealth } from "@/lib/api/health";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
@@ -22,9 +23,24 @@ export function ConnectionSection() {
     setApiKey(config.getApiKey());
   }, []);
 
+  const initialUrlRef = useRef("");
+  const initialKeyRef = useRef("");
+
+  useEffect(() => {
+    initialUrlRef.current = config.getApiUrl();
+    initialKeyRef.current = config.getApiKey();
+  }, []);
+
   function save() {
+    const changed =
+      apiUrl !== initialUrlRef.current || apiKey !== initialKeyRef.current;
     config.setApiUrl(apiUrl);
     config.setApiKey(apiKey);
+    if (changed) {
+      initialUrlRef.current = apiUrl;
+      initialKeyRef.current = apiKey;
+      toast.success("Connection settings saved");
+    }
   }
 
   async function testConnection() {

--- a/packages/web/src/components/symbols/symbol-drawer.tsx
+++ b/packages/web/src/components/symbols/symbol-drawer.tsx
@@ -28,7 +28,7 @@ export function SymbolDrawer({ symbol, repoId, onClose }: SymbolDrawerProps) {
             <div className="px-6 pt-6 pb-3">
               <DialogHeader>
                 <DialogTitle className="font-mono text-base">{symbol.name}</DialogTitle>
-                <DialogDescription className="font-mono text-xs text-[var(--color-text-tertiary)]">
+                <DialogDescription className="font-mono text-xs text-[var(--color-text-tertiary)] break-all">
                   {symbol.file_path}:{symbol.start_line}
                 </DialogDescription>
               </DialogHeader>

--- a/packages/web/src/components/symbols/symbol-table.tsx
+++ b/packages/web/src/components/symbols/symbol-table.tsx
@@ -236,8 +236,17 @@ export function SymbolTable({ repoId }: SymbolTableProps) {
                 {sorted.map((sym) => (
                   <tr
                     key={sym.id}
-                    className="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] transition-colors last:border-0 cursor-pointer"
+                    className="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] transition-colors last:border-0 cursor-pointer focus:outline-none focus:bg-[var(--color-bg-elevated)]"
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`View ${sym.qualified_name || sym.name}`}
                     onClick={() => setSelected(sym)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setSelected(sym);
+                      }
+                    }}
                   >
                     <td className="px-4 py-2.5">
                       <ImportanceBar score={importanceScores.get(sym.id) ?? 0} />
@@ -259,7 +268,7 @@ export function SymbolTable({ repoId }: SymbolTableProps) {
                         {truncatePath(sym.file_path)}:{sym.start_line}
                       </span>
                     </td>
-                    <td className="px-4 py-2.5 text-xs text-[var(--color-text-secondary)] tabular-nums hidden sm:table-cell">
+                    <td className="px-4 py-2.5 text-xs text-[var(--color-text-secondary)] tabular-nums hidden sm:table-cell text-right">
                       <span
                         className={cn(
                           sym.complexity_estimate > 15

--- a/packages/web/src/components/symbols/symbol-table.tsx
+++ b/packages/web/src/components/symbols/symbol-table.tsx
@@ -204,13 +204,21 @@ export function SymbolTable({ repoId }: SymbolTableProps) {
         <>
           <div className="rounded-lg border border-[var(--color-border-default)] overflow-x-auto">
             <table className="w-full text-sm">
-              <thead>
+              <thead className="sticky top-0 z-10">
                 <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
                   {columns.map(({ col, label, hideOnMobile }) => (
                     <th
                       key={col}
+                      scope="col"
+                      aria-sort={
+                        sortCol === col
+                          ? sortDir === "asc"
+                            ? "ascending"
+                            : "descending"
+                          : "none"
+                      }
                       className={cn(
-                        "px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider cursor-pointer select-none hover:text-[var(--color-text-primary)] transition-colors",
+                        "px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider cursor-pointer select-none hover:text-[var(--color-text-primary)] transition-colors bg-[var(--color-bg-elevated)]",
                         hideOnMobile && "hidden sm:table-cell",
                       )}
                       onClick={() => handleSort(col)}
@@ -234,10 +242,10 @@ export function SymbolTable({ repoId }: SymbolTableProps) {
                     <td className="px-4 py-2.5">
                       <ImportanceBar score={importanceScores.get(sym.id) ?? 0} />
                     </td>
-                    <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-primary)] min-w-0" style={{ maxWidth: 0 }}>
+                    <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-primary)] min-w-[200px] max-w-[420px]">
                       <span className="truncate block" title={sym.qualified_name || sym.name}>{sym.name}</span>
                       {sym.parent_name && (
-                        <span className="text-[var(--color-text-tertiary)]">.{sym.parent_name}</span>
+                        <span className="block truncate text-[var(--color-text-tertiary)]" title={sym.parent_name}>.{sym.parent_name}</span>
                       )}
                     </td>
                     <td className="px-4 py-2.5">
@@ -246,7 +254,7 @@ export function SymbolTable({ repoId }: SymbolTableProps) {
                     <td className="px-4 py-2.5 text-xs text-[var(--color-text-secondary)] hidden sm:table-cell">
                       {sym.language}
                     </td>
-                    <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-tertiary)] min-w-0 hidden sm:table-cell" style={{ maxWidth: 0 }}>
+                    <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-tertiary)] min-w-[200px] max-w-[420px] hidden sm:table-cell">
                       <span className="block truncate" title={`${sym.file_path}:${sym.start_line}`}>
                         {truncatePath(sym.file_path)}:{sym.start_line}
                       </span>

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -28,12 +28,16 @@ const badgeVariants = cva(
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
+  extends React.HTMLAttributes<HTMLSpanElement>,
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+    <span
+      className={cn(badgeVariants({ variant }), className)}
+      role={variant && ["fresh", "stale", "outdated"].includes(variant) ? "status" : undefined}
+      {...props}
+    />
   );
 }
 

--- a/packages/web/src/components/ui/confirm-dialog.tsx
+++ b/packages/web/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import * as React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  loading?: boolean;
+  onConfirm: () => void | Promise<void>;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive = false,
+  loading = false,
+  onConfirm,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description && <DialogDescription>{description}</DialogDescription>}
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={loading}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            onClick={async () => {
+              await onConfirm();
+            }}
+            disabled={loading}
+            className={
+              destructive
+                ? "bg-red-600 text-white hover:bg-red-700"
+                : undefined
+            }
+          >
+            {loading ? "Working…" : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/components/wiki/code-block.tsx
+++ b/packages/web/src/components/wiki/code-block.tsx
@@ -35,7 +35,8 @@ export function CodeBlock({ code, language, html }: Props) {
             "ml-auto flex items-center gap-1 text-xs text-[var(--color-text-tertiary)]",
             "hover:text-[var(--color-text-secondary)] transition-colors",
           )}
-          aria-label="Copy code"
+          aria-label={copied ? "Copied" : "Copy code"}
+          aria-live="polite"
         >
           {copied ? (
             <>

--- a/packages/web/src/components/wiki/mermaid-diagram.tsx
+++ b/packages/web/src/components/wiki/mermaid-diagram.tsx
@@ -32,6 +32,15 @@ export function MermaidDiagram({ chart }: Props) {
         .render(id, chart)
         .then(({ svg }) => {
           el.innerHTML = svg;
+          // Make the rendered SVG fluid so it reflows on narrow viewports
+          // instead of forcing horizontal scroll.
+          const svgEl = el.querySelector("svg");
+          if (svgEl) {
+            svgEl.removeAttribute("width");
+            svgEl.removeAttribute("height");
+            svgEl.style.maxWidth = "100%";
+            svgEl.style.height = "auto";
+          }
         })
         .catch((e: unknown) => {
           setError(e instanceof Error ? e.message : "Diagram render failed");
@@ -48,9 +57,12 @@ export function MermaidDiagram({ chart }: Props) {
   }
 
   return (
-    <div
-      ref={ref}
+    <figure
+      role="img"
+      aria-label="Mermaid diagram"
       className="my-4 flex justify-center overflow-x-auto rounded border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4"
-    />
+    >
+      <div ref={ref} className="w-full" />
+    </figure>
   );
 }

--- a/packages/web/src/components/wiki/wiki-renderer.tsx
+++ b/packages/web/src/components/wiki/wiki-renderer.tsx
@@ -28,8 +28,9 @@ const mdxComponents = {
   // Code blocks — pass Shiki-highlighted HTML via a server action wrapper
   // The actual Shiki call happens in the pre/code override below.
   h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => {
+    // Downgrade article-body H1 to H2 to keep the page header as the sole H1.
     const id = slugify(extractText(props.children));
-    return <h1 id={id} className="mt-8 mb-4 text-xl font-semibold text-[var(--color-text-primary)] first:mt-0 scroll-mt-16" {...props} />;
+    return <h2 id={id} className="mt-8 mb-4 text-xl font-semibold text-[var(--color-text-primary)] first:mt-0 scroll-mt-16" {...props} />;
   },
   h2: (props: React.HTMLAttributes<HTMLHeadingElement>) => {
     const id = slugify(extractText(props.children));

--- a/packages/web/src/components/workspace/co-change-table.tsx
+++ b/packages/web/src/components/workspace/co-change-table.tsx
@@ -30,20 +30,20 @@ export function CoChangeTable({ coChanges, compact }: CoChangeTableProps) {
           </tr>
         </thead>
         <tbody className="divide-y divide-[var(--color-border-default)]">
-          {coChanges.map((cc, i) => (
-            <tr key={i} className="hover:bg-[var(--color-bg-elevated)] transition-colors">
-              <td className="py-2 pr-4">
+          {coChanges.map((cc) => (
+            <tr key={`${cc.source_repo}|${cc.source_file}|${cc.target_repo}|${cc.target_file}`} className="hover:bg-[var(--color-bg-elevated)] transition-colors">
+              <td className="py-2 pr-4 min-w-[160px] max-w-[280px]">
                 <div className="flex flex-col gap-0.5">
                   <Badge variant="default" className="w-fit text-[11px]">{cc.source_repo}</Badge>
-                  <span className="text-xs font-mono text-[var(--color-text-secondary)] truncate max-w-[250px]">
+                  <span className="text-xs font-mono text-[var(--color-text-secondary)] truncate block" title={cc.source_file}>
                     {cc.source_file}
                   </span>
                 </div>
               </td>
-              <td className="py-2 pr-4">
+              <td className="py-2 pr-4 min-w-[160px] max-w-[280px]">
                 <div className="flex flex-col gap-0.5">
                   <Badge variant="default" className="w-fit text-[11px]">{cc.target_repo}</Badge>
-                  <span className="text-xs font-mono text-[var(--color-text-secondary)] truncate max-w-[250px]">
+                  <span className="text-xs font-mono text-[var(--color-text-secondary)] truncate block" title={cc.target_file}>
                     {cc.target_file}
                   </span>
                 </div>
@@ -62,12 +62,12 @@ export function CoChangeTable({ coChanges, compact }: CoChangeTableProps) {
                 </div>
               </td>
               {!compact && (
-                <td className="py-2 pr-4 text-xs text-[var(--color-text-secondary)] tabular-nums">
+                <td className="py-2 pr-4 text-xs text-[var(--color-text-secondary)] tabular-nums text-right">
                   {cc.frequency}x
                 </td>
               )}
               {!compact && (
-                <td className="py-2 text-xs text-[var(--color-text-tertiary)]">
+                <td className="py-2 text-xs text-[var(--color-text-tertiary)]" title={cc.last_date ? new Date(cc.last_date).toLocaleString() : undefined}>
                   {cc.last_date ? new Date(cc.last_date).toLocaleDateString() : "—"}
                 </td>
               )}

--- a/packages/web/src/components/workspace/contract-links-table.tsx
+++ b/packages/web/src/components/workspace/contract-links-table.tsx
@@ -31,8 +31,8 @@ export function ContractLinksTable({ links }: ContractLinksTableProps) {
         <tbody className="divide-y divide-[var(--color-border-default)]">
           {links.map((link, i) => (
             <tr key={i} className="hover:bg-[var(--color-bg-elevated)] transition-colors">
-              <td className="py-2 pr-4">
-                <span className="text-xs font-mono text-[var(--color-text-secondary)] break-all">
+              <td className="py-2 pr-4 min-w-[140px] max-w-[280px]">
+                <span className="text-xs font-mono text-[var(--color-text-secondary)] [overflow-wrap:anywhere]" title={link.contract_id}>
                   {link.contract_id}
                 </span>
               </td>
@@ -44,7 +44,7 @@ export function ContractLinksTable({ links }: ContractLinksTableProps) {
                   <span className="text-xs font-medium text-[var(--color-text-primary)]">
                     {link.provider_repo}
                   </span>
-                  <span className="text-xs font-mono text-[var(--color-text-tertiary)] truncate max-w-[200px]">
+                  <span className="text-xs font-mono text-[var(--color-text-tertiary)] truncate min-w-[140px] max-w-[260px] block" title={link.provider_file}>
                     {link.provider_file}
                   </span>
                 </div>
@@ -54,7 +54,7 @@ export function ContractLinksTable({ links }: ContractLinksTableProps) {
                   <span className="text-xs font-medium text-[var(--color-text-primary)]">
                     {link.consumer_repo}
                   </span>
-                  <span className="text-xs font-mono text-[var(--color-text-tertiary)] truncate max-w-[200px]">
+                  <span className="text-xs font-mono text-[var(--color-text-tertiary)] truncate min-w-[140px] max-w-[260px] block" title={link.consumer_file}>
                     {link.consumer_file}
                   </span>
                 </div>

--- a/packages/web/src/components/workspace/repo-card.tsx
+++ b/packages/web/src/components/workspace/repo-card.tsx
@@ -38,7 +38,7 @@ export function RepoCard({
                 </Badge>
               )}
             </div>
-            <p className="text-xs text-[var(--color-text-tertiary)] font-mono mt-0.5 truncate">
+            <p className="text-xs text-[var(--color-text-tertiary)] font-mono mt-0.5 truncate" title={`${alias} · ${path}`}>
               {alias} &middot; {path}
             </p>
           </div>

--- a/packages/web/src/lib/api/client.ts
+++ b/packages/web/src/lib/api/client.ts
@@ -38,7 +38,7 @@ function buildHeaders(extra?: Record<string, string>): Headers {
   return headers;
 }
 
-class ApiClientError extends Error {
+export class ApiClientError extends Error {
   constructor(
     public readonly status: number,
     public readonly detail: string,
@@ -134,4 +134,4 @@ export async function apiDelete<T>(
   return handleResponse<T>(res);
 }
 
-export { ApiClientError, BASE_URL, buildHeaders };
+export { BASE_URL, buildHeaders };

--- a/packages/web/src/lib/api/jobs.ts
+++ b/packages/web/src/lib/api/jobs.ts
@@ -1,4 +1,4 @@
-import { apiGet } from "./client";
+import { apiGet, apiPost } from "./client";
 import type { JobResponse } from "./types";
 
 export async function listJobs(opts?: {
@@ -12,6 +12,12 @@ export async function listJobs(opts?: {
 
 export async function getJob(jobId: string): Promise<JobResponse> {
   return apiGet<JobResponse>(`/api/jobs/${jobId}`);
+}
+
+/** Cancel a pending or running job. Marks it failed so the active-job
+ * guard releases and a new sync can be started. */
+export async function cancelJob(jobId: string): Promise<JobResponse> {
+  return apiPost<JobResponse>(`/api/jobs/${jobId}/cancel`);
 }
 
 /** Returns the SSE stream URL for a job. Use with EventSource or the useSSE hook. */

--- a/packages/web/src/lib/utils/format.ts
+++ b/packages/web/src/lib/utils/format.ts
@@ -14,8 +14,9 @@ export function formatTokens(n: number): string {
   return formatNumber(n);
 }
 
-/** Format USD cost: 0.004 → "$0.00", 4.2 → "$4.20", 18.6 → "$18.60" */
+/** Format USD cost: 0.004 → "<$0.01", 4.2 → "$4.20", 18.6 → "$18.60" */
 export function formatCost(usd: number): string {
+  if (usd > 0 && usd < 0.01) return "<$0.01";
   return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: "USD",

--- a/packages/web/src/styles/globals.css
+++ b/packages/web/src/styles/globals.css
@@ -54,6 +54,15 @@
   --color-error: #ef4444;
   --color-info: #f59520;
 
+  /* Aliases — short names used in component class strings.              */
+  /* Keep these in sync with the canonical confidence/accent tokens.     */
+  --color-fresh: var(--color-confidence-fresh);
+  --color-stale: var(--color-confidence-stale);
+  --color-outdated: var(--color-confidence-outdated);
+  --color-accent: var(--color-accent-primary);
+  --color-accent-blue: var(--color-accent-primary);
+  --color-border-accent: var(--color-accent-primary);
+
   /* ------------------------------------------------------------------ */
   /* Graph — React Flow                                                  */
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary

Bundle of doc refreshes, UI/UX audit fixes, and jobs/persistence reliability improvements that accumulated on this branch.

## Changes

- **Docs:** refreshed `packages/web` and `packages/server` READMEs; shipped UI/UX audit notes and first fix pass.
- **Web UI:** closed remaining audit items — confirmation dialogs, mobile breakpoints, a11y fixes, loading/empty/error states.
- **Jobs:**
  - new cancel endpoint, hydrated progress reporting, and stuck-job detection
  - reset stale `pending` jobs on server startup (not just `running`)
  - per-repo DB in workspace mode to avoid cross-repo contention
  - reduce SQLite write contention during sync
- **Repo hygiene:** `.gitignore` excludes local scratch dirs (`GitNexus/`, `graphify/`, `test-repos/`), Office temp files, and local-only planning docs.

## Test plan

- [ ] `pytest` green on server tests covering jobs reset/cancel/stuck-detection
- [ ] Manual smoke: index a repo, cancel mid-run, confirm cleanup
- [ ] Manual smoke: kill server during indexing, restart, confirm `pending` jobs reset
- [ ] Manual smoke: workspace mode indexes two repos without DB contention errors
- [ ] Web UI: spot-check confirmation dialogs, mobile layout at 375px, a11y with keyboard nav