### PR TITLE
docs: add --resume flag documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ repowise init .      # scans for git repos, indexes each, runs cross-repo analys
 repowise serve       # workspace dashboard + per-repo pages
 ```
 
+### Resuming an interrupted index
+
+If `repowise init` is interrupted (timeout, crash, Ctrl+C), you can resume from where it stopped:
+
+```bash
+repowise init . --resume
+```
+
+The `--resume` flag checks the vector store for already-generated pages and continues generation for only the missing pages. Pro tip: Always use `--resume` when re-running init on a large repo — it's a safe no-op if the repo is fully indexed.
+
+**How it works:** Pages are written to LanceDB incrementally during generation, but the SQL `generation_jobs` row only finalizes at the end. A hard interrupt can leave LanceDB ahead of SQL — `--resume` is the supported recovery path, and `repowise doctor` will flag any drift.
+
 That's it. `repowise init` automatically registers the MCP server, installs PreToolUse/PostToolUse hooks in `~/.claude/settings.json`, generates `.mcp.json` at the project root, and offers to install a post-commit git hook that keeps everything in sync after every commit. See [Auto-Sync](docs/AUTO_SYNC.md) for all sync methods (hooks, file watcher, GitHub/GitLab webhooks, polling).
 
 To manually add the MCP server to another editor:

--- a/packages/cli/src/repowise/cli/commands/init_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd.py
@@ -854,7 +854,12 @@ def _workspace_init(
     "--dry-run", is_flag=True, default=False, help="Show generation plan without running."
 )
 @click.option("--yes", "-y", is_flag=True, default=False, help="Skip cost confirmation prompt.")
-@click.option("--resume", is_flag=True, default=False, help="Resume from last checkpoint.")
+@click.option(
+    "--resume",
+    is_flag=True,
+    default=False,
+    help="Skip pages already generated in the vector store and continue from where a previous run stopped. Safe no-op on a fully indexed repo."
+)
 @click.option(
     "--force", is_flag=True, default=False, help="Regenerate all pages, ignoring existing."
 )


### PR DESCRIPTION
## Summary
- Added "Resuming an interrupted index" subsection to README with usage example and technical notes
- Updated `--resume` flag CLI help text from terse to descriptive explanation

## Test Plan
- [x] Verified README formatting renders correctly
- [x] Tested `repowise init --help` shows updated help text
- [x] All unit tests passing (1564 tests)

## Context
The `--resume` flag already existed but was undocumented. Users experienced data loss when long-running init operations were interrupted. This documentation update explains how to resume from interruptions and clarifies the LanceDB/SQL drift behavior.

Closes #113