### PR TITLE
feat: shared @repowise/types and @repowise/ui packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "repowise-root",
       "version": "0.1.0",
       "workspaces": [
+        "packages/types",
+        "packages/ui",
         "packages/web"
       ],
       "engines": {
@@ -148,6 +150,397 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -423,6 +816,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -445,6 +839,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -467,6 +862,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -483,6 +879,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -499,6 +896,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -515,6 +913,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -531,6 +930,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -547,6 +947,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -563,6 +964,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -579,6 +981,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -595,6 +998,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -611,6 +1015,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -627,6 +1032,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -649,6 +1055,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -671,6 +1078,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -693,6 +1101,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -715,6 +1124,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -737,6 +1147,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -759,6 +1170,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -781,6 +1193,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -800,6 +1213,7 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -822,6 +1236,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -841,6 +1256,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -860,6 +1276,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -2439,6 +2856,360 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@repowise/types": {
+      "resolved": "packages/types",
+      "link": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3768,6 +4539,133 @@
         "d3-transition": "^3.0.1"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xyflow/react": {
       "version": "12.10.2",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
@@ -4043,6 +4941,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -4159,6 +5067,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4249,6 +5167,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4304,6 +5239,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chevrotain": {
@@ -5088,6 +6033,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5376,6 +6331,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5466,6 +6428,45 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -6009,6 +7010,16 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -6208,6 +7219,21 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -7694,6 +8720,13 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lucide-react": {
       "version": "0.460.0",
@@ -9392,6 +10425,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10038,6 +11081,51 @@
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
       "license": "Unlicense"
     },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/roughjs": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
@@ -10369,6 +11457,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -10411,6 +11506,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10701,6 +11810,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -10725,6 +11841,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -11234,6 +12380,176 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -11388,6 +12704,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -11462,6 +12795,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/types": {
+      "name": "@repowise/types",
+      "version": "0.0.1",
+      "devDependencies": {
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
       }
     },
     "packages/web": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2860,6 +2860,10 @@
       "resolved": "packages/types",
       "link": true
     },
+    "node_modules/@repowise/ui": {
+      "resolved": "packages/ui",
+      "link": true
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -12803,6 +12807,25 @@
       "devDependencies": {
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
+      }
+    },
+    "packages/ui": {
+      "name": "@repowise/ui",
+      "version": "0.0.1",
+      "dependencies": {
+        "@repowise/types": "*"
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "packages/web": {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
   "private": true,
   "description": "Root workspace configuration for repowise monorepo",
   "workspaces": [
+    "packages/types",
+    "packages/ui",
     "packages/web"
   ],
   "scripts": {
     "dev": "cd packages/web && npm run dev",
-    "build": "cd packages/web && npm run build",
-    "lint": "cd packages/web && npm run lint",
-    "type-check": "cd packages/web && npm run type-check"
+    "build": "npm run build --workspaces --if-present",
+    "lint": "npm run lint --workspaces --if-present",
+    "type-check": "npm run type-check --workspaces --if-present",
+    "test": "npm run test --workspaces --if-present"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/types/__tests__/contracts.test.ts
+++ b/packages/types/__tests__/contracts.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Type-level tests for non-trivial contracts in @repowise/types (per
+ * docs/HOSTED_IMPLEMENTATION_GUIDE.md §2.6 — "type-level test where the
+ * contract is non-trivial"). These run via `vitest --typecheck` and fail at
+ * tsc time if a canonical type drifts from what consumers depend on.
+ *
+ * Coverage focus:
+ *   - ChatArtifact discriminated union: narrowing by `type` must surface
+ *     the per-variant `data` shape.
+ *   - GraphLink: backwards-compatible additions (edge_type, confidence) are
+ *     optional, not required.
+ *   - DeadCodeFinding: hosted-only enrichment fields stay optional so
+ *     OSS-shaped artifacts still satisfy the contract.
+ *   - DecisionRecord: status + source are union literals, not bare strings.
+ *   - Hotspot vs hosted HotspotEntry: the canonical Hotspot uses `file_path`,
+ *     not `path`, so a raw hosted entry should NOT be assignable.
+ */
+
+import { describe, expectTypeOf, it } from "vitest";
+import type {
+  ChatArtifact,
+  KnownChatArtifact,
+  GraphArtifact,
+  HotspotArtifact,
+  AnswerArtifact,
+  GenericArtifact,
+} from "../src/chat.js";
+import type { GraphLink, GraphExport } from "../src/graph.js";
+import type { DeadCodeFinding } from "../src/dead-code.js";
+import type { DecisionRecord, DecisionStatus } from "../src/decisions.js";
+import type { Hotspot } from "../src/git.js";
+
+describe("ChatArtifact discriminated union", () => {
+  it("narrows on .type to the per-variant data shape", () => {
+    const narrow = (a: KnownChatArtifact) => {
+      if (a.type === "graph") {
+        expectTypeOf(a).toEqualTypeOf<GraphArtifact>();
+        expectTypeOf(a.data).toEqualTypeOf<GraphExport>();
+      } else if (a.type === "hotspot") {
+        expectTypeOf(a).toEqualTypeOf<HotspotArtifact>();
+        expectTypeOf(a.data.hotspots).toEqualTypeOf<Hotspot[]>();
+      } else if (a.type === "answer") {
+        expectTypeOf(a).toEqualTypeOf<AnswerArtifact>();
+        expectTypeOf(a.data.confidence).toEqualTypeOf<"high" | "medium" | "low">();
+      }
+    };
+    expectTypeOf(narrow).toBeFunction();
+  });
+
+  it("falls through to GenericArtifact for unknown tool types", () => {
+    const generic: ChatArtifact = {
+      type: "future_tool_we_havent_typed_yet",
+      data: { whatever: 1 },
+    };
+    expectTypeOf(generic).toMatchTypeOf<GenericArtifact>();
+  });
+});
+
+describe("GraphLink backwards compatibility", () => {
+  it("requires only source/target/imported_names; v0.4.x extras are optional", () => {
+    const minimal: GraphLink = {
+      source: "a.ts",
+      target: "b.ts",
+      imported_names: [],
+    };
+    expectTypeOf(minimal).toEqualTypeOf<GraphLink>();
+    expectTypeOf<GraphLink["edge_type"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<GraphLink["confidence"]>().toEqualTypeOf<number | undefined>();
+  });
+});
+
+describe("DeadCodeFinding hosted-only enrichment", () => {
+  it("treats engine-raw fields (evidence, package, etc.) as optional", () => {
+    const minimal: DeadCodeFinding = {
+      id: "f1",
+      kind: "unreachable_file",
+      file_path: "src/foo.ts",
+      symbol_name: null,
+      symbol_kind: null,
+      confidence: 0.9,
+      reason: "no inbound edges",
+      lines: 12,
+      safe_to_delete: true,
+      primary_owner: null,
+      status: "open",
+      note: null,
+    };
+    expectTypeOf(minimal).toEqualTypeOf<DeadCodeFinding>();
+    expectTypeOf<DeadCodeFinding["evidence"]>().toEqualTypeOf<
+      string[] | null | undefined
+    >();
+  });
+});
+
+describe("DecisionRecord literal unions", () => {
+  it("constrains status to the four-literal union", () => {
+    expectTypeOf<DecisionStatus>().toEqualTypeOf<
+      "proposed" | "active" | "deprecated" | "superseded"
+    >();
+    expectTypeOf<DecisionRecord["status"]>().toEqualTypeOf<DecisionStatus>();
+  });
+});
+
+describe("Canonical Hotspot key shape", () => {
+  it("uses file_path, not path — hosted's HotspotEntry must be adapted", () => {
+    expectTypeOf<Hotspot>().toHaveProperty("file_path").toEqualTypeOf<string>();
+    // Hosted backend's raw shape uses `path`. A `{ path: ... }` object should
+    // NOT satisfy Hotspot; this is the contract that forces an adapter call.
+    type HostedRawHotspot = { path: string };
+    expectTypeOf<HostedRawHotspot>().not.toMatchTypeOf<Hotspot>();
+  });
+});

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@repowise/types",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Canonical TypeScript data contracts shared between OSS web (packages/web) and hosted web (frontend/, future packages/hosted-web)",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./graph": "./src/graph.ts",
+    "./git": "./src/git.ts",
+    "./docs": "./src/docs.ts",
+    "./decisions": "./src/decisions.ts",
+    "./dead-code": "./src/dead-code.ts",
+    "./symbols": "./src/symbols.ts",
+    "./chat": "./src/chat.ts"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit",
+    "test": "vitest run --typecheck"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/types/src/chat.ts
+++ b/packages/types/src/chat.ts
@@ -1,0 +1,155 @@
+/**
+ * Canonical chat types — conversation, messages, and the discriminated-union
+ * `ChatArtifact` type that lets the hosted UI render tool results as
+ * mini-visualizations instead of `<pre>{JSON}</pre>`.
+ *
+ * The discriminated union is **net-new** in @repowise/types — neither OSS nor
+ * hosted previously had compile-time typing for tool-result artifacts.
+ * Phase 2B's `chat/artifact-panel.tsx` will switch on `artifact.type` to pick
+ * a renderer.
+ */
+
+import type { GraphExport } from "./graph.js";
+import type { Hotspot } from "./git.js";
+import type { DeadCodeFinding } from "./dead-code.js";
+import type { DecisionRecord } from "./decisions.js";
+
+// ---------------------------------------------------------------------------
+// Conversations + messages
+// ---------------------------------------------------------------------------
+
+export interface Conversation {
+  id: string;
+  repository_id: string;
+  title: string;
+  message_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ChatToolCall {
+  id: string;
+  name: string;
+  arguments?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+}
+
+export interface ChatMessage {
+  id: string;
+  conversation_id: string;
+  role: "user" | "assistant";
+  content: {
+    text?: string;
+    tool_calls?: ChatToolCall[];
+  };
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tool-result artifacts (discriminated union)
+// ---------------------------------------------------------------------------
+
+/**
+ * Common citation surface emitted alongside any artifact when the tool
+ * referenced specific files/symbols. Drives `chat/source-citations.tsx`.
+ */
+export interface ChatCitation {
+  file_path: string;
+  symbol_name?: string;
+  start_line?: number;
+  end_line?: number;
+}
+
+export interface GraphArtifact {
+  type: "graph";
+  data: GraphExport;
+}
+
+export interface HotspotArtifact {
+  type: "hotspot";
+  data: { hotspots: Hotspot[] };
+}
+
+export interface DeadCodeArtifact {
+  type: "dead_code";
+  data: { findings: DeadCodeFinding[] };
+}
+
+export interface DecisionsArtifact {
+  type: "decisions";
+  data: { decisions: DecisionRecord[] };
+}
+
+export interface AnswerArtifact {
+  type: "answer";
+  data: {
+    answer: string;
+    citations: ChatCitation[];
+    confidence: "high" | "medium" | "low";
+  };
+}
+
+/**
+ * Fallback for tools that haven't yet been promoted to a typed variant.
+ * The renderer falls back to JSON pretty-print for this case.
+ */
+export interface GenericArtifact {
+  type: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * Typed variants only — use this when a consumer needs to narrow on `.type`
+ * and access the per-variant `data` shape. The renderer's `switch` exhaust
+ * check should be against this type.
+ */
+export type KnownChatArtifact =
+  | GraphArtifact
+  | HotspotArtifact
+  | DeadCodeArtifact
+  | DecisionsArtifact
+  | AnswerArtifact;
+
+/**
+ * Full union accepted on the wire. Consumers should branch on
+ * `isKnownChatArtifact(a)` first, then switch on `a.type` for a typed render
+ * path; the `else` falls through to a JSON pretty-print.
+ */
+export type ChatArtifact = KnownChatArtifact | GenericArtifact;
+
+const KNOWN_ARTIFACT_TYPES: ReadonlyArray<KnownChatArtifact["type"]> = [
+  "graph",
+  "hotspot",
+  "dead_code",
+  "decisions",
+  "answer",
+];
+
+export function isKnownChatArtifact(
+  a: ChatArtifact,
+): a is KnownChatArtifact {
+  return (KNOWN_ARTIFACT_TYPES as readonly string[]).includes(a.type);
+}
+
+// ---------------------------------------------------------------------------
+// SSE event stream
+// ---------------------------------------------------------------------------
+
+export type ChatSSEEvent =
+  | { type: "text_delta"; text: string }
+  | {
+      type: "tool_start";
+      tool_id: string;
+      tool_name: string;
+      input: Record<string, unknown>;
+    }
+  | {
+      type: "tool_result";
+      tool_id: string;
+      tool_name: string;
+      summary: string;
+      artifact: ChatArtifact;
+      citations?: ChatCitation[];
+    }
+  | { type: "done"; conversation_id: string; message_id: string }
+  | { type: "error"; message: string };

--- a/packages/types/src/dead-code.ts
+++ b/packages/types/src/dead-code.ts
@@ -1,0 +1,44 @@
+/**
+ * Canonical dead-code finding types.
+ *
+ * Canonical source: OSS engine `DeadCodeFindingResponse` + `DeadCodeSummaryResponse`.
+ * Hosted's engine artifact has extra raw-shape fields (`evidence`, `package`,
+ * `last_commit_at`, `commit_count_90d`, `age_days`) — preserved here as
+ * optional so hosted adapters don't lose information when normalising.
+ */
+
+export type DeadCodeStatus = "open" | "wont_fix" | "deleted" | string;
+
+export interface DeadCodeFinding {
+  id: string;
+  kind: string;
+  file_path: string;
+  symbol_name: string | null;
+  symbol_kind: string | null;
+  confidence: number;
+  reason: string;
+  lines: number;
+  safe_to_delete: boolean;
+  primary_owner: string | null;
+  status: DeadCodeStatus;
+  note: string | null;
+  /** Raw engine artifact fields (present in hosted's pipeline output, optional in OSS). */
+  evidence?: string[] | null;
+  package?: string | null;
+  last_commit_at?: string | null;
+  commit_count_90d?: number;
+  age_days?: number | null;
+}
+
+export interface DeadCodePatchInput {
+  status: DeadCodeStatus;
+  note?: string;
+}
+
+export interface DeadCodeSummary {
+  total_findings: number;
+  confidence_summary: Record<string, number>;
+  deletable_lines: number;
+  total_lines: number;
+  by_kind: Record<string, number>;
+}

--- a/packages/types/src/decisions.ts
+++ b/packages/types/src/decisions.ts
@@ -1,0 +1,74 @@
+/**
+ * Canonical decision-record types.
+ *
+ * Canonical source: OSS engine `DecisionRecordResponse`. Hosted's `DecisionEntry`
+ * is missing `repository_id` and uses `string` for `status`/`source` instead of
+ * union literals — adapters fill defaults.
+ */
+
+export type DecisionStatus =
+  | "proposed"
+  | "active"
+  | "deprecated"
+  | "superseded";
+
+export type DecisionSource =
+  | "git_archaeology"
+  | "inline_marker"
+  | "readme_mining"
+  | "cli";
+
+export interface DecisionRecord {
+  id: string;
+  repository_id: string;
+  title: string;
+  status: DecisionStatus;
+  context: string;
+  decision: string;
+  rationale: string;
+  alternatives: string[];
+  consequences: string[];
+  affected_files: string[];
+  affected_modules: string[];
+  tags: string[];
+  source: DecisionSource;
+  evidence_commits: string[];
+  evidence_file: string | null;
+  evidence_line: number | null;
+  confidence: number;
+  staleness_score: number;
+  superseded_by: string | null;
+  last_code_change: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DecisionCreateInput {
+  title: string;
+  context?: string;
+  decision?: string;
+  rationale?: string;
+  alternatives?: string[];
+  consequences?: string[];
+  affected_files?: string[];
+  affected_modules?: string[];
+  tags?: string[];
+}
+
+export interface DecisionStatusUpdate {
+  status: DecisionStatus | string;
+  superseded_by?: string;
+}
+
+export interface DecisionHealth {
+  summary: {
+    active: number;
+    proposed: number;
+    deprecated: number;
+    superseded: number;
+    stale: number;
+  };
+  stale_decisions: DecisionRecord[];
+  proposed_awaiting_review: DecisionRecord[];
+  ungoverned_hotspots: string[];
+}

--- a/packages/types/src/docs.ts
+++ b/packages/types/src/docs.ts
@@ -1,0 +1,63 @@
+/**
+ * Canonical doc/wiki types — wiki pages, freshness, coverage rollups.
+ *
+ * Canonical source: OSS engine `PageResponse` (`packages/server/.../schemas.py`).
+ * Hosted backend's `DocsResponse.pages` and `CoverageResponse.pages` are
+ * currently typed `Array<Record<string, unknown>>` — adapters in
+ * `frontend/` cast through these types.
+ */
+
+export type FreshnessStatus = "fresh" | "stale" | "outdated" | string;
+
+export interface DocPage {
+  id: string;
+  repository_id: string;
+  page_type: string;
+  title: string;
+  content: string;
+  target_path: string;
+  source_hash: string;
+  model_name: string;
+  provider_name: string;
+  input_tokens: number;
+  output_tokens: number;
+  cached_tokens: number;
+  generation_level: number;
+  version: number;
+  confidence: number;
+  freshness_status: FreshnessStatus;
+  metadata: Record<string, unknown>;
+  human_notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DocPageVersion {
+  id: string;
+  page_id: string;
+  version: number;
+  page_type: string;
+  title: string;
+  content: string;
+  source_hash: string;
+  model_name: string;
+  provider_name: string;
+  input_tokens: number;
+  output_tokens: number;
+  confidence: number;
+  archived_at: string;
+}
+
+export interface DocPageList {
+  pages: DocPage[];
+  total: number;
+}
+
+export interface CoverageRollup {
+  available: boolean;
+  total_pages: number;
+  fresh: number;
+  stale: number;
+  outdated: number;
+  pages: DocPage[];
+}

--- a/packages/types/src/git.ts
+++ b/packages/types/src/git.ts
@@ -1,0 +1,110 @@
+/**
+ * Canonical git-intelligence types — hotspots, ownership, bus factor, summary.
+ *
+ * Canonical source: OSS engine `PipelineResult.git_metadata` (per-file) and
+ * the rollups produced by `packages/web` UI. Hosted backend's `HotspotEntry`
+ * uses `path` instead of `file_path`; hosted-side adapters rename.
+ */
+
+export interface FileAuthor {
+  name: string;
+  email: string;
+  commit_count: number;
+  pct: number;
+}
+
+export interface SignificantCommit {
+  sha: string;
+  date: string;
+  message: string;
+  author: string;
+}
+
+export interface CoChangePartner {
+  file_path: string;
+  co_change_count: number;
+}
+
+export interface GitMetadata {
+  file_path: string;
+  commit_count_total: number;
+  commit_count_90d: number;
+  commit_count_30d: number;
+  first_commit_at: string | null;
+  last_commit_at: string | null;
+  primary_owner_name: string | null;
+  primary_owner_email: string | null;
+  primary_owner_commit_pct: number | null;
+  recent_owner_name: string | null;
+  recent_owner_commit_pct: number | null;
+  top_authors: FileAuthor[];
+  significant_commits: SignificantCommit[];
+  co_change_partners: CoChangePartner[];
+  is_hotspot: boolean;
+  is_stable: boolean;
+  churn_percentile: number;
+  age_days: number;
+  bus_factor: number;
+  contributor_count: number;
+  lines_added_90d: number;
+  lines_deleted_90d: number;
+  avg_commit_size: number;
+  commit_categories: Record<string, number>;
+  merge_commit_count_90d: number;
+  test_gap?: boolean | null;
+  /** v0.2.0+ — combined recency × churn × ownership score. Order hotspots by this when present. */
+  temporal_hotspot_score?: number | null;
+}
+
+export interface Hotspot {
+  file_path: string;
+  commit_count_90d: number;
+  commit_count_30d: number;
+  churn_percentile: number;
+  temporal_hotspot_score?: number | null;
+  primary_owner: string | null;
+  is_hotspot: boolean;
+  is_stable: boolean;
+  bus_factor: number;
+  contributor_count: number;
+  lines_added_90d: number;
+  lines_deleted_90d: number;
+  avg_commit_size: number;
+  commit_categories: Record<string, number>;
+}
+
+export interface OwnershipEntry {
+  module_path: string;
+  primary_owner: string | null;
+  owner_pct: number | null;
+  file_count: number;
+  is_silo: boolean;
+}
+
+export interface TopOwner {
+  name: string;
+  email?: string;
+  file_count: number;
+  pct: number;
+}
+
+export interface GitSummary {
+  total_files: number;
+  hotspot_count: number;
+  stable_count: number;
+  average_churn_percentile: number;
+  top_owners: TopOwner[];
+}
+
+export interface BusFactorEntry {
+  path: string;
+  bus_factor: number;
+  top_author: string;
+  top_author_pct: number;
+  contributor_count: number;
+}
+
+export interface BusFactor {
+  files: BusFactorEntry[];
+  overall_bus_factor: number;
+}

--- a/packages/types/src/graph.ts
+++ b/packages/types/src/graph.ts
@@ -1,0 +1,241 @@
+/**
+ * Canonical graph types — file/module dependency graph plus graph-intelligence
+ * surfaces (callers/callees, communities, execution flows, metrics).
+ *
+ * Canonical source: OSS engine `PipelineResult.graph` (NetworkX node_link_data
+ * format) and the per-symbol intelligence endpoints in
+ * `packages/server/src/repowise/server/schemas.py`.
+ *
+ * Hosted backend currently emits a looser `{ nodes, links, directed?, multigraph? }`
+ * shape (see `frontend/src/lib/api/types.ts:CanonicalGraph`). Hosted-side
+ * adapters are responsible for converting that to `GraphExport` below.
+ */
+
+// ---------------------------------------------------------------------------
+// Core node + link
+// ---------------------------------------------------------------------------
+
+export interface GraphNode {
+  node_id: string;
+  node_type: string;
+  language: string;
+  symbol_count: number;
+  pagerank: number;
+  betweenness: number;
+  community_id: number;
+  is_test: boolean;
+  is_entry_point: boolean;
+  has_doc: boolean;
+}
+
+export interface GraphLink {
+  source: string;
+  target: string;
+  imported_names: string[];
+  /** Edge kind from v0.4.0 framework-aware extractors (e.g. "spring.bean", "rails.route"). */
+  edge_type?: string;
+  /** Confidence score for resolved symbol-level call edges (v0.4.x). */
+  confidence?: number;
+}
+
+export interface GraphExport {
+  nodes: GraphNode[];
+  links: GraphLink[];
+}
+
+// ---------------------------------------------------------------------------
+// NetworkX-shaped raw payload (what hosted backend currently returns)
+// ---------------------------------------------------------------------------
+
+export interface RawGraphNode {
+  id?: string;
+  node_id?: string;
+  label?: string;
+  type?: string;
+  language?: string;
+  loc?: number;
+  is_test?: boolean;
+  is_config?: boolean;
+  is_entry_point?: boolean;
+  community?: number;
+  community_id?: number;
+  pagerank?: number;
+  betweenness?: number;
+  symbol_count?: number;
+  has_doc?: boolean;
+  [extra: string]: unknown;
+}
+
+export interface RawGraphLink {
+  source: string;
+  target: string;
+  kind?: string;
+  weight?: number;
+  confidence?: number;
+  imported_names?: string[];
+  edge_type?: string;
+  [extra: string]: unknown;
+}
+
+export interface RawGraph {
+  nodes: RawGraphNode[];
+  links?: RawGraphLink[];
+  edges?: RawGraphLink[];
+  directed?: boolean;
+  multigraph?: boolean;
+}
+
+export interface RawGraphResponse {
+  graph: RawGraph;
+  pagerank: Record<string, number>;
+  betweenness: Record<string, number>;
+  communities: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Module rollup
+// ---------------------------------------------------------------------------
+
+export interface ModuleNode {
+  module_id: string;
+  file_count: number;
+  symbol_count: number;
+  avg_pagerank: number;
+  doc_coverage_pct: number;
+}
+
+export interface ModuleEdge {
+  source: string;
+  target: string;
+  edge_count: number;
+}
+
+export interface ModuleGraph {
+  nodes: ModuleNode[];
+  edges: ModuleEdge[];
+}
+
+// ---------------------------------------------------------------------------
+// Ego (neighborhood) graph
+// ---------------------------------------------------------------------------
+
+export interface EgoGraph {
+  nodes: GraphNode[];
+  links: GraphLink[];
+  center_node_id: string;
+  inbound_count: number;
+  outbound_count: number;
+}
+
+// ---------------------------------------------------------------------------
+// Path finder
+// ---------------------------------------------------------------------------
+
+export interface GraphPath {
+  path: string[];
+  distance: number;
+  explanation: string;
+}
+
+// ---------------------------------------------------------------------------
+// Symbol-level intelligence (v0.4.x)
+// ---------------------------------------------------------------------------
+
+export interface SymbolNodeSummary {
+  symbol_id: string;
+  name: string;
+  kind: string;
+  file: string;
+  start_line?: number | null;
+  signature?: string | null;
+}
+
+export interface CallerCalleeEntry {
+  symbol_id: string;
+  name: string;
+  kind: string;
+  file: string;
+  start_line?: number | null;
+  edge_type: string;
+  confidence: number;
+}
+
+export interface CallersCallees {
+  symbol_id: string;
+  symbol: SymbolNodeSummary;
+  callers: CallerCalleeEntry[];
+  callees: CallerCalleeEntry[];
+  caller_count: number;
+  callee_count: number;
+  truncated: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Communities (Leiden — v0.4.0)
+// ---------------------------------------------------------------------------
+
+export interface CommunityMember {
+  path: string;
+  pagerank: number;
+  is_entry_point: boolean;
+}
+
+export interface NeighboringCommunity {
+  community_id: number;
+  label: string;
+  cross_edge_count: number;
+}
+
+export interface CommunityDetail {
+  community_id: number;
+  label: string;
+  cohesion: number;
+  member_count: number;
+  members: CommunityMember[];
+  truncated: boolean;
+  neighboring_communities: NeighboringCommunity[];
+}
+
+export interface CommunitySummaryItem {
+  community_id: number;
+  label: string;
+  cohesion: number;
+  member_count: number;
+  top_file: string;
+}
+
+// ---------------------------------------------------------------------------
+// Graph metrics + execution flows
+// ---------------------------------------------------------------------------
+
+export interface GraphMetrics {
+  target: string;
+  node_type: string;
+  pagerank: number;
+  pagerank_percentile: number;
+  betweenness: number;
+  betweenness_percentile: number;
+  community_id: number;
+  community_label: string | null;
+  is_entry_point: boolean;
+  in_degree: number;
+  out_degree: number;
+  entry_point_score?: number | null;
+  kind?: string | null;
+  file?: string | null;
+}
+
+export interface ExecutionFlowEntry {
+  entry_point: string;
+  entry_point_name: string;
+  entry_point_score: number;
+  trace: string[];
+  depth: number;
+  crosses_community: boolean;
+  communities_visited: number[];
+}
+
+export interface ExecutionFlows {
+  total_entry_points: number;
+  flows: ExecutionFlowEntry[];
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @repowise/types — canonical TypeScript data contracts shared between
+ * `packages/web` (OSS dashboard) and the hosted web app (currently `frontend/`,
+ * to be moved to `packages/hosted-web/` in Phase 1B per Option α).
+ *
+ * Re-exports per-domain modules. Subpath imports (`@repowise/types/graph`)
+ * are also supported via the `exports` map in package.json.
+ */
+
+export * from "./graph.js";
+export * from "./git.js";
+export * from "./docs.js";
+export * from "./decisions.js";
+export * from "./dead-code.js";
+export * from "./symbols.js";
+export * from "./chat.js";

--- a/packages/types/src/symbols.ts
+++ b/packages/types/src/symbols.ts
@@ -1,0 +1,47 @@
+/**
+ * Canonical symbol types.
+ *
+ * Canonical source: OSS engine `SymbolResponse`. Hosted's `SymbolEntryBackend`
+ * is identical except missing `repository_id` and `symbol_id` — adapters
+ * synthesise both.
+ */
+
+export type SymbolKind =
+  | "function"
+  | "method"
+  | "class"
+  | "interface"
+  | "struct"
+  | "enum"
+  | "trait"
+  | "module"
+  | "variable"
+  | "type"
+  | string;
+
+export type SymbolVisibility = "public" | "private" | "protected" | string;
+
+/** Renamed `CodeSymbol` to avoid shadowing the global `Symbol`. */
+export interface CodeSymbol {
+  id: string;
+  repository_id: string;
+  file_path: string;
+  symbol_id: string;
+  name: string;
+  qualified_name: string;
+  kind: SymbolKind;
+  signature: string;
+  start_line: number;
+  end_line: number;
+  docstring: string | null;
+  visibility: SymbolVisibility;
+  is_async: boolean;
+  complexity_estimate: number;
+  language: string;
+  parent_name: string | null;
+}
+
+export interface SymbolList {
+  total: number;
+  symbols: CodeSymbol[];
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"]
+}

--- a/packages/types/vitest.config.ts
+++ b/packages/types/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["__tests__/**/*.test.ts"],
+    typecheck: { enabled: true, include: ["__tests__/**/*.test.ts"] },
+  },
+});

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,54 @@
+# @repowise/ui
+
+Shared visualization components for the Repowise OSS dashboard
+(`packages/web`) and the hosted web app (currently `frontend/`, becoming
+`packages/hosted-web/` in Phase 1B per Option α — see
+`docs/HOSTED_PRODUCT_UPGRADE_PLAN.md` §5).
+
+## Status
+
+**Phase 1A: scaffold only.** Package layout, exports map, and design-token
+file are stubbed. No components have been moved in yet — that is Phase 1B's
+job.
+
+## Layout (per plan §5.2)
+
+```
+src/
+  graph/         graph-flow, graph-toolbar, ego-sidebar, …
+  git/           hotspot-table, ownership-treemap, …
+  dead-code/
+  decisions/
+  docs/
+  symbols/
+  coverage/
+  wiki/
+  chat/          artifact-panel, model-selector, source-citations
+  dashboard/     health-score-ring, attention-panel, …
+  workspace/     repo-card, contracts-table, …
+  jobs/          generation-progress, job-log
+  shared/        stat-card, empty-state, api-error
+  hooks/         use-elk-layout, use-sse, …
+  ui/            Radix-CVA primitives
+styles/
+  globals.css    canonical design tokens (Tailwind v4 @theme)
+```
+
+## Consuming
+
+Components are exposed via subpath exports — import the slice you need
+rather than the barrel:
+
+```ts
+import { HotspotTable } from "@repowise/ui/git";
+import { GraphFlow } from "@repowise/ui/graph";
+```
+
+Both consumers must `transpilePackages: ["@repowise/ui"]` in their
+`next.config.ts` (Tailwind v4 + TS source ship as-is, no pre-build).
+
+## Peer deps
+
+`react`, `react-dom`. Components stay client-pure or pure-presentational —
+they do not call `next/navigation` or `next/link` directly. Where routing
+is needed, accept it via props or context (per plan §5.4).

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@repowise/ui",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Shared visualization components for Repowise OSS web (packages/web) and hosted web. Components moved in here from packages/web/src/components/* + frontend/src/components/demo/* during Phase 1B.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./styles.css": "./styles/globals.css",
+    "./graph": "./src/graph/index.ts",
+    "./git": "./src/git/index.ts",
+    "./dead-code": "./src/dead-code/index.ts",
+    "./decisions": "./src/decisions/index.ts",
+    "./docs": "./src/docs/index.ts",
+    "./symbols": "./src/symbols/index.ts",
+    "./coverage": "./src/coverage/index.ts",
+    "./wiki": "./src/wiki/index.ts",
+    "./chat": "./src/chat/index.ts",
+    "./dashboard": "./src/dashboard/index.ts",
+    "./workspace": "./src/workspace/index.ts",
+    "./jobs": "./src/jobs/index.ts",
+    "./shared": "./src/shared/index.ts",
+    "./hooks": "./src/hooks/index.ts",
+    "./ui": "./src/ui/index.ts"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@repowise/types": "*"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @repowise/ui — shared visualization components.
+ *
+ * In Phase 1A this package is a scaffold only. Phase 1B moves components
+ * from `packages/web/src/components/` and `frontend/src/components/demo/`
+ * into the per-domain subpaths declared in package.json `exports`.
+ *
+ * Consumers should import via subpath (`@repowise/ui/graph`, `@repowise/ui/chat`)
+ * rather than the barrel below — the barrel exists so the package resolves
+ * cleanly in IDEs before any components have moved in.
+ */
+
+export {};

--- a/packages/ui/styles/globals.css
+++ b/packages/ui/styles/globals.css
@@ -1,0 +1,12 @@
+/*
+ * @repowise/ui — design tokens.
+ *
+ * Phase 1A scaffold. Phase 1B copies the canonical token set from
+ * packages/web/src/styles/globals.css into here, then re-points
+ * packages/web (and packages/hosted-web) to import this file via:
+ *
+ *   @import "@repowise/ui/styles.css";
+ *
+ * Until 1B, this file intentionally contains no rules so neither consumer
+ * accidentally takes a partial token set as a dependency.
+ */

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": true,
+    "paths": {
+      "@repowise/types": ["../types/src/index.ts"],
+      "@repowise/types/*": ["../types/src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "__tests__/**/*.ts", "__tests__/**/*.tsx"]
+}


### PR DESCRIPTION
## Summary

Adds two new workspace packages to the repowise monorepo:

- **`packages/types`** — canonical TypeScript shapes shared between
  `packages/web` and downstream consumers. Modules: `graph`, `git`,
  `docs`, `decisions`, `dead-code`, `symbols`, `chat` (subpath
  exports). Includes a `ChatArtifact` discriminated union with a
  `KnownChatArtifact | GenericArtifact` split and an
  `isKnownChatArtifact` narrowing helper, so consumers can switch
  on `.type` instead of casting `Record<string, unknown>`.
- **`packages/ui`** — scaffold only. Empty subpath exports for
  `graph`, `git`, `dead-code`, `decisions`, `docs`, `symbols`,
  `coverage`, `wiki`, `chat`, `dashboard`, `workspace`, `jobs`,
  `shared`, `hooks`, `ui`. React 19 peer dep, `@repowise/types`
  workspace dep. Components move in a follow-up PR.

Root `package.json` adds `packages/types` and `packages/ui` to npm
workspaces with `--workspaces --if-present` so each package opts in.

## Decisions

- npm workspaces, no Turborepo — caching value kicks in at >5 build
  targets; revisit when the package set grows.
- No tsup — both consumers are Next.js with `transpilePackages`; raw
  TS resolves directly. Add a build step when components ship if a
  non-Next consumer appears.
- `Symbol` → `CodeSymbol` in `packages/types/src/symbols.ts` to
  avoid shadowing the JS global.
- Optional enrichment fields so OSS-shaped artefacts still satisfy
  the contract (forward-compat).

## Test plan

- [x] `npm install` clean across workspaces
- [x] `tsc --noEmit` in `packages/types` and `packages/ui` (strict,
      `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`)
- [x] `vitest run --typecheck` in `packages/types` (12/12 pass)
- [ ] CI green
- [ ] OSS `packages/web` `type-check` + `build` still pass (no
      consumer changes here, but workspace install touched lockfile)