### PR TITLE
fix(tests): forward reasoning kwarg in _TrackingProvider override

### DIFF
--- a/tests/integration/test_generation_pipeline.py
+++ b/tests/integration/test_generation_pipeline.py
@@ -30,6 +30,7 @@ from repowise.core.ingestion.parser import ASTParser
 from repowise.core.ingestion.traverser import FileTraverser
 from repowise.core.providers.llm.base import GeneratedResponse
 from repowise.core.providers.llm.mock import MockProvider
+from repowise.core.reasoning import ReasoningMode
 
 SAMPLE_REPO = Path(__file__).parents[1] / "fixtures" / "sample_repo"
 
@@ -47,6 +48,7 @@ class _TrackingProvider(MockProvider):
         max_tokens: int = 4096,
         temperature: float = 0.3,
         request_id: str | None = None,
+        reasoning: ReasoningMode = "auto",
     ) -> GeneratedResponse:
         if "Required sections: ## Overview, ## Public API" in system_prompt:
             self.file_page_starts.append(time.perf_counter())
@@ -57,6 +59,7 @@ class _TrackingProvider(MockProvider):
             max_tokens=max_tokens,
             temperature=temperature,
             request_id=request_id,
+            reasoning=reasoning,
         )
 
 


### PR DESCRIPTION
## Summary

Fixes the `Integration tests` CI failure on `main` after #175.

`PageGenerator._call_provider` now always passes `reasoning=self._config.reasoning` to `provider.generate()`. The unit-test `MockProvider` was updated in #175 to accept the kwarg, but the **integration test's local subclass** `_TrackingProvider` in `tests/integration/test_generation_pipeline.py` overrode `generate()` without the new parameter — so every call inside `test_embedding_latency_does_not_gate_llm_concurrency` raised `TypeError: _TrackingProvider.generate() got an unexpected keyword argument 'reasoning'`, every page failed silently inside the pipeline's exception handler, and the test asserted `len(file_pages) == 4` against an empty list.

This wasn't caught pre-merge because the PR author's focused test command (`uv run pytest tests/unit/...`) didn't include `tests/integration/`, and the PR's CI run had `Integration tests: SKIPPED`.

## Change

One file: add `reasoning: ReasoningMode = "auto"` to the override signature and forward it to `super().generate(...)`. No behavior change for any other test.

## Test plan

- [x] `Integration tests` job goes green
- [x] `test_embedding_latency_does_not_gate_llm_concurrency` passes