### PR TITLE
fix(dead-code): drop residual unused-export false positives

### DIFF
--- a/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
@@ -305,6 +305,17 @@ class DeadCodeAnalyzer:
 
             file_has_importers = self.graph.in_degree(node) > 0
 
+            # Function/method line ranges in this file — used to skip symbols
+            # whose definition is nested inside another function (closures,
+            # inner helpers).  Such symbols are only reachable from their
+            # enclosing scope and are guaranteed false positives.
+            enclosing_ranges = [
+                (sym.get("start_line", 0), sym.get("end_line", 0))
+                for sym in symbols
+                if sym.get("kind") in ("function", "method", "async_function")
+                and sym.get("end_line", 0) > sym.get("start_line", 0)
+            ]
+
             for sym in symbols:
                 if sym.get("visibility") != "public":
                     continue
@@ -319,9 +330,25 @@ class DeadCodeAnalyzer:
                 if sym_name.startswith("__") and sym_name.endswith("__"):
                     continue
 
+                # Skip nested defs: a symbol whose start_line falls strictly
+                # inside another function/method's body cannot be imported
+                # by name from outside the enclosing scope.
+                sym_start = sym.get("start_line", 0)
+                if any(
+                    start < sym_start < end
+                    for start, end in enclosing_ranges
+                    if (start, end) != (sym_start, sym.get("end_line", 0))
+                ):
+                    continue
+
+                # Decorators are stored with the leading "@" (e.g. "@app.route").
+                # _FRAMEWORK_DECORATORS entries are bare prefixes, so compare
+                # against the stripped form.
                 decorators = sym.get("decorators", [])
                 if any(
-                    d.startswith(prefix) for d in decorators for prefix in _FRAMEWORK_DECORATORS
+                    d.lstrip("@").startswith(prefix)
+                    for d in decorators
+                    for prefix in _FRAMEWORK_DECORATORS
                 ):
                     continue
 

--- a/packages/core/src/repowise/core/ingestion/graph.py
+++ b/packages/core/src/repowise/core/ingestion/graph.py
@@ -150,6 +150,7 @@ class GraphBuilder:
                 language=sym.language,
                 parent_name=sym.parent_name,
                 signature=sym.signature,
+                decorators=sym.decorators,
             )
 
             # DEFINES edge: file → symbol

--- a/tests/unit/test_dead_code.py
+++ b/tests/unit/test_dead_code.py
@@ -282,6 +282,105 @@ def test_dynamic_pattern_excluded():
 
 
 # ---------------------------------------------------------------------------
+# 6b. test_nested_function_not_flagged
+# ---------------------------------------------------------------------------
+
+
+def test_nested_function_not_flagged():
+    """Symbols defined inside another function's body cannot be imported by
+    name and must not be flagged as unused exports."""
+    g = _build_graph(
+        nodes={
+            "pkg/server.py": {
+                "is_entry_point": False,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 2,
+                "symbols": [
+                    {
+                        "name": "chat",
+                        "kind": "function",
+                        "visibility": "public",
+                        "decorators": [],
+                        "start_line": 10,
+                        "end_line": 80,
+                    },
+                    # Nested closure / inner generator — line range strictly
+                    # contained inside ``chat``.
+                    {
+                        "name": "event_stream",
+                        "kind": "function",
+                        "visibility": "public",
+                        "decorators": [],
+                        "start_line": 25,
+                        "end_line": 60,
+                    },
+                ],
+            },
+        },
+    )
+
+    analyzer = DeadCodeAnalyzer(g, git_meta_map={})
+    report = analyzer.analyze(
+        {
+            "detect_unreachable_files": False,
+            "detect_zombie_packages": False,
+        }
+    )
+    sym_names = [f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT]
+    assert "event_stream" not in sym_names
+
+
+# ---------------------------------------------------------------------------
+# 6c. test_at_prefixed_decorator_excluded
+# ---------------------------------------------------------------------------
+
+
+def test_at_prefixed_decorator_excluded():
+    """Decorators stored with the leading '@' (as the parser emits them)
+    must still match the framework-decorator whitelist."""
+    g = _build_graph(
+        nodes={
+            "pkg/routes.py": {
+                "is_entry_point": False,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 2,
+                "symbols": [
+                    {
+                        "name": "list_items",
+                        "kind": "function",
+                        "visibility": "public",
+                        "decorators": ["@router.get(\"/items\")"],
+                        "start_line": 1,
+                        "end_line": 8,
+                    },
+                    {
+                        "name": "lifespan",
+                        "kind": "function",
+                        "visibility": "public",
+                        "decorators": ["@asynccontextmanager"],
+                        "start_line": 10,
+                        "end_line": 20,
+                    },
+                ],
+            },
+        },
+    )
+
+    analyzer = DeadCodeAnalyzer(g, git_meta_map={})
+    report = analyzer.analyze(
+        {
+            "detect_unreachable_files": False,
+            "detect_zombie_packages": False,
+        }
+    )
+    sym_names = [f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT]
+    assert "list_items" not in sym_names
+    assert "lifespan" not in sym_names
+
+
+# ---------------------------------------------------------------------------
 # 7. test_confidence_low_for_recent_files
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Addresses §3.4 / §3.5 follow-ups from `AUDIT_NOTES.md` — three concrete fixes that together remove the largest remaining classes of unused-export false positives uncovered in the local OSS dead-code precision audit.

## What ships

1. **Decorators were never reaching the analyzer.** `GraphBuilder.add_file` was not copying `Symbol.decorators` onto the symbol graph node, so the existing `_FRAMEWORK_DECORATORS` whitelist filter was a silent no-op — every `@pytest.fixture`, `@router.get`, `@asynccontextmanager`, etc. was still being flagged. Persist `decorators` on the node.

2. **Decorator prefix check now strips the leading `@`.** The parser stores decorators with their `@` (e.g. `@router.get("/items")`) but `_FRAMEWORK_DECORATORS` entries are bare prefixes. `d.startswith(prefix)` was failing for all real decorators. Compare against `d.lstrip(@)`.

3. **Nested function defs are skipped from unused-export analysis.** A symbol whose `start_line` falls strictly inside another function/method body in the same file cannot be imported by name from outside its enclosing scope — flagging it is a guaranteed FP. Per §3.5 mitigation #3, this catches inner generators (e.g. `event_stream` inside `chat()`), closures, and locally-defined helpers.

## Out of scope (residual, accepted)

Per §3.5 mitigation #4: pipeline/registry-instantiated classes (e.g. `DotNetDynamicHints` looked up by name from a registry) require attribute-access tracking and are left as ~5–10% residual FP rate.

## Test plan
- [x] 26/26 dead-code unit tests pass, including two new regression tests:
  - `test_nested_function_not_flagged` — `event_stream`-inside-`chat` shape
  - `test_at_prefixed_decorator_excluded` — `@router.get(...)` and `@asynccontextmanager`
- [x] 1034 unit tests pass overall (excluding pre-existing breakage in `tests/unit/persistence` and `tests/unit/server`)
- [ ] Re-run `repowise update --index-only` against this repo and spot-check the 20 known FPs from the audit to confirm precision lift