### PR TITLE
release: v0.6.0 — Sigma graph, parallel metrics, dead-code accuracy, workspace fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.6.0] — 2026-05-09
+
+### Added
+- **Sigma.js graph renderer** replaces React Flow as the primary graph view. ForceAtlas2 web-worker layout for the `force` mode and ELK-driven hierarchical layout share a single canvas. Inspection panel, search, community dimming, execution-flow highlighting, and legend counts all reach parity via Graphology adapters; double-click drills into modules and rebuilds the graph with child file nodes inline. Signal overlays (dead-code desaturation, hotspot tint, entry-point size boost) live in the Sigma `nodeReducer` (#148).
+- **Per-phase progress for graph build and metrics** — `GraphBuilder.build()` now reports imports/heritage/calls as sub-phases through the existing `ProgressCallback`, and the orchestrator drives metrics, communities, and flows as their own sub-phases by priming the lazy caches. `repowise init` now shows six indented bars under the graph phase instead of a single opaque spinner that previously sat at "0/1" for 5–10 minutes (#150).
+- **Dashboard `EmptyState` guards** — every dashboard panel now renders a labelled empty state instead of going blank when its data slice is missing (#148).
+
+### Changed
+- **`repowise update` defaults to the mode `init` was run with.** `repowise init` now persists `docs_enabled` to `.repowise/state.json` (true for full init, false for `--index-only`), and `repowise update` reads that field so the post-commit hook does the right thing without extra knobs. New `--docs/--no-docs` flags override per run; `--index-only` still wins. Index-only init now also writes `state.json`, so the post-commit hook has a baseline to diff against (#155).
+- **Cost-gate persistence.** Declining the cost gate now produces a clean index-only outcome instead of an aborted half-state — ingestion, graph, git, and dead-code work is persisted, `state.json` lands with `docs_enabled=False`, and subsequent `repowise update` runs default to index-only so there are no surprise LLM charges later (#156).
+- **Cost-gate prompt** is now visually separated from the Rich progress output above it (blank line + horizontal rule before the `[y/N]`), preventing the prompt from being missed mid-output (#156).
+- **Stale-wiki warning is much quieter.** The `repowise augment` PostToolUse hook used to fire on every Bash tool call after a commit until an update completed; now it suppresses while `repowise update` holds `.repowise/.update.lock`, and after warning once for a given HEAD it skips further warnings until HEAD moves. The hook installer also detects and excises legacy non-marker bodies before appending the marker block (#155).
+
+### Fixed
+- **Python relative imports drop their first imported name.** `from .X import Y` and `from .X import A, B, C` were being parsed with `Y`/`A` discarded because the binding extractor's "skip the first dotted_name" heuristic, correct for absolute `from foo.bar import X`, also fired on tree-sitter's `relative_import` wrapper. The graph stored `imported_names_json: []` for affected edges, which propagated into massive dead-code false positives on Repowise's own source (e.g. `GraphBuilder`, `DeadCodeAnalyzer`, `CallResolver` flagged at confidence 1.0). The extractor now detects `relative_import` and skips the heuristic, with regression coverage for both relative and absolute shapes (#149).
+- **Dead-code unused-export false positives.** Symbol decorators are now persisted on graph nodes (the framework-decorator whitelist was previously running against an empty list), `@`-prefixed decorator names are matched against the bare prefixes in `_FRAMEWORK_DECORATORS` (so `@router.get`, `@asynccontextmanager`, etc. are recognised), and nested function definitions are skipped from unused-export detection — closures and inner generators can't be imported by name and were being flagged spuriously (#153).
+- **State migration for legacy index-only installs.** `state.json` files written before #155 lack `docs_enabled`. The previous default would have charged a full LLM regen on the first upgrade-and-commit for users who had originally run `init --index-only`. The resolver now infers `docs_enabled=False` when `provider`/`model` are also absent (the legacy shape of an index-only state file), backfills the explicit value into `state.json` on first update, and preserves the existing default for full-init users (#156).
+- **Workspace-mode chat 404.** `POST /api/repos/{repo_id}/chat/messages` was the only `/api/repos/{repo_id}/...` endpoint not honouring `app.state.workspace_sessions`, so every non-primary repo's chat returned `404 Repository <id> not found` despite appearing in `GET /api/repos`. Factory-resolution logic is now lifted into `resolve_session_factory` / `resolve_request_session_factory` helpers in `deps.py`, the chat router uses the request-scoped helper, and the duplicate helper in `routers/repos.py` is now a one-line alias (#146).
+- **Init progress rendering** cleanup — phase labels and indentation alignment fixes (#151).
+
+### Performance
+- **Graph metrics fan out in parallel.** PageRank, betweenness, file/symbol community detection, and execution-flow tracing previously ran serially across persist + generation, with PageRank and betweenness recomputing from scratch on each call. `GraphBuilder` now caches all four kernels on the instance (invalidated on `build()`), and a new `compute_metrics_parallel()` runs them via `asyncio.gather` + `asyncio.to_thread` so subsequent lazy callers hit warm caches. Betweenness dominates worst-case wall-time (O(VE)); fanning it out alongside PageRank and community detection meaningfully shortens the metrics phase. Falls back to lazy computation if `compute_metrics_parallel()` is never called (#152).
+- **Tree-sitter query cache promoted to module-level `@lru_cache`** keyed by language tag. Process-pool parse workers each held their own per-instance cache and recompiled every `.scm` query on first use; now each worker compiles each grammar's query exactly once for its lifetime (#154).
+- **Per-file `Compiled query language=...` debug log dropped.** It fired once per parser-instance × language during ingestion and was the single noisiest source of unfiltered stdout during `repowise init` (#149).
+
+### Dependencies
+- `gitpython` 3.1.47 → 3.1.50 — security release: rejects out-of-repo reference manipulation (3.1.48) and rejects control characters in config writes (3.1.49) (#147).
+
+---
+
 ## [0.5.1] — 2026-05-07
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -6,4 +6,4 @@ git signals, dead code detection, architectural decisions, and
 AI-generated documentation.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.5.1"
+version = "0.6.0"
 description = "Codebase intelligence for developers and AI — generates and maintains a structured wiki for any codebase"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

First release since v0.5.1 (2026-05-07). Eleven PRs land here — no breaking changes, no API surface freeze, so this is a minor bump.

Highlights:

- **Sigma.js graph renderer** replaces React Flow as the primary view (#148). FA2 force layout + ELK hierarchical share one canvas; full parity for inspection, search, communities, execution-flow, drill-down, and signal overlays.
- **Per-phase progress for graph build + metrics** (#150). The "0/1 spinner for 5–10 minutes" problem is gone — six indented bars now.
- **Parallel metrics computation** (#152). PageRank, betweenness, communities, and execution flows run via `asyncio.gather` + `asyncio.to_thread` and cache on `GraphBuilder`.
- **Tree-sitter query cache promoted to module-level `lru_cache`** (#154). Workers compile each grammar's queries once for their lifetime instead of once per parser instance.
- **Python relative-import binding bug fixed** (#149). `from .X import Y` was dropping `Y`; this caused massive dead-code false positives on Repowise's own source. Regression coverage added.
- **Dead-code unused-export false positives fixed** (#153). Decorator persistence + `@`-prefix matching + nested-def skip.
- **`repowise update` mode persistence** (#155). `state.json` now stores `docs_enabled`; the post-commit hook does the right thing without extra knobs. Stale-wiki warning is no longer per-tool-call spam.
- **Cost-gate state migration + UX** (#156). Legacy index-only state files no longer accidentally trigger a full LLM regen on first upgrade. Decline now produces a clean index-only outcome (work persisted, future updates default to index-only). Prompt is visually separated from Rich output.
- **Workspace chat 404 fix** (#146). `POST /api/repos/{repo_id}/chat/messages` now routes by `workspace_sessions`.
- **gitpython 3.1.47 → 3.1.50** (#147) — security release.

Full per-PR notes in `docs/CHANGELOG.md`.

## Validation

- [x] Version bumped in all four files + `uv.lock` (no stale `0.5.1` references).
- [x] `uv build --wheel` produces `dist/repowise-0.6.0-py3-none-any.whl` cleanly.
- [x] Wheel structure: 19 commands under `cli/`, 15 `.scm` tree-sitter queries, 12 `.j2` templates, top-level packages `cli`/`core`/`server`.
- [x] Wheel installs cleanly into a fresh venv and `repowise --version` reports `0.6.0`.
- [x] `repowise.cli.__version__`, `repowise.core.__version__`, `repowise.server.__version__` all report `0.6.0`.
- [x] CI green on all 11 contributing PRs.
- [ ] **Reviewer:** verify `npm run build --workspace packages/web` succeeds (Sigma migration + types/ui workspace deps).
- [ ] **Reviewer:** end-to-end smoke test (`repowise serve`) — graph, hotspots, blast-radius, wiki, decisions, costs.
- [ ] **Post-merge:** tag `v0.6.0` on the merge commit and push to trigger `publish.yml`.

## Merge convention

Per `.claude/RELEASING.md`, this is a **regular merge commit** (not squash) so `main` keeps the per-PR commit history.
