### PR TITLE
docs: refresh README, add COMMERCIAL.md, fix layer/tool/biomarker counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Five intelligence layers. Nine MCP tools. Multi-repo workspaces. Auto-sync hooks
 
 Your AI coding agent reads files. It doesn't know which ones change together, which ones are dead, or why they were built the way they were. It has the source code and no memory of how the codebase got there.
 
-repowise fixes that. It indexes your codebase into four intelligence layers — dependency graph, git history, auto-generated documentation, and architectural decisions — and exposes them to Claude Code (and any MCP-compatible AI agent) through eight precisely designed tools. Multi-repo? Initialize a workspace and get cross-repo co-change detection, API contract extraction, and federated MCP queries across all your services. **27× fewer tokens per query. 36% cheaper. Same answer quality.**
+repowise fixes that. It indexes your codebase into five intelligence layers — dependency graph, git history, auto-generated documentation, architectural decisions, and code health — and exposes them to Claude Code (and any MCP-compatible AI agent) through nine precisely designed tools. Multi-repo? Initialize a workspace and get cross-repo co-change detection, API contract extraction, and federated MCP queries across all your services. **Up to 70% fewer tool calls, 89% fewer file reads, and 36% cheaper per query — at parity answer quality.**
 
 The result: your agent answers *"why does auth work this way?"* instead of *"here is what auth.ts contains."*
 
@@ -31,18 +31,34 @@ The result: your agent answers *"why does auth work this way?"* instead of *"her
 
 ## 🏆 Benchmarked against frontier LLMs
 
-> **[repowise-bench →](https://github.com/repowise-dev/repowise-bench)** — an open SWE-QA benchmark that grades how well standard LLMs answer real software-engineering questions over real repositories.
->
-> On 48 paired tasks from `pallets/flask` (`claude-sonnet-4-6`, end-to-end), repowise-augmented Claude Code matches baseline answer quality while being dramatically leaner:
->
-> | Metric (per task, mean) | Baseline | **+ repowise** | Δ |
-> |---|---|---|---|
-> | 💰 Cost | $0.1396 | **$0.0890** | **−36 %** |
-> | ⚡ Wall time | 41.7 s | **33.9 s** | **−19 %** |
-> | 🛠️ Tool calls | 7.4 | **3.8** | **−49 %** |
-> | 📄 Files read | 1.9 | **0.2** | **−89 %** |
->
-> **32 / 48 (67 %)** tasks are cheaper with repowise — at parity quality (judge Δ ≈ −0.01).
+Same model. Same harness. The only difference is whether the agent has repowise's MCP tools. On a paired SWE-QA benchmark over real repositories, repowise makes a state-of-the-art coding agent **dramatically cheaper and leaner — while answering just as well.**
+
+> **Up to −70 % tool calls · −89 % file reads · −36 % cost · ~2/3 of tasks cheaper — at parity answer quality.**
+
+**`pallets/flask`** — a ~25K-LOC web framework, 48 paired SWE-QA tasks. **Same answer quality, a third of the cost:**
+
+| Metric (per task, mean) | Baseline | **+ repowise** | Δ |
+|---|---|---|---|
+| ✅ Judge score (0–10) | 8.82 | **8.81** | **parity** |
+| 💰 Cost | $0.1396 | **$0.0890** | **−36 %** |
+| ⚡ Wall time | 41.7 s | **33.9 s** | **−19 %** |
+| 🛠️ Tool calls | 7.4 | **3.8** | **−49 %** |
+| 📄 Files read | 1.9 | **0.2** | **−89 %** |
+
+> **32 / 48 (67 %)** tasks cheaper, at **dead-even** answer quality — judge Δ = −0.01, identical medians.
+
+**`scikit-learn/scikit-learn`** — a ~300K-LOC ML library with a dense private-method surface, 48 paired SWE-QA tasks. **The win gets bigger on the larger, harder codebase:**
+
+| Metric (per task, mean) | Baseline | **+ repowise** | Δ |
+|---|---|---|---|
+| 🛠️ Tool calls | 8.1 | **2.4** | **−70 %** |
+| 📄 Files read | 1.8 | **0.6** | **−69 %** |
+| 💰 Cost | $0.1180 | **$0.0834** | **−29 %** |
+| ⚡ Wall time | 39.7 s | **28.6 s** | **−28 %** |
+
+> **33 / 48 (69 %)** tasks cheaper, **28 / 48 (58 %)** faster, answer quality within judge noise. The median repowise task reads **zero** source files — it answers straight from the index without opening a single file from the repo.
+
+The mechanism is the same on both repos: most of a coding agent's spend is *exploration* — greping, reading candidate files, re-reading them as context grows. repowise does that exploration once, offline, so the agent skips it on every query. **Bigger, more tangled codebase → more exploration to skip → bigger win.**
 
 ### Token efficiency — because context windows aren't free
 
@@ -56,7 +72,7 @@ There's a small genre of "token efficiency" benchmarks going around. It would be
 
 **209× less than naive (mean), 26.8× pooled, 1,214× best case. 41.7× less than git diff (mean), 6.2× pooled.** Same file list, same tokenizer (`cl100k_base`), no per-strategy fudge. We report mean, pooled, and median together because picking just one would be the kind of thing other people in this genre seem to do.
 
-> Full methodology, per-task tables, and the actual SWE-QA evaluation (which has third-party ground truth and an independently-scored LLM judge — unlike this sanity-check): **[repowise-bench →](https://github.com/repowise-dev/repowise-bench)**
+> Full methodology, per-task tables, per-model cost decomposition, and the complete variance discussion for both repos: **[repowise-bench →](https://github.com/repowise-dev/repowise-bench)**
 
 ---
 
@@ -85,7 +101,7 @@ The layer nobody else has. Architectural decisions captured from git history, in
 These become structured decision records, queryable by Claude Code via `get_why()`.
 
 ### ◈ Code Health Intelligence
-Twelve deterministic biomarkers compute a 1–10 health score per file — McCabe complexity, deep nesting, brain methods, native Rabin–Karp duplication detection, untested hotspots, primitive obsession, developer congestion, knowledge loss, and more. **Zero LLM calls, zero new runtime dependencies** — pure Python over tree-sitter and git data, designed to finish in under 30 seconds on a 3 000-file repo.
+Fifteen deterministic biomarkers compute a 1–10 health score per file — McCabe complexity, deep nesting, brain methods, native Rabin–Karp duplication detection, untested hotspots, primitive obsession, developer congestion, knowledge loss, blame-based function hotspots, code-age volatility, and more. **Zero LLM calls, zero new runtime dependencies** — pure Python over tree-sitter and git data, designed to finish in under 30 seconds on a 3 000-file repo.
 
 Ingest LCOV, Cobertura, or Clover coverage reports to light up the test-coverage biomarkers. Rolling 50-row snapshot history powers `Declining Health` and `Predicted Decline` alerts. Deterministic, rule-based refactoring suggestions surface on the dashboard and via `get_health(include=["refactoring"])`. Per-file overrides via `.repowise/health-rules.json`.
 
@@ -117,7 +133,7 @@ uv tool install repowise
 
 ```bash
 cd your-project
-repowise init        # builds all four intelligence layers (~25 min first time)
+repowise init        # builds all five intelligence layers (one-time)
 repowise serve       # starts MCP server + local dashboard
 ```
 
@@ -144,7 +160,7 @@ To manually add the MCP server to another editor:
 }
 ```
 
-> **Note on init time:** Initial indexing analyzes your entire codebase — AST parsing, git-history mining, LLM doc generation, embedding indexing, and decision archaeology. This is a one-time cost (~25 minutes for a 3,000-file project). Every subsequent update after a commit takes under 30 seconds and only regenerates the few pages affected by your changes.
+> **Note on init time:** The graph, git, dead-code, and code-health layers build in minutes with **zero LLM calls** — run `repowise init --index-only` and you have a queryable index almost immediately. The one-time cost is the documentation layer: LLM-generated wiki pages, which scale with repo size and run once (and can run in the background). After that, every update following a commit takes **under 30 seconds** and only regenerates the few pages your change touched.
 
 > **Full docs:** [Quickstart](docs/QUICKSTART.md) · [User Guide](docs/USER_GUIDE.md) · [CLI Reference](docs/CLI_REFERENCE.md) · [MCP Tools](docs/MCP_TOOLS.md) · [Workspaces](docs/WORKSPACES.md) · [Computed Glossary](docs/COMPUTED_GLOSSARY.md) · [Auto-Sync](docs/AUTO_SYNC.md)
 
@@ -204,7 +220,7 @@ Most tools are designed around data entities — one module, one file, one symbo
 | `get_risk(targets, changed_files?)` | Hotspot scores, dependents, co-change partners, ownership, test gaps, security signals. Pass `changed_files` for PR mode → response carries a `directive` block (`will_break`, `missing_cochanges`, `missing_tests`) for one-glance review plus cross-repo blast radius. | Before modifying files — understand what could break |
 | `get_why(query?, targets?)` | Architectural decision records, their status (active / proposed / deprecated / superseded), and the commits that are evidence for them. Falls back to git archaeology when no ADRs exist for a file. | Before architectural changes — understand existing intent |
 | `get_dead_code(min_confidence?, include_internals?)` | Unreachable code sorted by confidence tier with cleanup impact estimates. In workspace mode, cross-repo consumer detection lowers confidence on findings that other repos import. | Cleanup tasks |
-| `get_health(targets?, include?)` | Twelve deterministic biomarker scores per file. Dashboard mode returns KPIs + the lowest-scoring files + a per-module NLOC-weighted rollup; targeted mode returns per-file findings. `include` flags layer richer data: `"coverage"`, `"refactoring"` (rule-based suggestions), `"trend"` (snapshot diff + declining/predicted-decline alerts). `module:foo` targets expand to a module's file set. | Before refactoring — find the worst-scoring files and what to fix first |
+| `get_health(targets?, include?)` | Fifteen deterministic biomarker scores per file. Dashboard mode returns KPIs + the lowest-scoring files + a per-module NLOC-weighted rollup; targeted mode returns per-file findings. `include` flags layer richer data: `"coverage"`, `"refactoring"` (rule-based suggestions), `"trend"` (snapshot diff + declining/predicted-decline alerts). `module:foo` targets expand to a module's file set. | Before refactoring — find the worst-scoring files and what to fix first |
 
 ### Tool call comparison — a real task
 
@@ -215,19 +231,7 @@ Most tools are designed around data entities — one module, one file, one symbo
 | Claude Code alone (no MCP) | grep + read ~30 files | ~8 min | Ownership, prior decisions, hidden coupling |
 | **repowise (9 tools)** | **5 calls** | **~2 min** | **Nothing** |
 
-The 5 calls for that task:
-
-```python
-get_overview()                                         # orient: understand the architecture
-get_context(["middleware", "api/routes", "payments"])  # understand 3 modules at once
-get_risk(["middleware/auth.ts"])                       # assess: 47 dependents, co-changes
-get_why("rate limiting")                               # check: any prior decision?
-search_codebase("rate limit OR throttle OR retry")     # find: any prior implementation?
-```
-
----
-
-## How Claude Code uses it
+Here are those five calls, and what each one actually returns:
 
 ```
 User: Implement rate limiting on all API endpoints
@@ -473,7 +477,7 @@ The "why" usually walks out the door — when a teammate leaves, or when you reo
 | Auto-generated documentation | ✅ | ✅ Gemini | ✅ | ✅ PR2Doc | ❌ |
 | Private repo — no cloud | ✅ | ❌ in development | ❌ OSS forks only | ✅ Enterprise tier | ✅ |
 | Dead code detection | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Code health score (1–10) | ✅ 12 biomarkers | ❌ | ❌ | ❌ | ✅ 25–30 |
+| Code health score (1–10) | ✅ 15 biomarkers | ❌ | ❌ | ❌ | ✅ 25–30 |
 | Brain Method detection | ✅ | ❌ | ❌ | ❌ | ✅ |
 | Complexity biomarkers | ✅ native tree-sitter | ❌ | ❌ | ❌ | ✅ |
 | Test coverage intelligence | ✅ LCOV/Cobertura/Clover | ❌ | ❌ | ❌ | ❌ |
@@ -519,6 +523,8 @@ We use it on our own codebase — see the live snapshot of repowise indexing its
 - **Cross-repo intelligence at scale** — federated hotspots, dead code, and ownership across all your repos in one dashboard
 - **Integrations** *(rolling out)* — Slack alerts, Jira/Linear decision linking, Confluence/Notion doc sync, PagerDuty escalation
 
+Full breakdown of what's GA, in development, and planned — plus on-prem topology and pricing models: **[docs/COMMERCIAL.md](docs/COMMERCIAL.md)**
+
 [Get in touch →](https://www.repowise.dev/#contact) · [hello@repowise.dev](mailto:hello@repowise.dev)
 
 ---
@@ -548,6 +554,12 @@ repowise hook uninstall           # remove hooks
 repowise query "<question>"       # ask anything from the terminal
 repowise search "<query>"         # semantic search over the wiki
 repowise status                   # coverage, freshness, dead code summary
+
+# Code health
+repowise health                             # KPIs + lowest-scoring files
+repowise health --coverage cov.lcov         # ingest coverage, light up untested-hotspot
+repowise health --refactoring-targets       # ranked by impact / effort
+repowise health --trend                     # last 10 snapshots + declining/predicted-decline alerts
 
 # Dead code
 repowise dead-code                          # full report
@@ -671,7 +683,7 @@ Full guide including how to add languages and LLM providers: [CONTRIBUTING.md](C
 
 AGPL-3.0. Free for individuals, teams, and companies using repowise internally.
 
-For commercial licensing — embedding repowise in a product, white-labeling, or SaaS use without AGPL obligations — contact [hello@repowise.dev](mailto:hello@repowise.dev).
+For commercial licensing — the enterprise security & compliance layer, SSO/SCIM, RBAC, workflow integrations, priority support and SLA, or embedding repowise in a product without AGPL obligations — see **[docs/COMMERCIAL.md](docs/COMMERCIAL.md)** or contact [hello@repowise.dev](mailto:hello@repowise.dev).
 
 ---
 

--- a/docs/CODE_HEALTH.md
+++ b/docs/CODE_HEALTH.md
@@ -1,10 +1,11 @@
 # Code Health
 
-Repowise computes a 1–10 health score for every file in your repo from twelve
+Repowise computes a 1–10 health score for every file in your repo from fifteen
 deterministic biomarkers — McCabe complexity, deep nesting, brain methods,
-clone detection, untested hotspots, organizational risk, and more. **No LLM
-calls, no cloud requirement.** Pure Python over tree-sitter + git data,
-designed to finish in under 30 seconds on a 3 000-file repo.
+clone detection, untested hotspots, function-level churn, code-age volatility,
+organizational risk, and more. **No LLM calls, no cloud requirement.** Pure
+Python over tree-sitter + git data, designed to finish in under 30 seconds on a
+3 000-file repo.
 
 ## Quick start
 
@@ -25,11 +26,16 @@ most:
 
 | Category               | Cap   | Biomarkers |
 |------------------------|-------|------------|
-| Organizational         | −3.5  | developer_congestion, knowledge_loss, hidden_coupling |
+| Organizational         | −3.5  | developer_congestion, knowledge_loss, hidden_coupling, function_hotspot, code_age_volatility |
 | Structural complexity  | −2.5  | brain_method, nested_complexity, bumpy_road, complex_conditional |
 | Test coverage          | −2.0  | untested_hotspot, coverage_gap |
 | Size & complexity      | −1.5  | complex_method, large_method, primitive_obsession |
 | Duplication            | −1.0  | dry_violation |
+
+Fifteen biomarkers across five categories. `function_hotspot` and
+`code_age_volatility` are blame-based and sit in the organizational bucket —
+both are tier-aware and stay silent on ESSENTIAL-tier repos until the per-line
+blame index is built.
 
 Per-biomarker weight multipliers (see `scoring._BIOMARKER_WEIGHT_MULTIPLIER`)
 let the strongest empirical predictors deduct more than the uniform severity
@@ -205,7 +211,7 @@ Health: 7.4 (avg) · 6.2 (hotspots) · 2.1 (worst: payments/processor.ts)
 
 | Feature                          | Repowise | CodeScene | DeepSource | Sourcery |
 |----------------------------------|:--:|:--:|:--:|:--:|
-| Code health score (1–10)         | ✅ 12 biomarkers | ✅ 25–30 | ❌ | ❌ |
+| Code health score (1–10)         | ✅ 15 biomarkers | ✅ 25–30 | ❌ | ❌ |
 | Brain Method detection           | ✅ | ✅ | ❌ | ❌ |
 | Test coverage intelligence       | ✅ LCOV/Cobertura/Clover | ❌ | ❌ | ❌ |
 | Untested hotspot detection       | ✅ coverage × hotspot | ❌ | ❌ | ❌ |

--- a/docs/COMMERCIAL.md
+++ b/docs/COMMERCIAL.md
@@ -1,0 +1,323 @@
+# Repowise — Commercial Offering
+
+Repowise is dual-licensed: the core engine is **AGPL-3.0 and free** for individuals,
+teams, and companies using it internally; a **commercial license** adds the
+enterprise security, compliance, governance, and operations layer — and removes the
+AGPL obligations for anyone embedding Repowise in their own product.
+
+This document covers what the open-source distribution includes, what the commercial
+license adds on top, the honest GA / in-development / planned status of each
+commercial capability, the on-premise deployment model, and the available pricing
+models. Specific pricing figures are provided in a separate proposal.
+
+> **Looking for the open-source feature set?** The [README](../README.md) and
+> [docs/](.) cover everything in the AGPL distribution. This document is about what
+> sits *on top* of it commercially.
+
+---
+
+## 1. Who the commercial license is for
+
+The open-source distribution covers the full developer-experience surface — the five
+intelligence layers, the nine MCP tools, multi-repo workspaces, the local dashboard,
+auto-sync, and auto-generated `CLAUDE.md`. That is everything an engineer or a team
+needs to make their AI coding agents codebase-aware.
+
+The commercial license is for organizations that need to roll Repowise out **at
+scale, in a regulated or security-sensitive environment**:
+
+- Large, long-lived codebases — often multi-language, multi-repo, with deep tribal
+  knowledge that walks out the door when senior engineers leave.
+- Security and compliance obligations (PCI-DSS, SOC 2, audit trails, SBOMs) that
+  demand traceable rationale for architectural change, not just code diffs.
+- Platform/security/compliance teams that require SSO, RBAC, audit logging, and
+  on-prem or air-gapped deployment before a tool can touch source code.
+- Product teams that want to **embed** Repowise intelligence in their own internal
+  developer platforms without taking on AGPL obligations.
+
+---
+
+## 2. What ships in open source (AGPL-3.0)
+
+All of the following ship in `pip install repowise` today, free for internal use.
+
+- **Five intelligence layers** — Graph (tree-sitter AST across 14 languages, two-tier
+  dependency graph, call resolution, heritage extraction, Leiden communities,
+  PageRank / betweenness / SCC), Git (hotspots, ownership, co-change pairs, bus
+  factor, significant commits, contributor profiles, module health), Documentation
+  (LLM-generated wiki, freshness scoring, RAG search), Decision (architectural
+  decision records linked to graph nodes, staleness tracking), and Code Health
+  (fifteen deterministic biomarkers, 1–10 score per file, coverage ingestion, trend
+  alerts).
+- **Nine task-shaped MCP tools** — `get_overview`, `get_answer`, `get_context`,
+  `get_symbol`, `search_codebase`, `get_risk`, `get_why`, `get_dead_code`,
+  `get_health`. Benchmarked at **−36 % cost / −49 % tool calls** on `pallets/flask`
+  and **−29 % cost / −70 % tool calls** on `scikit-learn` versus a strong baseline
+  agent, at parity answer quality — see [repowise-bench](https://github.com/repowise-dev/repowise-bench).
+- **Multi-repo workspace intelligence** — cross-repo co-changes, API contract
+  extraction (HTTP / gRPC / topics) with provider↔consumer matching, package
+  dependency mapping, federated MCP queries (`repo="all"`), workspace dashboard and
+  `CLAUDE.md`.
+- **Proactive agent hooks** — PreToolUse graph enrichment on every `Grep`/`Glob`;
+  PostToolUse stale-wiki detection after `git commit`. No LLM calls, pure local
+  SQLite.
+- **Auto-sync** — post-commit hook, file watcher, GitHub webhook, GitLab webhook,
+  polling fallback. Typical incremental update touches 3–10 pages in under 30 s.
+- **Local dashboard** — Chat, Docs, Graph, C4, Search, Symbols, Coverage, Risk,
+  Contributors, Module Health, Hotspots, Dead Code, Decisions, Costs, Blast Radius,
+  Security (local pattern scan), Knowledge Map, and the workspace views.
+- **Dead-code detection** — pure graph traversal, confidence-tiered, framework-aware
+  (ASP.NET, Django, FastAPI, Flask, Rails, Laravel), dynamic-import aware.
+- **Privacy** — self-hosted; source never leaves your infrastructure; BYOK or fully
+  offline via Ollama; zero telemetry. Stored: graph, non-reversible embeddings, wiki
+  pages, git metadata, decision records. Raw source is processed transiently and
+  never persisted.
+
+---
+
+## 3. First-class language coverage
+
+Repowise treats **8 languages at Full tier** — Python, TypeScript, JavaScript, Java,
+Go, Rust, C++, and **C#** — with AST parsing, import resolution, named bindings, call
+resolution, heritage extraction, multi-project workspace resolvers, framework-aware
+edges, and per-language dynamic-hint extractors. A further 6 languages (C, Kotlin,
+Ruby, Swift, Scala, PHP) sit at Good tier.
+
+For estates built on a particular stack, the relevant Full-tier capabilities are
+worth calling out. For **.NET**, as one example:
+
+| Capability | Detail |
+|------------|--------|
+| Project graph | `.csproj`, `.sln`, `Directory.Build.props` parsed for `<ProjectReference>` / `<PackageReference>` |
+| Multi-project workspace | Namespace → file mapping propagated across projects in a solution |
+| Framework-aware edges | ASP.NET MVC / Minimal API, EF Core `DbContext`, gRPC-dotnet services |
+| Dynamic-hint extraction | .NET DI registrations, `Activator.CreateInstance`, reflection, `InternalsVisibleTo` |
+| Documentation | XML doc comments (`/// <summary>`) extracted into the wiki |
+| Contract extraction | ASP.NET HTTP routes and gRPC-dotnet service defs surfaced as workspace contracts |
+| Dead code | Confidence-tiered, respecting ASP.NET / EF Core decorators and DI registrations |
+
+The same depth exists for the other Full-tier languages. The language pipeline is
+modular by design — adding or deepening a language touches per-language subpackages,
+not the parser core — which is what makes the **custom language / framework
+extensions** in §5.4 a tractable commercial offering.
+
+---
+
+## 4. Commercial capabilities — at a glance
+
+Status is honest: **GA** (generally available today), **dev** (working internals,
+limited customer-facing surface), or **planned** (near-term roadmap). Sequencing
+against your procurement timeline is agreed as part of the commercial proposal —
+the items that matter most to you can be prioritized.
+
+| Capability | Open Source (AGPL) | Commercial License |
+|------------|:------------------:|:------------------:|
+| Five intelligence layers | ✅ | ✅ |
+| Nine MCP tools | ✅ | ✅ |
+| Multi-repo workspaces | ✅ | ✅ |
+| Full-tier language support (incl. C# / .NET) | ✅ | ✅ |
+| Local dashboard (incl. local security pattern scan) | ✅ | ✅ |
+| Auto-sync (hooks, watcher, webhooks) | ✅ | ✅ |
+| Auto-generated CLAUDE.md | ✅ | ✅ |
+| Graph-aware enhanced security scanning | — | ✅ *(dev)* |
+| Language-specific security rulesets | — | ✅ *(dev)* |
+| CVE-aware dependency analysis | — | ✅ *(planned)* |
+| Reachability-aware CVE triage | — | ✅ *(planned)* |
+| SBOM generation (CycloneDX) | — | ✅ *(planned)* |
+| Compliance reporting (PCI-DSS / SOC 2) | — | ✅ *(planned)* |
+| Audit trail (in-product + JSON / CSV export) | — | ✅ *(dev)* |
+| Jira / Confluence integration | — | ✅ *(rolling out)* |
+| GitHub Enterprise / Azure DevOps / GitLab / Bitbucket | — | ✅ *(rolling out)* |
+| Slack / Teams alerting | — | ✅ *(rolling out)* |
+| SAML / OIDC SSO + SCIM | — | ✅ *(rolling out)* |
+| RBAC + multi-tenant | — | ✅ *(planned)* |
+| Air-gapped install bundle | — | ✅ *(planned)* |
+| Reference HA topology | — | ✅ *(GA on customer infra)* |
+| Engineering leader dashboard | — | ✅ *(rolling out)* |
+| Custom language / framework extensions | — | ✅ *(GA)* |
+| Priority support & SLA | — | ✅ *(GA)* |
+| IP indemnification + defensive patent grant | — | ✅ *(GA)* |
+
+---
+
+## 5. Commercial capabilities — in detail
+
+### 5.1 Security & Compliance
+
+- **Security scanning layer** *(GA: local pattern scan; dev: graph-aware
+  enrichment)* — pattern-based detection for dangerous APIs (`eval`/`exec`,
+  `pickle.loads`, `shell=True`, `os.system`, hardcoded secrets, concat / f-string
+  SQL, `verify=False`, weak hashes) runs locally today in the dashboard's Security
+  view. Graph-aware enrichment — linking findings to graph nodes and surfacing them
+  through `get_risk` so AI agents see security context before modifying a file — is
+  in development.
+- **Language-specific security rulesets** *(dev)* — rulesets built on top of the
+  per-language dynamic-hint extractors and framework edges. For .NET, planned checks
+  include `[Authorize]` coverage on controllers and Minimal API endpoints,
+  `IConfiguration` secret leakage, EF Core raw-SQL risk, `HttpClient` lifetime
+  issues, and `AllowAnonymous` on sensitive routes. Each language's ruleset ships as
+  a focused subset, then expands on customer feedback.
+- **CVE-aware dependency analysis** *(planned)* — dependency manifests
+  (`*.csproj`, `packages.lock.json`, `package.json`, `pyproject.toml`, `go.mod`)
+  matched against NVD / GitHub Advisory / OSV feeds, with severity, fix availability,
+  and transitive-impact scoring.
+- **Reachability-aware CVE triage** *(planned)* — because Repowise holds a resolved
+  call graph, CVEs can be classified by whether the vulnerable function is actually
+  reachable from your code, reducing SCA noise. Precision is language- and
+  pattern-dependent; we report it honestly per language rather than quoting one
+  global number.
+- **SBOM generation** *(planned)* — CycloneDX output per commit with per-dependency
+  license detection and SBOM diffs between releases. SPDX and cross-format conversion
+  on the extended roadmap.
+- **Compliance reporting** *(planned)* — framework-mapping reports tying findings
+  back to specific files, owners, and decisions. Initial scope: **PCI-DSS** and
+  **SOC 2** control coverage. ISO 27001 Annex A and GDPR / data-residency mappings on
+  the extended roadmap — we'd rather ship two solid mappings than four shallow ones.
+- **Audit trail** *(dev)* — every decision, override, security-finding action, and
+  false-positive resolution logged with user, timestamp, and rationale. Queryable
+  in-product and exportable to JSON / CSV; streaming export to SIEM (Splunk / Datadog
+  / Elastic / syslog) on the roadmap.
+- **Secret-in-code detection** *(planned)* — gitleaks-style scanning across full git
+  history (not just `HEAD`), integrated with the graph so leaked secrets surface
+  which services / modules referenced them.
+
+### 5.2 Workflow Integrations *(rolling out)*
+
+The plumbing these sit on — audit trail, RBAC, the commercial event bus — is in
+development. The connectors themselves are sequenced by customer demand; additional
+integrations beyond this list are available on request.
+
+- **Jira** — bi-directional linking between architectural decisions / risk findings
+  and Jira issues; `get_why` surfaces the originating ticket; PR-impact reports
+  auto-comment on the linked issue.
+- **Confluence** — scheduled publication of the Repowise wiki to nominated spaces,
+  with link-backs preserved and freshness banners on stale pages.
+- **GitHub Enterprise / Azure DevOps / GitLab / Bitbucket** — managed webhooks, a
+  PR-comment bot that posts blast-radius and reviewer suggestions, and a
+  branch-protection check that blocks merges touching hotspots without a reviewer
+  from the ownership list.
+- **Slack & Microsoft Teams** — alerts on hotspot drift, bus-factor warnings,
+  decision staleness, and security findings, routed by ownership.
+- **SAML / OIDC SSO** — Okta, Entra ID, Auth0, Google Workspace, generic SAML 2.0.
+- **SCIM provisioning** — automatic user / group lifecycle.
+
+### 5.3 Engineering Leadership & Governance
+
+The underlying signals (ownership, bus factor, hotspot trends, decision staleness)
+are already computed and queryable today via the OSS dashboard; the leadership-facing
+presentation and policy layer is what's rolling out commercially.
+
+- **Engineering leader dashboard** *(rolling out)* — bus-factor trends, hotspot
+  evolution over time, cross-repo dead code, ownership drift, decision-staleness
+  curves, scheduled email digests (weekly / sprint / monthly / executive).
+- **Session intelligence harvesting** *(planned)* — architectural decisions surfaced
+  from AI coding sessions and proposed to the team knowledge base, so tribal
+  knowledge generated *during* AI-assisted work doesn't evaporate when the session
+  ends.
+- **Shared team context layer** *(dev)* — one `CLAUDE.md` backed by the full graph
+  and decision layer, auto-injected into every team member's IDE / agent session via
+  MCP. Every engineer's agent starts from the same institutional context.
+- **Cross-repo intelligence at scale** *(dev)* — hotspots, dead code, and ownership
+  across the entire estate with centralized dashboards (beyond the local-workspace
+  scope already shipping in OSS).
+- **Custom decision policies** *(planned)* — required-reviewer rules, mandatory
+  `get_why` checks for governed paths, and merge-gating policies tied to Repowise
+  findings.
+
+### 5.4 Enterprise Operations
+
+- **Role-based access control** *(planned)* — repo-, module-, and decision-level
+  permissions; SCIM group mapping.
+- **Multi-tenant deployment** *(planned)* — segregate engineering orgs / product
+  lines while sharing cross-cutting infrastructure repos.
+- **Air-gapped install bundle** *(planned)* — packaged install with bundled grammars,
+  embedding model, and optional Ollama runtime for fully offline environments.
+- **Reference HA topology** *(GA on customer infra; managed scaling tooling:
+  planned)* — Postgres-backed metadata store, S3-compatible artefact storage, and
+  horizontally scalable MCP servers.
+- **Backup & restore tooling** *(planned)* — point-in-time snapshots of the
+  intelligence layers.
+- **Priority support & SLA** *(GA)* — named support contact, response-time SLA, and a
+  quarterly architecture-review session.
+- **Custom language / framework extensions** *(GA)* — bespoke tree-sitter grammars or
+  framework edges, packaged and maintained by the Repowise team.
+- **IP indemnification** *(GA)* — protection against third-party IP claims related to
+  the Repowise software.
+- **Defensive patent grant** *(GA)*.
+
+---
+
+## 6. On-Premise Deployment
+
+A self-hosted commercial install runs as a set of containers on your own
+infrastructure. The reference topology is Kubernetes-based, but the same containers
+run on Nomad or plain Docker — a Helm chart is on the near-term roadmap.
+
+1. **Containerised services** — Repowise API server (FastAPI), indexer workers, and
+   dashboard (Next.js), backed by Postgres for metadata and LanceDB (or pgvector) for
+   embeddings. An optional Ollama container provides fully-offline LLM use.
+2. **Webhook receivers** for GitHub Enterprise / GitLab self-managed / Azure DevOps,
+   configured against each tracked repository.
+3. **SSO** wired through your existing Entra ID / Okta tenant (per §5.2 availability).
+4. **Outbound integrations** (Jira, Confluence, Slack / Teams — per §5.2
+   availability) configured via signed service tokens stored in the Repowise secret
+   store.
+5. **BYOK** for the LLM — your Anthropic / OpenAI enterprise contract, Azure OpenAI in
+   your tenant, or fully offline Ollama. The choice can be made per-repository, so
+   sensitive repos run fully offline while less sensitive tooling repos use a hosted
+   model.
+
+**Topology at a glance:** all Repowise services run inside your VPC or air-gapped
+network, backed by Postgres for metadata, LanceDB (or pgvector) for embeddings, and
+an in-memory NetworkX graph. The LLM provider and the git server sit alongside
+Repowise in the same network boundary — no outbound connectivity is required in
+air-gapped mode.
+
+**Indexing:** the graph, git, dead-code, and code-health layers build in minutes with
+zero LLM calls (`repowise init --index-only`); the documentation layer's one-time
+wiki generation scales with repo size and can run in the background. Incremental
+updates after each commit complete in under 30 seconds.
+
+---
+
+## 7. Licensing & Pricing
+
+### 7.1 What the commercial license grants
+
+1. **Proprietary modification rights** — modify Repowise source without releasing
+   modifications under AGPL.
+2. **Embedding rights** — embed Repowise intelligence in your internal tooling and
+   developer platforms.
+3. **Patent grant** — defensive patent grant covering Repowise's methods and
+   algorithms.
+4. **IP indemnification** — protection against third-party IP claims.
+5. **Support & maintenance** — dedicated engineering support with SLA-backed response
+   times.
+6. **Update rights** — all updates and new features during the license term.
+7. **Audit rights** — right to audit Repowise's security and compliance practices.
+
+### 7.2 Pricing models
+
+Commercial pricing is **flexible across three models** — pick whichever maps best to
+your procurement and org structure. Specific figures are provided in a separate
+proposal.
+
+| Model | How it scales | Best for |
+|-------|---------------|----------|
+| **Per-seat** | Priced per engineer with dashboard / API / MCP access. Inactive seats reclaimable. SCIM-managed lifecycle. | Spend tracks headcount; clean alignment with existing dev-tools billing (IDE licences, Copilot, etc.). |
+| **Per-repo** | Priced per indexed repository (workspace cross-repo intelligence included). Seats unlimited within the licensed repo set. | The value driver is codebase footprint, not headcount — useful when Repowise is consumed primarily via AI agents and CI rather than human dashboard use. |
+| **Enterprise-wide** | Unlimited seats, unlimited repos, all commercial features, on-prem / air-gapped, named support, MFC clause. | Org-wide standardisation. Removes per-repo accounting overhead and aligns with single-procurement contracts. |
+
+All three models include the full set of §5 commercial features; the difference is
+purely the scaling dimension. Hybrid arrangements (e.g. enterprise-wide for one
+business unit, per-repo elsewhere) are available.
+
+---
+
+## 8. Get in touch
+
+Commercial-proposal requests, scoping questions, and security reviews:
+
+- General / commercial: [hello@repowise.dev](mailto:hello@repowise.dev) ·
+  [repowise.dev/#contact](https://www.repowise.dev/#contact)
+- Security-specific: [security@repowise.dev](mailto:security@repowise.dev)


### PR DESCRIPTION
## What

Refreshes the README, fixes stale counts across docs, and adds a public commercial-offering doc.

### Count corrections (correctness)
The README headline claimed *five layers / nine tools* but the body still said *four / eight / twelve*. Now consistent everywhere:
- **Five** intelligence layers (added Code Health to the lead paragraph)
- **Nine** MCP tools
- **Fifteen** code-health biomarkers — verified against `biomarkers/registry.py` (the prior "twelve" was stale by two releases; `function_hotspot` + `code_age_volatility` were added but never reflected in docs)

### Benchmark section
- Added **`scikit-learn` (~300K LOC)** results alongside Flask — pulled from `repowise-bench`.
- Reordered to lead with the strongest legitimate numbers (**−70% tool calls, −89% file reads**) and with **parity answer quality** on Flask.
- Framed the larger-codebase result as a scaling win rather than a caveat. Full variance discussion stays in the linked report.

### Init-time reframe
Dropped the misleading one-time full-index minute count. Now frames it around `repowise init --index-only` (fast, zero-LLM) + `<30s` incremental updates, with the doc-wiki layer as a one-time, background-able cost.

### docs/COMMERCIAL.md (new)
Genericized commercial-offering doc: AGPL-vs-commercial capability matrix with honest GA / in-dev / planned status, on-prem topology, and the three pricing models. Linked from the README's hosted + license sections.

### Smaller
- Added `repowise health` to the CLI reference.
- Merged the duplicate rate-limiting demo into one section.
- `CODE_HEALTH.md`: twelve → fifteen; updated the category cap table.

## Scope
Docs only — no code changes.