### PR TITLE
chore: add .well-known/funding-manifest-urls for FLOSS/fund verification

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://www.repowise.dev/funding.json


### PR DESCRIPTION
Adds `.well-known/funding-manifest-urls` containing the funding manifest URL (`https://www.repowise.dev/funding.json`).

This is the repo side of FLOSS/fund's cross-host verification: the manifest's `repositoryUrl.wellKnown` points here, proving the manifest publisher is authorised to solicit funding on behalf of this repository. Clears the 'Unverified URL' flag on the GitHub link in the directory.

Paired with a frontend change adding the `wellKnown` field to `repositoryUrl`.