### PR TITLE
chore(uv): sync lockfile to v0.5.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3010,7 +3010,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.4.1"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

The repowise package self-entry in `uv.lock` was still pinned to `0.4.1` after PR #132 bumped `pyproject.toml` to `0.5.0`. Regenerated to keep editable-install metadata consistent with the release.

Blocks the `v0.5.0` tag — without this, the published release ships a lockfile inconsistent with its pyproject version.

## Test plan

- [x] `uv.lock` `repowise` entry now reads `version = "0.5.0"`.
- [x] No other lockfile entries changed.