### PR TITLE
Add reasoning mode configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,12 @@ REPOWISE_DEFAULT_MODEL=claude-sonnet-4-6
 # Max concurrent LLM calls during generation
 REPOWISE_MAX_CONCURRENT=5
 
+# Reasoning mode for supported docs-generation providers: auto | off | minimal
+# auto = provider default; off = disable Qwen3/OpenRouter effort reasoning when supported;
+# minimal = request the lowest supported OpenAI/OpenRouter reasoning effort.
+# Unsupported explicit modes fail before an API call.
+REPOWISE_REASONING=auto
+
 # Max pages to regenerate per maintenance run
 REPOWISE_CASCADE_BUDGET=30
 

--- a/README.md
+++ b/README.md
@@ -577,9 +577,10 @@ repowise reindex                  # rebuild vector store (no LLM calls)
 `repowise init` generates `.repowise/config.yaml`. Key options:
 
 ```yaml
-provider: anthropic               # anthropic | openai | ollama | litellm
+provider: anthropic               # anthropic | openai | openrouter | gemini | deepseek | ollama | litellm | mock
 model: claude-sonnet-4-5
 embedding_model: voyage-3
+reasoning: auto                   # auto | off | minimal
 
 git:
   co_change_commit_limit: 500
@@ -593,6 +594,10 @@ maintenance:
   cascade_budget: 30              # max pages fully regenerated per commit
   background_regen_schedule: "0 2 * * *"
 ```
+
+`reasoning` applies to documentation generation. `auto` preserves provider
+defaults; explicit `off` / `minimal` modes are translated only by providers and
+models that support them, otherwise repowise fails before making an API call.
 
 Full configuration reference: [docs/CONFIG.md](docs/CONFIG.md)
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -50,7 +50,7 @@ In workspace mode, adds: repo scanning, per-repo indexing, cross-repo analysis (
 
 | Flag | Description |
 |------|-------------|
-| `--provider` | LLM provider: `anthropic`, `openai`, `gemini`, `ollama`, `mock` |
+| `--provider` | LLM provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `ollama`, `litellm`, `mock` |
 | `--model` | Model name override (e.g., `claude-sonnet-4-6`) |
 | `--embedder` | Embedder for semantic search: `gemini`, `openai`, `mock` |
 | `--index-only` | Skip LLM generation. Only parse, build graph, and index git. Free. |
@@ -61,6 +61,7 @@ In workspace mode, adds: repo scanning, per-repo indexing, cross-repo analysis (
 | `--exclude / -x` | Gitignore-style exclusion patterns. Repeatable. |
 | `--include-submodules` | Include git submodule directories. |
 | `--concurrency` | Max concurrent LLM calls (default: 5). |
+| `--reasoning` | Reasoning mode for supported providers: `auto`, `off`, or `minimal` (default: `auto`). |
 | `--resume` | Resume from the last checkpoint if interrupted. |
 | `--force` | Regenerate all pages even if they exist. |
 | `--commit-limit` | Max commits to analyze per file (default: 500). |
@@ -76,6 +77,8 @@ repowise init --provider anthropic --yes              # automated
 repowise init --index-only                            # free, no LLM
 repowise init --dry-run                               # preview cost
 repowise init --test-run                              # quick test (10 files)
+repowise init --provider openai --model qwen3 --reasoning off
+repowise init --provider openrouter --model openai/gpt-5 --reasoning minimal
 repowise init -x vendor/ -x "*.gen.go"               # exclude patterns
 repowise init --include-submodules                    # include submodules
 repowise init .                                       # workspace mode
@@ -95,6 +98,7 @@ Incrementally update wiki pages for files changed since the last sync.
 | `--provider` | Override LLM provider for this run |
 | `--model` | Override model |
 | `--since` | Git ref to diff from (overrides `state.json`) |
+| `--reasoning` | Reasoning mode for supported providers: `auto`, `off`, or `minimal` |
 | `--cascade-budget` | Max pages to regenerate (default: auto) |
 | `--dry-run` | Show what would be updated without regenerating |
 | `--workspace` | Update all stale repos in the workspace + cross-repo analysis |
@@ -109,6 +113,7 @@ Incrementally update wiki pages for files changed since the last sync.
 repowise update                        # diff since last sync
 repowise update --dry-run              # preview
 repowise update --since v1.0.0         # diff from a tag
+repowise update --reasoning off        # one-off supported-provider thinking-off run
 repowise update --workspace            # all workspace repos (incl. first-time indexing)
 repowise update --repo backend         # specific workspace repo
 repowise update --no-workspace         # force single-repo mode in a workspace root

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -162,7 +162,7 @@ repowise init [PATH]
 
 | Flag | Description |
 |------|-------------|
-| `--provider` | LLM provider: `anthropic`, `openai`, `gemini`, `ollama`, `mock`. Auto-detected from env vars if not set. |
+| `--provider` | LLM provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `ollama`, `litellm`, `mock`. Auto-detected from env vars if not set. |
 | `--model` | Model name override (e.g., `claude-sonnet-4-6`, `gpt-5.4-nano`) |
 | `--embedder` | Embedder for semantic search: `gemini`, `openai`, `mock`. Auto-detected from env vars. |
 | `--index-only` | Skip LLM generation entirely. Only parse, build graph, and index git. Free. |
@@ -172,6 +172,7 @@ repowise init [PATH]
 | `--skip-infra` | Exclude infrastructure files (Dockerfiles, Makefiles, Terraform, shell scripts). |
 | `--exclude / -x` | Gitignore-style exclusion patterns. Repeatable: `-x vendor/ -x "*.generated.*"` |
 | `--concurrency` | Max concurrent LLM calls (default: 5). Higher = faster but more API pressure. |
+| `--reasoning` | Reasoning mode for supported providers: `auto`, `off`, or `minimal` (default: `auto`). |
 | `--resume` | Resume from the last checkpoint if a previous run was interrupted. |
 | `--force` | Regenerate all pages even if they already exist. |
 | `--commit-limit` | Max commits to analyze per file (default: 500, max: 5000). Saved to config. |
@@ -196,6 +197,9 @@ repowise init --provider openai --dry-run
 
 # Quick test with 10 files
 repowise init --provider gemini --test-run
+
+# OpenRouter with minimal reasoning effort
+repowise init --provider openrouter --model openai/gpt-5 --reasoning minimal
 
 # Exclude vendor and generated code
 repowise init -x vendor/ -x "*.gen.go" -x "**/__generated__/**"
@@ -228,6 +232,7 @@ Much faster and cheaper than a full `init` — only regenerates pages for change
 | `--provider` | Override LLM provider for this run |
 | `--model` | Override model |
 | `--since` | Git ref to diff from (overrides `state.json`). Example: `--since v1.0.0` |
+| `--reasoning` | Reasoning mode for supported providers: `auto`, `off`, or `minimal`. |
 | `--cascade-budget` | Max pages to regenerate per run (default: 30). Prevents runaway regeneration. |
 | `--dry-run` | Show what would be updated without regenerating. |
 
@@ -246,6 +251,9 @@ repowise update --since v2.0.0
 
 # Limit regeneration scope
 repowise update --cascade-budget 10
+
+# Disable reasoning for a supported provider/model for this run
+repowise update --reasoning off
 ```
 
 ---

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1617,7 +1617,7 @@ Key files:
 Full configuration with defaults (`.repowise/config.yaml`):
 
 ```yaml
-provider: anthropic          # anthropic | openai | ollama | litellm
+provider: anthropic          # anthropic | openai | openrouter | gemini | deepseek | ollama | litellm | mock
 model: claude-sonnet-4-5    # passed through to the provider
 embedding_provider: anthropic
 embedding_model: voyage-3

--- a/packages/cli/src/repowise/cli/commands/init_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd.py
@@ -21,6 +21,7 @@ from repowise.cli.helpers import (
     load_config,
     load_state,
     resolve_provider,
+    resolve_reasoning,
     resolve_repo_path,
     run_async,
     save_config,
@@ -277,7 +278,9 @@ async def _persist_result(
 
         # Record a completed GenerationJob so the web UI can show
         # "last synced" / "last re-indexed" timestamps.
-        from datetime import datetime, UTC as _UTC
+        from datetime import UTC as _UTC
+        from datetime import datetime
+
         from repowise.core.persistence.crud import upsert_generation_job
 
         now = datetime.now(_UTC)
@@ -318,6 +321,7 @@ def _run_workspace_generation(
     skip_tests: bool,
     skip_infra: bool,
     test_run: bool,
+    reasoning: str = "auto",
 ) -> list[Any]:
     """Run LLM generation for a single repo in the workspace init flow.
 
@@ -326,20 +330,28 @@ def _run_workspace_generation(
     workspace run.
     """
     from repowise.cli.cost_estimator import build_generation_plan, estimate_cost
+    from repowise.cli.helpers import get_db_url_for_repo
     from repowise.cli.ui import BRAND, RichProgressCallback
     from repowise.core.generation import GenerationConfig
     from repowise.core.generation.cost_tracker import CostTracker
-    from repowise.core.persistence.vector_store import InMemoryVectorStore
-    from repowise.core.providers.embedding.base import MockEmbedder
-    from repowise.core.pipeline import run_generation
-    from repowise.cli.helpers import get_db_url_for_repo
     from repowise.core.persistence import (
         create_engine as _ce,
+    )
+    from repowise.core.persistence import (
         create_session_factory as _csf,
+    )
+    from repowise.core.persistence import (
         get_session as _gs,
+    )
+    from repowise.core.persistence import (
         init_db as _idb,
+    )
+    from repowise.core.persistence import (
         upsert_repository as _ur,
     )
+    from repowise.core.persistence.vector_store import InMemoryVectorStore
+    from repowise.core.pipeline import run_generation
+    from repowise.core.providers.embedding.base import MockEmbedder
 
     # Build embedder
     embedder_impl: Any
@@ -371,7 +383,10 @@ def _run_workspace_generation(
         vector_store = InMemoryVectorStore(embedder_impl)
 
     # Cost estimate
-    gen_config = GenerationConfig(max_concurrency=concurrency)
+    gen_config = GenerationConfig(
+        max_concurrency=concurrency,
+        reasoning=resolve_reasoning(reasoning),
+    )
     plans = build_generation_plan(
         result.parsed_files, result.graph_builder, gen_config, skip_tests, skip_infra
     )
@@ -475,6 +490,7 @@ def _workspace_init(
     skip_infra: bool = False,
     concurrency: int = 5,
     test_run: bool = False,
+    reasoning: str | None = None,
     yes: bool = False,
     dry_run: bool = False,
     resume: bool = False,
@@ -574,6 +590,7 @@ def _workspace_init(
             if adv.get("exclude"):
                 exclude_patterns = list(exclude_patterns) + list(adv["exclude"])
             test_run = adv.get("test_run", test_run)
+            reasoning = adv.get("reasoning") or reasoning
             embedder_name_resolved = _resolve_embedder(adv.get("embedder") or embedder_name)
         elif not index_only:
             # "full" mode
@@ -582,6 +599,8 @@ def _workspace_init(
             )
 
     # Resolve provider once (shared across all repos for generation)
+    primary_cfg = load_config(primary_repo.path)
+    resolved_reasoning = resolve_reasoning(reasoning, primary_cfg)
     provider = None
     if not index_only:
         try:
@@ -591,6 +610,8 @@ def _workspace_init(
                 f"Model: [cyan]{provider.model_name}[/cyan]"
             )
             console.print(f"  Embedder: [cyan]{embedder_name_resolved}[/cyan]\n")
+            if resolved_reasoning != "auto":
+                console.print(f"  Reasoning: [cyan]{resolved_reasoning}[/cyan]\n")
         except Exception as exc:
             console.print(f"  [yellow]Provider setup failed ({exc}); falling back to index-only.[/yellow]")
             index_only = True
@@ -693,6 +714,7 @@ def _workspace_init(
                         skip_tests=skip_tests,
                         skip_infra=skip_infra,
                         test_run=test_run,
+                        reasoning=resolved_reasoning,
                     )
                     result.generated_pages = generated_pages
                     total_pages += len(generated_pages)
@@ -753,6 +775,7 @@ def _workspace_init(
                 embedder_name_resolved,
                 exclude_patterns=exclude_patterns if exclude_patterns else None,
                 commit_limit=resolved_commit_limit,
+                reasoning=resolved_reasoning,
             )
 
     # Save workspace config with updated timestamps
@@ -867,7 +890,10 @@ def _workspace_init(
     "--provider",
     "provider_name",
     default=None,
-    help="LLM provider name (anthropic, openai, gemini, deepseek, ollama, litellm, mock).",
+    help=(
+        "LLM provider name (anthropic, openai, openrouter, gemini, "
+        "deepseek, ollama, litellm, mock)."
+    ),
 )
 @click.option("--model", default=None, help="Model identifier override.")
 @click.option(
@@ -888,6 +914,12 @@ def _workspace_init(
     "--force", is_flag=True, default=False, help="Regenerate all pages, ignoring existing."
 )
 @click.option("--concurrency", type=int, default=5, help="Max concurrent LLM calls.")
+@click.option(
+    "--reasoning",
+    type=click.Choice(["auto", "off", "minimal"]),
+    default=None,
+    help="Reasoning mode for supported providers: auto, off, or minimal. Default: auto.",
+)
 @click.option(
     "--test-run",
     is_flag=True,
@@ -951,6 +983,7 @@ def init_command(
     resume: bool,
     force: bool,
     concurrency: int,
+    reasoning: str | None,
     test_run: bool,
     index_only: bool,
     exclude: tuple[str, ...],
@@ -1012,6 +1045,7 @@ def init_command(
             skip_tests=skip_tests,
             skip_infra=skip_infra,
             concurrency=concurrency,
+            reasoning=reasoning,
             test_run=test_run,
             yes=yes,
             dry_run=dry_run,
@@ -1073,6 +1107,7 @@ def init_command(
             skip_tests = adv["skip_tests"]
             skip_infra = adv["skip_infra"]
             concurrency = adv["concurrency"]
+            reasoning = adv.get("reasoning") or reasoning
             exclude = adv["exclude"]
             test_run = adv["test_run"]
             embedder_name = adv.get("embedder") or embedder_name
@@ -1090,6 +1125,7 @@ def init_command(
     # Merge exclude_patterns from config.yaml and --exclude/-x flags
     config = load_config(repo_path)
     language = config.get("language", "en")
+    resolved_reasoning = resolve_reasoning(reasoning, config)
     exclude_patterns: list[str] = list(config.get("exclude_patterns") or []) + list(exclude)
 
     # Resolve commit limit: CLI flag → config.yaml → default (500)
@@ -1153,13 +1189,22 @@ def init_command(
         console.print(f"  Embedder: [cyan]{embedder_name_resolved}[/cyan]")
         if language != "en":
             console.print(f"  Language: [cyan]{language}[/cyan]")
+        if resolved_reasoning != "auto":
+            console.print(f"  Reasoning: [cyan]{resolved_reasoning}[/cyan]")
 
         # Validate provider connection
         from repowise.core.providers.llm.base import ProviderError
 
         with console.status("  Verifying provider connection…", spinner="dots"):
             try:
-                run_async(provider.generate("You are a test.", "Reply with OK.", max_tokens=50))
+                run_async(
+                    provider.generate(
+                        "You are a test.",
+                        "Reply with OK.",
+                        max_tokens=50,
+                        reasoning=resolved_reasoning,
+                    )
+                )
             except ProviderError as exc:
                 raise click.ClickException(f"Provider validation failed: {exc}") from exc
         console.print("  [green]✓[/green] Provider connection verified")
@@ -1269,7 +1314,11 @@ def init_command(
 
         # Cost estimation
         from repowise.core.generation import GenerationConfig
-        gen_config = GenerationConfig(max_concurrency=concurrency, language=language)
+        gen_config = GenerationConfig(
+            max_concurrency=concurrency,
+            language=language,
+            reasoning=resolved_reasoning,
+        )
         plans = build_generation_plan(
             result.parsed_files, result.graph_builder, gen_config, skip_tests, skip_infra
         )
@@ -1365,13 +1414,21 @@ def init_command(
                 # is persisted to the llm_costs table.  We need the repo_id from the
                 # database row that was created/upserted during _persist_result
                 # (which has not run yet), so we look it up or fall back to in-memory.
-                from repowise.core.generation.cost_tracker import CostTracker
                 from repowise.cli.helpers import get_db_url_for_repo
+                from repowise.core.generation.cost_tracker import CostTracker
                 from repowise.core.persistence import (
                     create_engine as _create_engine,
+                )
+                from repowise.core.persistence import (
                     create_session_factory as _create_sf,
+                )
+                from repowise.core.persistence import (
                     get_session as _get_session,
+                )
+                from repowise.core.persistence import (
                     init_db as _init_db,
+                )
+                from repowise.core.persistence import (
                     upsert_repository as _upsert_repo,
                 )
 
@@ -1522,6 +1579,7 @@ def init_command(
             embedder_name_resolved,
             exclude_patterns=exclude_patterns if exclude_patterns else None,
             commit_limit=resolved_commit_limit if commit_limit is not None else None,
+            reasoning=resolved_reasoning,
         )
 
     # ---- Completion panel ----

--- a/packages/cli/src/repowise/cli/commands/update_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd.py
@@ -19,11 +19,11 @@ from repowise.cli.helpers import (
     release_update_lock,
     resolve_command_target,
     resolve_provider,
+    resolve_reasoning,
     resolve_repo_path,
     run_async,
     save_state,
 )
-
 
 # ---------------------------------------------------------------------------
 # Mode resolution
@@ -174,6 +174,12 @@ def _workspace_update(
 @click.option("--since", default=None, help="Base git ref to diff from (overrides state).")
 @click.option("--concurrency", type=int, default=5, help="Max concurrent LLM calls.")
 @click.option(
+    "--reasoning",
+    type=click.Choice(["auto", "off", "minimal"]),
+    default=None,
+    help="Reasoning mode for supported providers: auto, off, or minimal.",
+)
+@click.option(
     "--cascade-budget",
     type=int,
     default=None,
@@ -228,6 +234,7 @@ def update_command(
     provider_name: str | None,
     model: str | None,
     since: str | None,
+    reasoning: str | None,
     cascade_budget: int | None,
     dry_run: bool,
     workspace: bool,
@@ -353,7 +360,11 @@ def update_command(
 
     cfg = load_config(repo_path)
     language = cfg.get("language", "en")
-    config = GenerationConfig(max_concurrency=concurrency, language=language)
+    config = GenerationConfig(
+        max_concurrency=concurrency,
+        language=language,
+        reasoning=resolve_reasoning(reasoning, cfg),
+    )
 
     # Read exclude patterns from config (set during init or via web UI)
     exclude_patterns: list[str] = list(cfg.get("exclude_patterns") or [])
@@ -692,7 +703,9 @@ def update_command(
 
         # Record a GenerationJob so the web UI "last synced" timestamp updates
         try:
-            from datetime import datetime, UTC as _UTC
+            from datetime import UTC as _UTC
+            from datetime import datetime
+
             from repowise.core.persistence.crud import upsert_generation_job
 
             async with get_session(sf) as session:

--- a/packages/cli/src/repowise/cli/commands/workspace_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/workspace_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from rich.table import Table
@@ -10,9 +11,13 @@ from rich.table import Table
 from repowise.cli.helpers import (
     console,
     find_workspace_root,
+    resolve_reasoning,
     resolve_repo_path,
     run_async,
 )
+
+if TYPE_CHECKING:
+    from repowise.core.workspace.config import WorkspaceConfig
 
 
 # ---------------------------------------------------------------------------
@@ -493,6 +498,7 @@ def _run_index_for_repo(
     # Run LLM doc generation through the existing single-repo init pathway
     # so we get cost gating, cascading, and full parity with `repowise init`.
     generated_pages = 0
+    resolved_reasoning = resolve_reasoning(config=primary_cfg)
     if generate_docs and provider is not None:
         try:
             generated_pages = _generate_docs_for_added_repo(
@@ -500,6 +506,7 @@ def _run_index_for_repo(
                 provider=provider,
                 embedder_name=embedder_name,
                 concurrency=concurrency,
+                reasoning=resolved_reasoning,
                 exclude_patterns=exclude_patterns,
             )
             console.print(f"  [green]✓[/green] Generated {generated_pages} pages")
@@ -529,6 +536,7 @@ def _run_index_for_repo(
             embedder_name,
             exclude_patterns=exclude_patterns or None,
             commit_limit=int(commit_limit) if commit_limit else None,
+            reasoning=resolved_reasoning,
         )
 
     # Update workspace config entry
@@ -563,6 +571,7 @@ def _generate_docs_for_added_repo(
     provider: object,
     embedder_name: str,
     concurrency: int,
+    reasoning: str,
     exclude_patterns: list[str],
 ) -> int:
     """Generate wiki pages for a newly-added workspace repo.
@@ -613,7 +622,10 @@ def _generate_docs_for_added_repo(
             continue
     graph_builder.build()
 
-    config = GenerationConfig(max_concurrency=concurrency)
+    config = GenerationConfig(
+        max_concurrency=concurrency,
+        reasoning=reasoning,
+    )
     assembler = ContextAssembler(config)
     generator = PageGenerator(provider, assembler, config, language=config.language)
 

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -13,7 +13,13 @@ from typing import Any, Literal, TypeVar
 import click
 from rich.console import Console
 
-CONFIG_FILENAME = "config.yaml"
+from repowise.core.reasoning import (
+    ReasoningMode,
+)
+from repowise.core.reasoning import (
+    resolve_reasoning as resolve_core_reasoning,
+)
+from repowise.core.repo_config import CONFIG_FILENAME, load_repo_config
 
 T = TypeVar("T")
 
@@ -223,22 +229,18 @@ def get_head_commit(repo_path: Path) -> str | None:
 
 def load_config(repo_path: Path) -> dict[str, Any]:
     """Load ``.repowise/config.yaml`` or return an empty dict if absent."""
-    config_path = get_repowise_dir(repo_path) / CONFIG_FILENAME
-    if not config_path.exists():
-        return {}
-    text = config_path.read_text(encoding="utf-8")
-    try:
-        import yaml  # type: ignore[import-untyped]
+    return load_repo_config(repo_path)
 
-        return yaml.safe_load(text) or {}
-    except ImportError:
-        # Simple line-by-line parser for the flat key: value format we write
-        result: dict[str, Any] = {}
-        for line in text.splitlines():
-            if ":" in line:
-                k, _, v = line.partition(":")
-                result[k.strip()] = v.strip()
-        return result
+
+def resolve_reasoning(
+    reasoning: str | None = None,
+    config: dict[str, Any] | None = None,
+) -> ReasoningMode:
+    """Resolve generation reasoning from CLI flag, env, config, then default."""
+    try:
+        return resolve_core_reasoning(reasoning, config)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def save_config(
@@ -249,6 +251,7 @@ def save_config(
     *,
     exclude_patterns: list[str] | None = None,
     commit_limit: int | None = None,
+    reasoning: str | None = None,
 ) -> None:
     """Write provider/model/embedder (and optionally exclude_patterns) to ``.repowise/config.yaml``.
 
@@ -266,6 +269,8 @@ def save_config(
         existing["exclude_patterns"] = exclude_patterns
     if commit_limit is not None:
         existing["commit_limit"] = commit_limit
+    if reasoning is not None:
+        existing["reasoning"] = resolve_reasoning(reasoning)
 
     try:
         import yaml  # type: ignore[import-untyped]
@@ -277,6 +282,8 @@ def save_config(
     except ImportError:
         # Fallback: write simple key-value format (lists not supported)
         lines = [f"provider: {provider}", f"model: {model}", f"embedder: {embedder}"]
+        if reasoning is not None:
+            lines.append(f"reasoning: {resolve_reasoning(reasoning)}")
         config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 

--- a/packages/cli/src/repowise/cli/ui.py
+++ b/packages/cli/src/repowise/cli/ui.py
@@ -746,6 +746,12 @@ def interactive_advanced_config(
         type=int,
     )
 
+    result["reasoning"] = click.prompt(
+        "  Reasoning mode",
+        default="auto",
+        type=click.Choice(["auto", "off", "minimal"]),
+    )
+
     # Embedder selection
     detected_embedder = _resolve_embedder_from_env()
     embedder_choices = ["gemini", "openai", "mock"]
@@ -772,6 +778,7 @@ def interactive_advanced_config(
     summary.add_row("Commit limit", str(result["commit_limit"]))
     summary.add_row("Follow renames", "yes" if result["follow_renames"] else "no")
     summary.add_row("Concurrency", str(result["concurrency"]))
+    summary.add_row("Reasoning", result["reasoning"])
     summary.add_row("Embedder", result["embedder"])
     if patterns:
         if len(patterns) <= 5:

--- a/packages/core/src/repowise/core/generation/models.py
+++ b/packages/core/src/repowise/core/generation/models.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Literal
 
+from repowise.core.reasoning import ReasoningMode, normalize_reasoning
+
 # ---------------------------------------------------------------------------
 # PageType and generation levels
 # ---------------------------------------------------------------------------
@@ -64,6 +66,7 @@ class GenerationConfig:
         max_concurrency:          asyncio.Semaphore size for parallel calls.
         embed_concurrency:        asyncio.Semaphore size for vector-store writes.
                                   Defaults to max_concurrency.
+        reasoning:                Provider-level reasoning intent.
         cache_enabled:            In-memory SHA256 prompt deduplication.
         staleness_threshold_days: Days before a page is considered stale.
         expiry_threshold_days:    Days before a page is considered expired.
@@ -76,6 +79,7 @@ class GenerationConfig:
     token_budget: int = 48000
     max_concurrency: int = 5
     embed_concurrency: int | None = None
+    reasoning: ReasoningMode = "auto"
     cache_enabled: bool = True
     staleness_threshold_days: int = 7
     expiry_threshold_days: int = 30
@@ -90,6 +94,7 @@ class GenerationConfig:
     def __post_init__(self) -> None:
         if self.embed_concurrency is None:
             object.__setattr__(self, "embed_concurrency", self.max_concurrency)
+        object.__setattr__(self, "reasoning", normalize_reasoning(self.reasoning))
 
 
 # ---------------------------------------------------------------------------

--- a/packages/core/src/repowise/core/generation/page_generator.py
+++ b/packages/core/src/repowise/core/generation/page_generator.py
@@ -968,6 +968,7 @@ class PageGenerator:
             max_tokens=self._config.max_tokens,
             temperature=self._config.temperature,
             request_id=request_id,
+            reasoning=self._config.reasoning,
         )
 
         if self._config.cache_enabled:

--- a/packages/core/src/repowise/core/pipeline/orchestrator.py
+++ b/packages/core/src/repowise/core/pipeline/orchestrator.py
@@ -166,6 +166,7 @@ async def run_pipeline(
     resume: bool = False,
     progress: ProgressCallback | None = None,
     cost_tracker: Any | None = None,
+    generation_config: Any | None = None,
 ) -> PipelineResult:
     """Run the repowise indexing/analysis/generation pipeline.
 
@@ -200,6 +201,10 @@ async def run_pipeline(
         Limit generation to top 10 files by PageRank (for quick validation).
     progress:
         Optional callback for progress reporting. Pass None for silent operation.
+    generation_config:
+        Optional ``GenerationConfig`` used for page generation. When omitted,
+        generation uses repo-local config such as ``reasoning`` from
+        ``.repowise/config.yaml`` and ``REPOWISE_REASONING``.
 
     Returns
     -------
@@ -322,6 +327,17 @@ async def run_pipeline(
         if progress:
             progress.on_message("info", "Phase 3: Generation")
 
+        resolved_generation_config = generation_config
+        if resolved_generation_config is None:
+            from repowise.core.generation import GenerationConfig
+            from repowise.core.reasoning import resolve_reasoning
+            from repowise.core.repo_config import load_repo_config
+
+            resolved_generation_config = GenerationConfig(
+                max_concurrency=concurrency,
+                reasoning=resolve_reasoning(config=load_repo_config(repo_path))
+            )
+
         generated_pages = await run_generation(
             repo_path=repo_path,
             parsed_files=parsed_files,
@@ -335,6 +351,7 @@ async def run_pipeline(
             concurrency=concurrency,
             progress=progress,
             resume=resume,
+            generation_config=resolved_generation_config,
         )
 
     # ---- Execution flow tracing -----------------------------------------------

--- a/packages/core/src/repowise/core/providers/llm/anthropic.py
+++ b/packages/core/src/repowise/core/providers/llm/anthropic.py
@@ -13,18 +13,19 @@ Recommended models (as of 2026):
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING, Any, AsyncIterator
 
 import structlog
+from anthropic import APIStatusError as _AnthropicAPIStatusError
 from anthropic import AsyncAnthropic
 from anthropic import RateLimitError as _AnthropicRateLimitError
-from anthropic import APIStatusError as _AnthropicAPIStatusError
 from tenacity import (
+    RetryError,
+    before_sleep_log,
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
-    before_sleep_log,
-    RetryError,
 )
 
 from repowise.core.providers.llm.base import (
@@ -34,10 +35,10 @@ from repowise.core.providers.llm.base import (
     GeneratedResponse,
     ProviderError,
     RateLimitError,
+    ensure_reasoning_supported,
 )
-
-from typing import TYPE_CHECKING, Any, AsyncIterator
 from repowise.core.rate_limiter import RateLimiter
+from repowise.core.reasoning import ReasoningMode
 
 if TYPE_CHECKING:
     from repowise.core.generation.cost_tracker import CostTracker
@@ -95,7 +96,9 @@ class AnthropicProvider(BaseProvider):
         max_tokens: int = 4096,
         temperature: float = 0.3,
         request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
     ) -> GeneratedResponse:
+        ensure_reasoning_supported("anthropic", self._model, reasoning)
         if self._rate_limiter:
             await self._rate_limiter.acquire(estimated_tokens=max_tokens)
 

--- a/packages/core/src/repowise/core/providers/llm/base.py
+++ b/packages/core/src/repowise/core/providers/llm/base.py
@@ -17,6 +17,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Protocol, runtime_checkable
 
+from repowise.core.reasoning import ReasoningMode, normalize_reasoning
+
 
 @dataclass
 class GeneratedResponse:
@@ -69,6 +71,7 @@ class BaseProvider(ABC):
         max_tokens: int = 4096,
         temperature: float = 0.3,
         request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
     ) -> GeneratedResponse:
         """Generate a response from the LLM.
 
@@ -81,6 +84,9 @@ class BaseProvider(ABC):
             temperature:   Sampling temperature. 0.0 is fully deterministic.
                            repowise uses 0.3 for consistent doc style.
             request_id:    Optional trace ID for logging and debugging.
+            reasoning:     Provider-level reasoning intent. ``auto`` preserves
+                           provider defaults; ``off`` and ``minimal`` are
+                           translated by providers that support them.
 
         Returns:
             GeneratedResponse with content and token usage.
@@ -138,6 +144,29 @@ class RateLimitError(ProviderError):
     but RateLimitError signals that backing off longer won't help —
     the operator needs to review rate limits or reduce concurrency.
     """
+
+
+def ensure_reasoning_supported(
+    provider: str,
+    model: str,
+    reasoning: ReasoningMode,
+    supported_modes: tuple[ReasoningMode, ...] = (),
+    *,
+    detail: str | None = None,
+) -> ReasoningMode:
+    """Return normalized reasoning mode or fail before issuing an API call."""
+    mode = normalize_reasoning(reasoning)
+    if mode == "auto" or mode in supported_modes:
+        return mode
+
+    supported = ", ".join(dict.fromkeys(("auto", *supported_modes)))
+    message = (
+        f"reasoning={mode!r} is not supported by provider {provider!r} "
+        f"for model {model!r}. Supported reasoning modes: {supported}."
+    )
+    if detail:
+        message = f"{message} {detail}"
+    raise ProviderError(provider, message)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/core/src/repowise/core/providers/llm/deepseek.py
+++ b/packages/core/src/repowise/core/providers/llm/deepseek.py
@@ -36,8 +36,10 @@ from repowise.core.providers.llm.base import (
     GeneratedResponse,
     ProviderError,
     RateLimitError,
+    ensure_reasoning_supported,
 )
 from repowise.core.rate_limiter import RateLimiter
+from repowise.core.reasoning import ReasoningMode
 
 if TYPE_CHECKING:
     from repowise.core.generation.cost_tracker import CostTracker
@@ -100,7 +102,9 @@ class DeepSeekProvider(BaseProvider):
         max_tokens: int = 4096,
         temperature: float = 0.3,
         request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
     ) -> GeneratedResponse:
+        ensure_reasoning_supported("deepseek", self._model, reasoning)
         if self._rate_limiter:
             await self._rate_limiter.acquire(estimated_tokens=max_tokens)
 

--- a/packages/core/src/repowise/core/providers/llm/gemini.py
+++ b/packages/core/src/repowise/core/providers/llm/gemini.py
@@ -19,6 +19,8 @@ import structlog
 # Suppress "Both GOOGLE_API_KEY and GEMINI_API_KEY are set" from google-genai SDK.
 # We resolve and pass the key explicitly, so the env-var conflict warning is noise.
 logging.getLogger("google_genai._api_client").setLevel(logging.ERROR)
+from typing import TYPE_CHECKING, Any, AsyncIterator
+
 from tenacity import (
     RetryError,
     retry,
@@ -34,10 +36,10 @@ from repowise.core.providers.llm.base import (
     GeneratedResponse,
     ProviderError,
     RateLimitError,
+    ensure_reasoning_supported,
 )
-
-from typing import TYPE_CHECKING, Any, AsyncIterator
 from repowise.core.rate_limiter import RateLimiter
+from repowise.core.reasoning import ReasoningMode
 
 if TYPE_CHECKING:
     from repowise.core.generation.cost_tracker import CostTracker
@@ -99,7 +101,9 @@ class GeminiProvider(BaseProvider):
         max_tokens: int = 4096,
         temperature: float = 0.3,
         request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
     ) -> GeneratedResponse:
+        ensure_reasoning_supported("gemini", self._model, reasoning)
         if self._rate_limiter:
             await self._rate_limiter.acquire(estimated_tokens=max_tokens)
 
@@ -392,8 +396,9 @@ def _to_gemini_contents(messages: list[dict[str, Any]]) -> list:
     round-trips use native Gemini Content objects (preserving thought
     signatures).
     """
-    from google.genai import types as genai_types  # type: ignore[import-untyped]
     import json as _json
+
+    from google.genai import types as genai_types  # type: ignore[import-untyped]
 
     contents = []
     for msg in messages:

--- a/packages/core/src/repowise/core/providers/llm/litellm.py
+++ b/packages/core/src/repowise/core/providers/llm/litellm.py
@@ -20,13 +20,15 @@ Reference: https://docs.litellm.ai/docs/providers
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING, Any, AsyncIterator
+
 import structlog
 from tenacity import (
+    RetryError,
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
-    RetryError,
 )
 
 from repowise.core.providers.llm.base import (
@@ -36,10 +38,10 @@ from repowise.core.providers.llm.base import (
     GeneratedResponse,
     ProviderError,
     RateLimitError,
+    ensure_reasoning_supported,
 )
-
-from typing import TYPE_CHECKING, Any, AsyncIterator
 from repowise.core.rate_limiter import RateLimiter
+from repowise.core.reasoning import ReasoningMode
 
 if TYPE_CHECKING:
     from repowise.core.generation.cost_tracker import CostTracker
@@ -98,7 +100,9 @@ class LiteLLMProvider(BaseProvider):
         max_tokens: int = 4096,
         temperature: float = 0.3,
         request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
     ) -> GeneratedResponse:
+        ensure_reasoning_supported("litellm", self._model, reasoning)
         if self._rate_limiter:
             await self._rate_limiter.acquire(estimated_tokens=max_tokens)
 
@@ -207,6 +211,7 @@ class LiteLLMProvider(BaseProvider):
         tool_executor: Any | None = None,
     ) -> AsyncIterator[ChatStreamEvent]:
         import json as _json
+
         import litellm  # type: ignore[import-untyped]
 
         litellm.set_verbose = False

--- a/packages/core/src/repowise/core/providers/llm/mock.py
+++ b/packages/core/src/repowise/core/providers/llm/mock.py
@@ -32,6 +32,7 @@ import json
 from pathlib import Path
 
 from repowise.core.providers.llm.base import BaseProvider, GeneratedResponse
+from repowise.core.reasoning import ReasoningMode
 
 # Resolve fixture directory relative to this file so tests work regardless
 # of working directory. Goes up: mock.py → providers/ → core/ → repowise/ →
@@ -108,6 +109,7 @@ class MockProvider(BaseProvider):
         max_tokens: int = 4096,
         temperature: float = 0.3,
         request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
     ) -> GeneratedResponse:
         """Return a fixture response without calling any external API."""
         self._calls.append(
@@ -117,6 +119,7 @@ class MockProvider(BaseProvider):
                 "max_tokens": max_tokens,
                 "temperature": temperature,
                 "request_id": request_id,
+                "reasoning": reasoning,
             }
         )
         call_idx = self._call_count

--- a/packages/core/src/repowise/core/providers/llm/ollama.py
+++ b/packages/core/src/repowise/core/providers/llm/ollama.py
@@ -21,15 +21,17 @@ Usage:
 from __future__ import annotations
 
 import os
+from typing import Any, AsyncIterator
+
 import structlog
-from openai import AsyncOpenAI
 from openai import APIStatusError as _OpenAIAPIStatusError
+from openai import AsyncOpenAI
 from tenacity import (
+    RetryError,
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
-    RetryError,
 )
 
 from repowise.core.providers.llm.base import (
@@ -38,10 +40,10 @@ from repowise.core.providers.llm.base import (
     ChatToolCall,
     GeneratedResponse,
     ProviderError,
+    ensure_reasoning_supported,
 )
-
-from typing import Any, AsyncIterator
 from repowise.core.rate_limiter import RateLimiter
+from repowise.core.reasoning import ReasoningMode
 
 log = structlog.get_logger(__name__)
 
@@ -100,7 +102,9 @@ class OllamaProvider(BaseProvider):
         max_tokens: int = 4096,
         temperature: float = 0.3,
         request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
     ) -> GeneratedResponse:
+        ensure_reasoning_supported("ollama", self._model, reasoning)
         if self._rate_limiter:
             await self._rate_limiter.acquire(estimated_tokens=max_tokens)
 

--- a/packages/core/src/repowise/core/providers/llm/openai.py
+++ b/packages/core/src/repowise/core/providers/llm/openai.py
@@ -13,17 +13,18 @@ Recommended models (as of 2026):
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING, Any, AsyncIterator
 
 import structlog
+from openai import APIStatusError as _OpenAIAPIStatusError
 from openai import AsyncOpenAI
 from openai import RateLimitError as _OpenAIRateLimitError
-from openai import APIStatusError as _OpenAIAPIStatusError
 from tenacity import (
+    RetryError,
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
-    RetryError,
 )
 
 from repowise.core.providers.llm.base import (
@@ -33,10 +34,10 @@ from repowise.core.providers.llm.base import (
     GeneratedResponse,
     ProviderError,
     RateLimitError,
+    ensure_reasoning_supported,
 )
-
-from typing import TYPE_CHECKING, Any, AsyncIterator
 from repowise.core.rate_limiter import RateLimiter
+from repowise.core.reasoning import ReasoningMode, normalize_reasoning
 
 if TYPE_CHECKING:
     from repowise.core.generation.cost_tracker import CostTracker
@@ -46,6 +47,70 @@ log = structlog.get_logger(__name__)
 _MAX_RETRIES = 3
 _MIN_WAIT = 1.0
 _MAX_WAIT = 4.0
+_QWEN_THINKING_MODEL_MARKERS = ("qwen", "qwq")
+_OPENAI_MINIMAL_REASONING_EXACT_MODELS = ("gpt-5", "gpt-5-mini", "gpt-5-nano")
+_OPENAI_MINIMAL_REASONING_PREFIXES = ("gpt-5-mini-", "gpt-5-nano-")
+
+
+def _model_leaf(model: str) -> str:
+    return model.rsplit("/", 1)[-1].lower()
+
+
+def _supports_openai_reasoning_effort(model: str) -> bool:
+    leaf = _model_leaf(model)
+    # Keep this conservative: dotted, pro, codex, and future aliases do not all
+    # accept the same Chat Completions reasoning_effort values.
+    return leaf in _OPENAI_MINIMAL_REASONING_EXACT_MODELS or leaf.startswith(
+        _OPENAI_MINIMAL_REASONING_PREFIXES
+    )
+
+
+def _supports_chat_template_thinking_toggle(model: str) -> bool:
+    leaf = _model_leaf(model)
+    return any(marker in leaf for marker in _QWEN_THINKING_MODEL_MARKERS)
+
+
+def _openai_supported_reasoning_modes(model: str) -> tuple[ReasoningMode, ...]:
+    modes: list[ReasoningMode] = []
+    if _supports_openai_reasoning_effort(model):
+        modes.append("minimal")
+    if _supports_chat_template_thinking_toggle(model):
+        modes.append("off")
+    return tuple(modes)
+
+
+def _resolve_openai_reasoning_mode(
+    reasoning: ReasoningMode, *, model: str
+) -> ReasoningMode:
+    """Validate OpenAI-compatible reasoning support before retry handling."""
+    return ensure_reasoning_supported(
+        "openai",
+        model,
+        normalize_reasoning(reasoning),
+        _openai_supported_reasoning_modes(model),
+        detail=(
+            "OpenAIProvider maps minimal to OpenAI reasoning_effort only for "
+            "known compatible OpenAI model ids (gpt-5, gpt-5-mini, "
+            "gpt-5-nano, and mini/nano snapshot ids), and maps off to "
+            "Qwen/QwQ chat_template_kwargs for OpenAI-compatible endpoints."
+        ),
+    )
+
+
+def _openai_reasoning_kwargs(reasoning: ReasoningMode) -> dict[str, Any]:
+    """Translate a validated repowise reasoning intent to OpenAI kwargs."""
+    mode = normalize_reasoning(reasoning)
+    if mode == "auto":
+        return {}
+    if mode == "minimal":
+        return {"reasoning_effort": "minimal"}
+    return {
+        "extra_body": {
+            "chat_template_kwargs": {
+                "enable_thinking": False,
+            },
+        },
+    }
 
 
 class OpenAIProvider(BaseProvider):
@@ -93,7 +158,11 @@ class OpenAIProvider(BaseProvider):
         max_tokens: int = 4096,
         temperature: float = 0.3,
         request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
     ) -> GeneratedResponse:
+        reasoning_mode = _resolve_openai_reasoning_mode(
+            reasoning, model=self._model
+        )
         if self._rate_limiter:
             await self._rate_limiter.acquire(estimated_tokens=max_tokens)
 
@@ -111,6 +180,7 @@ class OpenAIProvider(BaseProvider):
                 max_tokens=max_tokens,
                 temperature=temperature,
                 request_id=request_id,
+                reasoning=reasoning_mode,
             )
         except RetryError as exc:
             raise ProviderError(
@@ -131,16 +201,21 @@ class OpenAIProvider(BaseProvider):
         max_tokens: int,
         temperature: float,
         request_id: str | None,
+        reasoning: ReasoningMode,
     ) -> GeneratedResponse:
         try:
-            response = await self._client.chat.completions.create(
-                model=self._model,
-                max_completion_tokens=max_tokens,
-                temperature=temperature,
-                messages=[
+            kwargs: dict[str, Any] = {
+                "model": self._model,
+                "max_completion_tokens": max_tokens,
+                "temperature": temperature,
+                "messages": [
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
+            }
+            kwargs.update(_openai_reasoning_kwargs(reasoning))
+            response = await self._client.chat.completions.create(
+                **kwargs,
             )
         except _OpenAIRateLimitError as exc:
             raise RateLimitError("openai", str(exc), status_code=429) from exc

--- a/packages/core/src/repowise/core/providers/llm/openrouter.py
+++ b/packages/core/src/repowise/core/providers/llm/openrouter.py
@@ -14,17 +14,18 @@ Popular models:
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING, Any, AsyncIterator
 
 import structlog
+from openai import APIStatusError as _OpenAIAPIStatusError
 from openai import AsyncOpenAI
 from openai import RateLimitError as _OpenAIRateLimitError
-from openai import APIStatusError as _OpenAIAPIStatusError
 from tenacity import (
+    RetryError,
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential_jitter,
-    RetryError,
 )
 
 from repowise.core.providers.llm.base import (
@@ -34,10 +35,10 @@ from repowise.core.providers.llm.base import (
     GeneratedResponse,
     ProviderError,
     RateLimitError,
+    ensure_reasoning_supported,
 )
-
-from typing import TYPE_CHECKING, Any, AsyncIterator
 from repowise.core.rate_limiter import RateLimiter
+from repowise.core.reasoning import ReasoningMode, normalize_reasoning
 
 if TYPE_CHECKING:
     from repowise.core.generation.cost_tracker import CostTracker
@@ -47,6 +48,62 @@ log = structlog.get_logger(__name__)
 _MAX_RETRIES = 3
 _MIN_WAIT = 1.0
 _MAX_WAIT = 4.0
+_OPENROUTER_OPENAI_REASONING_PREFIXES = ("o1", "o3", "o4")
+_OPENROUTER_OPENAI_GPT5_EXACT_MODELS = ("gpt-5", "gpt-5-mini", "gpt-5-nano")
+_OPENROUTER_OPENAI_GPT5_PREFIXES = ("gpt-5-mini-", "gpt-5-nano-")
+
+
+def _model_leaf(model: str) -> str:
+    return model.rsplit("/", 1)[-1].lower()
+
+
+def _openrouter_supports_reasoning_effort(model: str) -> bool:
+    normalized = model.lower()
+    leaf = _model_leaf(model)
+    if normalized.startswith(("x-ai/grok", "xai/grok")):
+        return True
+    if normalized.startswith("openai/"):
+        if leaf.startswith(_OPENROUTER_OPENAI_REASONING_PREFIXES):
+            return True
+        if leaf in _OPENROUTER_OPENAI_GPT5_EXACT_MODELS:
+            return True
+        if leaf.startswith(_OPENROUTER_OPENAI_GPT5_PREFIXES):
+            return True
+    return False
+
+
+def _resolve_openrouter_reasoning_mode(
+    reasoning: ReasoningMode, *, model: str
+) -> ReasoningMode:
+    """Validate OpenRouter reasoning support before retry handling."""
+    supported_modes: tuple[ReasoningMode, ...] = (
+        ("off", "minimal") if _openrouter_supports_reasoning_effort(model) else ()
+    )
+    return ensure_reasoning_supported(
+        "openrouter",
+        model,
+        normalize_reasoning(reasoning),
+        supported_modes,
+        detail=(
+            "OpenRouter maps reasoning.effort for OpenAI reasoning and Grok "
+            "model families with known effort support. Unknown, dotted, and "
+            "pro GPT-5 routes fail fast until explicitly mapped."
+        ),
+    )
+
+
+def _openrouter_reasoning_kwargs(reasoning: ReasoningMode) -> dict[str, Any]:
+    """Translate a validated repowise reasoning intent to OpenRouter kwargs."""
+    mode = normalize_reasoning(reasoning)
+    if mode == "auto":
+        return {}
+    return {
+        "extra_body": {
+            "reasoning": {
+                "effort": "none" if mode == "off" else "minimal",
+            }
+        }
+    }
 
 
 class OpenRouterProvider(BaseProvider):
@@ -112,7 +169,11 @@ class OpenRouterProvider(BaseProvider):
         max_tokens: int = 4096,
         temperature: float = 0.3,
         request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
     ) -> GeneratedResponse:
+        reasoning_mode = _resolve_openrouter_reasoning_mode(
+            reasoning, model=self._model
+        )
         if self._rate_limiter:
             await self._rate_limiter.acquire(estimated_tokens=max_tokens)
 
@@ -130,6 +191,7 @@ class OpenRouterProvider(BaseProvider):
                 max_tokens=max_tokens,
                 temperature=temperature,
                 request_id=request_id,
+                reasoning=reasoning_mode,
             )
         except RetryError as exc:
             raise ProviderError(
@@ -150,17 +212,20 @@ class OpenRouterProvider(BaseProvider):
         max_tokens: int,
         temperature: float,
         request_id: str | None,
+        reasoning: ReasoningMode,
     ) -> GeneratedResponse:
         try:
-            response = await self._client.chat.completions.create(
-                model=self._model,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                messages=[
+            kwargs: dict[str, Any] = {
+                "model": self._model,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "messages": [
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
-            )
+            }
+            kwargs.update(_openrouter_reasoning_kwargs(reasoning))
+            response = await self._client.chat.completions.create(**kwargs)
         except _OpenAIRateLimitError as exc:
             raise RateLimitError("openrouter", str(exc), status_code=429) from exc
         except _OpenAIAPIStatusError as exc:

--- a/packages/core/src/repowise/core/reasoning.py
+++ b/packages/core/src/repowise/core/reasoning.py
@@ -1,0 +1,40 @@
+"""Shared reasoning-mode helpers for generation providers."""
+
+from __future__ import annotations
+
+import os
+from typing import Literal, cast
+
+ReasoningMode = Literal["auto", "off", "minimal"]
+REASONING_MODES: tuple[ReasoningMode, ...] = ("auto", "off", "minimal")
+
+
+def normalize_reasoning(
+    value: object,
+    *,
+    default: ReasoningMode = "auto",
+) -> ReasoningMode:
+    """Normalize a user/config supplied reasoning mode.
+
+    ``auto`` preserves provider defaults. ``off`` and ``minimal`` are provider
+    intents; each provider decides whether and how to translate them.
+    """
+    if value is None:
+        return default
+
+    normalized = str(value).strip().lower()
+    if normalized not in REASONING_MODES:
+        choices = ", ".join(REASONING_MODES)
+        raise ValueError(f"reasoning must be one of: {choices}")
+    return cast(ReasoningMode, normalized)
+
+
+def resolve_reasoning(
+    reasoning: str | None = None,
+    config: dict[str, object] | None = None,
+) -> ReasoningMode:
+    """Resolve reasoning from explicit value, env, repo config, then default."""
+    raw = reasoning or os.environ.get("REPOWISE_REASONING")
+    if raw is None and config:
+        raw = config.get("reasoning")
+    return normalize_reasoning(raw)

--- a/packages/core/src/repowise/core/repo_config.py
+++ b/packages/core/src/repowise/core/repo_config.py
@@ -1,0 +1,48 @@
+"""Repo-local configuration helpers shared by CLI, server, and core paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+CONFIG_FILENAME = "config.yaml"
+
+
+def get_repowise_dir(repo_path: Path | str) -> Path:
+    """Return the repo-local ``.repowise`` directory."""
+    return Path(repo_path) / ".repowise"
+
+
+def load_repo_config(repo_path: Path | str) -> dict[str, Any]:
+    """Load ``.repowise/config.yaml`` or return an empty dict if absent."""
+    config_path = get_repowise_dir(repo_path) / CONFIG_FILENAME
+    if not config_path.exists():
+        return {}
+
+    text = config_path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore[import-untyped]
+
+        result = yaml.safe_load(text) or {}
+        if isinstance(result, dict) and isinstance(result.get("reasoning"), bool):
+            raw_reasoning = _read_flat_scalar(text, "reasoning")
+            if raw_reasoning:
+                result["reasoning"] = raw_reasoning
+        return result
+    except ImportError:
+        # Simple line-by-line parser for the flat key: value format we write.
+        result: dict[str, Any] = {}
+        for line in text.splitlines():
+            if ":" in line:
+                key, _, value = line.partition(":")
+                result[key.strip()] = value.strip()
+        return result
+
+
+def _read_flat_scalar(text: str, key: str) -> str | None:
+    """Read a top-level scalar from config text before YAML bool coercion."""
+    for line in text.splitlines():
+        current_key, separator, value = line.partition(":")
+        if separator and current_key.strip() == key:
+            return value.split("#", 1)[0].strip().strip("'\"")
+    return None

--- a/packages/server/src/repowise/server/job_executor.py
+++ b/packages/server/src/repowise/server/job_executor.py
@@ -461,10 +461,14 @@ async def _incremental_page_regen(
         affected_source = {p: s for p, s in result.source_map.items() if p in regen_set}
 
         from repowise.core.generation import ContextAssembler, GenerationConfig, PageGenerator
+        from repowise.core.reasoning import resolve_reasoning
+        from repowise.core.repo_config import load_repo_config
 
-        config = GenerationConfig()
-        assembler = ContextAssembler(config)
-        generator = PageGenerator(llm_client, assembler, config)
+        generation_config = GenerationConfig(
+            reasoning=resolve_reasoning(config=load_repo_config(repo_path))
+        )
+        assembler = ContextAssembler(generation_config)
+        generator = PageGenerator(llm_client, assembler, generation_config)
 
         pages = await generator.generate_all(
             affected_parsed,

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -37,11 +37,13 @@ class TestCliBasics:
         assert "--provider" in result.output
         assert "--dry-run" in result.output
         assert "--skip-tests" in result.output
+        assert "--reasoning" in result.output
 
     def test_update_help(self, runner):
         result = runner.invoke(cli, ["update", "--help"])
         assert result.exit_code == 0
         assert "--since" in result.output
+        assert "--reasoning" in result.output
 
     def test_search_help(self, runner):
         result = runner.invoke(cli, ["search", "--help"])

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -8,13 +8,14 @@ from typing import Any
 import pytest
 
 from repowise.cli.helpers import (
-    ensure_repowise_dir,
     CONFIG_FILENAME,
+    ensure_repowise_dir,
     get_db_url_for_repo,
     get_head_commit,
     get_repowise_dir,
     load_state,
     resolve_provider,
+    resolve_reasoning,
     resolve_repo_path,
     run_async,
     save_state,
@@ -98,6 +99,20 @@ class TestDbUrl:
         expected_path = (tmp_path / ".repowise" / "wiki.db").as_posix()
         assert url == f"sqlite+aiosqlite:///{expected_path}"
         assert (tmp_path / ".repowise").exists()
+
+
+class TestResolveReasoning:
+    def test_flag_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("REPOWISE_REASONING", "minimal")
+        assert resolve_reasoning("off", {"reasoning": "auto"}) == "off"
+
+    def test_env_wins_over_config(self, monkeypatch):
+        monkeypatch.setenv("REPOWISE_REASONING", "minimal")
+        assert resolve_reasoning(config={"reasoning": "off"}) == "minimal"
+
+    def test_config_wins_over_default(self, monkeypatch):
+        monkeypatch.delenv("REPOWISE_REASONING", raising=False)
+        assert resolve_reasoning(config={"reasoning": "off"}) == "off"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/generation/test_models.py
+++ b/tests/unit/generation/test_models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from repowise.core.generation.models import (
     ConfidenceDecayResult,
     GeneratedPage,
@@ -152,8 +154,19 @@ def test_generation_config_defaults():
     assert config.expiry_threshold_days == 30
     assert config.top_symbol_percentile == 0.10
     assert config.large_file_source_pct == 0.4
+    assert config.reasoning == "auto"
 
 
 def test_generation_config_embed_concurrency_defaults_to_max_concurrency():
     config = GenerationConfig(max_concurrency=3)
     assert config.embed_concurrency == 3
+
+
+def test_generation_config_normalizes_reasoning():
+    config = GenerationConfig(reasoning="OFF")
+    assert config.reasoning == "off"
+
+
+def test_generation_config_rejects_invalid_reasoning():
+    with pytest.raises(ValueError):
+        GenerationConfig(reasoning="verbose")

--- a/tests/unit/generation/test_page_generator.py
+++ b/tests/unit/generation/test_page_generator.py
@@ -108,6 +108,26 @@ async def test_generate_file_page_increments_call_count(
     assert provider.call_count == 1
 
 
+async def test_generate_file_page_forwards_reasoning_config(
+    sample_parsed_file, sample_graph, graph_metrics, sample_source_bytes
+):
+    provider = MockProvider()
+    config = GenerationConfig(reasoning="off")
+    assembler = ContextAssembler(config)
+    gen = PageGenerator(provider, assembler, config)
+
+    await gen.generate_file_page(
+        sample_parsed_file,
+        sample_graph,
+        graph_metrics["pagerank"],
+        graph_metrics["betweenness"],
+        graph_metrics["community"],
+        sample_source_bytes,
+    )
+
+    assert provider.calls[0]["reasoning"] == "off"
+
+
 # ---------------------------------------------------------------------------
 # Prompt cache
 # ---------------------------------------------------------------------------

--- a/tests/unit/generation/test_pipeline_reasoning.py
+++ b/tests/unit/generation/test_pipeline_reasoning.py
@@ -1,0 +1,33 @@
+"""Reasoning propagation tests for programmatic generation paths."""
+
+from __future__ import annotations
+
+from repowise.core.pipeline import run_pipeline
+from repowise.core.providers.llm.mock import MockProvider
+
+
+async def test_run_pipeline_loads_repo_reasoning_config(tmp_path):
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    (repo_path / "main.py").write_text(
+        'def hello() -> str:\n    return "hello"\n',
+        encoding="utf-8",
+    )
+    (repo_path / ".repowise").mkdir()
+    (repo_path / ".repowise" / "config.yaml").write_text(
+        "reasoning: off  # disable thinking for Qwen3-style models\n",
+        encoding="utf-8",
+    )
+
+    provider = MockProvider()
+    result = await run_pipeline(
+        repo_path,
+        generate_docs=True,
+        llm_client=provider,
+        concurrency=1,
+        test_run=True,
+    )
+
+    assert result.generated_pages
+    assert provider.calls
+    assert all(call["reasoning"] == "off" for call in provider.calls)

--- a/tests/unit/test_providers/test_deepseek_provider.py
+++ b/tests/unit/test_providers/test_deepseek_provider.py
@@ -11,7 +11,11 @@ import pytest
 
 pytest.importorskip("openai", reason="openai SDK not installed")
 
-from repowise.core.providers.llm.base import ChatStreamEvent, GeneratedResponse, ProviderError, RateLimitError
+from repowise.core.providers.llm.base import (
+    GeneratedResponse,
+    ProviderError,
+    RateLimitError,
+)
 from repowise.core.providers.llm.deepseek import DeepSeekProvider
 
 
@@ -125,6 +129,17 @@ async def test_generate_uses_correct_model_name():
         mock_client.return_value.chat.completions.create.assert_called_once()
         kwargs = mock_client.return_value.chat.completions.create.call_args.kwargs
         assert kwargs["model"] == "deepseek-v4-flash"
+
+
+async def test_generate_rejects_unsupported_reasoning_mode():
+    provider = DeepSeekProvider(api_key="sk-test")
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        provider._client = mock_client.return_value
+        with pytest.raises(ProviderError, match="reasoning='off' is not supported"):
+            await provider.generate("system", "user", reasoning="off")
+
+    mock_client.return_value.chat.completions.create.assert_not_called()
 
 
 async def test_generate_rate_limit_retry():

--- a/tests/unit/test_providers/test_openai_provider.py
+++ b/tests/unit/test_providers/test_openai_provider.py
@@ -116,9 +116,84 @@ async def test_generate_sends_correct_messages():
     assert kw["model"] == "gpt-5.4-mini"
     assert kw["max_completion_tokens"] == 2048
     assert kw["temperature"] == 0.5
+    assert "reasoning_effort" not in kw
+    assert "extra_body" not in kw
     messages = kw["messages"]
     assert messages[0] == {"role": "system", "content": "system msg"}
     assert messages[1] == {"role": "user", "content": "user msg"}
+
+
+async def test_generate_forwards_minimal_reasoning_effort():
+    provider = OpenAIProvider(api_key="sk-test", model="gpt-5-mini")
+    mock_response = _make_mock_chat_response()
+    captured_kwargs: list[dict] = []
+
+    async def fake_create(**kwargs):
+        captured_kwargs.append(kwargs)
+        return mock_response
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = fake_create
+        provider._client = mock_client.return_value
+        await provider.generate("system msg", "user msg", reasoning="minimal")
+
+    assert captured_kwargs[0]["reasoning_effort"] == "minimal"
+
+
+async def test_generate_forwards_off_reasoning_extra_body():
+    provider = OpenAIProvider(api_key="sk-test", model="qwen3")
+    mock_response = _make_mock_chat_response()
+    captured_kwargs: list[dict] = []
+
+    async def fake_create(**kwargs):
+        captured_kwargs.append(kwargs)
+        return mock_response
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = fake_create
+        provider._client = mock_client.return_value
+        await provider.generate("system msg", "user msg", reasoning="off")
+
+    assert captured_kwargs[0]["extra_body"] == {
+        "chat_template_kwargs": {"enable_thinking": False}
+    }
+
+
+async def test_generate_rejects_minimal_for_non_reasoning_model():
+    provider = OpenAIProvider(api_key="sk-test", model="gpt-4o")
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        provider._client = mock_client.return_value
+        with pytest.raises(ProviderError, match="reasoning='minimal' is not supported"):
+            await provider.generate("system msg", "user msg", reasoning="minimal")
+
+    mock_client.return_value.chat.completions.create.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gpt-5.1", "gpt-5.2", "gpt-5-pro", "gpt-5-codex", "gpt-5.4-nano"],
+)
+async def test_generate_rejects_minimal_for_known_unsupported_reasoning_models(model):
+    provider = OpenAIProvider(api_key="sk-test", model=model)
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        provider._client = mock_client.return_value
+        with pytest.raises(ProviderError, match="reasoning='minimal' is not supported"):
+            await provider.generate("system msg", "user msg", reasoning="minimal")
+
+    mock_client.return_value.chat.completions.create.assert_not_called()
+
+
+async def test_generate_rejects_off_for_non_qwen_model():
+    provider = OpenAIProvider(api_key="sk-test", model="gpt-5-mini")
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        provider._client = mock_client.return_value
+        with pytest.raises(ProviderError, match="reasoning='off' is not supported"):
+            await provider.generate("system msg", "user msg", reasoning="off")
+
+    mock_client.return_value.chat.completions.create.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_providers/test_openrouter_provider.py
+++ b/tests/unit/test_providers/test_openrouter_provider.py
@@ -149,9 +149,74 @@ async def test_generate_sends_correct_messages():
     assert kw["model"] == "google/gemini-3.1-flash-lite-preview"
     assert kw["max_tokens"] == 2048
     assert kw["temperature"] == 0.5
+    assert "extra_body" not in kw
     messages = kw["messages"]
     assert messages[0] == {"role": "system", "content": "system msg"}
     assert messages[1] == {"role": "user", "content": "user msg"}
+
+
+async def test_generate_forwards_minimal_reasoning_extra_body():
+    provider = OpenRouterProvider(api_key="sk-or-test", model="openai/gpt-5")
+    mock_response = _make_mock_chat_response()
+    captured_kwargs: list[dict] = []
+
+    async def fake_create(**kwargs):
+        captured_kwargs.append(kwargs)
+        return mock_response
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = fake_create
+        provider._client = mock_client.return_value
+        await provider.generate("system msg", "user msg", reasoning="minimal")
+
+    assert captured_kwargs[0]["extra_body"] == {
+        "reasoning": {"effort": "minimal"}
+    }
+
+
+async def test_generate_forwards_off_reasoning_extra_body():
+    provider = OpenRouterProvider(api_key="sk-or-test", model="x-ai/grok-4")
+    mock_response = _make_mock_chat_response()
+    captured_kwargs: list[dict] = []
+
+    async def fake_create(**kwargs):
+        captured_kwargs.append(kwargs)
+        return mock_response
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        mock_client.return_value.chat.completions.create = fake_create
+        provider._client = mock_client.return_value
+        await provider.generate("system msg", "user msg", reasoning="off")
+
+    assert captured_kwargs[0]["extra_body"] == {"reasoning": {"effort": "none"}}
+
+
+async def test_generate_rejects_reasoning_for_unsupported_openrouter_model():
+    provider = OpenRouterProvider(
+        api_key="sk-or-test", model="google/gemini-3.1-flash-lite-preview"
+    )
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        provider._client = mock_client.return_value
+        with pytest.raises(ProviderError, match="reasoning='minimal' is not supported"):
+            await provider.generate("system msg", "user msg", reasoning="minimal")
+
+    mock_client.return_value.chat.completions.create.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["openai/gpt-5.2", "openai/gpt-5-pro", "openai/gpt-5-codex", "openai/gpt-5.4-nano"],
+)
+async def test_generate_rejects_reasoning_for_known_unsupported_openai_route(model):
+    provider = OpenRouterProvider(api_key="sk-or-test", model=model)
+
+    with patch("openai.AsyncOpenAI") as mock_client:
+        provider._client = mock_client.return_value
+        with pytest.raises(ProviderError, match="reasoning='minimal' is not supported"):
+            await provider.generate("system msg", "user msg", reasoning="minimal")
+
+    mock_client.return_value.chat.completions.create.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/website/cli-reference.md
+++ b/website/cli-reference.md
@@ -44,7 +44,7 @@ repowise init [PATH] [OPTIONS]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--provider` | string | auto | LLM provider: `anthropic`, `openai`, `gemini`, `ollama`, `litellm`, `mock` |
+| `--provider` | string | auto | LLM provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `ollama`, `litellm`, `mock` |
 | `--model` | string | — | Model override (e.g., `claude-sonnet-4-6`, `gpt-4.1`) |
 | `--embedder` | choice | auto | Embedding provider: `gemini`, `openai`, `mock` |
 | `--index-only` | flag | false | Skip LLM generation — parse, graph, git, dead code only |
@@ -55,6 +55,7 @@ repowise init [PATH] [OPTIONS]
 | `--exclude` / `-x` | string | — | Gitignore-style exclude pattern (repeatable: `-x vendor/ -x "*.gen.*"`) |
 | `--include-submodules` | flag | false | Include git submodule directories (excluded by default) |
 | `--concurrency` | int | 5 | Max concurrent LLM calls |
+| `--reasoning` | choice | auto | Reasoning mode for supported providers: `auto`, `off`, or `minimal` |
 | `--resume` | flag | false | Resume from last checkpoint after an interruption |
 | `--force` | flag | false | Regenerate all pages even if up to date |
 | `--commit-limit` | int | 500 | Max commits per file for git analysis (max 5000, saved to config) |
@@ -70,6 +71,12 @@ repowise init
 
 # Non-interactive, specific provider
 repowise init --provider anthropic --yes
+
+# OpenAI-compatible Qwen3 endpoint with thinking disabled
+repowise init --provider openai --model qwen3 --reasoning off
+
+# OpenRouter with minimal reasoning effort
+repowise init --provider openrouter --model openai/gpt-5 --reasoning minimal
 
 # Analysis only — free, no API key needed
 repowise init --index-only
@@ -121,6 +128,7 @@ repowise update [PATH] [OPTIONS]
 | `--provider` | string | — | Override LLM provider |
 | `--model` | string | — | Override model |
 | `--since` | string | — | Git ref to diff from (overrides saved `state.json`) |
+| `--reasoning` | choice | auto | Reasoning mode for supported providers: `auto`, `off`, or `minimal` |
 | `--cascade-budget` | int | auto | Max pages to regenerate from cascading changes |
 | `--dry-run` | flag | false | Show affected pages without regenerating |
 
@@ -129,6 +137,7 @@ repowise update [PATH] [OPTIONS]
 ```bash
 repowise update                      # Sync since last indexed commit
 repowise update --since HEAD~10      # Re-sync last 10 commits
+repowise update --reasoning off      # One-off supported-provider thinking-off run
 repowise update --dry-run            # Preview what would change
 repowise update --cascade-budget 20  # Limit cascade regeneration
 ```

--- a/website/configuration.md
+++ b/website/configuration.md
@@ -46,6 +46,7 @@ The main configuration file. Created after first `init`, updated when you pass `
 provider: anthropic                  # LLM provider
 model: claude-sonnet-4-6             # Model identifier
 embedder: gemini                     # Embedding provider
+reasoning: auto                      # auto | off | minimal
 exclude_patterns:                    # Gitignore-style patterns
   - vendor/
   - "*.generated.*"
@@ -55,6 +56,18 @@ follow_renames: false                # Track file renames in git history
 ```
 
 You can edit this file directly. Changes take effect on the next `init`, `update`, or `serve` run.
+
+`reasoning` controls documentation-generation calls for reasoning-capable chat
+models. `auto` preserves provider defaults. `off` disables Qwen3-style thinking
+for OpenAI-compatible vLLM/SGLang endpoints by sending
+`extra_body.chat_template_kwargs.enable_thinking=false`, and maps to
+OpenRouter's `reasoning.effort=none` for effort-capable OpenRouter model
+families. `minimal` requests OpenAI's lowest supported reasoning effort for
+supported OpenAI reasoning models and maps to OpenRouter's
+`reasoning.effort=minimal` for effort-capable OpenRouter model families.
+Providers or models that cannot translate an explicit mode fail before making
+an API call. The interactive `serve` chat streaming path is separate and does
+not currently consume this setting.
 
 ---
 
@@ -91,6 +104,20 @@ export OPENAI_API_KEY="sk-..."
 
 ```bash
 repowise init --provider openai --model gpt-4.1
+```
+
+For an OpenAI-compatible Qwen3 endpoint served by vLLM or SGLang:
+
+```bash
+export OPENAI_BASE_URL="http://localhost:8000/v1"
+repowise init --provider openai --model qwen3 --reasoning off
+```
+
+For OpenRouter:
+
+```bash
+repowise init --provider openrouter --model openai/gpt-5 --reasoning minimal
+repowise init --provider openrouter --model x-ai/grok-4 --reasoning off
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Add `GenerationConfig.reasoning: Literal["auto","off","minimal"] = "auto"` and a `--reasoning` flag / `REPOWISE_REASONING` env / `reasoning:` config key so documentation generation can pass a single provider-neutral intent end to end.
- Map the intent inside provider implementations: OpenAI's reasoning models receive `reasoning_effort="minimal"`, OpenAI-compatible Qwen/QwQ endpoints (vLLM / SGLang) receive `extra_body.chat_template_kwargs.enable_thinking=False`, and OpenRouter receives `extra_body.reasoning.effort` for known effort-capable model families.
- Fail fast before any API call when an explicit `off` / `minimal` mode hits a provider/model with no known mapping, so the knob is never silently dropped.

## Related Issues

Fixes #137

## Test Plan

Focused suite:

```bash
uv run pytest \
  tests/unit/test_providers/test_openai_provider.py \
  tests/unit/test_providers/test_openrouter_provider.py \
  tests/unit/test_providers/test_deepseek_provider.py \
  tests/unit/generation/test_models.py \
  tests/unit/generation/test_page_generator.py \
  tests/unit/generation/test_pipeline_reasoning.py \
  tests/unit/cli/test_helpers.py \
  tests/unit/cli/test_commands.py -q
```

Result: `160 passed, 433 warnings`.

Static / compile checks:

```bash
uv run ruff check --select F821,I \
  packages/core/src/repowise/core/providers/llm/openai.py \
  packages/core/src/repowise/core/providers/llm/openrouter.py \
  packages/cli/src/repowise/cli/commands/workspace_cmd.py \
  tests/unit/test_providers/test_openai_provider.py \
  tests/unit/test_providers/test_openrouter_provider.py

uv run ruff check --select F401 \
  packages/core/src/repowise/core/providers/llm/openai.py \
  packages/core/src/repowise/core/providers/llm/openrouter.py \
  packages/cli/src/repowise/cli/commands/workspace_cmd.py \
  tests/unit/test_providers/test_openai_provider.py \
  tests/unit/test_providers/test_openrouter_provider.py

uv run python -m compileall -q \
  packages/core/src/repowise/core \
  packages/cli/src/repowise/cli \
  packages/server/src/repowise/server
```

New coverage at a glance:

- Provider gating: positive (`gpt-5-mini` minimal; `qwen3` off; `openai/gpt-5` minimal; `x-ai/grok-4` off) and negative (`gpt-4o`, `gpt-5.1`, `gpt-5.2`, `gpt-5-pro`, `gpt-5-codex`, `gpt-5.4-nano`, `google/gemini-3.1-flash-lite-preview`, `openai/gpt-5.2`, `openai/gpt-5-pro`, `openai/gpt-5-codex`, `openai/gpt-5.4-nano`, DeepSeek `off`).
- Config precedence: CLI > env > repo config > default.
- Generation pipeline: `run_pipeline` picks up `reasoning: off` from `.repowise/config.yaml` and propagates it into provider `generate()` calls via `MockProvider.calls`.
- `GenerationConfig` normalizes case (`"OFF"` -> `"off"`) and rejects unknown modes.
- `init --help` / `update --help` advertise `--reasoning`.

- [x] Tests pass (`pytest`)
- [x] Lint passes (`ruff check`, focused touched-file selectors above)
- [ ] Web build passes (`npm run build`) *(no frontend changes)*

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed (`README.md`, `docs/CLI_REFERENCE.md`, `docs/USER_GUIDE.md`, `website/cli-reference.md`, `website/configuration.md`, `.env.example`)

## Implementation Notes

**Provider-neutral intent.** `GenerationConfig.reasoning` is a single config-level intent shared by `PageGenerator`, `run_pipeline`, the `init` / `update` CLIs, the web server's incremental regen path, and workspace fan-out. The generation engine never branches on provider identity; it forwards `reasoning=...` into `BaseProvider.generate()` and each provider decides whether and how to map it. This keeps the engine free of provider-specific reasoning APIs and lets future providers plug in by extending only their own mapping.

**Config precedence.** Resolution lives in `repowise/core/reasoning.py` and is explicit: CLI flag -> `REPOWISE_REASONING` env -> `.repowise/config.yaml` -> `auto`. `tests/unit/cli/test_helpers.py::TestResolveReasoning` pins each hop. `auto` is the default and is a strict no-op, so existing users see no behavior change.

**Capability gating with conservative known mapping sets.** A shared helper `ensure_reasoning_supported(provider, model, reasoning, supported_modes, ...)` in `providers/llm/base.py` rejects any non-`auto` mode that the provider/model cannot translate, raising `ProviderError` before the API call. The known sets:

- OpenAI provider: `minimal` is allowed for a conservative known set: exact `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, plus `gpt-5-mini-*` / `gpt-5-nano-*` snapshot-style ids. Dotted, pro, codex, default-cost-table aliases, and future GPT-5 routes fail fast until explicitly mapped. `off` is allowed for model leaf names containing Qwen/QwQ markers (`qwen` / `qwq`), targeting OpenAI-compatible vLLM / SGLang Qwen3 endpoints. `off` is translated to `extra_body.chat_template_kwargs.enable_thinking=False`; `minimal` is translated to `reasoning_effort="minimal"`.
- OpenRouter provider: `off` / `minimal` are allowed only for known effort-capable model families: `x-ai/grok*` / `xai/grok*`, `openai/o1*`, `openai/o3*`, `openai/o4*`, exact `openai/gpt-5`, `openai/gpt-5-mini`, `openai/gpt-5-nano`, and mini/nano snapshot-style ids. Translation goes through OpenRouter's unified `extra_body.reasoning.effort` (`"minimal"` or `"none"`).
- Anthropic / Gemini / DeepSeek / LiteLLM / Ollama / Mock: no known mapping yet, so any explicit `off` / `minimal` fails fast with a descriptive `ProviderError`.

OpenRouter is included in this PR (not deferred) because it shares the same non-streaming docs-generation path and OpenRouter exposes a normalized reasoning API across effort-capable model families. Gating is per known model family, not provider-wide.

**Streaming deferred.** The interactive `serve` chat streaming path (`ChatProvider.stream_chat` + SSE) is intentionally untouched. OpenRouter streams reasoning detail chunks that need an explicit display / drop / persist decision, and that surface is separate from doc generation. It is documented in `website/configuration.md` and can land in a follow-up.

**YAML "off" bool trap.** YAML 1.1 maps the bare word `off` to the boolean `False`, so a `.repowise/config.yaml` containing `reasoning: off` would be parsed as `{"reasoning": False}` and the validator would reject it. The new `load_repo_config` helper detects a `bool` value for the `reasoning` key post-parse and re-reads it as a raw scalar (stripping inline comments and quotes) so users can write the obvious `reasoning: off` without quoting. `tests/unit/generation/test_pipeline_reasoning.py` covers the round-trip end to end through `run_pipeline`.
