### PR TITLE
feat(ui): Shiki code highlighting, DOM heatmap, docs filter defaults

### DIFF
--- a/.github/workflows/publish-internal.yml
+++ b/.github/workflows/publish-internal.yml
@@ -1,7 +1,7 @@
 name: Publish internal prereleases
 
 # Publishes @repowise-dev/types and @repowise-dev/ui to GitHub Packages on
-# every push to `next`, tagged as `0.0.0-internal.<short-sha>`. Downstream
+# every push to `main`, tagged as `0.0.0-internal.<short-sha>`. Downstream
 # consumers (e.g. hosted-frontend) pin to a specific SHA.
 #
 # Source package.json files declare the published names directly
@@ -14,12 +14,11 @@ name: Publish internal prereleases
 #   - push to `next` (auto)
 #   - workflow_dispatch (manual, for re-publishes)
 #
-# Explicitly NOT triggered on push to `main` to avoid surfacing prereleases
-# from main while the package consumption pattern is still being validated.
+# Triggers on push to `main` so merged PRs automatically publish.
 
 on:
   push:
-    branches: [next]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1324,7 +1324,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1347,7 +1346,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1370,7 +1368,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1387,7 +1384,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1404,7 +1400,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1421,7 +1416,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1438,7 +1432,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1455,7 +1448,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1472,7 +1464,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1489,7 +1480,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1506,7 +1496,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1523,7 +1512,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1540,7 +1528,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1563,7 +1550,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1586,7 +1572,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1609,7 +1594,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1632,7 +1616,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1655,7 +1638,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1678,7 +1660,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1701,7 +1682,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1721,7 +1701,6 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -1744,7 +1723,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1764,7 +1742,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1784,7 +1761,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3906,6 +3882,33 @@
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "1.29.2"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@shikijs/themes": {
@@ -11508,6 +11511,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
     "node_modules/oniguruma-to-es": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
@@ -14551,6 +14560,7 @@
         "react-markdown": "^10.1.0",
         "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
+        "shiki": "^4.0.0",
         "sigma": "^3.0.3",
         "tailwind-merge": "^3.5.0"
       },
@@ -14571,6 +14581,86 @@
         "react-dom": "^19.0.0"
       }
     },
+    "packages/ui/node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/ui/node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/ui/node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/ui/node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/ui/node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/ui/node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "packages/ui/node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -14584,6 +14674,17 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "packages/ui/node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
       }
     },
     "packages/ui/node_modules/recharts": {
@@ -14614,6 +14715,43 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "packages/ui/node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "packages/ui/node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "packages/ui/node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/ui/node_modules/tailwind-merge": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -107,6 +107,7 @@
     "react-markdown": "^10.1.0",
     "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
+    "shiki": "^4.0.0",
     "sigma": "^3.0.3",
     "tailwind-merge": "^3.5.0"
   },

--- a/packages/ui/src/dashboard/dependency-heatmap.tsx
+++ b/packages/ui/src/dashboard/dependency-heatmap.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useEffect } from "react";
+import { useMemo, useState, useCallback, Fragment } from "react";
 import { Grid3X3 } from "lucide-react";
 import { EmptyState } from "../shared/empty-state";
 import type { ModuleGraph } from "@repowise-dev/types/graph";
@@ -11,20 +11,38 @@ interface DependencyHeatmapProps {
 
 function heatColor(count: number, max: number): string {
   if (count === 0) return "transparent";
-  const intensity = Math.min(1, count / Math.max(max, 1));
-  if (intensity > 0.7) return `rgba(245, 149, 32, ${0.4 + intensity * 0.5})`;
-  if (intensity > 0.3) return `rgba(245, 149, 32, ${0.15 + intensity * 0.35})`;
-  return `rgba(245, 149, 32, ${0.05 + intensity * 0.15})`;
+  const t = Math.min(1, count / Math.max(max, 1));
+  if (t > 0.7) return `rgba(245, 149, 32, ${0.55 + t * 0.4})`;
+  if (t > 0.3) return `rgba(245, 149, 32, ${0.2 + t * 0.35})`;
+  return `rgba(245, 149, 32, ${0.08 + t * 0.18})`;
+}
+
+function displayLabel(moduleId: string): string {
+  let label = moduleId;
+  if (label.startsWith("external:")) label = label.slice(9);
+  const last = label.split("/").pop() ?? label;
+  return last.length > 14 ? last.slice(0, 13) + "…" : last;
 }
 
 export function DependencyHeatmap({ moduleGraph }: DependencyHeatmapProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [hover, setHover] = useState<{
+    row: number;
+    col: number;
+    x: number;
+    y: number;
+  } | null>(null);
 
   const { modules, matrix, maxCount } = useMemo(() => {
+    const connectedSet = new Set<string>();
+    for (const e of moduleGraph.edges) {
+      connectedSet.add(e.source);
+      connectedSet.add(e.target);
+    }
+
     const mods = moduleGraph.nodes
-      .slice()
+      .filter((n) => connectedSet.has(n.module_id))
       .sort((a, b) => b.avg_pagerank - a.avg_pagerank)
-      .slice(0, 20)
+      .slice(0, 15)
       .map((m) => m.module_id);
 
     const modIdx = new Map<string, number>();
@@ -39,100 +57,167 @@ export function DependencyHeatmap({ moduleGraph }: DependencyHeatmapProps) {
       const si = modIdx.get(e.source);
       const ti = modIdx.get(e.target);
       if (si !== undefined && ti !== undefined) {
-        const row = mat[si];
-        if (!row) continue;
+        const row = mat[si]!;
         row[ti] = (row[ti] ?? 0) + e.edge_count;
-        if ((row[ti] ?? 0) > max) max = row[ti] ?? 0;
+        if (row[ti]! > max) max = row[ti]!;
       }
     }
 
     return { modules: mods, matrix: mat, maxCount: max };
   }, [moduleGraph]);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas || modules.length === 0) return;
+  const handleMouseEnter = useCallback(
+    (row: number, col: number, e: React.MouseEvent) => {
+      const rect = (e.currentTarget as HTMLElement)
+        .closest("[data-heatmap-grid]")!
+        .getBoundingClientRect();
+      const cellRect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      setHover({
+        row,
+        col,
+        x: cellRect.left - rect.left + cellRect.width / 2,
+        y: cellRect.top - rect.top,
+      });
+    },
+    [],
+  );
 
-    const size = modules.length;
-    const cellSize = Math.max(14, Math.min(28, Math.floor(300 / size)));
-    const labelWidth = 100;
-    const padding = 4;
-    const totalWidth = labelWidth + size * (cellSize + padding) + padding;
-    const totalHeight = labelWidth + size * (cellSize + padding) + padding;
-
-    canvas.width = totalWidth * 2;
-    canvas.height = totalHeight * 2;
-    canvas.style.width = `${totalWidth}px`;
-    canvas.style.height = `${totalHeight}px`;
-
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    ctx.scale(2, 2);
-
-    ctx.clearRect(0, 0, totalWidth, totalHeight);
-
-    ctx.save();
-    ctx.font = "9px var(--font-geist-mono, monospace)";
-    ctx.fillStyle = "var(--color-text-tertiary)";
-    ctx.textAlign = "right";
-    for (let i = 0; i < size; i++) {
-      const mod = modules[i];
-      if (!mod) continue;
-      const label = mod.split("/").pop() ?? mod;
-      const x = labelWidth + i * (cellSize + padding) + cellSize / 2;
-      ctx.save();
-      ctx.translate(x, labelWidth - 4);
-      ctx.rotate(-Math.PI / 4);
-      ctx.fillText(label.slice(0, 12), 0, 0);
-      ctx.restore();
-    }
-
-    ctx.textAlign = "right";
-    ctx.textBaseline = "middle";
-    for (let i = 0; i < size; i++) {
-      const mod = modules[i];
-      if (!mod) continue;
-      const label = mod.split("/").pop() ?? mod;
-      const y = labelWidth + i * (cellSize + padding) + cellSize / 2;
-      ctx.fillText(label.slice(0, 12), labelWidth - 6, y);
-    }
-    ctx.restore();
-
-    for (let r = 0; r < size; r++) {
-      const row = matrix[r];
-      if (!row) continue;
-      for (let c = 0; c < size; c++) {
-        const count = row[c] ?? 0;
-        const x = labelWidth + c * (cellSize + padding);
-        const y = labelWidth + r * (cellSize + padding);
-
-        if (r === c) {
-          ctx.fillStyle = "rgba(255,255,255,0.03)";
-        } else {
-          ctx.fillStyle = heatColor(count, maxCount);
-        }
-        ctx.beginPath();
-        ctx.roundRect(x, y, cellSize, cellSize, 2);
-        ctx.fill();
-      }
-    }
-  }, [modules, matrix, maxCount]);
+  const handleMouseLeave = useCallback(() => setHover(null), []);
 
   if (modules.length < 2) {
     return (
-      <div className="overflow-x-auto">
-        <EmptyState
-          icon={<Grid3X3 className="h-8 w-8" />}
-          title="No dependency data"
-          description="Not enough modules to generate a dependency heatmap."
-        />
-      </div>
+      <EmptyState
+        icon={<Grid3X3 className="h-8 w-8" />}
+        title="No dependency data"
+        description="Not enough modules to generate a dependency heatmap."
+      />
     );
   }
 
+  const size = modules.length;
+  const hoverCount =
+    hover != null ? (matrix[hover.row]?.[hover.col] ?? 0) : 0;
+
   return (
-    <div className="overflow-x-auto">
-      <canvas ref={canvasRef} />
+    <div className="relative" data-heatmap-grid>
+      {/* Tooltip — only for non-zero cells */}
+      {hover && hoverCount > 0 && (
+        <div
+          className="absolute z-20 pointer-events-none px-2.5 py-1.5 rounded-md text-xs bg-[var(--color-bg-elevated)] border border-[var(--color-border-default)] shadow-lg whitespace-nowrap"
+          style={{
+            left: hover.x,
+            top: hover.y - 8,
+            transform: "translate(-50%, -100%)",
+          }}
+        >
+          <span className="text-[var(--color-accent-primary)] font-medium">
+            {displayLabel(modules[hover.row]!)}
+          </span>
+          <span className="text-[var(--color-text-tertiary)]"> → </span>
+          <span className="text-[var(--color-text-primary)] font-medium">
+            {displayLabel(modules[hover.col]!)}
+          </span>
+          <span className="text-[var(--color-text-tertiary)] ml-1.5">
+            {hoverCount} {hoverCount === 1 ? "dep" : "deps"}
+          </span>
+        </div>
+      )}
+
+      <div className="overflow-x-auto">
+        <div
+          className="inline-grid gap-px"
+          style={{
+            gridTemplateColumns: `auto repeat(${size}, minmax(24px, 1fr))`,
+            gridTemplateRows: `auto repeat(${size}, minmax(24px, 1fr))`,
+            minWidth: Math.max(360, size * 32 + 100),
+          }}
+        >
+          {/* Top-left corner — empty */}
+          <div />
+
+          {/* Column headers */}
+          {modules.map((mod) => (
+            <div
+              key={`col-${mod}`}
+              className="flex items-end justify-center pb-1.5"
+              style={{ height: 100 }}
+            >
+              <span
+                className="text-[10px] leading-tight text-[var(--color-text-tertiary)] font-mono overflow-hidden text-ellipsis"
+                style={{
+                  writingMode: "vertical-rl",
+                  transform: "rotate(180deg)",
+                  maxHeight: 90,
+                }}
+                title={mod}
+              >
+                {displayLabel(mod)}
+              </span>
+            </div>
+          ))}
+
+          {/* Rows */}
+          {modules.map((rowMod, r) => {
+            const row = matrix[r]!;
+            return (
+              <Fragment key={rowMod}>
+                {/* Row label */}
+                <div className="flex items-center justify-end pr-2.5 min-w-[60px]">
+                  <span
+                    className="text-[11px] text-[var(--color-text-tertiary)] font-mono truncate max-w-[110px]"
+                    title={rowMod}
+                  >
+                    {displayLabel(rowMod)}
+                  </span>
+                </div>
+
+                {/* Cells */}
+                {modules.map((colMod, c) => {
+                  const count = row[c] ?? 0;
+                  const isDiag = r === c;
+
+                  return (
+                    <div
+                      key={`${rowMod}-${colMod}`}
+                      className="aspect-square rounded-[3px] transition-opacity duration-100 cursor-default"
+                      style={{
+                        backgroundColor: isDiag
+                          ? "rgba(255,255,255,0.03)"
+                          : heatColor(count, maxCount),
+                        opacity:
+                          hover && hover.row !== r && hover.col !== c
+                            ? 0.35
+                            : 1,
+                      }}
+                      onMouseEnter={(e) => handleMouseEnter(r, c, e)}
+                      onMouseLeave={handleMouseLeave}
+                    />
+                  );
+                })}
+              </Fragment>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center gap-2 mt-3 pt-2 border-t border-[var(--color-border-default)]">
+        <span className="text-[10px] text-[var(--color-text-tertiary)]">
+          Fewer
+        </span>
+        <div className="flex gap-0.5">
+          {[0.1, 0.3, 0.5, 0.7, 0.9].map((t) => (
+            <div
+              key={t}
+              className="w-4 h-3 rounded-sm"
+              style={{ backgroundColor: heatColor(t * maxCount, maxCount) }}
+            />
+          ))}
+        </div>
+        <span className="text-[10px] text-[var(--color-text-tertiary)]">
+          More dependencies
+        </span>
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/docs/docs-tree.tsx
+++ b/packages/ui/src/docs/docs-tree.tsx
@@ -342,7 +342,7 @@ export function DocsTree({ pages, selectedPageId, onSelectPage, className }: Doc
     }
     return dirs;
   });
-  const [showFilters, setShowFilters] = useState(false);
+  const [showFilters, setShowFilters] = useState(true);
 
   const tree = useMemo(() => buildTree(pages), [pages]);
   const filteredTree = useMemo(

--- a/packages/ui/src/wiki/wiki-markdown.tsx
+++ b/packages/ui/src/wiki/wiki-markdown.tsx
@@ -4,7 +4,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Components } from "react-markdown";
 import { MermaidDiagram } from "./mermaid-diagram";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Copy, Check } from "lucide-react";
 import { cn } from "../lib/cn";
 
@@ -17,6 +17,22 @@ function slugify(text: string): string {
 
 function ClientCodeBlock({ code, language }: { code: string; language: string }) {
   const [copied, setCopied] = useState(false);
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    import("shiki")
+      .then(({ codeToHtml }) =>
+        codeToHtml(code, { lang: language as never, theme: "vesper" }),
+      )
+      .then((result) => {
+        if (!cancelled) setHtml(result);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [code, language]);
 
   async function copy() {
     await navigator.clipboard.writeText(code);
@@ -53,11 +69,18 @@ function ClientCodeBlock({ code, language }: { code: string; language: string })
           )}
         </button>
       </div>
-      <pre className="overflow-x-auto p-4 bg-[var(--color-bg-inset)]">
-        <code className="text-xs font-mono text-[var(--color-text-primary)]">
-          {code}
-        </code>
-      </pre>
+      {html ? (
+        <div
+          className="overflow-x-auto text-sm [&>pre]:p-4 [&>pre]:m-0 [&>pre]:bg-transparent!"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      ) : (
+        <pre className="overflow-x-auto p-4 bg-[var(--color-bg-inset)]">
+          <code className="text-xs font-mono text-[var(--color-text-primary)]">
+            {code}
+          </code>
+        </pre>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- wiki-markdown: add client-side Shiki syntax highlighting to ClientCodeBlock with vesper theme (lazy-loaded, falls back to plain text on failure)
- dependency-heatmap: rewrite from canvas to CSS Grid with hover tooltips, row/col highlighting, legend, displayLabel stripping "external:" prefix, and capped at 15 connected modules
- docs-tree: default filter panel to expanded on first render
- Add shiki ^4.0.0 to packages/ui dependencies

## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

-

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- How did you verify this works? -->

- [ ] Tests pass (`pytest`)
- [ ] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(if frontend changes)*

## Checklist

- [ ] My code follows the project's code style
- [ ] I have added tests for new functionality
- [ ] All existing tests still pass
- [ ] I have updated documentation if needed
