### PR TITLE
feat(health-ui): surface new biomarkers + recalibration polish

### DIFF
--- a/packages/ui/src/health/ai-prompt-builder.ts
+++ b/packages/ui/src/health/ai-prompt-builder.ts
@@ -30,6 +30,61 @@ function bulletList(items: (string | null | undefined | false)[]): string {
   return items.filter(Boolean).map((s) => `- ${s}`).join("\n");
 }
 
+function biomarkerExtraContext(
+  biomarkerType: string,
+  details: Record<string, unknown> | null | undefined,
+): string | null {
+  if (!details) return null;
+  const numField = (k: string): number | null => {
+    const v = details[k];
+    if (typeof v === "number" && Number.isFinite(v)) return v;
+    if (typeof v === "string" && v !== "" && Number.isFinite(Number(v))) {
+      return Number(v);
+    }
+    return null;
+  };
+  const strField = (k: string): string | null => {
+    const v = details[k];
+    return typeof v === "string" && v.length > 0 ? v : null;
+  };
+
+  if (biomarkerType === "hidden_coupling") {
+    const partner = strField("partner");
+    if (!partner) return null;
+    const co = numField("co_change_count");
+    const corr = numField("correlation");
+    const pct = corr != null ? `${Math.round(corr * 100)}%` : null;
+    const tail = [
+      co != null ? `${co} co-changes` : null,
+      pct ? `${pct} of shared commits` : null,
+    ]
+      .filter(Boolean)
+      .join(" — ");
+    return `Partner file: \`${partner}\`${tail ? ` — ${tail}` : ""}`;
+  }
+  if (biomarkerType === "complex_conditional") {
+    const ops = numField("operator_count");
+    if (ops == null) return null;
+    return `Boolean operators in this condition: ${ops}`;
+  }
+  if (biomarkerType === "function_hotspot") {
+    const mod = numField("modification_count") ?? numField("mod_count");
+    const p80 = numField("repo_p80") ?? numField("p80");
+    if (mod == null) return null;
+    return `Function modified across ${mod} distinct commits${p80 != null ? ` (repo p80 = ${p80})` : ""}`;
+  }
+  if (biomarkerType === "code_age_volatility") {
+    const age = numField("median_age_days");
+    const recent = numField("recent_mod_count");
+    if (age == null && recent == null) return null;
+    const parts: string[] = [];
+    if (age != null) parts.push(`median line age ~${age} days`);
+    if (recent != null) parts.push(`${recent} distinct commits in last 30 days`);
+    return parts.join(", ");
+  }
+  return null;
+}
+
 function effortHint(effort: RefactoringTarget["effort_bucket"]): string {
   switch (effort) {
     case "S":
@@ -89,12 +144,19 @@ export function buildAiPrompt({
               : ""
           }`
         : "file-level";
+      const extra = biomarkerExtraContext(
+        f.biomarker_type,
+        (f as { details?: Record<string, unknown> | null }).details,
+      );
       return [
         `${i + 1}. **${info.label}** · ${CATEGORY_LABEL[info.category]} · ${f.severity.toUpperCase()} · health impact −${f.health_impact.toFixed(2)}`,
         `   - Where: ${loc}`,
         `   - Why it's a problem: ${info.description}`,
         `   - Observed: ${f.reason}`,
-      ].join("\n");
+        extra ? `   - Extra context: ${extra}` : null,
+      ]
+        .filter(Boolean)
+        .join("\n");
     })
     .join("\n\n");
 

--- a/packages/ui/src/health/biomarker-details.tsx
+++ b/packages/ui/src/health/biomarker-details.tsx
@@ -6,7 +6,7 @@ export type BiomarkerDetailsRecord = Record<string, unknown>;
 
 export interface BiomarkerDetailsProps {
   biomarkerType: string;
-  details?: BiomarkerDetailsRecord | null;
+  details?: BiomarkerDetailsRecord | null | undefined;
   onPartnerSelect?: ((path: string) => void) | undefined;
   onPartnerHref?: ((path: string) => string) | undefined;
 }

--- a/packages/ui/src/health/biomarker-details.tsx
+++ b/packages/ui/src/health/biomarker-details.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { ArrowLeftRight } from "lucide-react";
+
+export type BiomarkerDetailsRecord = Record<string, unknown>;
+
+export interface BiomarkerDetailsProps {
+  biomarkerType: string;
+  details?: BiomarkerDetailsRecord | null;
+  onPartnerSelect?: ((path: string) => void) | undefined;
+  onPartnerHref?: ((path: string) => string) | undefined;
+}
+
+function num(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && v !== "" && Number.isFinite(Number(v))) {
+    return Number(v);
+  }
+  return null;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+export function BiomarkerDetails({
+  biomarkerType,
+  details,
+  onPartnerSelect,
+  onPartnerHref,
+}: BiomarkerDetailsProps) {
+  if (!details) return null;
+
+  if (biomarkerType === "hidden_coupling") {
+    const partner = str(details.partner);
+    const correlation = num(details.correlation);
+    const coChanges = num(details.co_change_count);
+    if (!partner) return null;
+    const corrPct =
+      correlation != null ? `${Math.round(correlation * 100)}%` : null;
+    const href = onPartnerHref ? onPartnerHref(partner) : undefined;
+    const inner = (
+      <span className="inline-flex items-center gap-1 font-mono truncate">
+        <ArrowLeftRight className="h-3 w-3 shrink-0" aria-hidden="true" />
+        <span className="truncate">{partner}</span>
+      </span>
+    );
+    return (
+      <div className="text-[11px] text-[var(--color-text-tertiary)]">
+        {href ? (
+          <a
+            href={href}
+            onClick={(e) => {
+              if (onPartnerSelect) {
+                e.preventDefault();
+                onPartnerSelect(partner);
+              }
+            }}
+            className="text-[var(--color-accent-primary)] hover:underline"
+          >
+            {inner}
+          </a>
+        ) : onPartnerSelect ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onPartnerSelect(partner);
+            }}
+            className="text-[var(--color-accent-primary)] hover:underline text-left"
+          >
+            {inner}
+          </button>
+        ) : (
+          inner
+        )}
+        {corrPct || coChanges != null ? (
+          <span className="ml-1 tabular-nums">
+            {corrPct ? ` · ${corrPct} co-change` : ""}
+            {coChanges != null ? ` · ${coChanges} commits` : ""}
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (biomarkerType === "complex_conditional") {
+    const ops = num(details.operator_count);
+    if (ops == null) return null;
+    return (
+      <div className="text-[11px] text-[var(--color-text-tertiary)] tabular-nums">
+        ({ops} ops)
+      </div>
+    );
+  }
+
+  if (biomarkerType === "function_hotspot") {
+    const mod =
+      num(details.modification_count) ?? num(details.mod_count);
+    const p80 = num(details.repo_p80) ?? num(details.p80);
+    if (mod == null) return null;
+    return (
+      <div className="text-[11px] text-[var(--color-text-tertiary)] tabular-nums">
+        mod {mod}
+        {p80 != null ? ` / p80 ${p80}` : ""}
+      </div>
+    );
+  }
+
+  if (biomarkerType === "code_age_volatility") {
+    const age = num(details.median_age_days);
+    const recent = num(details.recent_mod_count);
+    if (age == null && recent == null) return null;
+    return (
+      <div className="text-[11px] text-[var(--color-text-tertiary)] tabular-nums">
+        {age != null ? `~${age}d old` : ""}
+        {age != null && recent != null ? " · " : ""}
+        {recent != null ? `${recent} edits/30d` : ""}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/packages/ui/src/health/biomarker-glossary.ts
+++ b/packages/ui/src/health/biomarker-glossary.ts
@@ -29,11 +29,11 @@ export const CATEGORY_LABEL: Record<BiomarkerCategory, string> = {
 };
 
 export const CATEGORY_CAP: Record<BiomarkerCategory, number> = {
-  structural_complexity: 3.5,
-  size_and_complexity: 2.0,
-  duplication: 1.5,
+  organizational: 3.5,
+  structural_complexity: 2.5,
   test_coverage: 2.0,
-  organizational: 1.0,
+  size_and_complexity: 1.5,
+  duplication: 1.0,
 };
 
 export const BIOMARKER_GLOSSARY: Record<string, BiomarkerInfo> = {
@@ -102,6 +102,30 @@ export const BIOMARKER_GLOSSARY: Record<string, BiomarkerInfo> = {
     category: "organizational",
     description:
       "Files whose primary author has reduced or stopped contributing — a bus-factor warning.",
+  },
+  hidden_coupling: {
+    label: "Hidden coupling",
+    category: "organizational",
+    description:
+      "Two files co-change in git history but have no explicit import between them. The implicit contract is invisible at the source level, so changes slip out of sync and break in production.",
+  },
+  complex_conditional: {
+    label: "Complex conditional",
+    category: "structural_complexity",
+    description:
+      "A boolean expression stitching three or more operators together. Compound conditions like these usually encode two policies fighting for one line and are easy to misread under pressure.",
+  },
+  function_hotspot: {
+    label: "Function hotspot",
+    category: "organizational",
+    description:
+      "A single function concentrating an outsized share of the file's churn while carrying real structural complexity. Defects accumulate where modification frequency and complexity collide.",
+  },
+  code_age_volatility: {
+    label: "Code age volatility",
+    category: "organizational",
+    description:
+      "A long-stable function (median line age ≥ 1 year) that has suddenly started moving again. This edit profile is one of the strongest empirical predictors of regressions.",
   },
 };
 

--- a/packages/ui/src/health/biomarker-list.tsx
+++ b/packages/ui/src/health/biomarker-list.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { biomarkerLabel, biomarkerInfo, CATEGORY_LABEL } from "./biomarker-glossary";
+import { BiomarkerDetails, type BiomarkerDetailsRecord } from "./biomarker-details";
 import { SEVERITY_CHIP, SEVERITY_LABEL, SEVERITY_ORDER, type Severity } from "./tokens";
 
 export interface BiomarkerFinding {
@@ -13,6 +14,7 @@ export interface BiomarkerFinding {
   function_name: string | null;
   health_impact: number;
   reason: string;
+  details?: BiomarkerDetailsRecord | null;
 }
 
 export interface BiomarkerListProps {
@@ -23,6 +25,10 @@ export interface BiomarkerListProps {
   minSeverity?: Severity;
   onSelect?: ((f: BiomarkerFinding) => void) | undefined;
   maxPerGroup?: number;
+  /** Click-handler for the partner-file chip on hidden_coupling rows. */
+  onPartnerSelect?: ((path: string) => void) | undefined;
+  /** Optional anchor href for the partner-file chip. */
+  onPartnerHref?: ((path: string) => string) | undefined;
 }
 
 export function BiomarkerList({
@@ -31,6 +37,8 @@ export function BiomarkerList({
   minSeverity,
   onSelect,
   maxPerGroup = 8,
+  onPartnerSelect,
+  onPartnerHref,
 }: BiomarkerListProps) {
   const filtered = minSeverity
     ? findings.filter((f) => SEVERITY_ORDER[f.severity] >= SEVERITY_ORDER[minSeverity])
@@ -48,7 +56,13 @@ export function BiomarkerList({
     return (
       <ul className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] divide-y divide-[var(--color-border-default)]">
         {filtered.map((f) => (
-          <FindingRow key={f.id} finding={f} onSelect={onSelect} />
+          <FindingRow
+            key={f.id}
+            finding={f}
+            onSelect={onSelect}
+            onPartnerSelect={onPartnerSelect}
+            onPartnerHref={onPartnerHref}
+          />
         ))}
       </ul>
     );
@@ -73,6 +87,8 @@ export function BiomarkerList({
           findings={group}
           onSelect={onSelect}
           maxPerGroup={maxPerGroup}
+          onPartnerSelect={onPartnerSelect}
+          onPartnerHref={onPartnerHref}
         />
       ))}
     </div>
@@ -84,11 +100,15 @@ function BiomarkerGroup({
   findings,
   onSelect,
   maxPerGroup,
+  onPartnerSelect,
+  onPartnerHref,
 }: {
   type: string;
   findings: BiomarkerFinding[];
   onSelect?: ((f: BiomarkerFinding) => void) | undefined;
   maxPerGroup: number;
+  onPartnerSelect?: ((path: string) => void) | undefined;
+  onPartnerHref?: ((path: string) => string) | undefined;
 }) {
   const [expanded, setExpanded] = useState(false);
   const info = biomarkerInfo(type);
@@ -132,7 +152,14 @@ function BiomarkerGroup({
       </button>
       <ul className="divide-y divide-[var(--color-border-default)] border-t border-[var(--color-border-default)]">
         {visible.map((f) => (
-          <FindingRow key={f.id} finding={f} onSelect={onSelect} hideBiomarker />
+          <FindingRow
+            key={f.id}
+            finding={f}
+            onSelect={onSelect}
+            hideBiomarker
+            onPartnerSelect={onPartnerSelect}
+            onPartnerHref={onPartnerHref}
+          />
         ))}
         {!expanded && findings.length > maxPerGroup ? (
           <li className="px-3 py-2 text-xs text-[var(--color-text-tertiary)]">
@@ -148,10 +175,14 @@ function FindingRow({
   finding,
   onSelect,
   hideBiomarker = false,
+  onPartnerSelect,
+  onPartnerHref,
 }: {
   finding: BiomarkerFinding;
   onSelect?: ((f: BiomarkerFinding) => void) | undefined;
   hideBiomarker?: boolean;
+  onPartnerSelect?: ((path: string) => void) | undefined;
+  onPartnerHref?: ((path: string) => string) | undefined;
 }) {
   const f = finding;
   const interactive = !!onSelect;
@@ -180,6 +211,12 @@ function FindingRow({
         {f.function_name ? ` :: ${f.function_name}` : ""}
       </p>
       <p className="text-xs text-[var(--color-text-tertiary)] line-clamp-2">{f.reason}</p>
+      <BiomarkerDetails
+        biomarkerType={f.biomarker_type}
+        details={f.details}
+        onPartnerSelect={onPartnerSelect}
+        onPartnerHref={onPartnerHref}
+      />
     </li>
   );
 }

--- a/packages/ui/src/health/health-file-drawer.tsx
+++ b/packages/ui/src/health/health-file-drawer.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { ExternalLink, X } from "lucide-react";
 import { biomarkerLabel, biomarkerInfo, CATEGORY_LABEL } from "./biomarker-glossary";
+import { BiomarkerDetails, type BiomarkerDetailsRecord } from "./biomarker-details";
 import { ScoreBreakdown, type ScoreBreakdownCategory } from "./score-breakdown";
 import {
   SEVERITY_CHIP,
@@ -21,6 +22,7 @@ export interface HealthDrawerFinding {
   health_impact: number;
   reason: string;
   status?: string;
+  details?: BiomarkerDetailsRecord | null;
 }
 
 export interface HealthDrawerMetric {
@@ -48,7 +50,11 @@ export interface HealthFileDrawerProps {
   findings?: HealthDrawerFinding[];
   suggestions?: Record<string, string>;
   fileViewHref?: string;
+  /** Build a per-line deep-link from the drawer's function:line span. */
+  fileViewHrefFor?: ((lineStart: number) => string) | undefined;
   permalinkHref?: string;
+  onPartnerSelect?: ((path: string) => void) | undefined;
+  onPartnerHref?: ((path: string) => string) | undefined;
 }
 
 export function HealthFileDrawer({
@@ -60,7 +66,10 @@ export function HealthFileDrawer({
   findings = [],
   suggestions = {},
   fileViewHref,
+  fileViewHrefFor,
   permalinkHref,
+  onPartnerSelect,
+  onPartnerHref,
 }: HealthFileDrawerProps) {
   // ESC to close
   useEffect(() => {
@@ -190,15 +199,36 @@ export function HealthFileDrawer({
                             <span className="text-[10px] uppercase tracking-wider text-[var(--color-text-tertiary)]">
                               {CATEGORY_LABEL[info.category]}
                             </span>
-                            {f.function_name ? (
-                              <span className="text-xs font-mono text-[var(--color-text-tertiary)]">
-                                {f.function_name}
-                                {f.line_start ? `:${f.line_start}` : ""}
-                              </span>
-                            ) : null}
+                            {f.function_name ? (() => {
+                              const label = `${f.function_name}${f.line_start ? `:${f.line_start}` : ""}`;
+                              const lineHref =
+                                f.line_start != null && fileViewHrefFor
+                                  ? fileViewHrefFor(f.line_start)
+                                  : f.line_start != null
+                                    ? fileViewHref
+                                    : undefined;
+                              return lineHref ? (
+                                <a
+                                  href={lineHref}
+                                  className="text-xs font-mono text-[var(--color-accent-primary)] hover:underline"
+                                >
+                                  {label}
+                                </a>
+                              ) : (
+                                <span className="text-xs font-mono text-[var(--color-text-tertiary)]">
+                                  {label}
+                                </span>
+                              );
+                            })() : null}
                             <span className="ml-auto text-xs tabular-nums text-red-500">−{f.health_impact.toFixed(2)}</span>
                           </div>
                           <p className="text-xs text-[var(--color-text-secondary)]">{f.reason}</p>
+                          <BiomarkerDetails
+                            biomarkerType={f.biomarker_type}
+                            details={f.details}
+                            onPartnerSelect={onPartnerSelect}
+                            onPartnerHref={onPartnerHref}
+                          />
                           {suggestions[f.biomarker_type] ? (
                             <p className="text-xs text-[var(--color-text-tertiary)] italic">
                               {suggestions[f.biomarker_type]}

--- a/packages/ui/src/health/hidden-coupling-list.tsx
+++ b/packages/ui/src/health/hidden-coupling-list.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { ArrowLeftRight } from "lucide-react";
+import type { BiomarkerDetailsRecord } from "./biomarker-details";
+import { SEVERITY_CHIP, SEVERITY_LABEL, type Severity } from "./tokens";
+
+export interface HiddenCouplingFinding {
+  id: string;
+  file_path: string;
+  biomarker_type: string;
+  severity: Severity;
+  health_impact: number;
+  details?: BiomarkerDetailsRecord | null;
+}
+
+export interface HiddenCouplingListProps {
+  findings: HiddenCouplingFinding[];
+  limit?: number;
+  onSelect?: ((path: string) => void) | undefined;
+  hrefFor?: ((path: string) => string) | undefined;
+}
+
+interface CouplingPair {
+  key: string;
+  a: string;
+  b: string;
+  correlation: number;
+  co_change_count: number;
+  worst_severity: Severity;
+  impact: number;
+}
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+};
+
+function num(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && v !== "" && Number.isFinite(Number(v))) {
+    return Number(v);
+  }
+  return null;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function aggregate(findings: HiddenCouplingFinding[]): CouplingPair[] {
+  const byKey = new Map<string, CouplingPair>();
+  for (const f of findings) {
+    if (f.biomarker_type !== "hidden_coupling") continue;
+    const partner = str(f.details?.partner);
+    if (!partner) continue;
+    const sorted = [f.file_path, partner].sort();
+    const key = sorted.join("|");
+    const corr = num(f.details?.correlation) ?? 0;
+    const co = num(f.details?.co_change_count) ?? 0;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.correlation = Math.max(existing.correlation, corr);
+      existing.co_change_count = Math.max(existing.co_change_count, co);
+      existing.impact = Math.max(existing.impact, f.health_impact);
+      if (SEVERITY_RANK[f.severity] > SEVERITY_RANK[existing.worst_severity]) {
+        existing.worst_severity = f.severity;
+      }
+    } else {
+      byKey.set(key, {
+        key,
+        a: sorted[0]!,
+        b: sorted[1]!,
+        correlation: corr,
+        co_change_count: co,
+        worst_severity: f.severity,
+        impact: f.health_impact,
+      });
+    }
+  }
+  return [...byKey.values()].sort(
+    (a, b) => b.correlation - a.correlation || b.impact - a.impact,
+  );
+}
+
+export function HiddenCouplingList({
+  findings,
+  limit = 15,
+  onSelect,
+  hrefFor,
+}: HiddenCouplingListProps) {
+  const rows = aggregate(findings).slice(0, limit);
+  if (rows.length === 0) return null;
+
+  return (
+    <section className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
+      <header className="flex items-center gap-2 px-4 py-3 border-b border-[var(--color-border-default)]">
+        <ArrowLeftRight className="h-4 w-4 text-violet-500" aria-hidden="true" />
+        <h2 className="text-sm font-medium text-[var(--color-text-primary)]">
+          Hidden coupling pairs
+        </h2>
+        <span className="text-xs text-[var(--color-text-tertiary)]">
+          Files that co-change without an import edge
+        </span>
+        <span className="ml-auto text-xs text-[var(--color-text-tertiary)]">
+          {rows.length} pair{rows.length === 1 ? "" : "s"}
+        </span>
+      </header>
+      <ul className="divide-y divide-[var(--color-border-default)]">
+        {rows.map((row) => (
+          <li key={row.key} className="p-3 space-y-1.5">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span
+                className={`inline-block rounded px-1.5 py-px text-[10px] uppercase font-semibold ${SEVERITY_CHIP[row.worst_severity]}`}
+              >
+                {SEVERITY_LABEL[row.worst_severity]}
+              </span>
+              <span className="ml-auto inline-flex items-center gap-3 text-xs tabular-nums text-[var(--color-text-tertiary)]">
+                <span title="Correlation = co-change count / min(commits A, commits B)">
+                  {Math.round(row.correlation * 100)}%
+                </span>
+                <span>· {row.co_change_count} co-commits</span>
+              </span>
+            </div>
+            <div className="grid grid-cols-1 gap-1 text-[11px] font-mono">
+              <PairLink path={row.a} onSelect={onSelect} hrefFor={hrefFor} />
+              <span className="text-[var(--color-text-tertiary)] inline-flex items-center gap-1">
+                <ArrowLeftRight className="h-3 w-3" aria-hidden="true" />
+              </span>
+              <PairLink path={row.b} onSelect={onSelect} hrefFor={hrefFor} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function PairLink({
+  path,
+  onSelect,
+  hrefFor,
+}: {
+  path: string;
+  onSelect?: ((path: string) => void) | undefined;
+  hrefFor?: ((path: string) => string) | undefined;
+}) {
+  const href = hrefFor?.(path);
+  if (onSelect) {
+    return (
+      <button
+        type="button"
+        onClick={() => onSelect(path)}
+        className="text-left text-[var(--color-accent-primary)] hover:underline truncate"
+      >
+        {path}
+      </button>
+    );
+  }
+  if (href) {
+    return (
+      <a
+        href={href}
+        className="text-[var(--color-accent-primary)] hover:underline truncate"
+      >
+        {path}
+      </a>
+    );
+  }
+  return <span className="text-[var(--color-text-primary)] truncate">{path}</span>;
+}

--- a/packages/ui/src/health/hot-functions-panel.tsx
+++ b/packages/ui/src/health/hot-functions-panel.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { ArrowUpRight, Flame } from "lucide-react";
+import { biomarkerLabel } from "./biomarker-glossary";
+import type { BiomarkerDetailsRecord } from "./biomarker-details";
+import { SEVERITY_CHIP, SEVERITY_LABEL, type Severity } from "./tokens";
+
+export interface HotFunctionFinding {
+  id: string;
+  file_path: string;
+  biomarker_type: string;
+  severity: Severity;
+  function_name: string | null;
+  line_start?: number | null;
+  health_impact: number;
+  reason: string;
+  details?: BiomarkerDetailsRecord | null;
+}
+
+export interface HotFunctionsPanelProps {
+  findings: HotFunctionFinding[];
+  /** Maximum function entries to render. */
+  limit?: number;
+  /** Click → open file drawer (and ideally scroll to the function). */
+  onSelect?: ((f: HotFunctionFinding) => void) | undefined;
+}
+
+const HOT_FUNCTION_BIOMARKERS = new Set([
+  "function_hotspot",
+  "code_age_volatility",
+  "complex_conditional",
+]);
+
+interface AggregatedFunction {
+  key: string;
+  file_path: string;
+  function_name: string;
+  total_impact: number;
+  worst_severity: Severity;
+  biomarkers: Set<string>;
+  representative: HotFunctionFinding;
+}
+
+const SEVERITY_RANK: Record<Severity, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+  critical: 3,
+};
+
+function aggregate(findings: HotFunctionFinding[]): AggregatedFunction[] {
+  const byKey = new Map<string, AggregatedFunction>();
+  for (const f of findings) {
+    if (!HOT_FUNCTION_BIOMARKERS.has(f.biomarker_type)) continue;
+    if (!f.function_name) continue;
+    const key = `${f.file_path}::${f.function_name}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.total_impact += f.health_impact;
+      existing.biomarkers.add(f.biomarker_type);
+      if (SEVERITY_RANK[f.severity] > SEVERITY_RANK[existing.worst_severity]) {
+        existing.worst_severity = f.severity;
+      }
+      if (f.health_impact > existing.representative.health_impact) {
+        existing.representative = f;
+      }
+    } else {
+      byKey.set(key, {
+        key,
+        file_path: f.file_path,
+        function_name: f.function_name,
+        total_impact: f.health_impact,
+        worst_severity: f.severity,
+        biomarkers: new Set([f.biomarker_type]),
+        representative: f,
+      });
+    }
+  }
+  return [...byKey.values()].sort((a, b) => b.total_impact - a.total_impact);
+}
+
+export function HotFunctionsPanel({
+  findings,
+  limit = 15,
+  onSelect,
+}: HotFunctionsPanelProps) {
+  const rows = aggregate(findings).slice(0, limit);
+  if (rows.length === 0) return null;
+
+  return (
+    <section className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
+      <header className="flex items-center gap-2 px-4 py-3 border-b border-[var(--color-border-default)]">
+        <Flame className="h-4 w-4 text-amber-500" aria-hidden="true" />
+        <h2 className="text-sm font-medium text-[var(--color-text-primary)]">
+          Hot functions
+        </h2>
+        <span className="text-xs text-[var(--color-text-tertiary)]">
+          Top functions where churn, age, and complexity collide
+        </span>
+        <span className="ml-auto text-xs text-[var(--color-text-tertiary)]">
+          {rows.length} function{rows.length === 1 ? "" : "s"}
+        </span>
+      </header>
+      <ul className="divide-y divide-[var(--color-border-default)]">
+        {rows.map((row) => {
+          const interactive = !!onSelect;
+          return (
+            <li
+              key={row.key}
+              className={`p-3 ${interactive ? "cursor-pointer hover:bg-[var(--color-bg-elevated)]" : ""}`}
+              onClick={interactive ? () => onSelect!(row.representative) : undefined}
+            >
+              <div className="flex items-center gap-2 flex-wrap">
+                <span
+                  className={`inline-block rounded px-1.5 py-px text-[10px] uppercase font-semibold ${SEVERITY_CHIP[row.worst_severity]}`}
+                >
+                  {SEVERITY_LABEL[row.worst_severity]}
+                </span>
+                <span className="text-xs font-mono text-[var(--color-text-primary)]">
+                  {row.function_name}
+                </span>
+                <span className="text-[11px] font-mono text-[var(--color-text-tertiary)] truncate">
+                  {row.file_path}
+                </span>
+                <span className="ml-auto inline-flex items-center gap-2">
+                  <span className="text-xs tabular-nums text-red-500">
+                    −{row.total_impact.toFixed(2)}
+                  </span>
+                  {interactive ? (
+                    <ArrowUpRight className="h-3.5 w-3.5 text-[var(--color-text-tertiary)]" />
+                  ) : null}
+                </span>
+              </div>
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
+                {[...row.biomarkers].map((b) => (
+                  <span
+                    key={b}
+                    className="inline-block rounded border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-1.5 py-px text-[10px] text-[var(--color-text-secondary)]"
+                  >
+                    {biomarkerLabel(b)}
+                  </span>
+                ))}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/packages/ui/src/health/index.ts
+++ b/packages/ui/src/health/index.ts
@@ -23,3 +23,6 @@ export * from "./impact-effort-quadrant";
 export * from "./health-file-drawer";
 export * from "./ai-prompt-builder";
 export * from "./ai-prompt-modal";
+export * from "./hot-functions-panel";
+export * from "./hidden-coupling-list";
+export * from "./recalibration-banner";

--- a/packages/ui/src/health/index.ts
+++ b/packages/ui/src/health/index.ts
@@ -4,6 +4,7 @@ export * from "./biomarker-chip";
 export * from "./kpi-cards";
 export * from "./file-table";
 export * from "./biomarker-list";
+export * from "./biomarker-details";
 export * from "./coverage-bar";
 export * from "./module-coverage-list";
 export * from "./untested-hotspot-warning";

--- a/packages/ui/src/health/recalibration-banner.tsx
+++ b/packages/ui/src/health/recalibration-banner.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Info, X } from "lucide-react";
+
+const STORAGE_PREFIX = "repowise:health:recalibration-banner-dismissed:";
+
+export interface RecalibrationBannerProps {
+  repoId: string;
+}
+
+export function RecalibrationBanner({ repoId }: RecalibrationBannerProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const dismissed = window.localStorage.getItem(STORAGE_PREFIX + repoId);
+      if (!dismissed) setVisible(true);
+    } catch {
+      setVisible(true);
+    }
+  }, [repoId]);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    try {
+      window.localStorage.setItem(STORAGE_PREFIX + repoId, "1");
+    } catch {
+      /* localStorage unavailable — just hide in this session. */
+    }
+    setVisible(false);
+  };
+
+  return (
+    <div
+      role="status"
+      className="flex items-start gap-3 rounded-lg border border-[var(--color-accent-primary)]/40 bg-[var(--color-accent-muted)] px-4 py-3 text-sm"
+    >
+      <Info
+        className="mt-0.5 h-4 w-4 shrink-0 text-[var(--color-accent-primary)]"
+        aria-hidden="true"
+      />
+      <div className="flex-1 space-y-1">
+        <p className="font-medium text-[var(--color-text-primary)]">
+          Scores were recalibrated.
+        </p>
+        <p className="text-[var(--color-text-secondary)]">
+          Organizational signals — developer congestion, knowledge
+          concentration, hidden coupling — now weigh more heavily because
+          they&apos;re the strongest empirical predictors of defects. Some
+          files moved.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss"
+        className="rounded p-1 text-[var(--color-text-tertiary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/health/refactoring-card.tsx
+++ b/packages/ui/src/health/refactoring-card.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { ArrowUpRight, ChevronDown, ChevronRight, Sparkles } from "lucide-react";
 import { biomarkerLabel } from "./biomarker-glossary";
+import type { BiomarkerDetailsRecord } from "./biomarker-details";
 import { SEVERITY_CHIP, SEVERITY_LABEL, type Severity } from "./tokens";
 
 export type EffortBucket = "S" | "M" | "L" | "XL";
@@ -12,9 +13,12 @@ export interface RefactoringTargetFinding {
   biomarker_type: string;
   severity: Severity;
   function_name: string | null;
+  line_start?: number | null;
+  line_end?: number | null;
   health_impact: number;
   reason: string;
   status?: string;
+  details?: BiomarkerDetailsRecord | null;
 }
 
 export interface RefactoringTarget {

--- a/packages/ui/src/health/score-breakdown.tsx
+++ b/packages/ui/src/health/score-breakdown.tsx
@@ -52,7 +52,18 @@ export function ScoreBreakdown({
       </div>
 
       <div className="space-y-2.5">
-        {categories.map((c) => {
+        {[...categories]
+          .sort((a, b) => {
+            if (b.applied_deduction !== a.applied_deduction) {
+              return b.applied_deduction - a.applied_deduction;
+            }
+            const capA =
+              CATEGORY_CAP[a.category as BiomarkerCategory] ?? a.cap;
+            const capB =
+              CATEGORY_CAP[b.category as BiomarkerCategory] ?? b.cap;
+            return capB - capA;
+          })
+          .map((c) => {
           const label =
             CATEGORY_LABEL[c.category as BiomarkerCategory] ?? c.category;
           const cap = CATEGORY_CAP[c.category as BiomarkerCategory] ?? c.cap;

--- a/packages/web/src/app/repos/[id]/health/page.tsx
+++ b/packages/web/src/app/repos/[id]/health/page.tsx
@@ -11,6 +11,9 @@ import {
   HealthFileTable,
   BiomarkerList,
   ModuleRollupList,
+  HotFunctionsPanel,
+  HiddenCouplingList,
+  RecalibrationBanner,
   type FileSortField,
   type Severity,
 } from "@repowise-dev/ui/health";
@@ -18,6 +21,8 @@ import {
   getHealthOverview,
   getHealthTrend,
   listHealthFiles,
+  listHealthFindings,
+  type HealthFinding,
   type HealthOverviewResponse,
   type HealthTrendResponse,
   type HealthFilesResponse,
@@ -36,6 +41,36 @@ export default function HealthPage() {
     () => getHealthOverview(id, 25),
     { revalidateOnFocus: false },
   );
+  const { data: hotFunctionFindings } = useSWR<HealthFinding[]>(
+    `code-health-hot-functions:${id}`,
+    async () => {
+      const types = [
+        "function_hotspot",
+        "code_age_volatility",
+        "complex_conditional",
+      ] as const;
+      const batches = await Promise.all(
+        types.map((t) =>
+          listHealthFindings(id, { biomarker_type: t, limit: 100 }).catch(
+            () => [] as HealthFinding[],
+          ),
+        ),
+      );
+      return batches.flat();
+    },
+    { revalidateOnFocus: false },
+  );
+
+  const { data: couplingFindings } = useSWR<HealthFinding[]>(
+    `code-health-hidden-coupling:${id}`,
+    () =>
+      listHealthFindings(id, {
+        biomarker_type: "hidden_coupling",
+        limit: 100,
+      }).catch(() => []),
+    { revalidateOnFocus: false },
+  );
+
   const { data: trend } = useSWR<HealthTrendResponse>(
     `code-health-trend:${id}`,
     () => getHealthTrend(id, 20),
@@ -131,6 +166,7 @@ export default function HealthPage() {
         </div>
       ) : overview ? (
         <>
+          <RecalibrationBanner repoId={id} />
           <HealthKpiCards
             summary={overview.summary}
             averageHistory={avgSeries}
@@ -234,6 +270,20 @@ export default function HealthPage() {
               />
             </div>
           </div>
+
+          {hotFunctionFindings && hotFunctionFindings.length >= 3 ? (
+            <HotFunctionsPanel
+              findings={hotFunctionFindings}
+              onSelect={(f) => setSelectedFile(f.file_path)}
+            />
+          ) : null}
+
+          {couplingFindings && couplingFindings.length >= 3 ? (
+            <HiddenCouplingList
+              findings={couplingFindings}
+              onSelect={(path) => setSelectedFile(path)}
+            />
+          ) : null}
 
           {overview.modules && overview.modules.length > 0 ? (
             <div className="space-y-2">

--- a/packages/web/src/components/health/health-file-drawer-host.tsx
+++ b/packages/web/src/components/health/health-file-drawer-host.tsx
@@ -31,6 +31,12 @@ export function HealthFileDrawerHost({
       findings={data?.findings ?? []}
       suggestions={data?.suggestions ?? {}}
       fileViewHref={filePath ? `/repos/${repoId}/files?path=${encodeURIComponent(filePath)}` : undefined}
+      fileViewHrefFor={
+        filePath
+          ? (line: number) =>
+              `/repos/${repoId}/files?path=${encodeURIComponent(filePath)}#L${line}`
+          : undefined
+      }
     />
   );
 }


### PR DESCRIPTION
## Summary

Exposes the four new code-health biomarkers (`hidden_coupling`, `complex_conditional`, `function_hotspot`, `code_age_volatility`) and the recent scoring recalibration in the shared UI package and the OSS web app. No backend changes.

## Must-fix items

- Glossary entries for the four new biomarkers added to `packages/ui/src/health/biomarker-glossary.ts` (one-to-two-sentence descriptions explaining why each matters).
- `CATEGORY_CAP` recalibrated to match `scoring.CATEGORY_CAPS`: organizational 1.0→3.5, structural_complexity 3.5→2.5, size_and_complexity 2.0→1.5, duplication 1.5→1.0; test_coverage unchanged.
- `ScoreBreakdown` category order is now sorted client-side by `applied_deduction` desc (cap desc tie-break) so the largest contributor leads.

## BiomarkerDetails switcher

New `BiomarkerDetails` component renders biomarker-specific extras inline under each row in `BiomarkerList` and the drawer findings list:
- `hidden_coupling` — clickable chip with partner path, correlation %, co-change count. `BiomarkerList` / drawer accept optional `onPartnerSelect` / `onPartnerHref` callbacks.
- `complex_conditional` — `(N ops)` operator-count badge.
- `function_hotspot` — `mod N / p80 M`.
- `code_age_volatility` — `~Nd old · M edits/30d`.

## Drawer function:line deep-link

`HealthFileDrawer` now accepts an optional `fileViewHrefFor(lineStart)` callback. When provided, every `function_name:line` span becomes a real anchor; falls back to the static `fileViewHref` otherwise. The OSS host wires it as `#L{line}` on top of the existing file viewer URL.

## AI prompt builder

`buildAiPrompt` appends an `Extra context:` sub-bullet under each new-biomarker finding with the partner path / operator count / mod and p80 / median age and recent commits. `details` flows through `RefactoringTargetFinding` so it propagates from the server payload without other changes.

## New surfaces

- `HotFunctionsPanel` — groups findings from `function_hotspot`, `code_age_volatility`, and `complex_conditional` by `(file, function)`, sums impacts, renders top 15 with contributing biomarker chips. Hidden until at least three entries.
- `HiddenCouplingList` — top 15 coupled pairs, deduped via sorted `[a, b]` key, with both files clickable. Hidden until at least three pairs.
- `RecalibrationBanner` — dismissible per repo via `localStorage` (`repowise:health:recalibration-banner-dismissed:<repoId>`).

All three render on `/repos/[id]/health`. Data is fetched from the existing `listHealthFindings` endpoint filtered by biomarker type — no server change.

## Polish

- Categories drive chip color via existing CSS tokens; new biomarkers inherit (no per-biomarker palette added).
- File table left unchanged by design — the new biomarkers are function-level and surface in the hot-functions panel, not as new file columns.

## Limitations / follow-ups

- `effort_bucket` on refactoring targets is still file-NLOC-based. Sizing function-level findings by function NLOC would improve the AI prompt's effort hint; deferred until the walker exposes per-function NLOC.
- Visual verification was not run against a live backend in this branch (no live data available locally). Type-check, lint, and production build all pass.

## Test plan

- [x] `npm run type-check` — clean across `types`, `ui`, `web`.
- [x] `npm run lint` — clean.
- [x] `npm run build` — production build succeeds; static-page fetches against the local backend fail with ECONNREFUSED as expected offline.
- [ ] Visual verification on a live repo — pending; deferred (no live backend in this session).