### PR TITLE
perf(csharp): restore near-linear scaling in .NET import resolver

### DIFF
--- a/packages/core/src/repowise/core/ingestion/resolvers/csharp.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/csharp.py
@@ -34,10 +34,18 @@ from .context import ResolverContext
 from .dotnet import get_or_build_index
 
 
-def _to_repo_relative(abs_path: Path, repo_path: Path) -> str | None:
-    """Return *abs_path* relative to *repo_path* in posix form, or None."""
+def _to_repo_relative(abs_path: Path, repo_root_resolved: Path) -> str | None:
+    """Return *abs_path* relative to a pre-resolved repo root in posix form.
+
+    ``abs_path`` is expected to already be resolved — every value we pass
+    in here comes out of ``DotNetProjectIndex.file_to_project`` /
+    ``namespace_map``, both of which are keyed by resolved absolute paths.
+    Re-resolving on every call (as the original implementation did) costs
+    a stat-per-path-component on Windows and dominates ``graph.imports``
+    wall-clock on large C# monorepos.
+    """
     try:
-        return abs_path.resolve().relative_to(repo_path.resolve()).as_posix()
+        return abs_path.relative_to(repo_root_resolved).as_posix()
     except ValueError:
         return None
 
@@ -59,6 +67,44 @@ def _legacy_stem_resolve(
     return None
 
 
+_REPO_ROOT_RESOLVED_ATTR = "_repo_root_resolved"
+_IMPORTER_RESOLVED_ATTR = "_importer_resolved_cache"
+
+
+def _repo_root_resolved(index: object, repo_path: Path) -> Path:
+    """Return ``repo_path.resolve()`` from a cache on the index.
+
+    A C# monorepo can fire tens of thousands of ``resolve_csharp_import``
+    calls; resolving the repo root each time accounts for a measurable
+    chunk of ``graph.imports`` wall-clock on Windows.
+    """
+    cached = getattr(index, _REPO_ROOT_RESOLVED_ATTR, None)
+    if cached is not None:
+        return cached
+    resolved = repo_path.resolve()
+    setattr(index, _REPO_ROOT_RESOLVED_ATTR, resolved)
+    return resolved
+
+
+def _resolve_importer(index: object, repo_path: Path, importer_path: str) -> Path:
+    """Cache importer-path → resolved absolute path on the index.
+
+    Each .cs file has multiple ``using`` directives and each one triggers
+    a resolve of the same importer. Memoising collapses that to one
+    resolve per importer across the whole indexing run.
+    """
+    cache: dict[str, Path] | None = getattr(index, _IMPORTER_RESOLVED_ATTR, None)
+    if cache is None:
+        cache = {}
+        setattr(index, _IMPORTER_RESOLVED_ATTR, cache)
+    cached = cache.get(importer_path)
+    if cached is not None:
+        return cached
+    resolved = (repo_path / importer_path).resolve()
+    cache[importer_path] = resolved
+    return resolved
+
+
 def _matches_package_prefix(module_path: str, packages: set[str]) -> bool:
     """True if *module_path* equals or is a child namespace of any package id."""
     for pkg in packages:
@@ -77,11 +123,18 @@ def resolve_csharp_import(
         legacy = _legacy_stem_resolve(module_path, ctx)
         return legacy if legacy else ctx.add_external_node(module_path)
 
-    # Locate the importer's project (if any).
-    importer_abs = (ctx.repo_path / importer_path).resolve()
-    importer_proj = index.project_for_file(importer_abs)
+    # Locate the importer's project (if any). Both lookups below previously
+    # ran ``.resolve()`` per call — on Windows that's a stat per path
+    # component. The index resolved every .cs file once at build time, so
+    # we cache the importer's resolved path on the index keyed by the
+    # raw repo-relative string and reuse it across all of this file's
+    # imports.
+    importer_abs = _resolve_importer(index, ctx.repo_path, importer_path)
+    importer_csproj = index.file_to_project.get(importer_abs)
+    importer_proj = index.projects.get(importer_csproj) if importer_csproj else None
 
     candidates = index.files_for_namespace(module_path)
+    repo_root_resolved = _repo_root_resolved(index, ctx.repo_path)
 
     if candidates:
         # Rank: same project, then referenced projects, then anywhere.
@@ -104,7 +157,7 @@ def resolve_csharp_import(
             ordered = candidates
 
         chosen = ordered[0]
-        rel = _to_repo_relative(chosen, ctx.repo_path)
+        rel = _to_repo_relative(chosen, repo_root_resolved)
         if rel and rel in ctx.path_set:
             return rel
 

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/index.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/index.py
@@ -51,6 +51,17 @@ class DotNetProjectIndex:
 
     sln_paths: list[Path] = field(default_factory=list)
 
+    # Cache for per-from_file project resolution. Stores
+    # ``input Path → (resolved Path, enclosing csproj or None)``.
+    # ``rank_type_candidates`` is called once per ``TypeReference`` —
+    # dozens per file across thousands of files in a real C# monorepo —
+    # and each call previously paid a fresh ``Path.resolve()`` (a stat
+    # per component on Windows). Memoising collapses that to one
+    # resolve per unique source file across the entire indexing run.
+    _from_proj_cache: dict[Path, tuple[Path, Path | None]] = field(
+        default_factory=dict, repr=False
+    )
+
     # ------------------------------------------------------------------
     # Lookups
     # ------------------------------------------------------------------
@@ -59,6 +70,19 @@ class DotNetProjectIndex:
         """Return the project enclosing *file_abs*, or None."""
         csproj = self.file_to_project.get(file_abs.resolve())
         return self.projects.get(csproj) if csproj else None
+
+    def _resolve_from_file(self, from_file: Path) -> tuple[Path, Path | None]:
+        """Memoised resolve + project lookup for repeated callers."""
+        cached = self._from_proj_cache.get(from_file)
+        if cached is not None:
+            return cached
+        try:
+            resolved = from_file.resolve()
+        except OSError:
+            resolved = from_file
+        entry = (resolved, self.file_to_project.get(resolved))
+        self._from_proj_cache[from_file] = entry
+        return entry
 
     def referenced_projects(self, csproj: Path) -> set[Path]:
         """Return the direct ProjectReference set for *csproj*."""
@@ -90,8 +114,7 @@ class DotNetProjectIndex:
         if not candidates:
             return []
 
-        from_resolved = from_file.resolve()
-        from_proj = self.file_to_project.get(from_resolved)
+        from_resolved, from_proj = self._resolve_from_file(from_file)
         ref_projs = self.project_refs_by_proj.get(from_proj, set()) if from_proj else set()
 
         same_proj: list[Path] = []
@@ -153,16 +176,30 @@ def _bucket_files_by_project(
 ) -> dict[Path, Path]:
     """Map each resolved .cs file → enclosing csproj path via longest-prefix.
 
-    *project_dirs* is a list of ``(project_dir_resolved, csproj_path)``
-    pairs sorted by descending path-component depth so the most
-    specific project wins for nested project layouts (e.g. a test
-    project nested under its production project's directory).
+    Walks each file's parent chain ONCE against a precomputed
+    ``{project_dir → csproj}`` dict, so the cost is O(N x depth)
+    rather than the previous O(N x M_projects x depth). Because we
+    walk parents from deepest to shallowest, the first hit is by
+    construction the most specific project — no separate
+    descending-depth sort of projects required.
+
+    *project_dirs* is retained as a sequence (deterministic order)
+    only to seed the dict; the lookup itself is dict-only.
     """
+    dir_to_proj: dict[Path, Path] = {}
+    for proj_dir, csproj in project_dirs:
+        # If two projects somehow share a directory, the first wins
+        # (callers pass a stable-ordered iterable). Nested layouts are
+        # disambiguated by the parent walk below, not by this dict.
+        dir_to_proj.setdefault(proj_dir, csproj)
+
     out: dict[Path, Path] = {}
     for f in cs_files:
-        parents = set(f.parents)
-        for proj_dir, csproj in project_dirs:
-            if proj_dir in parents or proj_dir == f.parent:
+        # Walk parents from immediate dir outward; first match wins,
+        # which is always the most deeply-nested enclosing project.
+        for parent in f.parents:
+            csproj = dir_to_proj.get(parent)
+            if csproj is not None:
                 out[f] = csproj
                 break
     return out
@@ -217,13 +254,12 @@ def build_index(repo_path: Path) -> DotNetProjectIndex:
         except OSError:
             continue
 
-    # Build the file → project map by longest-prefix match. Sort by
-    # descending parent-depth so nested projects (e.g. a test project
-    # whose directory sits under its prod project's tree) bind first.
-    project_dirs: list[tuple[Path, Path]] = sorted(
-        ((proj.project_dir.resolve(), proj.path) for proj in index.projects.values()),
-        key=lambda t: -len(t[0].parts),
-    )
+    # Build the file → project map by longest-prefix match. The bucketer
+    # walks each file's parent chain (deepest-first) against a dict of
+    # project dirs, so nested projects bind naturally without a pre-sort.
+    project_dirs: list[tuple[Path, Path]] = [
+        (proj.project_dir.resolve(), proj.path) for proj in index.projects.values()
+    ]
     index.file_to_project = _bucket_files_by_project(all_cs_files, project_dirs)
 
     # ---- 4. Namespace + type map from cached texts ----

--- a/tests/unit/ingestion/test_csharp_resolver.py
+++ b/tests/unit/ingestion/test_csharp_resolver.py
@@ -274,3 +274,67 @@ class TestProjectIndexCaching:
 )
 def test_namespace_regex_edge_cases(raw: str, expected: list[str]) -> None:
     assert declared_namespaces(raw) == expected
+
+
+def test_bucketer_binds_nested_project_first(tmp_path: Path) -> None:
+    """A test project nested under its prod project must bind to the
+    inner csproj, not the enclosing one. The deepest-parent-first walk
+    in ``_bucket_files_by_project`` is what guarantees this — regressing
+    to project-order iteration would silently misroute files.
+    """
+    from repowise.core.ingestion.resolvers.dotnet.index import (
+        _bucket_files_by_project,
+    )
+
+    repo = tmp_path.resolve()
+    prod_dir = repo / "src" / "Prod"
+    test_dir = prod_dir / "Tests"
+    prod_csproj = prod_dir / "Prod.csproj"
+    test_csproj = test_dir / "Tests.csproj"
+    f_prod = prod_dir / "A.cs"
+    f_test = test_dir / "B.cs"
+
+    # Pass projects in the "wrong" order (outer first) — the bucketer
+    # must still pick the deepest enclosing project per file.
+    out = _bucket_files_by_project(
+        [f_prod, f_test],
+        [(prod_dir, prod_csproj), (test_dir, test_csproj)],
+    )
+    assert out[f_prod] == prod_csproj
+    assert out[f_test] == test_csproj
+
+
+def test_rank_type_candidates_memoises_from_file(tmp_path: Path) -> None:
+    """Per-call ``Path.resolve()`` on the source file is the hot loop's
+    biggest cost. Verify the second call for the same ``from_file``
+    short-circuits via the memo dict rather than re-statting.
+    """
+    (tmp_path / "A").mkdir()
+    (tmp_path / "A" / "A.csproj").write_text(
+        '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup>'
+        "<TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>"
+    )
+    (tmp_path / "A" / "Foo.cs").write_text("namespace A;\nclass Foo {}\n")
+    (tmp_path / "A" / "Bar.cs").write_text("namespace A;\nclass Bar {}\n")
+
+    index = build_index(tmp_path)
+    from_file = tmp_path / "A" / "Foo.cs"
+    index.rank_type_candidates("Bar", from_file)
+    # Memo dict should now contain the input Path verbatim.
+    assert from_file in index._from_proj_cache
+
+    # Monkey-patch resolve to detect any additional invocations.
+    calls = {"n": 0}
+    original = Path.resolve
+
+    def _spy(self: Path, *a: object, **kw: object) -> Path:
+        calls["n"] += 1
+        return original(self, *a, **kw)
+
+    Path.resolve = _spy  # type: ignore[method-assign]
+    try:
+        for _ in range(50):
+            index.rank_type_candidates("Bar", from_file)
+    finally:
+        Path.resolve = original  # type: ignore[method-assign]
+    assert calls["n"] == 0, "rank_type_candidates re-resolved from_file"


### PR DESCRIPTION
## Summary

The C# import-resolution path scaled ~O(n^1.6) on large C# monorepos:
a 4x increase in file count grew `graph.dotnet_index` + `graph.imports`
wall-clock ~20x. Extrapolated, a 30k-file repo took multiple hours just
to wire up imports. Three independent algorithmic issues — fixed
without changing resolution semantics.

- **Bucketing**: `_bucket_files_by_project` previously did O(N x M_projects x depth) — built `set(f.parents)` per file then scanned every project dir. Now walks each file's parent chain ONCE against a precomputed `{project_dir: csproj}` dict. Nested projects still bind to the innermost csproj.
- **Type-ref ranking**: `rank_type_candidates` paid a fresh `Path.resolve()` per TypeReference (dozens per file x thousands of files; a stat per component on Windows). Memoised per source file so each unique file resolves once for the whole run.
- **Using-directive resolution**: `resolve_csharp_import` and `_to_repo_relative` re-resolved the importer path and repo root on every call, even though `file_to_project` / `namespace_map` are already keyed by resolved absolute paths. Cached importer-path → resolved on the index and made `_to_repo_relative` take a pre-resolved root.

## Benchmark (synthetic C# repo, 2000 files, fast mode)

| Phase              | Before  | After  | Delta |
|--------------------|---------|--------|-------|
| graph.dotnet_index | 74.5s   | 34.8s  | -53%  |
| graph.imports      | 117.6s  | 22.9s  | -80%  |
| Combined           | 192.1s  | 57.7s  | -70%  |

Scaling of the combined dotnet phases at 4x file count went from ~20x
to ~7.4x — near-linear restored.

## Test plan

- [x] `pytest tests/unit/ingestion` — 557 passed, 2 xfailed (unchanged)
- [x] All 78 C#-specific tests still pass
- [x] Added regression test `test_bucketer_binds_nested_project_first` — guards the deepest-parent-first invariant in the new bucketer
- [x] Added regression test `test_rank_type_candidates_memoises_from_file` — asserts no `Path.resolve()` on repeat calls
- [x] Synthetic-repo benchmark at 500 and 2000 files (numbers above)