### PR TITLE
refactor(ui): move HealthPageChrome into @repowise-dev/ui/health

### DIFF
--- a/packages/ui/src/health/health-tabs.tsx
+++ b/packages/ui/src/health/health-tabs.tsx
@@ -7,6 +7,10 @@ export type HealthTabKey = "overview" | "trend" | "coverage" | "refactoring";
 export interface HealthTabsProps {
   repoId: string;
   active: HealthTabKey;
+  /** Override the URL prefix the tabs build hrefs against. Defaults to
+   *  `/repos/${repoId}/health`. Consumers with a different URL shape
+   *  (snapshot-scoped, owner/name-scoped, …) pass their own prefix. */
+  basePath?: string;
   /** Optional render-prop that produces a `<a href>` / `<Link>`. Lets the
    *  caller plug Next's `<Link>` without dragging the next dep into ui/. */
   renderLink?: (props: {
@@ -25,12 +29,13 @@ const TABS: { key: HealthTabKey; label: string; suffix: string; Icon: React.Comp
   { key: "refactoring", label: "Refactoring", suffix: "/refactoring-targets", Icon: Wrench },
 ];
 
-export function HealthTabs({ repoId, active, renderLink }: HealthTabsProps) {
+export function HealthTabs({ repoId, active, basePath, renderLink }: HealthTabsProps) {
+  const prefix = basePath ?? `/repos/${repoId}/health`;
   return (
     <div className="border-b border-[var(--color-border-default)]">
       <nav className="-mb-px flex flex-wrap gap-1" aria-label="Code health views">
         {TABS.map((t) => {
-          const href = `/repos/${repoId}/health${t.suffix}`;
+          const href = `${prefix}${t.suffix}`;
           const isActive = active === t.key;
           const baseCls =
             "inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 transition-colors";

--- a/packages/ui/src/health/index.ts
+++ b/packages/ui/src/health/index.ts
@@ -15,6 +15,7 @@ export * from "./severity-distribution";
 export * from "./score-breakdown";
 export * from "./sparkline";
 export * from "./health-tabs";
+export * from "./page-chrome";
 export * from "./trend-chart";
 export * from "./risk-coverage-scatter";
 export * from "./impact-effort-quadrant";

--- a/packages/ui/src/health/page-chrome.tsx
+++ b/packages/ui/src/health/page-chrome.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { HealthTabs, type HealthTabKey, type HealthTabsProps } from "./health-tabs";
+
+export interface HealthPageChromeProps {
+  repoId: string;
+  active: HealthTabKey;
+  title: string;
+  subtitle?: React.ReactNode;
+  icon?: React.ReactNode;
+  meta?: {
+    last_indexed_at: string | null;
+    head_commit: string | null;
+    snapshot_count: number;
+  } | null;
+  actions?: React.ReactNode;
+  /** Forwarded to `HealthTabs`. Overrides the default `/repos/${repoId}/health`
+   *  prefix the tabs build hrefs against. */
+  basePath?: string;
+  /** Forwarded to `HealthTabs`. Lets the caller plug a framework-specific
+   *  link (e.g. Next.js `<Link>`) without dragging that dep into ui/. */
+  renderLink?: HealthTabsProps["renderLink"];
+}
+
+function formatIndexedAt(iso: string | null): string {
+  if (!iso) return "never";
+  const d = new Date(iso);
+  const diff = Date.now() - d.getTime();
+  const minutes = Math.round(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return d.toLocaleDateString();
+}
+
+export function HealthPageChrome({
+  repoId,
+  active,
+  title,
+  subtitle,
+  icon,
+  meta,
+  actions,
+  basePath,
+  renderLink,
+}: HealthPageChromeProps) {
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-xl font-semibold text-[var(--color-text-primary)] mb-1 flex items-center gap-2">
+            {icon}
+            {title}
+          </h1>
+          {subtitle ? (
+            <p className="text-sm text-[var(--color-text-secondary)]">{subtitle}</p>
+          ) : null}
+          {meta ? (
+            <p className="mt-1 text-[11px] text-[var(--color-text-tertiary)]">
+              Indexed {formatIndexedAt(meta.last_indexed_at)}
+              {meta.head_commit ? (
+                <>
+                  {" "}
+                  · <span className="font-mono">{meta.head_commit.slice(0, 7)}</span>
+                </>
+              ) : null}
+              {meta.snapshot_count > 0 ? <> · {meta.snapshot_count} snapshots</> : null}
+            </p>
+          ) : null}
+        </div>
+        {actions ? <div className="flex items-center gap-2 shrink-0">{actions}</div> : null}
+      </div>
+      <HealthTabs
+        repoId={repoId}
+        active={active}
+        {...(basePath !== undefined ? { basePath } : {})}
+        {...(renderLink !== undefined ? { renderLink } : {})}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/components/health/health-page-chrome.tsx
+++ b/packages/web/src/components/health/health-page-chrome.tsx
@@ -1,90 +1,34 @@
 "use client";
 
 import Link from "next/link";
-import { HealthTabs, type HealthTabKey } from "@repowise-dev/ui/health";
+import {
+  HealthPageChrome as BaseHealthPageChrome,
+  type HealthPageChromeProps as BaseHealthPageChromeProps,
+} from "@repowise-dev/ui/health";
 
-interface HealthPageChromeProps {
-  repoId: string;
-  active: HealthTabKey;
-  title: string;
-  subtitle?: React.ReactNode;
-  icon?: React.ReactNode;
-  meta?: {
-    last_indexed_at: string | null;
-    head_commit: string | null;
-    snapshot_count: number;
-  } | null;
-  actions?: React.ReactNode;
-}
+export type HealthPageChromeProps = Omit<BaseHealthPageChromeProps, "renderLink">;
 
-function formatIndexedAt(iso: string | null): string {
-  if (!iso) return "never";
-  const d = new Date(iso);
-  const diff = Date.now() - d.getTime();
-  const minutes = Math.round(diff / 60_000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  if (days < 30) return `${days}d ago`;
-  return d.toLocaleDateString();
-}
-
-export function HealthPageChrome({
-  repoId,
-  active,
-  title,
-  subtitle,
-  icon,
-  meta,
-  actions,
-}: HealthPageChromeProps) {
+/** Web binding for the shared `HealthPageChrome` — injects Next's `<Link>`
+ *  so health-tab navigation is client-routed instead of hard-reloading. */
+export function HealthPageChrome(props: HealthPageChromeProps) {
   return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0">
-          <h1 className="text-xl font-semibold text-[var(--color-text-primary)] mb-1 flex items-center gap-2">
-            {icon}
-            {title}
-          </h1>
-          {subtitle ? (
-            <p className="text-sm text-[var(--color-text-secondary)]">{subtitle}</p>
-          ) : null}
-          {meta ? (
-            <p className="mt-1 text-[11px] text-[var(--color-text-tertiary)]">
-              Indexed {formatIndexedAt(meta.last_indexed_at)}
-              {meta.head_commit ? (
-                <>
-                  {" "}
-                  · <span className="font-mono">{meta.head_commit.slice(0, 7)}</span>
-                </>
-              ) : null}
-              {meta.snapshot_count > 0 ? <> · {meta.snapshot_count} snapshots</> : null}
-            </p>
-          ) : null}
-        </div>
-        {actions ? <div className="flex items-center gap-2 shrink-0">{actions}</div> : null}
-      </div>
-      <HealthTabs
-        repoId={repoId}
-        active={active}
-        renderLink={({ href, label, active: isActive, icon, key }) => (
-          <Link
-            key={key}
-            href={href}
-            className={
-              "inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 transition-colors " +
-              (isActive
-                ? "border-emerald-500 text-[var(--color-text-primary)]"
-                : "border-transparent text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-border-default)]")
-            }
-          >
-            {icon}
-            {label}
-          </Link>
-        )}
-      />
-    </div>
+    <BaseHealthPageChrome
+      {...props}
+      renderLink={({ href, label, active, icon, key }) => (
+        <Link
+          key={key}
+          href={href}
+          className={
+            "inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 transition-colors " +
+            (active
+              ? "border-emerald-500 text-[var(--color-text-primary)]"
+              : "border-transparent text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:border-[var(--color-border-default)]")
+          }
+        >
+          {icon}
+          {label}
+        </Link>
+      )}
+    />
   );
 }


### PR DESCRIPTION
## Summary

- Promote the `HealthPageChrome` wrapper around the four `/health/*` dashboard pages from `packages/web` into `@repowise-dev/ui/health`, so downstream consumers of the shared UI package can reuse it.
- Add an optional `basePath` prop on `HealthTabs` so callers with a different URL shape can override the default `/repos/\${repoId}/health` prefix without forking the component.
- Leave a thin Next-Link binding at `packages/web/src/components/health/health-page-chrome.tsx`. The four existing page imports continue to resolve unchanged and `/health/*` navigation stays client-routed.

## Details

The previous `HealthPageChrome` lived in `packages/web` and imported `next/link` directly, which kept it from being lifted into `@repowise-dev/ui`. The new framework-agnostic version follows the render-prop pattern that `HealthTabs` already uses — it accepts an optional `renderLink` and forwards it down — so `ui/` stays free of any framework dependency.

## Test plan

- [x] `npm run type-check` is clean across `types`, `ui`, and `web`.
- [ ] `/repos/[id]/health`, `/health/trend`, `/health/coverage`, and `/health/refactoring-targets` render unchanged in a local `npm run dev`.
- [ ] Tab links use Next client routing (no full-page reload between health tabs).