### PR TITLE
fix(ingestion): treat nested git repos as traversal boundaries

### DIFF
--- a/packages/core/src/repowise/core/ingestion/traverser.py
+++ b/packages/core/src/repowise/core/ingestion/traverser.py
@@ -57,6 +57,7 @@ class TraversalStats:
     skipped_unknown_language: int = 0
     skipped_dir_ignore: int = 0
     skipped_submodule: int = 0
+    skipped_nested_repo: int = 0
     lang_counts: dict[str, int] = field(default_factory=dict)
 
 
@@ -186,6 +187,15 @@ class FileTraverser:
             (from CLI ``--exclude`` flags or ``repo.settings["exclude_patterns"]``).
         include_submodules: When False (default), directories listed in
             ``.gitmodules`` are skipped during traversal.
+        include_nested_repos: When False (default), any subdirectory that is
+            itself a git repository (contains a ``.git`` directory or file)
+            is treated as a hard traversal boundary and skipped.  This
+            matches the workspace scanner's behaviour: nested git repos are
+            independent units, not part of the parent repo's working tree.
+            Without this, a parent repo that physically contains sibling
+            repos (common when a workspace root is itself versioned) would
+            be walked end-to-end, pulling in hundreds of thousands of files
+            that belong to the nested repos.
     """
 
     def __init__(
@@ -196,6 +206,7 @@ class FileTraverser:
         extra_ignore_filename: str = ".repowiseIgnore",
         extra_exclude_patterns: list[str] | None = None,
         include_submodules: bool = False,
+        include_nested_repos: bool = False,
     ) -> None:
         self.repo_root = repo_root.resolve()
         self.max_file_size_bytes = max_file_size_kb * 1024
@@ -215,6 +226,7 @@ class FileTraverser:
         self._submodule_paths: frozenset[str] = frozenset()
         if not include_submodules:
             self._submodule_paths = _parse_gitmodules(self.repo_root)
+        self._include_nested_repos = include_nested_repos
         self.stats = TraversalStats()
         self._count_lock = threading.Lock()
         log.info(
@@ -223,6 +235,7 @@ class FileTraverser:
             max_file_size_kb=max_file_size_kb,
             extra_exclude_patterns=len(patterns),
             submodules_skipped=len(self._submodule_paths),
+            include_nested_repos=include_nested_repos,
         )
 
     # ------------------------------------------------------------------
@@ -292,7 +305,9 @@ class FileTraverser:
 
             # Prune ignored directories in-place (affects os.walk recursion)
             dirnames[:] = sorted(
-                d for d in dirnames if not self._should_skip_dir(d, rel_dir / d, dir_ignore)
+                d
+                for d in dirnames
+                if not self._should_skip_dir(d, rel_dir / d, dirpath_obj / d, dir_ignore)
             )
 
             for filename in sorted(filenames):
@@ -315,6 +330,7 @@ class FileTraverser:
         self,
         dirname: str,
         rel_path: Path,
+        abs_path: Path,
         dir_ignore: pathspec.PathSpec | None = None,
     ) -> bool:
         if dirname in _BLOCKED_DIRS:
@@ -322,6 +338,15 @@ class FileTraverser:
         rel_str = rel_path.as_posix()
         if rel_str in self._submodule_paths:
             self.stats.skipped_submodule += 1
+            return True
+        # Nested git repos are independent units — stop at the boundary
+        # unless the caller explicitly opted in. Mirrors the workspace
+        # scanner, which already refuses to descend into nested `.git`
+        # markers. Without this, a parent repo that physically contains
+        # sibling repos gets walked end-to-end.
+        if not self._include_nested_repos and _is_nested_git_repo(abs_path):
+            self.stats.skipped_nested_repo += 1
+            log.debug("Skipping nested git repo", path=rel_str)
             return True
         if self._gitignore.match_file(rel_str + "/"):
             return True
@@ -573,6 +598,20 @@ def _find_entry_points_in(directory: Path, repo_root: Path) -> list[str]:
     except OSError:
         pass
     return sorted(result)
+
+
+def _is_nested_git_repo(path: Path) -> bool:
+    """Return True if *path* is itself a git repository.
+
+    A directory is a git repository when it contains a ``.git`` entry,
+    which may be a directory (regular repo) or a file (git submodule,
+    worktree, or repo with an externally located gitdir). We test for
+    existence rather than `.is_dir()` to catch all three forms.
+    """
+    try:
+        return (path / ".git").exists()
+    except OSError:
+        return False
 
 
 def _parse_gitmodules(repo_root: Path) -> frozenset[str]:

--- a/packages/core/src/repowise/core/pipeline/orchestrator.py
+++ b/packages/core/src/repowise/core/pipeline/orchestrator.py
@@ -169,6 +169,7 @@ async def run_pipeline(
     skip_infra: bool = False,
     exclude_patterns: list[str] | None = None,
     include_submodules: bool = False,
+    include_nested_repos: bool = False,
     generate_docs: bool = False,
     llm_client: Any | None = None,
     embedder: Any | None = None,
@@ -254,6 +255,7 @@ async def run_pipeline(
             repo_path,
             exclude_patterns=exclude_patterns,
             include_submodules=include_submodules,
+            include_nested_repos=include_nested_repos,
             skip_tests=skip_tests,
             skip_infra=skip_infra,
             progress=progress,
@@ -447,6 +449,7 @@ async def _run_ingestion(
     *,
     exclude_patterns: list[str] | None,
     include_submodules: bool = False,
+    include_nested_repos: bool = False,
     skip_tests: bool,
     skip_infra: bool,
     progress: ProgressCallback | None,
@@ -462,6 +465,7 @@ async def _run_ingestion(
         repo_path,
         extra_exclude_patterns=exclude_patterns or None,
         include_submodules=include_submodules,
+        include_nested_repos=include_nested_repos,
     )
 
     # Walk directory tree
@@ -677,6 +681,8 @@ async def _run_ingestion(
             parts.append(f"{stats.skipped_extra_ignore:,} by .repowiseIgnore")
         if stats.skipped_submodule:
             parts.append(f"{stats.skipped_submodule:,} submodule dirs")
+        if stats.skipped_nested_repo:
+            parts.append(f"{stats.skipped_nested_repo:,} nested git repos")
         if stats.skipped_unknown_language:
             parts.append(f"{stats.skipped_unknown_language:,} unknown type")
 

--- a/tests/unit/ingestion/test_traverser.py
+++ b/tests/unit/ingestion/test_traverser.py
@@ -423,3 +423,99 @@ class TestSubmoduleHandling:
         assert any("app.py" in p for p in paths)
         assert not any("libs/foo" in p for p in paths)
         assert not any("libs/bar" in p for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# Nested git repo handling
+# ---------------------------------------------------------------------------
+
+
+class TestNestedGitRepoHandling:
+    """A parent repo may physically contain other independent git repos as
+    subdirectories (common when a workspace root is itself versioned).
+    Those subdirs must be treated as traversal boundaries — not walked into
+    as if they were part of the parent's working tree.
+    """
+
+    def _make_repo(self, path: Path, gitdir_is_file: bool = False) -> None:
+        path.mkdir(parents=True, exist_ok=True)
+        git_marker = path / ".git"
+        if gitdir_is_file:
+            git_marker.write_text("gitdir: /elsewhere/.git\n")
+        else:
+            git_marker.mkdir()
+
+    def test_skips_nested_git_repo_dir(self, tmp_path: Path) -> None:
+        self._make_repo(tmp_path / "child_repo")
+        (tmp_path / "child_repo" / "inner.py").write_text("pass")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("pass")
+
+        traverser = FileTraverser(tmp_path)
+        paths = [f.path for f in traverser.traverse()]
+
+        assert any("app.py" in p for p in paths)
+        assert not any("child_repo" in p for p in paths)
+        assert traverser.stats.skipped_nested_repo >= 1
+
+    def test_skips_nested_git_repo_when_gitdir_is_file(self, tmp_path: Path) -> None:
+        # `.git` as a file (submodule / worktree / external gitdir) still
+        # marks the directory as an independent repo and must be skipped.
+        self._make_repo(tmp_path / "linked_repo", gitdir_is_file=True)
+        (tmp_path / "linked_repo" / "inner.py").write_text("pass")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("pass")
+
+        traverser = FileTraverser(tmp_path)
+        paths = [f.path for f in traverser.traverse()]
+
+        assert not any("linked_repo" in p for p in paths)
+        assert traverser.stats.skipped_nested_repo >= 1
+
+    def test_skips_multiple_nested_repos(self, tmp_path: Path) -> None:
+        for name in ("backend", "frontend", "shared"):
+            self._make_repo(tmp_path / name)
+            (tmp_path / name / f"{name}.py").write_text("pass")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.py").write_text("pass")
+
+        traverser = FileTraverser(tmp_path)
+        paths = [f.path for f in traverser.traverse()]
+
+        assert any("app.py" in p for p in paths)
+        for name in ("backend", "frontend", "shared"):
+            assert not any(name in p for p in paths)
+        assert traverser.stats.skipped_nested_repo == 3
+
+    def test_root_itself_being_a_git_repo_is_fine(self, tmp_path: Path) -> None:
+        # The root .git must NOT cause the traverser to skip the root.
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "app.py").write_text("pass")
+
+        traverser = FileTraverser(tmp_path)
+        paths = [f.path for f in traverser.traverse()]
+
+        assert any("app.py" in p for p in paths)
+        assert traverser.stats.skipped_nested_repo == 0
+
+    def test_include_nested_repos_flag_opts_in(self, tmp_path: Path) -> None:
+        self._make_repo(tmp_path / "child_repo")
+        (tmp_path / "child_repo" / "inner.py").write_text("pass")
+
+        traverser = FileTraverser(tmp_path, include_nested_repos=True)
+        paths = [f.path for f in traverser.traverse()]
+
+        assert any("inner.py" in p for p in paths)
+        assert traverser.stats.skipped_nested_repo == 0
+
+    def test_deeply_nested_repo_is_still_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "a" / "b" / "c").mkdir(parents=True)
+        self._make_repo(tmp_path / "a" / "b" / "c" / "vendored")
+        (tmp_path / "a" / "b" / "c" / "vendored" / "lib.py").write_text("pass")
+        (tmp_path / "a" / "ok.py").write_text("pass")
+
+        traverser = FileTraverser(tmp_path)
+        paths = [f.path for f in traverser.traverse()]
+
+        assert any("ok.py" in p for p in paths)
+        assert not any("vendored" in p for p in paths)


### PR DESCRIPTION
## Summary

- `FileTraverser` now treats any subdirectory containing a `.git` entry as a hard traversal boundary, so a parent repo whose working tree physically contains other independent git repos no longer gets walked end-to-end through them. Detects both `.git` directories and `.git` files (submodules, worktrees, external gitdir pointers).
- Adds `include_nested_repos=False` (opt-in) to `FileTraverser` and plumbs it through `run_pipeline` → `_run_ingestion` for callers that genuinely want the old behaviour.
- New `TraversalStats.skipped_nested_repo` counter, surfaced in the orchestrator's "Excluded:" summary line.

## Motivation

The workspace scanner (`packages/core/src/repowise/core/workspace/scanner.py`) already refuses to descend past nested `.git` markers — nested git repos are independent units, not part of the parent's working tree. The ingestion traverser did not mirror this, so when a workspace root was itself a git repo containing sibling repos as subdirectories, indexing the root pulled in every file from every nested repo regardless of which entries the user actually selected. This brings the two layers in line with each other and with git's own model.

## Test plan

- [x] `pytest tests/unit/ingestion/test_traverser.py` — 48 pass (6 new)
- [x] `pytest tests/unit/ingestion/` — 518 pass, 2 xfailed
- [ ] Re-run `repowise init` on a workspace root that contains nested repos; verify only the selected repo's files are traversed and the "Excluded:" line reports nested git repos skipped