### PR TITLE
feat(providers): add DeepSeek provider (V4 Flash, V4 Pro)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 # OpenAI
 OPENAI_API_KEY=your_openai_api_key_here
 
+# DeepSeek
+DEEPSEEK_API_KEY=your_deepseek_api_key_here
+# DEEPSEEK_BASE_URL=https://api.deepseek.com
+
 # Ollama — no API key needed, but set base URL if non-default
 # OLLAMA_BASE_URL=http://localhost:11434
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd.py
@@ -819,7 +819,7 @@ def _workspace_init(
     "--provider",
     "provider_name",
     default=None,
-    help="LLM provider name (anthropic, openai, gemini, ollama, mock).",
+    help="LLM provider name (anthropic, openai, gemini, deepseek, ollama, litellm, mock).",
 )
 @click.option("--model", default=None, help="Model identifier override.")
 @click.option(

--- a/packages/cli/src/repowise/cli/commands/mcp_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/mcp_cmd.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import click
 
 from repowise.cli.helpers import console, resolve_repo_path
+from repowise.cli.ui import load_dotenv
 
 
 @click.command("mcp")
@@ -27,6 +28,10 @@ def mcp_command(path: str | None, transport: str, port: int) -> None:
     Exposes 16 tools for querying the repowise wiki via the MCP protocol.
     Supports both stdio (for Claude Code, Cursor, Cline) and SSE transports.
 
+    Loads ``<repo>/.repowise/.env`` into the environment before starting so
+    that MCP tools (e.g. ``get_answer``) can resolve the configured LLM
+    provider and API keys.
+
     Examples:
 
         repowise mcp                     # stdio, current directory
@@ -34,6 +39,7 @@ def mcp_command(path: str | None, transport: str, port: int) -> None:
         repowise mcp --transport sse     # SSE on port 7338
     """
     repo_path = resolve_repo_path(path)
+    load_dotenv(repo_path)
 
     repowise_dir = repo_path / ".repowise"
     if not repowise_dir.exists():

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -316,6 +316,7 @@ def resolve_provider(
             "anthropic": ["ANTHROPIC_BASE_URL"],
             "openai": ["OPENAI_BASE_URL"],
             "gemini": ["GEMINI_BASE_URL"],
+            "deepseek": ["DEEPSEEK_BASE_URL"],
             "ollama": ["OLLAMA_BASE_URL"],
             "litellm": ["LITELLM_BASE_URL", "LITELLM_API_BASE"],
         }
@@ -357,6 +358,10 @@ def resolve_provider(
             kwargs["api_key"] = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
         elif provider_name == "openrouter" and os.environ.get("OPENROUTER_API_KEY"):
             kwargs["api_key"] = os.environ["OPENROUTER_API_KEY"]
+        elif provider_name == "deepseek" and os.environ.get("DEEPSEEK_API_KEY"):
+            kwargs["api_key"] = os.environ["DEEPSEEK_API_KEY"]
+        elif provider_name == "litellm" and os.environ.get("LITELLM_API_KEY"):
+            kwargs["api_key"] = os.environ["LITELLM_API_KEY"]
         elif provider_name == "ollama" and os.environ.get("OLLAMA_BASE_URL"):
             kwargs["base_url"] = os.environ["OLLAMA_BASE_URL"]
 
@@ -406,10 +411,20 @@ def resolve_provider(
         if base_url:
             kwargs["base_url"] = base_url
         return get_provider("gemini", **kwargs)
+    if os.environ.get("DEEPSEEK_API_KEY") and os.environ["DEEPSEEK_API_KEY"].strip():
+        kwargs = (
+            {"model": model, "api_key": os.environ["DEEPSEEK_API_KEY"]}
+            if model
+            else {"api_key": os.environ["DEEPSEEK_API_KEY"]}
+        )
+        base_url = _resolve_base_url("deepseek")
+        if base_url:
+            kwargs["base_url"] = base_url
+        return get_provider("deepseek", **kwargs)
 
     raise click.ClickException(
         "No provider configured. Use --provider, set REPOWISE_PROVIDER, "
-        "or set ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY / OLLAMA_BASE_URL / GEMINI_API_KEY / GOOGLE_API_KEY."
+        "or set ANTHROPIC_API_KEY / OPENAI_API_KEY / OPENROUTER_API_KEY / OLLAMA_BASE_URL / GEMINI_API_KEY / GOOGLE_API_KEY / DEEPSEEK_API_KEY / LITELLM_API_KEY."
     )
 
 
@@ -444,6 +459,7 @@ def validate_provider_config(provider_name: str | None = None) -> list[str]:
         "anthropic": ["ANTHROPIC_API_KEY"],
         "openai": ["OPENAI_API_KEY"],
         "openrouter": ["OPENROUTER_API_KEY"],
+        "deepseek": ["DEEPSEEK_API_KEY"],
         "gemini": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],  # Either one
         "ollama": ["OLLAMA_BASE_URL"],
         "litellm": ["LITELLM_API_KEY"],  # May need others depending on backend

--- a/packages/cli/src/repowise/cli/ui.py
+++ b/packages/cli/src/repowise/cli/ui.py
@@ -280,6 +280,7 @@ _PROVIDER_DEFAULTS: dict[str, str] = {
     "gemini": "gemini-3.1-flash-lite-preview",
     "openai": "gpt-4.1",
     "anthropic": "claude-sonnet-4-6",
+    "deepseek": "deepseek-v4-flash",
     "ollama": "llama3.2",
     "openrouter": "anthropic/claude-sonnet-4.6",
     "litellm": "groq/llama-3.1-70b-versatile",
@@ -289,6 +290,7 @@ _PROVIDER_ENV: dict[str, str] = {
     "gemini": "GEMINI_API_KEY",
     "openai": "OPENAI_API_KEY",
     "anthropic": "ANTHROPIC_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
     "ollama": "OLLAMA_BASE_URL",
     "openrouter": "OPENROUTER_API_KEY",
 }
@@ -297,6 +299,7 @@ _PROVIDER_SIGNUP: dict[str, str] = {
     "gemini": "https://aistudio.google.com/apikey",
     "openai": "https://platform.openai.com/api-keys",
     "anthropic": "https://console.anthropic.com/settings/keys",
+    "deepseek": "https://platform.deepseek.com/api_keys",
     "ollama": "https://ollama.com/download",
     "openrouter": "https://openrouter.ai/keys",
 }
@@ -308,19 +311,46 @@ _PROVIDER_SIGNUP: dict[str, str] = {
 
 
 def load_dotenv(repo_path: Path) -> None:
-    """Load ``<repo>/.repowise/.env`` into ``os.environ`` (without overwriting)."""
+    """Load ``<repo>/.repowise/.env`` into ``os.environ`` (without overwriting).
+
+    Supports ``export KEY=value``, quoted values (``KEY="value"``, ``KEY='value'``),
+    and inline comments (``KEY=value  # comment``).
+    """
     env_file = repo_path / ".repowise" / ".env"
     if not env_file.exists():
         return
     for line in env_file.read_text(encoding="utf-8").splitlines():
         line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
+        if not line or line.startswith("#"):
             continue
-        key, _, value = line.partition("=")
-        key, value = key.strip(), value.strip()
+        # Support `export KEY=value`
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        if "=" not in line:
+            continue
+        key, _, raw_value = line.partition("=")
+        key = key.strip()
+        # Strip inline comments from the value (e.g. "sk-xxx  # my key")
+        raw_value = raw_value.strip()
+        if "#" in raw_value:
+            # Only strip if # is preceded by whitespace (avoid stripping # in URLs)
+            hash_idx = raw_value.find(" #")
+            if hash_idx == -1:
+                hash_idx = raw_value.find("\t#")
+            if hash_idx >= 0:
+                raw_value = raw_value[:hash_idx].rstrip()
+        # Strip matching surrounding quotes
+        value = _strip_quotes(raw_value)
         # Don't overwrite existing env vars (explicit env takes priority)
         if key and value and key not in os.environ:
             os.environ[key] = value
+
+
+def _strip_quotes(value: str) -> str:
+    """Strip one pair of matching surrounding single or double quotes."""
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+        return value[1:-1]
+    return value
 
 
 def _save_key_to_dotenv(repo_path: Path, env_var: str, value: str) -> None:

--- a/packages/core/src/repowise/core/generation/cost_tracker.py
+++ b/packages/core/src/repowise/core/generation/cost_tracker.py
@@ -36,6 +36,9 @@ _PRICING: dict[str, dict[str, float]] = {
     # Gemini preview / experimental models
     "gemini-3.1-flash-lite-preview": {"input": 0.075, "output": 0.30},
     "gemini-3-flash-preview": {"input": 0.075, "output": 0.30},
+    # DeepSeek
+    "deepseek-v4-flash": {"input": 0.14, "output": 0.28},
+    "deepseek-v4-pro": {"input": 1.74, "output": 3.48},
 }
 
 _FALLBACK_PRICING: dict[str, float] = {"input": 3.0, "output": 15.0}

--- a/packages/core/src/repowise/core/providers/llm/__init__.py
+++ b/packages/core/src/repowise/core/providers/llm/__init__.py
@@ -13,6 +13,7 @@ Built-in providers:
     openai     — gpt-5.4-nano, gpt-5.4-mini, gpt-5.4
     gemini     — gemini-3.1-flash-lite-preview, gemini-3-flash-preview, gemini-3.1-pro-preview
     openrouter — 200+ models via OpenRouter (anthropic/claude-sonnet-4.6, etc.)
+    deepseek   — deepseek-v4-flash, deepseek-v4-pro via api.deepseek.com
     ollama     — local inference (llama3.2, codellama, etc.)
     litellm    — 100+ providers via LiteLLM proxy
     mock       — deterministic test provider

--- a/packages/core/src/repowise/core/providers/llm/deepseek.py
+++ b/packages/core/src/repowise/core/providers/llm/deepseek.py
@@ -1,0 +1,284 @@
+"""DeepSeek provider for repowise.
+
+Access DeepSeek models (V4 Flash, V4 Pro) via the DeepSeek API at
+https://api.deepseek.com. The API is fully OpenAI-compatible — this provider
+uses the openai Python SDK with a custom base_url, following the same pattern
+as OpenRouterProvider.
+
+Models:
+    - deepseek-v4-flash  — fast, economical (284B total / 13B active params) [default]
+    - deepseek-v4-pro    — highest quality, full reasoning
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from openai import APIStatusError as _OpenAIAPIStatusError
+from openai import AsyncOpenAI
+from openai import RateLimitError as _OpenAIRateLimitError
+from tenacity import (
+    RetryError,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+from repowise.core.providers.llm.base import (
+    BaseProvider,
+    ChatStreamEvent,
+    ChatToolCall,
+    GeneratedResponse,
+    ProviderError,
+    RateLimitError,
+)
+from repowise.core.rate_limiter import RateLimiter
+
+if TYPE_CHECKING:
+    from repowise.core.generation.cost_tracker import CostTracker
+
+log = structlog.get_logger(__name__)
+
+_MAX_RETRIES = 3
+_MIN_WAIT = 1.0
+_MAX_WAIT = 4.0
+
+_DEFAULT_BASE_URL = "https://api.deepseek.com"
+
+
+class DeepSeekProvider(BaseProvider):
+    """DeepSeek provider — access DeepSeek V4 models via OpenAI-compatible API.
+
+    Args:
+        api_key:      DeepSeek API key. Falls back to DEEPSEEK_API_KEY env var.
+        model:        Model identifier. Defaults to deepseek-v4-flash.
+        base_url:     Override the DeepSeek API URL (rarely needed).
+        rate_limiter: Optional RateLimiter instance.
+        cost_tracker: Optional CostTracker instance for usage recording.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        model: str = "deepseek-v4-flash",
+        base_url: str | None = None,
+        rate_limiter: RateLimiter | None = None,
+        cost_tracker: CostTracker | None = None,
+    ) -> None:
+        resolved_key = api_key or os.environ.get("DEEPSEEK_API_KEY")
+        if not resolved_key:
+            raise ProviderError(
+                "deepseek",
+                "No API key provided. Pass api_key= or set DEEPSEEK_API_KEY.",
+            )
+        resolved_base_url = base_url or os.environ.get("DEEPSEEK_BASE_URL") or _DEFAULT_BASE_URL
+        self._client = AsyncOpenAI(
+            api_key=resolved_key,
+            base_url=resolved_base_url,
+        )
+        self._model = model
+        self._rate_limiter = rate_limiter
+        self._cost_tracker = cost_tracker
+
+    @property
+    def provider_name(self) -> str:
+        return "deepseek"
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    async def generate(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int = 4096,
+        temperature: float = 0.3,
+        request_id: str | None = None,
+    ) -> GeneratedResponse:
+        if self._rate_limiter:
+            await self._rate_limiter.acquire(estimated_tokens=max_tokens)
+
+        log.debug(
+            "deepseek.generate.start",
+            model=self._model,
+            max_tokens=max_tokens,
+            request_id=request_id,
+        )
+
+        try:
+            return await self._generate_with_retry(
+                system_prompt=system_prompt,
+                user_prompt=user_prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                request_id=request_id,
+            )
+        except RetryError as exc:
+            raise ProviderError(
+                "deepseek",
+                f"All {_MAX_RETRIES} retries exhausted: {exc}",
+            ) from exc
+
+    @retry(
+        retry=retry_if_exception_type(ProviderError),
+        stop=stop_after_attempt(_MAX_RETRIES),
+        wait=wait_exponential_jitter(initial=_MIN_WAIT, max=_MAX_WAIT),
+        reraise=True,
+    )
+    async def _generate_with_retry(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        max_tokens: int,
+        temperature: float,
+        request_id: str | None,
+    ) -> GeneratedResponse:
+        try:
+            response = await self._client.chat.completions.create(
+                model=self._model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+            )
+        except _OpenAIRateLimitError as exc:
+            raise RateLimitError("deepseek", str(exc), status_code=429) from exc
+        except _OpenAIAPIStatusError as exc:
+            raise ProviderError(
+                "deepseek", str(exc), status_code=exc.status_code
+            ) from exc
+
+        usage = response.usage
+        result = GeneratedResponse(
+            content=response.choices[0].message.content or "",
+            input_tokens=usage.prompt_tokens if usage else 0,
+            output_tokens=usage.completion_tokens if usage else 0,
+            cached_tokens=0,
+            usage={
+                "prompt_tokens": usage.prompt_tokens if usage else 0,
+                "completion_tokens": usage.completion_tokens if usage else 0,
+                "total_tokens": usage.total_tokens if usage else 0,
+            },
+        )
+        log.debug(
+            "deepseek.generate.done",
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
+            request_id=request_id,
+        )
+
+        if self._cost_tracker is not None:
+            import asyncio
+
+            with contextlib.suppress(RuntimeError):
+                asyncio.get_event_loop().create_task(
+                    self._cost_tracker.record(
+                        model=self._model,
+                        input_tokens=result.input_tokens,
+                        output_tokens=result.output_tokens,
+                        operation="doc_generation",
+                        file_path=None,
+                    )
+                )
+
+        return result
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        system_prompt: str,
+        max_tokens: int = 8192,
+        temperature: float = 0.7,
+        request_id: str | None = None,
+        tool_executor: Any | None = None,
+    ) -> AsyncIterator[ChatStreamEvent]:
+        import json as _json
+
+        full_messages = [{"role": "system", "content": system_prompt}, *messages]
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "messages": full_messages,
+            "stream": True,
+        }
+        if tools:
+            kwargs["tools"] = tools
+
+        try:
+            stream = await self._client.chat.completions.create(**kwargs)
+        except _OpenAIRateLimitError as exc:
+            raise RateLimitError("deepseek", str(exc), status_code=429) from exc
+        except _OpenAIAPIStatusError as exc:
+            raise ProviderError("deepseek", str(exc), status_code=exc.status_code) from exc
+
+        tool_calls_acc: dict[int, dict[str, Any]] = {}
+
+        try:
+            async for chunk in stream:
+                choice = chunk.choices[0] if chunk.choices else None
+                if not choice:
+                    if chunk.usage:
+                        yield ChatStreamEvent(
+                            type="usage",
+                            input_tokens=chunk.usage.prompt_tokens or 0,
+                            output_tokens=chunk.usage.completion_tokens or 0,
+                        )
+                    continue
+
+                delta = choice.delta
+                finish = choice.finish_reason
+
+                if delta and delta.content:
+                    yield ChatStreamEvent(type="text_delta", text=delta.content)
+
+                if delta and delta.tool_calls:
+                    for tc_delta in delta.tool_calls:
+                        idx = tc_delta.index
+                        if idx not in tool_calls_acc:
+                            tool_calls_acc[idx] = {
+                                "id": tc_delta.id or "",
+                                "name": "",
+                                "arguments": "",
+                            }
+                        acc = tool_calls_acc[idx]
+                        if tc_delta.id:
+                            acc["id"] = tc_delta.id
+                        if tc_delta.function:
+                            if tc_delta.function.name:
+                                acc["name"] = tc_delta.function.name
+                            if tc_delta.function.arguments:
+                                acc["arguments"] += tc_delta.function.arguments
+
+                if finish:
+                    for idx in sorted(tool_calls_acc.keys()):
+                        acc = tool_calls_acc[idx]
+                        try:
+                            args = _json.loads(acc["arguments"]) if acc["arguments"] else {}
+                        except Exception:
+                            args = {}
+                        yield ChatStreamEvent(
+                            type="tool_start",
+                            tool_call=ChatToolCall(
+                                id=acc["id"],
+                                name=acc["name"],
+                                arguments=args,
+                            ),
+                        )
+                    tool_calls_acc.clear()
+
+                    stop_reason = "tool_use" if finish == "tool_calls" else "end_turn"
+                    yield ChatStreamEvent(type="stop", stop_reason=stop_reason)
+        except _OpenAIRateLimitError as exc:
+            raise RateLimitError("deepseek", str(exc), status_code=429) from exc
+        except _OpenAIAPIStatusError as exc:
+            raise ProviderError("deepseek", str(exc), status_code=exc.status_code) from exc

--- a/packages/core/src/repowise/core/providers/llm/registry.py
+++ b/packages/core/src/repowise/core/providers/llm/registry.py
@@ -8,6 +8,7 @@ Built-in providers:
     - anthropic   → AnthropicProvider
     - openai      → OpenAIProvider
     - openrouter  → OpenRouterProvider
+    - deepseek    → DeepSeekProvider
     - ollama      → OllamaProvider
     - litellm     → LiteLLMProvider
     - mock        → MockProvider (testing only)
@@ -41,6 +42,7 @@ _BUILTIN_PROVIDERS: dict[str, tuple[str, str]] = {
     "gemini": ("repowise.core.providers.llm.gemini", "GeminiProvider"),
     "ollama": ("repowise.core.providers.llm.ollama", "OllamaProvider"),
     "litellm": ("repowise.core.providers.llm.litellm", "LiteLLMProvider"),
+    "deepseek": ("repowise.core.providers.llm.deepseek", "DeepSeekProvider"),
     "mock": ("repowise.core.providers.llm.mock", "MockProvider"),
 }
 
@@ -137,6 +139,7 @@ def get_provider(
             "gemini": "google-genai",
             "ollama": "openai",  # ollama uses the openai package
             "openrouter": "openai",  # openrouter uses the openai package
+            "deepseek": "openai",  # deepseek uses the openai package
             "litellm": "litellm",
         }
         package = _missing.get(name, name)

--- a/packages/core/src/repowise/core/rate_limiter.py
+++ b/packages/core/src/repowise/core/rate_limiter.py
@@ -50,6 +50,7 @@ PROVIDER_DEFAULTS: dict[str, RateLimitConfig] = {
     # Ollama runs locally — effectively unlimited, but we cap to avoid OOM
     "ollama": RateLimitConfig(requests_per_minute=1_000, tokens_per_minute=10_000_000),
     "litellm": RateLimitConfig(requests_per_minute=60, tokens_per_minute=150_000),
+    "deepseek": RateLimitConfig(requests_per_minute=60, tokens_per_minute=200_000),
 }
 
 

--- a/packages/server/src/repowise/server/mcp_server/tool_answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer.py
@@ -351,7 +351,7 @@ def _resolve_provider_for_answer(repo_path: Path | None = None):
     try:
         from repowise.core.providers.llm.registry import get_provider
     except Exception:
-        _log.debug("Provider registry import failed", exc_info=True)
+        _log.warning("Provider registry import failed", exc_info=True)
         return None
 
     persisted_name, persisted_model, env_overlay = _load_repo_provider_config(
@@ -374,7 +374,7 @@ def _resolve_provider_for_answer(repo_path: Path | None = None):
         try:
             return get_provider(provider_name, **kwargs)
         except Exception:
-            _log.debug("get_provider(%s) failed", provider_name, exc_info=True)
+            _log.warning("get_provider(%s) failed", provider_name, exc_info=True)
             return None
 
     def _resolve_base_url(provider_name: str) -> str | None:
@@ -382,6 +382,7 @@ def _resolve_provider_for_answer(repo_path: Path | None = None):
             "openai": ["OPENAI_BASE_URL"],
             "anthropic": ["ANTHROPIC_BASE_URL"],
             "gemini": ["GEMINI_BASE_URL"],
+            "deepseek": ["DEEPSEEK_BASE_URL"],
             "ollama": ["OLLAMA_BASE_URL"],
             "litellm": ["LITELLM_BASE_URL", "LITELLM_API_BASE"],
         }
@@ -400,6 +401,8 @@ def _resolve_provider_for_answer(repo_path: Path | None = None):
             kw["api_key"] = _env("ANTHROPIC_API_KEY")
         elif name == "openai" and _env("OPENAI_API_KEY"):
             kw["api_key"] = _env("OPENAI_API_KEY")
+        elif name == "deepseek" and _env("DEEPSEEK_API_KEY"):
+            kw["api_key"] = _env("DEEPSEEK_API_KEY")
         elif name == "gemini" and (
             _env("GEMINI_API_KEY") or _env("GOOGLE_API_KEY")
         ):
@@ -439,6 +442,14 @@ def _resolve_provider_for_answer(repo_path: Path | None = None):
         if model:
             kw["model"] = model
         return _try("ollama", **kw)
+    if _env("DEEPSEEK_API_KEY"):
+        kw = {"api_key": _env("DEEPSEEK_API_KEY")}
+        if model:
+            kw["model"] = model
+        base_url = _resolve_base_url("deepseek")
+        if base_url:
+            kw["base_url"] = base_url
+        return _try("deepseek", **kw)
     return None
 
 

--- a/packages/server/src/repowise/server/provider_config.py
+++ b/packages/server/src/repowise/server/provider_config.py
@@ -61,6 +61,14 @@ PROVIDER_CATALOG: list[dict[str, Any]] = [
         "requires_key": True,
     },
     {
+        "id": "deepseek",
+        "name": "DeepSeek",
+        "default_model": "deepseek-v4-flash",
+        "models": ["deepseek-v4-flash", "deepseek-v4-pro"],
+        "env_keys": ["DEEPSEEK_API_KEY"],
+        "requires_key": True,
+    },
+    {
         "id": "ollama",
         "name": "Ollama (Local)",
         "default_model": "llama3.2",
@@ -139,6 +147,7 @@ def _get_base_url_for_provider(provider_id: str) -> str | None:
         "openai": ["OPENAI_BASE_URL"],
         "gemini": ["GEMINI_BASE_URL"],
         "ollama": ["OLLAMA_BASE_URL"],
+        "deepseek": ["DEEPSEEK_BASE_URL"],
         "litellm": ["LITELLM_BASE_URL", "LITELLM_API_BASE"],
     }
     for env_var in env_map.get(provider_id, []):

--- a/packages/ui/src/dashboard/quick-actions.tsx
+++ b/packages/ui/src/dashboard/quick-actions.tsx
@@ -27,6 +27,8 @@ const COST_TABLE_EXACT: Record<string, [number, number]> = {
   "claude-opus-4-6": [0.005, 0.025],
   "claude-sonnet-4-6": [0.003, 0.015],
   "claude-haiku-4-5": [0.001, 0.005],
+  "deepseek-v4-flash": [0.00014, 0.00028],
+  "deepseek-v4-pro": [0.00174, 0.00348],
 };
 
 const COST_TABLE_PREFIX: [string, [number, number]][] = [
@@ -37,6 +39,7 @@ const COST_TABLE_PREFIX: [string, [number, number]][] = [
   ["claude-sonnet", [0.003, 0.015]],
   ["claude-haiku", [0.001, 0.005]],
   ["claude", [0.003, 0.015]],
+  ["deepseek", [0.00014, 0.00028]],
   ["gemini", [0.00025, 0.0015]],
   ["llama", [0, 0]],
   ["mock", [0, 0]],

--- a/packages/web/src/components/repos/run-config-form.tsx
+++ b/packages/web/src/components/repos/run-config-form.tsx
@@ -27,7 +27,7 @@ interface Props {
   onChange: (v: RunConfig) => void;
 }
 
-const PROVIDERS = ["litellm", "openai", "anthropic", "ollama", "mock"] as const;
+const PROVIDERS = ["litellm", "openai", "anthropic", "gemini", "deepseek", "ollama", "mock"] as const;
 
 export function RunConfigForm({ value, onChange }: Props) {
   // Seed from saved settings on mount

--- a/packages/web/src/components/settings/provider-section.tsx
+++ b/packages/web/src/components/settings/provider-section.tsx
@@ -14,13 +14,14 @@ import {
   SelectValue,
 } from "@repowise-dev/ui/ui/select";
 
-const PROVIDERS = ["gemini", "openai", "anthropic", "ollama", "litellm", "mock"] as const;
+const PROVIDERS = ["gemini", "openai", "anthropic", "deepseek", "ollama", "litellm", "mock"] as const;
 const EMBEDDERS = ["mock", "gemini", "openai"] as const;
 
 const MODEL_PLACEHOLDERS: Record<string, string> = {
   gemini: "gemini-3.1-flash-lite-preview",
   openai: "gpt-4.1",
   anthropic: "claude-sonnet-4-6",
+  deepseek: "deepseek-v4-flash",
   ollama: "llama3.2",
   litellm: "groq/llama-3.1-70b-versatile",
   mock: "mock",
@@ -31,6 +32,7 @@ const PROVIDER_ENV_VARS: Record<string, { vars: string[]; installHint: string }>
   openai: { vars: ["OPENAI_API_KEY"], installHint: "pip install openai" },
   anthropic: { vars: ["ANTHROPIC_API_KEY"], installHint: "pip install anthropic" },
   ollama: { vars: ["OLLAMA_BASE_URL"], installHint: "https://ollama.ai" },
+  deepseek: { vars: ["DEEPSEEK_API_KEY"], installHint: "pip install openai" },
   litellm: { vars: ["LITELLM_*"], installHint: "pip install litellm" },
   mock: { vars: [], installHint: "No key needed" },
 };

--- a/tests/providers/test_registry.py
+++ b/tests/providers/test_registry.py
@@ -115,5 +115,5 @@ class TestCustomProviderRegistration:
         assert received.get("api_key") == "key-123"
 
     def test_builtin_count(self) -> None:
-        """Sanity check: we have exactly 7 built-in providers."""
-        assert len(_BUILTIN_PROVIDERS) == 7
+        """Sanity check: we have exactly 8 built-in providers."""
+        assert len(_BUILTIN_PROVIDERS) == 8

--- a/tests/unit/test_providers/test_deepseek_provider.py
+++ b/tests/unit/test_providers/test_deepseek_provider.py
@@ -1,0 +1,225 @@
+"""Unit tests for DeepSeekProvider.
+
+All tests mock the AsyncOpenAI client — no real API calls are made.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("openai", reason="openai SDK not installed")
+
+from repowise.core.providers.llm.base import ChatStreamEvent, GeneratedResponse, ProviderError, RateLimitError
+from repowise.core.providers.llm.deepseek import DeepSeekProvider
+
+
+def test_provider_name():
+    p = DeepSeekProvider(api_key="sk-test")
+    assert p.provider_name == "deepseek"
+
+
+def test_default_model_is_flash():
+    p = DeepSeekProvider(api_key="sk-test")
+    assert p.model_name == "deepseek-v4-flash"
+
+
+def test_api_key_from_env(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-env-test")
+    p = DeepSeekProvider()
+    assert p.provider_name == "deepseek"
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    with pytest.raises(ProviderError):
+        DeepSeekProvider()
+
+
+def test_custom_model():
+    p = DeepSeekProvider(api_key="sk-test", model="deepseek-v4-pro")
+    assert p.model_name == "deepseek-v4-pro"
+
+
+def test_custom_base_url():
+    p = DeepSeekProvider(api_key="sk-test", base_url="https://custom.deepseek.com")
+    assert p.provider_name == "deepseek"
+
+
+def _make_mock_chat_response(text: str = "# Doc\nContent.") -> MagicMock:
+    usage = MagicMock()
+    usage.prompt_tokens = 120
+    usage.completion_tokens = 60
+    usage.total_tokens = 180
+
+    choice = MagicMock()
+    choice.message.content = text
+
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = usage
+    return response
+
+
+def _make_mock_stream_chunks(text: str) -> list[MagicMock]:
+    chunks = []
+    for char in text:
+        delta = MagicMock()
+        delta.content = char
+        delta.tool_calls = None
+        choice = MagicMock()
+        choice.delta = delta
+        choice.finish_reason = None
+        chunk = MagicMock()
+        chunk.choices = [choice]
+        chunk.usage = None
+        chunks.append(chunk)
+
+    finish_delta = MagicMock()
+    finish_delta.content = None
+    finish_delta.tool_calls = None
+    finish_choice = MagicMock()
+    finish_choice.delta = finish_delta
+    finish_choice.finish_reason = "stop"
+    finish_chunk = MagicMock()
+    finish_chunk.choices = [finish_choice]
+    finish_chunk.usage = None
+    chunks.append(finish_chunk)
+
+    return chunks
+
+
+async def test_generate_returns_generated_response():
+    provider = DeepSeekProvider(api_key="sk-test")
+    mock_response = _make_mock_chat_response("Hello from DeepSeek")
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = AsyncMock(return_value=mock_response)
+        provider._client = mock_client.return_value
+
+        result = await provider.generate(
+            system_prompt="You are a test assistant",
+            user_prompt="Say hello",
+        )
+
+    assert isinstance(result, GeneratedResponse)
+    assert result.content == "Hello from DeepSeek"
+    assert result.input_tokens == 120
+    assert result.output_tokens == 60
+
+
+async def test_generate_uses_correct_model_name():
+    provider = DeepSeekProvider(api_key="sk-test", model="deepseek-v4-flash")
+    mock_response = _make_mock_chat_response()
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = AsyncMock(return_value=mock_response)
+        provider._client = mock_client.return_value
+
+        await provider.generate(
+            system_prompt="system",
+            user_prompt="user",
+        )
+
+        mock_client.return_value.chat.completions.create.assert_called_once()
+        kwargs = mock_client.return_value.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "deepseek-v4-flash"
+
+
+async def test_generate_rate_limit_retry():
+    from openai import RateLimitError as _OpenAIRateLimitError
+
+    provider = DeepSeekProvider(api_key="sk-test")
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = AsyncMock(
+            side_effect=_OpenAIRateLimitError(
+                message="Rate limited",
+                body={},
+                response=MagicMock(status_code=429),
+            )
+        )
+        provider._client = mock_client.return_value
+
+        with pytest.raises(RateLimitError):
+            await provider.generate(
+                system_prompt="system",
+                user_prompt="user",
+            )
+
+
+async def test_generate_api_error():
+    from openai import APIStatusError as _OpenAIAPIStatusError
+
+    provider = DeepSeekProvider(api_key="sk-test")
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = AsyncMock(
+            side_effect=_OpenAIAPIStatusError(
+                message="Internal error",
+                body={},
+                response=MagicMock(status_code=500),
+            )
+        )
+        provider._client = mock_client.return_value
+
+        with pytest.raises(ProviderError) as excinfo:
+            await provider.generate(
+                system_prompt="system",
+                user_prompt="user",
+            )
+        assert excinfo.value.status_code == 500
+
+
+async def test_cost_tracker_called():
+    from repowise.core.generation.cost_tracker import CostTracker
+
+    mock_tracker = MagicMock(spec=CostTracker)
+    mock_tracker.record = AsyncMock(return_value=0.0)
+
+    provider = DeepSeekProvider(api_key="sk-test", cost_tracker=mock_tracker)
+    mock_response = _make_mock_chat_response()
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = AsyncMock(return_value=mock_response)
+        provider._client = mock_client.return_value
+
+        await provider.generate(
+            system_prompt="system",
+            user_prompt="user",
+        )
+
+    mock_tracker.record.assert_called_once()
+    call_kwargs = mock_tracker.record.call_args.kwargs
+    assert call_kwargs["model"] == "deepseek-v4-flash"
+    assert call_kwargs["input_tokens"] == 120
+    assert call_kwargs["output_tokens"] == 60
+
+
+async def test_stream_chat_emits_text_delta_and_stop():
+    provider = DeepSeekProvider(api_key="sk-test")
+
+    async def _async_gen():
+        for chunk in _make_mock_stream_chunks("Hi"):
+            yield chunk
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = AsyncMock(return_value=_async_gen())
+        provider._client = mock_client.return_value
+
+        events = []
+        async for event in provider.stream_chat(
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            system_prompt="You are helpful",
+        ):
+            events.append(event)
+
+    text_deltas = [e for e in events if e.type == "text_delta"]
+    stops = [e for e in events if e.type == "stop"]
+    assert len(text_deltas) == 2
+    assert text_deltas[0].text == "H"
+    assert text_deltas[1].text == "i"
+    assert len(stops) == 1
+    assert stops[0].stop_reason == "end_turn"


### PR DESCRIPTION
Add support for DeepSeek models as a first-class LLM provider via the
OpenAI-compatible API at api.deepseek.com.

## Provider implementation

`packages/core/.../providers/llm/deepseek.py` — Uses the OpenAI SDK with
`base_url=https://api.deepseek.com`. Supports `generate()` and `stream_chat()`
with tool calling. Default model: `deepseek-v4-flash`. Also supports
`deepseek-v4-pro` for full reasoning. 3 retry attempts with exponential
backoff on rate limits.

## Full-stack integration

- **Core**: provider registration, cost tracking, rate limiting
- **CLI**: provider resolution, defaults, env var config, signup URL
- **Server**: provider catalog, base_url resolution, MCP auto-detection
- **Web UI**: provider listing, run-config form, cost display
- **MCP `get_answer`**: provider auto-detection with DeepSeek in the
  resolution chain

## `.env` parser fixes

`load_dotenv` now correctly handles `KEY="value"` (strips quotes),
`export KEY=value`, and inline comments — fixing a common 401 error
where quoted API keys were used literally.

## MCP server fix

`repowise mcp` now loads `.repowise/.env` at startup (was missing),
enabling `get_answer` to resolve the configured provider and API keys.

## Tests

12 unit tests covering generation, streaming, error handling, and edge
cases. All 1495 tests pass.

## Files changed

17 files, +610 / -12