### PR TITLE
feat(types): add Heritage and SecurityFinding canonical types

### DIFF
--- a/packages/types/__tests__/contracts.test.ts
+++ b/packages/types/__tests__/contracts.test.ts
@@ -28,6 +28,12 @@ import type { GraphLink } from "../src/graph.js";
 import type { DeadCodeFinding } from "../src/dead-code.js";
 import type { DecisionRecord, DecisionStatus } from "../src/decisions.js";
 import type { Hotspot } from "../src/git.js";
+import type {
+  HeritageKind,
+  HeritageRelation,
+  SymbolHeritage,
+} from "../src/symbols.js";
+import type { SecurityFinding, SecuritySeverity } from "../src/security.js";
 
 describe("ChatArtifact discriminated union", () => {
   it("narrows on .type to the per-variant data shape", () => {
@@ -102,6 +108,62 @@ describe("DecisionRecord literal unions", () => {
       "proposed" | "active" | "deprecated" | "superseded"
     >();
     expectTypeOf<DecisionRecord["status"]>().toEqualTypeOf<DecisionStatus>();
+  });
+});
+
+describe("Heritage relation shape", () => {
+  it("constrains kind to the six-literal union", () => {
+    expectTypeOf<HeritageKind>().toEqualTypeOf<
+      | "extends"
+      | "implements"
+      | "trait_impl"
+      | "mixin"
+      | "method_overrides"
+      | "method_implements"
+    >();
+  });
+
+  it("treats child_id/parent_id/confidence as optional (raw vs resolved)", () => {
+    const raw: HeritageRelation = {
+      child_name: "Cat",
+      parent_name: "Animal",
+      kind: "extends",
+      line: 10,
+    };
+    expectTypeOf(raw).toEqualTypeOf<HeritageRelation>();
+    expectTypeOf<HeritageRelation["confidence"]>().toEqualTypeOf<
+      number | undefined
+    >();
+  });
+
+  it("SymbolHeritage exposes both directions", () => {
+    expectTypeOf<SymbolHeritage["parents"]>().toEqualTypeOf<
+      HeritageRelation[]
+    >();
+    expectTypeOf<SymbolHeritage["children"]>().toEqualTypeOf<
+      HeritageRelation[]
+    >();
+  });
+});
+
+describe("SecurityFinding canonical shape", () => {
+  it("severity is the three-literal union widened to string", () => {
+    expectTypeOf<SecuritySeverity>().toEqualTypeOf<
+      "high" | "med" | "low" | string
+    >();
+  });
+
+  it("snippet is nullable; detected_at is an ISO string", () => {
+    const f: SecurityFinding = {
+      id: 1,
+      file_path: "src/auth.py",
+      kind: "hardcoded_secret",
+      severity: "high",
+      snippet: null,
+      detected_at: "2026-05-02T00:00:00Z",
+    };
+    expectTypeOf(f.snippet).toEqualTypeOf<string | null>();
+    expectTypeOf(f.detected_at).toEqualTypeOf<string>();
   });
 });
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,7 +18,8 @@
     "./workspace": "./src/workspace.ts",
     "./blast-radius": "./src/blast-radius.ts",
     "./jobs": "./src/jobs.ts",
-    "./settings": "./src/settings.ts"
+    "./settings": "./src/settings.ts",
+    "./security": "./src/security.ts"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,3 +18,4 @@ export * from "./workspace.js";
 export * from "./blast-radius.js";
 export * from "./jobs.js";
 export * from "./settings.js";
+export * from "./security.js";

--- a/packages/types/src/security.ts
+++ b/packages/types/src/security.ts
@@ -1,0 +1,23 @@
+/**
+ * Canonical security finding types.
+ *
+ * Mirrors the engine's `security_findings` table (per-snapshot persisted
+ * results from the `security_scan` analyser) and the consumer-side shape
+ * already used by the OSS web `listSecurityFindings` API client.
+ */
+
+export type SecuritySeverity = "high" | "med" | "low" | string;
+
+export interface SecurityFinding {
+  id: number;
+  file_path: string;
+  kind: string;
+  severity: SecuritySeverity;
+  snippet: string | null;
+  detected_at: string;
+}
+
+export interface SecurityFindingList {
+  total: number;
+  findings: SecurityFinding[];
+}

--- a/packages/types/src/symbols.ts
+++ b/packages/types/src/symbols.ts
@@ -45,3 +45,51 @@ export interface SymbolList {
   total: number;
   symbols: CodeSymbol[];
 }
+
+// ---------------------------------------------------------------------------
+// Heritage (extends / implements / trait_impl / mixin / overrides)
+// ---------------------------------------------------------------------------
+
+/**
+ * Heritage relation kinds. Mirrors the engine's edge_type values for
+ * heritage edges in the symbol graph plus the raw AST-level "mixin" kind.
+ */
+export type HeritageKind =
+  | "extends"
+  | "implements"
+  | "trait_impl"
+  | "mixin"
+  | "method_overrides"
+  | "method_implements";
+
+/**
+ * A single resolved heritage edge.
+ *
+ * `child_id` and `parent_id` are symbol-graph node IDs (e.g.
+ * `src/app.py::MyClass`). `confidence` is present for resolved relations
+ * (0.0–1.0) and absent for raw, unresolved entries lifted directly out of
+ * `parsed_files.json::heritage` (in which case only `child_name`,
+ * `parent_name`, `kind`, and `line` are meaningful).
+ */
+export interface HeritageRelation {
+  child_id?: string;
+  parent_id?: string;
+  child_name: string;
+  parent_name: string;
+  kind: HeritageKind;
+  line: number;
+  confidence?: number;
+}
+
+/**
+ * Heritage view for a single symbol — both directions of the relation.
+ *
+ * `parents` are the relations where this symbol is the child (i.e. what it
+ * extends/implements). `children` are the relations where this symbol is the
+ * parent (i.e. what extends/implements it).
+ */
+export interface SymbolHeritage {
+  symbol_id: string;
+  parents: HeritageRelation[];
+  children: HeritageRelation[];
+}


### PR DESCRIPTION
## Summary

- Add `HeritageKind`, `HeritageRelation`, `SymbolHeritage` to `@repowise-dev/types/symbols` so consumers can render symbol-level inheritance / interface-implementation / trait-impl edges without redeclaring the shape.
- Add `SecuritySeverity`, `SecurityFinding`, `SecurityFindingList` to a new `@repowise-dev/types/security` subpath. Shape is taken verbatim from the consumer-side `packages/web/src/lib/api/security.ts` interface so existing OSS-web callers don't need an adapter.
- Type-level tests (`vitest --typecheck`) pin the discriminants (six-literal `HeritageKind`, three-literal `SecuritySeverity` widened to string) and the optional-vs-required split (raw entries lifted out of `parsed_files.json::heritage` carry only `child_name` / `parent_name` / `kind` / `line`; resolved relations additionally carry `child_id`, `parent_id`, and `confidence`).

## Why

Downstream consumers want to render heritage edges in symbol drawers and security findings on overview tiles, but neither shape was canonicalised in `@repowise-dev/types`. Without this PR, every consumer ends up shipping its own type and the contracts drift.

## Test plan

- [x] `npm run test --workspace=@repowise-dev/types` — 22/22 passing including the 5 new type-level assertions.
- [x] `npm run type-check --workspace=@repowise-dev/types` — clean.
- [x] `npm run type-check --workspace=repowise-web` — still clean (existing OSS-web `SecurityFinding` shape remains source-compatible because the new canonical type is a structural superset).
- [ ] After merge into `next`, the `publish-internal` workflow auto-publishes `@repowise-dev/types@0.0.0-internal.<sha>`; downstream consumers pin the new internal version.