### PR TITLE
fix(ui): unblock publish-internal workflow

### DIFF
--- a/packages/ui/src/shared/results-footer.tsx
+++ b/packages/ui/src/shared/results-footer.tsx
@@ -10,15 +10,15 @@ interface ResultsFooterProps {
   /** True when more pages are available. */
   hasMore: boolean;
   /** Disables the load-more button while the next page is in flight. */
-  loading?: boolean;
+  loading?: boolean | undefined;
   /**
    * Called when the user requests more rows. The parent decides the page
    * size; this primitive only owns the affordance and the count surface.
    */
-  onLoadMore?: () => void;
+  onLoadMore?: (() => void) | undefined;
   /** Optional label tweak — defaults to "results". */
-  noun?: string;
-  className?: string;
+  noun?: string | undefined;
+  className?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary

\`publish-internal.yml\` has been failing on the last two pushes to \`main\` because \`packages/ui\`'s \`tsc --noEmit\` runs with \`exactOptionalPropertyTypes: true\`. Under that flag, declaring \`loading?: boolean\` rejects callers that pass \`loading={maybeUndef}\` (because \`undefined\` is not assignable to \`boolean\` — only the absence of the key is).

The \`web\` package's tsconfig doesn't have that flag, so this only ever broke at publish time, not in PR CI.

## Fix

Widen the \`ResultsFooter\` optional props to \`prop?: T | undefined\`, which is the existing convention in other shared components (see \`module-health-list\`, \`module-health-card\`). No behavior change.

## Test plan
- [ ] \`packages/ui\` \`npm run type-check\` passes locally.
- [ ] \`publish-internal\` workflow goes green on the merge commit so the new \`@repowise-dev/ui\` prerelease publishes.