### PR TITLE
release: v0.7.0 — Web UI overhaul (Risk/Security/Costs/Docs/Symbols/Graph)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.0] — 2026-05-10
+
+### Added
+- **Risk page (consolidated).** New `/repos/<id>/risk` route brings the Heatmap, Hotspots, Dead Code, and Impact views under a single page with a persistent summary strip across the top. Hotspot rows are now clickable and open the universal File Card (#168).
+- **Security page.** New `/repos/<id>/security` route renders severity distribution, findings-by-directory, and a clickable findings table over the existing security signals (#168).
+- **Costs reorganization.** `/repos/<id>/costs` now splits into five tabs — Daily, Cache, Hotspots, Providers, Operations — backed by new `cache-hit-ratio-card`, `cost-heatmap`, `operation-breakdown`, and `provider-comparison` components (#168).
+- **Universal File Card.** New `FileCard` + `FileCardDialog` (`@repowise-dev/ui/shared/file-card`) shows a unified overview of any file — git signals, docs, symbols, dead-code findings, decisions, security issues — with sections that render only when the underlying data exists. Wired into Risk and Symbols (#168).
+- **Hot Symbols Board** with score-driven intensity bars over the symbols table; **Centrality Leaderboard** as a collapsible right-rail panel on the graph view (PageRank / Betweenness / Degree) (#168).
+- **Docs onboarding.** `FirstFiveFiles` "Start here" card on the Docs page (collapsed by default) links to `/docs?page=<id>`. New `DriftBanner` and `ConfidenceVsFreshnessMatrix` on docs/coverage. Mermaid diagrams now have a maximize button with a zoom/pan modal and a neutral brand theme (#168).
+- **Cross-page surfacing.** Shared `RelatedAcrossRepowise` collapsible footer plus new `EntityLink` / `EntityHoverCard` primitives and a `ContextDrawer` scaffold with URL sync (#168).
+- **`packages/ui` exports.** New entry points: `./costs`, `./security`, `./onboarding`, `./shared/file-card`, `./shared/related` (#168).
+
+### Fixed
+- **SymbolDrawer right-rail text cutoff** — drawer widened and `ScrollArea` padding adjusted (#168).
+- **Risk Hotspots table overflow** — long rows now truncate cleanly and open the File Card on click instead of pushing the layout (#168).
+- **Health-score ring** skipped doc components for index-only repos so the score reflects what was actually computed (#168).
+- **Chat `ToolCallBlock` hydration error** — split a button nested inside another button into sibling elements (#168).
+- **Docs explorer sidebar toggle** anchored to its `relative` parent instead of falling back to the viewport, so it no longer overlaps the header (#168).
+- **Docs "Start here" links** now route to `/docs?page=<id>` instead of broken wiki slugs (#168).
+
+---
+
 ## [0.6.2] — 2026-05-10
 
 ### Fixed

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -6,4 +6,4 @@ git signals, dead code detection, architectural decisions, and
 AI-generated documentation.
 """
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.6.2"
+version = "0.7.0"
 description = "Codebase intelligence for developers and AI — generates and maintains a structured wiki for any codebase"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.6.2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Cuts v0.7.0. Only OSS change since v0.6.2 is the web UI overhaul from #168 — new Risk and Security pages, Costs reorganized into 5 tabs, universal File Card, Mermaid zoom/pan, Hot Symbols Board, Centrality Leaderboard, Docs onboarding. Minor bump (not patch) because of new routes and new `packages/ui` entry points (`./costs`, `./security`, `./onboarding`, `./shared/file-card`, `./shared/related`).

## Changes in this PR

- Version bump in the four canonical files: `pyproject.toml`, `packages/{cli,core,server}/src/repowise/*/+__init__.py`
- `uv.lock` regenerated (`repowise` self-entry: 0.6.2 → 0.7.0)
- `docs/CHANGELOG.md` — new `## [0.7.0] — 2026-05-10` section above 0.6.2

## Test plan

- [x] `uv build --wheel` succeeds → `dist/repowise-0.7.0-py3-none-any.whl`
- [x] `uv lock` clean, no version drift (`git grep "0\.6\.2"` returns nothing in versioned files)
- [ ] Reviewer: confirm changelog wording matches what shipped in #168
- [ ] **After merge**, on `main`:
  - `git checkout main && git pull --ff-only`
  - `git tag v0.7.0 && git push origin v0.7.0` to trigger `publish.yml`
  - Watch `gh run list --workflow=publish.yml --limit 1` (build-web + build-python in parallel, then release; ~2m20s historically)
  - Verify GitHub release has all 3 assets and PyPI shows 0.7.0

**Merge convention:** regular merge commit, **not squash** (per release runbook — tag must point at a `main` commit with correct artifact provenance).