### PR TITLE
fix(upgrade): recompute code health after fast->full upgrade

### DIFF
--- a/packages/cli/src/repowise/cli/commands/upgrade_flow.py
+++ b/packages/cli/src/repowise/cli/commands/upgrade_flow.py
@@ -229,6 +229,56 @@ async def _run_upgrade(
     except Exception:
         pass  # FTS indexing is best-effort
 
+    # 7. Recompute + persist code health against the now-FULL git tier.
+    # The fast index persisted ESSENTIAL-tier findings only, so the blame /
+    # co-change biomarkers (function_hotspot, code_age_volatility,
+    # hidden_coupling) were no-ops. Now that the backfill has promoted the git
+    # tier and rehydrated the graph, re-run the full-repo health pass so those
+    # biomarkers land — otherwise the upgrade leaves the health tables frozen
+    # at the fast index's ESSENTIAL state. Mirrors what `init` / `update` do.
+    try:
+        from repowise.core.persistence.crud import (
+            save_health_findings,
+            save_health_metrics,
+            save_health_snapshot,
+        )
+        from repowise.core.pipeline.orchestrator import _run_health_analysis
+
+        health_report = await _run_health_analysis(
+            graph_builder,
+            git_meta_map,
+            parsed_files,
+            repo_path=repo_path,
+            progress=None,
+        )
+        if health_report is not None:
+            async with get_session(sf) as session:
+                await save_health_metrics(session, repo_id, health_report.metrics or [])
+                if health_report.findings:
+                    await save_health_findings(session, repo_id, health_report.findings)
+                kpis = health_report.kpis or {}
+                try:
+                    await save_health_snapshot(
+                        session,
+                        repo_id,
+                        hotspot_health=float(kpis.get("hotspot_health", 10.0)),
+                        average_health=float(kpis.get("average_health", 10.0)),
+                        worst_performer_path=kpis.get("worst_performer_path"),
+                        worst_performer_score=kpis.get("worst_performer_score"),
+                        per_file_scores={
+                            m.file_path: round(float(m.score), 2)
+                            for m in health_report.metrics or []
+                        },
+                    )
+                except Exception:
+                    pass  # snapshot is best-effort
+            console.print(
+                f"Code health recomputed at FULL tier: "
+                f"[cyan]{len(health_report.findings)}[/cyan] findings."
+            )
+    except Exception as exc:
+        console.print(f"[yellow]Health recompute skipped: {exc}[/yellow]")
+
     await engine.dispose()
     return generated_pages
 


### PR DESCRIPTION
## Problem

`repowise update --full` (the fast→full upgrade added in #224) backfills the git tier ESSENTIAL→FULL and regenerates LLM docs, but **never re-runs the health analysis**. The persisted health tables therefore stay frozen at the fast index's ESSENTIAL-tier findings.

The blame/co-change biomarkers added in #221/#222 — `function_hotspot`, `code_age_volatility`, `hidden_coupling` — are intentional no-ops at fast-index time (no per-line blame, no co-change). Because the upgrade never recomputed health, they remained **invisible after an upgrade** even though the FULL git data to support them was now present. A user following the documented `init --mode fast` → `update --full` flow got full docs but stale, ESSENTIAL-tier code health.

## Fix

Run a full-repo `HealthAnalyzer` pass at the end of `upgrade_flow._run_upgrade`, against the already-rehydrated graph + FULL `git_meta_map`, and persist findings/metrics/snapshot — mirroring what `init` (`persist_pipeline_result`) and the normal `update` path already do. Reuses the existing `_run_health_analysis` orchestrator helper (graceful fallback, module map, parallel path) and `save_health_{findings,metrics,snapshot}`.

## Verification

Tested locally on `test-repos/microdot`:

| | Before fix | After fix |
|---|---|---|
| Persisted findings after `update --full` | 274 (== ESSENTIAL set) | **289** (FULL set) |
| `function_hotspot` (persisted) | 0 | **15** |

The post-upgrade DB now matches a fresh full-tier `repowise health` recompute exactly. (`code_age_volatility`/`hidden_coupling` stay 0 — microdot genuinely doesn't trigger them even at FULL tier.)

Existing tests pass: `test_upgrade_fast_to_full`, `test_graph_rehydrate`, `test_git_backfill_resume`, `test_git_indexer_tiers` — 15 passed.