### PR TITLE
chore(ui): declare sideEffects for tree-shaking

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,6 +6,10 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "sideEffects": [
+    "./styles/globals.css",
+    "**/*.css"
+  ],
   "exports": {
     ".": "./src/index.ts",
     "./styles.css": "./styles/globals.css",


### PR DESCRIPTION
## Summary

- Declares `sideEffects` on `@repowise-dev/ui`'s package.json so bundlers can drop unused subpath modules.
- Lists CSS files as the only retained side-effecting modules; everything under `src/` is pure ESM.
- No behaviour change for consumers — they just get leaner bundles when importing a subset of components.

Without this field, Webpack / Rollup / Turbopack must assume every module has side effects, which defeats the granular subpath exports (`./graph/*`, `./dashboard/*`, etc.).

## Test plan

- [x] `pnpm install` succeeds in `packages/web` (workspace consumer).
- [ ] Downstream consumer build smoke-tested with reduced bundle.