### PR TITLE
release: v0.11.0 — fast index mode, fast→full upgrade, four new health biomarkers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.11.0] — 2026-05-24
+
+### Added
+- **Fast index mode + incremental fast→full upgrade.** `repowise init --mode fast` does a quick first pass on very large repos — builds the dependency graph and indexes only the *essential* git tier (last commits, no per-file blame or co-change), and skips LLM doc generation. `repowise update --full` then upgrades that index to a full one **incrementally**: it backfills the git tier to FULL (per-file blame + repo-wide co-change) via a resumable, checkpointed worker, rehydrates the persisted graph from SQL rather than re-parsing and re-resolving it, and generates the docs fast mode skipped. Because the expensive import/call/heritage resolution and centrality computation are reused, the upgrade is measurably cheaper than re-running a full `init` (~14× faster on the avoided structural work at 2k files). The backfill is resumable — an interrupted `update --full` picks up where it left off (#220, #224).
+- **Four new code-health biomarkers.** `hidden_coupling` flags pairs of files that consistently change in the same commits without an explicit import/dependency edge — behavioral coupling static analysis can't see. `complex_conditional` catches branch/loop guards combining three or more boolean operators (severity grows with operator count). `function_hotspot` flags functions that are both structurally complex and frequently modified, and `code_age_volatility` flags old, settled functions that are suddenly being edited — both computed from a per-line blame index built once per file. The three git-derived biomarkers are tier-aware: they no-op on an ESSENTIAL-tier (fast) index and light up once the FULL git tier is present (#221, #222).
+- **Pluggable storage seams + capability registries.** New async `IndexStore` / `GraphStore` / `JobStore` interfaces with SQL/in-process default implementations, and process-wide `cli_registry` / `mcp_tool_registry` / `pipeline_hooks` registries so downstream packages can extend the CLI, MCP tool list, and pipeline phases without monkey-patching internals. Behavior is unchanged for OSS users — same CLI commands, same MCP tools, same default storage (#219).
+
+### Changed
+- **Code-health scoring recalibrated.** The organizational category cap is lifted from −1.0 to −3.5 so the strongest empirical predictors (`developer_congestion`, `untested_hotspot`, `hidden_coupling`) are no longer suppressed, and a per-biomarker weight multiplier was added (`developer_congestion` ×1.5, `untested_hotspot` ×1.3, `function_hotspot` ×1.2). `knowledge_loss` is de-rated to ×0.4 per OSS calibration (legacy code that works gets handed off) — enterprise users can raise it back via per-repo overrides. See the updated category-cap table in `docs/CODE_HEALTH.md` (#221).
+- **Health web UI surfaces the new biomarkers.** Glossary entries and biomarker-specific detail views for all four new biomarkers (partner-file chip for `hidden_coupling`, operator count for `complex_conditional`, mod/p80 ratio for `function_hotspot`, median age + recent edits for `code_age_volatility`), recalibrated category caps in the score breakdown (now sorted by applied deduction), and a clickable `function:line` deep-link in the file drawer. The new biomarker details also flow into the AI refactor prompt (#223).
+- **Doc generation scales to very large repos.** Batch embedding (one model call per generation level instead of N upserts), pipeline checkpoint/resume over the new JobStore seam, and graph metrics computed in SQL. Default behavior is unchanged when the new knobs aren't set (#220).
+
+### Fixed
+- **`repowise update --full` now recomputes code health at the FULL tier.** The upgrade backfilled the git tier and regenerated docs but never re-ran the health analysis, so the persisted health tables stayed frozen at the fast index's ESSENTIAL-tier findings — the blame/co-change biomarkers stayed invisible after an upgrade. The upgrade now runs a full-repo health pass against the rehydrated graph and persists findings/metrics/snapshot, matching what `init` and the normal `update` path do (#225).
+
+### Documentation
+- README mentions the Repowise PR Bot in the hosted-version section (#217).
+
+---
+
 ## [0.10.0] — 2026-05-18
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -6,4 +6,4 @@ git signals, dead code detection, architectural decisions, and
 AI-generated documentation.
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.10.0"
+version = "0.11.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Cuts **v0.11.0**. Version bumped across the four hardcoded files + `uv.lock`, changelog updated.

## Highlights (since v0.10.0)

- **Fast index mode + incremental fast→full upgrade** — `repowise init --mode fast` (graph + essential git, no LLM); `repowise update --full` backfills git to FULL and generates docs while reusing the persisted graph instead of re-resolving it (#220, #224).
- **Four new code-health biomarkers** — `hidden_coupling`, `complex_conditional`, `function_hotspot`, `code_age_volatility`; the git-derived ones are tier-aware and light up only at the FULL git tier (#221, #222).
- **Health scoring recalibrated** + web UI surfaces the new biomarkers (#221, #223).
- **Pluggable storage seams + capability registries**; doc generation scales to very large repos (#219, #220).
- **Fix:** `update --full` now recomputes code health at the FULL tier so the blame/co-change biomarkers aren't left invisible after an upgrade (#225).

Full detail in `docs/CHANGELOG.md`.

## Test plan

- [x] Version bumped in all 4 files + `uv.lock` (no `0.10.0` drift)
- [x] `uv build --wheel` clean → `repowise-0.11.0-py3-none-any.whl` (22 command modules, `.scm`/`.j2` data present)
- [x] Functional testing of the release contents on a real repo (microdot): fast index, tier-aware biomarkers, fast→full upgrade, post-upgrade health recompute all verified
- [x] Upgrade / rehydrate / backfill test suites pass (15 passed)
- [ ] Web build (`npm run build --workspace packages/web`) — CI `build-web` job on tag
- [ ] Browser smoke test of the served UI (post-merge, handed to maintainer)
- [ ] Tag `v0.11.0` on `main` after merge → triggers `publish.yml`

## Merge convention

**Use a regular merge commit — do NOT squash.** The tag must point at a real merge commit on `main` containing the bump-only diff so artifact provenance is traceable.