### PR TITLE
release: v0.9.1 — fix web tarball missing from v0.9.0 release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.1] — 2026-05-13
+
+### Fixed
+- **`repowise serve` 404 on the web tarball for v0.9.0.** The v0.9.0 publish workflow failed during the web build: two `packages/ui` components introduced this release (`attention-panel.tsx`, `co-change-list.tsx`) imported `useState` without a `"use client"` directive, so Next.js' RSC compiler rejected them when `packages/web` pulled them transitively via the overview page and wiki git-history panel. The Python wheel published to PyPI but no `repowise-web.tar.gz` was attached to the v0.9.0 GitHub release, so end-user `repowise serve` falls through to "API only". v0.9.1 adds the missing `"use client"` directive at the top of both files. **Anyone who installed 0.9.0 should upgrade to 0.9.1** to get a working web UI from `repowise serve`.
+
+---
+
 ## [0.9.0] — 2026-05-13
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -6,4 +6,4 @@ git signals, dead code detection, architectural decisions, and
 AI-generated documentation.
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/packages/ui/src/dashboard/attention-panel.tsx
+++ b/packages/ui/src/dashboard/attention-panel.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 import {
   AlertTriangle,

--- a/packages/ui/src/git/co-change-list.tsx
+++ b/packages/ui/src/git/co-change-list.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 import { truncatePath } from "../lib/format";
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.9.0"
+version = "0.9.1"
 description = "Codebase intelligence for developers and AI — generates and maintains a structured wiki for any codebase"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

v0.9.0 publish workflow failed during the web build: two new `packages/ui` components imported `useState` without a `"use client"` directive, so Next.js RSC compilation rejected them when `packages/web` pulled them transitively. No `repowise-web.tar.gz` was attached to the v0.9.0 GitHub release.

- `packages/ui/src/dashboard/attention-panel.tsx` — add `"use client"`
- `packages/ui/src/git/co-change-list.tsx` — add `"use client"`

Same shape as the v0.7.0 → v0.7.1 incident.

## Test plan

Pre-merge (validated locally):
- [x] `npm run build --workspace packages/web` completes cleanly — 27 routes built, no RSC errors
- [x] Version bumped in all four files + `uv.lock`
- [x] Changelog updated with the v0.9.1 hotfix note + upgrade advisory

Post-merge:
- [ ] `git checkout main && git pull --ff-only`
- [ ] `git tag v0.9.1 && git push origin v0.9.1` → triggers `publish.yml`
- [ ] Confirm `build-web` job succeeds this time
- [ ] `gh release view v0.9.1 --json assets` — confirm wheel + `repowise-web.tar.gz` both attached
- [ ] PyPI shows 0.9.1
- [ ] Fresh-dir end-user smoke: `pip install --upgrade repowise && repowise --version && repowise serve`

**Merge convention:** regular merge commit (not squash).