### PR TITLE
release: v0.5.1 - TYPO3 framework edges + dead-code CLI fix + dep bumps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.1] — 2026-05-07
+
+### Added
+- **TYPO3 framework edges** — composer-based extension discovery (`"type": "typo3-cms-extension"`, canonical for v11–v14) with legacy `ext_emconf.php` fallback and project-mode `vendor/<vendor>/<package>/` walking. Convention-loaded files (`ext_localconf.php`, `ext_tables.php`/`.sql`, `Configuration/TCA/*.php`, `Configuration/TCA/Overrides/*.php`, `Configuration/Backend/*.php`, `Configuration/Services.{php,yaml,yml}`, `JavaScriptModules.php`, `ContentSecurityPolicies.php`, `RequestMiddlewares.php`, `Icons.php`, `RTE/*.{yaml,yml}`) now receive incoming edges from a synthetic `framework:typo3-core` anchor and are no longer flagged as unreachable. `Configuration/JavaScriptModules.php` is parsed for `EXT:<key>/...js` references and edges are added to the registered JS modules. `tech_stack.detect_tech_stack` recognises `typo3/cms-core`, `symfony/framework-bundle`, and `laravel/framework` from `composer.json` (#114).
+- **`framework:` synthetic-node prefix in dead-code analysis** — distinguishes framework-mediated wiring from third-party `external:` imports. `framework:` predecessors count as cross-package importers (preventing legitimate convention dirs like `Configuration/` from showing as zombie packages); `external:` predecessors do not (#114).
+
+### Fixed
+- **`repowise dead-code` now invokes `add_framework_edges`** — the CLI previously skipped framework-aware edge synthesis, so even Django/Laravel/Rails repos showed convention files as false-positive unreachable findings. The dead-code command now calls `detect_tech_stack` and adds framework edges before running the analyzer (#114).
+
+### Dependencies
+- `cryptography` 43.0.3 → 46.0.7 (#130).
+- `lodash` 4.17.23 → 4.18.1 (#131).
+- `lodash-es` and `langium` transitive bumps (#129).
+- `esbuild`, `vitest`, and `vite` dev tooling bumps (#134).
+
+---
+
 ## [0.5.0] — 2026-05-03
 
 ### Changed

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -6,4 +6,4 @@ git signals, dead code detection, architectural decisions, and
 AI-generated documentation.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.5.0"
+version = "0.5.1"
 description = "Codebase intelligence for developers and AI — generates and maintains a structured wiki for any codebase"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
﻿## Summary

Release v0.5.1 batches the TYPO3 framework-edges work plus four dependency bumps that have been sitting in the queue.

### Headline changes

- **TYPO3 framework edges (#114)** — convention files (`ext_localconf.php`, `Configuration/TCA/*`, `JavaScriptModules.php` registrations, etc.) are no longer flagged as unreachable. Validated against 20 production TYPO3 extensions with 0 framework-file false positives.
- **Latent CLI bug fix (#114)** — `repowise dead-code` was never calling `add_framework_edges`, so Django/Laravel/Rails repos have been showing convention files as dead-code false positives since framework-edge support was added. Now fixed for all frameworks, not just TYPO3.
- **`framework:` synthetic-node prefix** — distinct from `external:`, lets the analyzer treat framework-mediated wiring as cross-package importer in zombie-package detection. Internal change, no user-visible impact beyond fewer false positives.

### Dependency bumps

- `cryptography` 43.0.3 → 46.0.7 (#130)
- `lodash` 4.17.23 → 4.18.1 (#131)
- `lodash-es` + `langium` transitive (#129)
- `esbuild` + `vitest` + `vite` dev tooling (#134)

## Version bump

All four hardcoded version strings updated to `0.5.1`:

- `pyproject.toml`
- `packages/cli/src/repowise/cli/__init__.py`
- `packages/core/src/repowise/core/__init__.py`
- `packages/server/src/repowise/server/__init__.py`
- `uv.lock` regenerated via `uv lock`

## Test plan

- [x] Wheel builds cleanly: `uv build --wheel` produced `dist/repowise-0.5.1-py3-none-any.whl`
- [x] No version drift: `git grep "0\.5\.0"` clean across version files
- [x] CHANGELOG updated under `## [0.5.1] - 2026-05-07`
- [x] All 5 batched PRs merged into main with green CI on Py 3.11/3.12/3.13
- [ ] After merge: tag `v0.5.1` from main → triggers `publish.yml` → wheel + web tarball on PyPI/GitHub Releases
- [ ] Post-release: `pip install --upgrade repowise` and `repowise --version` shows `0.5.1` in a fresh venv
