### PR TITLE
quality: skip Win32 entry points, MSTest macros, pch and ClassFactory

### DIFF
--- a/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
@@ -102,6 +102,28 @@ _ENTRY_POINT_SYMBOL_NAMES: frozenset[str] = frozenset({
     "DllRegisterServer",
     "DllUnregisterServer",
     "DllGetActivationFactory",
+    "DllInstall",          # legacy MSI custom-action entry
+    # ---- Win32 GUI / console entry points ---------------------------
+    "wWinMain",            # Unicode WinMain
+    "WinMain",             # ANSI WinMain
+    "wmain",               # Unicode console main
+    "ServiceMain",         # Win32 service entry
+    # ---- Windows hook / ETW callbacks invoked by macros / runtime ----
+    "LowLevelKeyboardProc",
+    "LowLevelMouseProc",
+    "RegisterProvider",    # ETW provider registration (macro-invoked)
+    # ---- MSTest unit-test macro --------------------------------------
+    # ``TEST_METHOD(Name)`` expands into a public static function with
+    # ``TEST_METHOD`` as the captured symbol name; the runner finds it
+    # by attribute reflection. Same shape on every C++ unit test file.
+    "TEST_METHOD",
+    "TEST_CLASS",
+    "TEST_METHOD_INITIALIZE",
+    "TEST_METHOD_CLEANUP",
+    "TEST_CLASS_INITIALIZE",
+    "TEST_CLASS_CLEANUP",
+    "BEGIN_TEST_METHOD_PROPERTIES",
+    "END_TEST_METHOD_PROPERTIES",
 })
 from .dynamic_markers import find_dynamic_edge_files, find_dynamic_import_files
 from .models import DeadCodeFindingData, DeadCodeKind, DeadCodeReport

--- a/packages/core/src/repowise/core/analysis/dead_code/constants.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/constants.py
@@ -138,10 +138,37 @@ _NEVER_FLAG_PATTERNS: tuple[str, ...] = (
     "*.UITests/*.cs",
     "*UITest/*.cs",
     "*UITestAutomation/*.cs",
+    # Singular forms used by PowerToys / Wox / etc.
+    "*UnitTest/*.cs",
+    "*.UnitTest/*.cs",
+    "*.Test/*.cs",
+    "*/Wox.Test/*.cs",
+    # MSTest convention of ``UnitTests-<Subject>`` / ``UITest-<Subject>``
+    # directories (PowerToys preview handler / per-module test projects).
+    "*/UnitTests-*/*.cs",
+    "*/UITest-*/*.cs",
+    "*/UnitTests-*/*.cpp",
+    "*/UnitTests-*/*.h",
     "*/unittests/*.cpp",
     "*/unittests/*.h",
+    # File-suffix conventions for tests dropped outside a test project.
     "*Tests.cs",
     "*UnitTests.cs",
+    "*Test.cs",
+    "*Test.cpp",
+    "*Tests.cpp",
+    # ---- Precompiled headers and COM ClassFactory shims --------------
+    # ``pch.h`` / ``pch.cpp`` (and the older ``stdafx.*``) are MSVC
+    # precompiled-header anchors — referenced by build settings, never
+    # by user code. ``*ClassFactory.cpp`` is the COM ``IClassFactory``
+    # implementation; the type is registered via DllGetClassObject and
+    # activated by Windows, so it has no static caller.
+    "*/pch.h",
+    "*/pch.cpp",
+    "*/stdafx.h",
+    "*/stdafx.cpp",
+    "*ClassFactory.cpp",
+    "*ClassFactory.h",
 )
 
 # Decorator patterns that indicate framework usage (route handlers, fixtures, etc.)

--- a/tests/unit/test_dead_code.py
+++ b/tests/unit/test_dead_code.py
@@ -199,6 +199,49 @@ def test_unused_export_detected():
     assert "helper_func" in sym_names
 
 
+def test_entry_point_names_never_flagged():
+    """Runtime entry points (wWinMain, TEST_METHOD, DllInstall…) are
+    never flagged regardless of incoming-edge counts. The Win32 / COM /
+    MSTest runners reach them by mechanism, not by a `using` import."""
+    g = _build_graph(
+        nodes={
+            "src/main.cpp": {
+                "is_entry_point": False,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 3,
+                "language": "cpp",
+                "symbols": [
+                    {
+                        "name": "wWinMain",
+                        "kind": "function",
+                        "visibility": "public",
+                        "decorators": [],
+                        "start_line": 1, "end_line": 10,
+                        "complexity_estimate": 1,
+                    },
+                    {
+                        "name": "TEST_METHOD",
+                        "kind": "function",
+                        "visibility": "public",
+                        "decorators": [],
+                        "start_line": 12, "end_line": 20,
+                        "complexity_estimate": 1,
+                    },
+                ],
+            },
+        },
+        edges=[],
+    )
+    analyzer = DeadCodeAnalyzer(g, git_meta_map={})
+    report = analyzer.analyze(
+        {"detect_unreachable_files": False, "detect_zombie_packages": False}
+    )
+    names = [f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT]
+    assert "wWinMain" not in names
+    assert "TEST_METHOD" not in names
+
+
 def test_unused_export_skipped_when_symbol_has_incoming_calls():
     """A public symbol with no file-level importers but at least one
     incoming ``calls`` edge on the symbol itself is still in use —


### PR DESCRIPTION
## Summary

Two small static lists were leaking high-confidence false positives across desktop C++ / Win32 / MSTest code.

### Entry-point symbol names
Added to `_ENTRY_POINT_SYMBOL_NAMES`:
- **Win32 entry points**: `wWinMain`, `WinMain`, `wmain`, `ServiceMain`
- **Legacy DLL entry**: `DllInstall`
- **Runtime callbacks**: `LowLevelKeyboardProc`, `LowLevelMouseProc`, `RegisterProvider` (ETW macro)
- **MSTest macro family**: `TEST_METHOD`, `TEST_CLASS`, `TEST_METHOD_INITIALIZE`, `TEST_METHOD_CLEANUP`, `TEST_CLASS_INITIALIZE`, `TEST_CLASS_CLEANUP`, `BEGIN_TEST_METHOD_PROPERTIES`, `END_TEST_METHOD_PROPERTIES`

Every one is reached by the OS loader, hook subsystem, ETW macro expansion, or test runner — never by a `using` import or named call.

### Never-flag path globs
- **Precompiled headers**: `*/pch.h`, `*/pch.cpp`, `*/stdafx.h`, `*/stdafx.cpp`
- **COM ClassFactory shims**: `*ClassFactory.cpp`, `*ClassFactory.h`
- **Broader test-project conventions**: `*.UnitTest/*.cs`, `*.Test/*.cs`, `*/Wox.Test/*.cs`, MSTest `*/UnitTests-*/` and `*/UITest-*/` directories (covering .cs / .cpp / .h)
- **File-suffix conventions** for tests dropped outside test projects: `*Test.cs`, `*Test.cpp`, `*Tests.cpp`

### Estimated impact (probed against PowerToys wiki.db)

~520 high-confidence findings now covered by the new patterns. Top buckets:

| Bucket | Findings covered |
|---|---|
| `*/UnitTests-*/*.cpp` | 101 |
| `*/pch.h` | 96 |
| `*/pch.cpp` | 92 |
| `TEST_CLASS` macro | 68 |
| `TEST_METHOD` macro | 41 |
| `*Tests.cpp` | 35 |
| `*ClassFactory.h` | 28 |
| `wWinMain` / `WinMain` | 18 |
| `*ClassFactory.cpp` | 13 |
| Other (TEST_METHOD_* macros, ServiceMain, DllInstall, etc.) | ~30 |

Projected: PowerToys 4,793 high-confidence findings → ~4,270 (about 11% reduction). Precision climbs proportionally — these were all unambiguously alive at face value.

## Test plan
- [x] 528 ingestion / dead-code tests passing
- [x] New `test_entry_point_names_never_flagged` covers `wWinMain` and `TEST_METHOD`