### PR TITLE
release: v0.7.1 — fix /settings prerender (Suspense for ContextDrawerShell)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.7.1] — 2026-05-10
+
+### Fixed
+- **`repowise serve` 404 on the web tarball for v0.7.0.** The v0.7.0 publish workflow failed during the web build: `useSearchParams()` inside the new `ContextDrawerShell` (mounted in the root layout for the `?drawer=` URL sync added in #168) tripped Next.js' static prerender of `/settings` with a missing-Suspense bailout. The Python wheel published to PyPI but no `repowise-web.tar.gz` was attached to the v0.7.0 GitHub release, so end-user `repowise serve` falls through to "API only". v0.7.1 wraps `ContextDrawerShell` in a `<Suspense>` boundary in `packages/web/src/app/layout.tsx` so the layout no longer blocks static prerendering. **Anyone who installed 0.7.0 should upgrade to 0.7.1** to get a working web UI from `repowise serve`.
+
+---
+
 ## [0.7.0] — 2026-05-10
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -6,4 +6,4 @@ git signals, dead code detection, architectural decisions, and
 AI-generated documentation.
 """
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
@@ -55,18 +56,20 @@ export default async function RootLayout({
         </a>
         <NuqsAdapter>
         <TooltipProvider delayDuration={300}>
-          <ContextDrawerShell>
-            <div className="flex h-screen overflow-hidden">
-              <Sidebar repos={repos} workspace={workspace} />
-              <div className="flex flex-1 flex-col min-w-0 overflow-hidden">
-                <MobileNav repos={repos} workspace={workspace} />
-                <main id="main-content" className="flex-1 overflow-auto min-w-0">
-                  {children}
-                </main>
+          <Suspense fallback={null}>
+            <ContextDrawerShell>
+              <div className="flex h-screen overflow-hidden">
+                <Sidebar repos={repos} workspace={workspace} />
+                <div className="flex flex-1 flex-col min-w-0 overflow-hidden">
+                  <MobileNav repos={repos} workspace={workspace} />
+                  <main id="main-content" className="flex-1 overflow-auto min-w-0">
+                    {children}
+                  </main>
+                </div>
               </div>
-            </div>
-            <CommandPalette repos={repos} workspace={workspace} />
-          </ContextDrawerShell>
+              <CommandPalette repos={repos} workspace={workspace} />
+            </ContextDrawerShell>
+          </Suspense>
         </TooltipProvider>
         </NuqsAdapter>
         <Toaster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.7.0"
+version = "0.7.1"
 description = "Codebase intelligence for developers and AI — generates and maintains a structured wiki for any codebase"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Hotfix for v0.7.0. The v0.7.0 `publish.yml` run failed in the `build-web` job: `ContextDrawerShell` (added in #168 to URL-sync the context drawer via `?drawer=`) calls `useSearchParams()` and is mounted in the root layout, which tripped Next.js' static prerender of `/settings` with a missing-Suspense bailout. The Python wheel **did publish to PyPI**, but no `repowise-web.tar.gz` is attached to the v0.7.0 GitHub release — so `repowise serve` on a fresh install 404s on the tarball download and falls through to "API only".

Fix: wrap `<ContextDrawerShell>` in `<Suspense fallback={null}>` in `packages/web/src/app/layout.tsx`. Verified locally with `npm run build --workspace packages/web` — `/settings` now prerenders cleanly as static.

## Changes

- `packages/web/src/app/layout.tsx` — `Suspense` import + boundary around `ContextDrawerShell`
- Version bump to 0.7.1 in the four canonical files
- `uv.lock` self-entry refreshed (0.7.0 → 0.7.1)
- `docs/CHANGELOG.md` — `## [0.7.1]` section explaining the failed v0.7.0 release and the fix

## Test plan

- [x] `npm run build --workspace packages/web` succeeds; `/settings` shows up as `○ (Static)` in the route summary
- [x] `uv lock` clean
- [ ] **After merge**, on `main`:
  - `git checkout main && git pull --ff-only`
  - `git tag v0.7.1 && git push origin v0.7.1`
  - Watch `gh run list --workflow=publish.yml --limit 1` — both `build-web` and `build-python` must succeed this time
  - Verify GitHub release v0.7.1 has all 3 assets and PyPI shows 0.7.1
- [ ] Communicate to anyone who already pulled 0.7.0 to upgrade

**Merge convention:** regular merge commit, **not squash**.