### PR TITLE
feat(web): nav restructure, docs perf pass, and serve provider-key fix

### DIFF
--- a/packages/cli/src/repowise/cli/commands/serve_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/serve_cmd.py
@@ -155,6 +155,40 @@ def _save_global_embedder(embedder: str, api_key: str) -> None:
         pass  # Non-fatal — user just gets prompted again next time.
 
 
+def _load_local_provider_config() -> None:
+    """Load ``.repowise/.env`` and seed the chat provider from ``config.yaml``.
+
+    The API server runs in-process here, so env vars set now are inherited by
+    the provider-resolution code. ``load_dotenv`` never overwrites an existing
+    var, and we only set ``REPOWISE_PROVIDER``/``REPOWISE_MODEL`` when unset, so
+    explicit environment configuration always wins.
+    """
+    from repowise.cli.helpers import load_config
+    from repowise.cli.ui import load_dotenv
+
+    cwd = Path.cwd()
+    if not (cwd / ".repowise").exists():
+        return
+
+    # 1) API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, …) from .repowise/.env
+    load_dotenv(cwd)
+
+    # 2) Provider/model from .repowise/config.yaml → env vars the server reads
+    cfg = load_config(cwd)
+    provider = cfg.get("provider")
+    if provider and not os.environ.get("REPOWISE_PROVIDER"):
+        os.environ["REPOWISE_PROVIDER"] = str(provider)
+        model = cfg.get("model")
+        if model and not os.environ.get("REPOWISE_MODEL"):
+            os.environ["REPOWISE_MODEL"] = str(model)
+        console.print(f"[dim]Using provider from config: {provider}[/dim]")
+
+    # 3) Embedder from config so chat/search work without an interactive prompt.
+    embedder = cfg.get("embedder")
+    if embedder and embedder != "mock" and not os.environ.get("REPOWISE_EMBEDDER"):
+        os.environ["REPOWISE_EMBEDDER"] = str(embedder)
+
+
 _GITHUB_REPO = "repowise-dev/repowise"
 _WEB_CACHE_DIR = Path.home() / ".repowise" / "web"
 _MARKER_FILE = _WEB_CACHE_DIR / ".version"
@@ -394,6 +428,14 @@ def serve_command(
     except ImportError:
         console.print("[red]uvicorn is not installed. Install it with: pip install repowise[/red]")
         raise SystemExit(1) from None
+
+    # Load the local .repowise/.env (API keys written by `repowise init`) and
+    # seed the chat/search provider + embedder from .repowise/config.yaml. This
+    # runs before _setup_embedder so a configured embedder/key is detected
+    # instead of re-prompting, and so the in-process API server starts with a
+    # working provider (otherwise chat fails even though `init` saved a key).
+    # Existing env vars always take precedence.
+    _load_local_provider_config()
 
     _setup_embedder()
 

--- a/packages/server/src/repowise/server/provider_config.py
+++ b/packages/server/src/repowise/server/provider_config.py
@@ -163,7 +163,18 @@ def list_provider_status() -> dict[str, Any]:
     active_id = config.get("active_provider")
     active_model = config.get("active_model")
 
-    # Auto-detect active if not set
+    # Honour the repo's configured provider/model (``.repowise/config.yaml``,
+    # surfaced as env vars by ``repowise serve``) when nothing has been
+    # explicitly selected through the UI/config file yet.
+    if not active_id:
+        env_provider = os.environ.get("REPOWISE_PROVIDER")
+        if env_provider and env_provider in _CATALOG_BY_ID:
+            active_id = env_provider
+            active_model = os.environ.get("REPOWISE_MODEL") or _CATALOG_BY_ID[
+                env_provider
+            ]["default_model"]
+
+    # Auto-detect active if still unset
     if not active_id:
         for p in PROVIDER_CATALOG:
             if _get_key_for_provider(p["id"]) or not p["requires_key"]:

--- a/packages/ui/src/onboarding/first-five-files.tsx
+++ b/packages/ui/src/onboarding/first-five-files.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Sparkles, ArrowUpRight } from "lucide-react";
+import { useState } from "react";
+import { Sparkles, ArrowUpRight, ChevronDown, ChevronRight } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { Badge } from "../ui/badge";
 
@@ -20,62 +21,84 @@ export interface FirstFiveFilesProps {
   hrefFor?: (file: FirstFiveFile) => string | undefined;
   /** Override the title (e.g. for a "Start here" pinned section). */
   title?: string;
+  /** Render the header as a toggle that collapses the file list. */
+  collapsible?: boolean;
+  /** When collapsible, start collapsed. Defaults to false. */
+  defaultCollapsed?: boolean;
 }
 
 export function FirstFiveFiles({
   files,
   hrefFor,
   title = "First five files",
+  collapsible = false,
+  defaultCollapsed = false,
 }: FirstFiveFilesProps) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
   if (files.length === 0) return null;
   const top = files.slice(0, 5);
 
+  const header = (
+    <CardTitle className="text-[13px] flex items-center gap-1.5">
+      {collapsible &&
+        (collapsed ? (
+          <ChevronRight className="h-3.5 w-3.5 text-[var(--color-text-tertiary)]" />
+        ) : (
+          <ChevronDown className="h-3.5 w-3.5 text-[var(--color-text-tertiary)]" />
+        ))}
+      <Sparkles className="h-3.5 w-3.5 text-[var(--color-accent-primary)]" />
+      {title}
+      <span className="text-[10px] font-normal text-[var(--color-text-tertiary)] uppercase tracking-wider">
+        the first {top.length} files to read
+      </span>
+    </CardTitle>
+  );
+
   return (
     <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-sm flex items-center gap-2">
-          <Sparkles className="h-4 w-4 text-[var(--color-accent-primary)]" />
-          {title}
-          <span className="text-[10px] font-normal text-[var(--color-text-tertiary)] uppercase tracking-wider">
-            start here
-          </span>
-        </CardTitle>
+      <CardHeader className="p-2.5">
+        {collapsible ? (
+          <button
+            type="button"
+            onClick={() => setCollapsed((c) => !c)}
+            aria-expanded={!collapsed}
+            className="flex w-full items-center text-left"
+          >
+            {header}
+          </button>
+        ) : (
+          header
+        )}
       </CardHeader>
-      <CardContent className="pt-0">
-        <ol className="space-y-1.5">
+      {!collapsed && (
+      <CardContent className="p-2.5 pt-0">
+        <ol className="space-y-1">
           {top.map((f, i) => {
             const href = hrefFor?.(f) ?? f.doc_url;
             const Wrapper = (props: { children: React.ReactNode }) =>
               href ? (
                 <a
                   href={href}
-                  className="group flex items-start gap-2.5 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2 hover:border-[var(--color-accent-primary)] transition-colors"
+                  className="group flex items-center gap-2 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2.5 py-1.5 hover:border-[var(--color-accent-primary)] transition-colors"
                 >
                   {props.children}
                 </a>
               ) : (
-                <div className="flex items-start gap-2.5 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2">
+                <div className="flex items-center gap-2 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-2.5 py-1.5">
                   {props.children}
                 </div>
               );
             return (
               <li key={f.file_path}>
                 <Wrapper>
-                  <span className="text-xs tabular-nums text-[var(--color-text-tertiary)] mt-0.5">{i + 1}</span>
-                  <div className="min-w-0 flex-1">
-                    <p className="font-mono text-xs text-[var(--color-text-primary)] truncate">
-                      {f.file_path}
-                    </p>
-                    <div className="flex flex-wrap items-center gap-1.5 mt-0.5">
-                      {f.is_entry_point && <Badge variant="accent" className="h-4 text-[10px]">entry point</Badge>}
-                      {f.has_doc && <Badge variant="outline" className="h-4 text-[10px]">has doc</Badge>}
-                      {f.reason && (
-                        <span className="text-[11px] text-[var(--color-text-secondary)]">{f.reason}</span>
-                      )}
-                    </div>
-                  </div>
+                  <span className="text-[11px] tabular-nums text-[var(--color-text-tertiary)]">{i + 1}</span>
+                  <p className="font-mono text-[11px] text-[var(--color-text-primary)] truncate min-w-0 flex-1">
+                    {f.file_path}
+                  </p>
+                  {f.is_entry_point && <Badge variant="accent" className="h-4 text-[10px] shrink-0">entry</Badge>}
+                  {f.has_doc && <Badge variant="outline" className="h-4 text-[10px] shrink-0">doc</Badge>}
                   {href && (
-                    <ArrowUpRight className="h-3.5 w-3.5 text-[var(--color-text-tertiary)] mt-0.5 opacity-0 group-hover:opacity-100 transition-opacity" />
+                    <ArrowUpRight className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-tertiary)] opacity-0 group-hover:opacity-100 transition-opacity" />
                   )}
                 </Wrapper>
               </li>
@@ -83,6 +106,7 @@ export function FirstFiveFiles({
           })}
         </ol>
       </CardContent>
+      )}
     </Card>
   );
 }

--- a/packages/ui/src/wiki/wiki-markdown.tsx
+++ b/packages/ui/src/wiki/wiki-markdown.tsx
@@ -282,9 +282,15 @@ export function WikiMarkdown({
     return buildComponents(resolveLink, LinkComponent);
   }, [wikiLinks, buildHref, LinkComponent]);
 
-  return (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
-      {content}
-    </ReactMarkdown>
+  // Parsing + reconciling a large markdown document is the dominant cost when a
+  // page opens. Memoize the rendered tree on (content, components) so unrelated
+  // parent re-renders — sidebar toggles, hover state, etc. — don't re-parse it.
+  return useMemo(
+    () => (
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {content}
+      </ReactMarkdown>
+    ),
+    [content, components],
   );
 }

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { Sidebar } from "@/components/layout/sidebar";
 import { MobileNav } from "@/components/layout/mobile-nav";
 import { CommandPalette } from "@/components/search/command-palette";
 import { ContextDrawerShell } from "@/components/layout/context-drawer-provider";
+import { SWRProvider } from "@/components/layout/swr-provider";
 import { listRepos } from "@/lib/api/repos";
 import { getWorkspace } from "@/lib/api/workspace";
 import type { WorkspaceResponse } from "@/lib/api/types";
@@ -55,6 +56,7 @@ export default async function RootLayout({
           Skip to content
         </a>
         <NuqsAdapter>
+        <SWRProvider>
         <TooltipProvider delayDuration={300}>
           <Suspense fallback={null}>
             <ContextDrawerShell>
@@ -71,6 +73,7 @@ export default async function RootLayout({
             </ContextDrawerShell>
           </Suspense>
         </TooltipProvider>
+        </SWRProvider>
         </NuqsAdapter>
         <Toaster
           theme="dark"

--- a/packages/web/src/app/repos/[id]/docs/page.tsx
+++ b/packages/web/src/app/repos/[id]/docs/page.tsx
@@ -8,7 +8,7 @@ import { Button } from "@repowise-dev/ui/ui/button";
 import { FirstFiveFiles, type FirstFiveFile } from "@repowise-dev/ui/onboarding/first-five-files";
 import { DocsCommandPalette } from "@repowise-dev/ui/docs/command-palette";
 import { DocsExplorer } from "@/components/docs/docs-explorer";
-import { listAllPages, listPages } from "@/lib/api/pages";
+import { listAllPages } from "@/lib/api/pages";
 import { search as searchPages } from "@/lib/api/search";
 import { getGraph } from "@/lib/api/graph";
 import type { DocPage } from "@repowise-dev/types/docs";
@@ -41,9 +41,11 @@ export default function DocsPage({
     { revalidateOnFocus: false, revalidateOnReconnect: false },
   );
 
+  // Share the exact SWR key the explorer's `usePages` uses so the (large) full
+  // page list — content included — is fetched once and deduped, not twice.
   const { data: docPages } = useSWR<DocPage[]>(
-    `docs-list:${repoId}`,
-    () => listPages(repoId, { limit: 1000 }),
+    `pages:${repoId}:all`,
+    () => listAllPages(repoId) as Promise<DocPage[]>,
     { revalidateOnFocus: false },
   );
 
@@ -150,29 +152,18 @@ export default function DocsPage({
 
       {startHere.length > 0 && (
         <div className="px-4 sm:px-6 pt-3">
-          <div className="rounded-lg border border-[var(--color-border-accent)] bg-[var(--color-accent-muted)]/30">
-            <div className="flex items-center gap-2 px-4 pt-3 pb-1">
-              <span className="text-[var(--color-accent-primary)]">✨</span>
-              <span className="text-sm font-medium text-[var(--color-text-primary)]">
-                Start here
-              </span>
-              <span className="text-[10px] font-normal text-[var(--color-text-tertiary)] uppercase tracking-wider">
-                the first {startHere.length} files to read
-              </span>
-            </div>
-            <div className="px-3 pb-3 pt-1">
-              <FirstFiveFiles
-                files={startHere}
-                title="Start here"
-                hrefFor={(f) => {
-                  const pageId = (f as FirstFiveFile & { page_id?: string }).page_id;
-                  return pageId
-                    ? `/repos/${repoId}/docs?page=${encodeURIComponent(pageId)}`
-                    : undefined;
-                }}
-              />
-            </div>
-          </div>
+          <FirstFiveFiles
+            files={startHere}
+            title="Start here"
+            collapsible
+            defaultCollapsed
+            hrefFor={(f) => {
+              const pageId = (f as FirstFiveFile & { page_id?: string }).page_id;
+              return pageId
+                ? `/repos/${repoId}/docs?page=${encodeURIComponent(pageId)}`
+                : undefined;
+            }}
+          />
         </div>
       )}
 

--- a/packages/web/src/app/repos/[id]/graph/page.tsx
+++ b/packages/web/src/app/repos/[id]/graph/page.tsx
@@ -9,7 +9,6 @@ import { GraphDocPanel } from "@/components/graph/graph-doc-panel";
 import { GraphTruncationBanner } from "@repowise-dev/ui/graph/graph-truncation-banner";
 import { getGraph } from "@/lib/api/graph";
 import type { GraphExportResponse } from "@/lib/api/types";
-import { HealthRisksPanel } from "@/components/health/health-risks-panel";
 
 const VALID_VIEW_MODES = new Set(["module", "full", "architecture", "dead", "hotfiles", "unified"]);
 
@@ -111,15 +110,6 @@ export default function GraphPage({
               nodeId={docNodeId}
               onClose={() => setDocNodeId(null)}
             />
-          )}
-          {!docNodeId && (
-            <div className="absolute bottom-3 right-3 w-72 pointer-events-auto">
-              <HealthRisksPanel
-                repoId={repoId}
-                title="Health risks"
-                limit={5}
-              />
-            </div>
           )}
         </div>
       </div>

--- a/packages/web/src/app/repos/[id]/risk/page.tsx
+++ b/packages/web/src/app/repos/[id]/risk/page.tsx
@@ -9,9 +9,10 @@ import { HotspotsTab } from "@/components/risk/hotspots-tab";
 import { DeadCodeTab } from "@/components/risk/dead-code-tab";
 import { ImpactTab } from "@/components/risk/impact-tab";
 import { ModulesTab } from "@/components/risk/modules-tab";
+import { SecurityTab } from "@/components/risk/security-tab";
 import { RiskSummaryStrip } from "@/components/risk/risk-summary-strip";
 
-const TABS = ["heatmap", "hotspots", "modules", "dead-code", "impact"] as const;
+const TABS = ["heatmap", "hotspots", "modules", "dead-code", "impact", "security"] as const;
 type TabId = (typeof TABS)[number];
 
 export default function RiskPage() {
@@ -56,6 +57,7 @@ export default function RiskPage() {
           <TabsTrigger value="modules">Modules</TabsTrigger>
           <TabsTrigger value="dead-code">Dead code</TabsTrigger>
           <TabsTrigger value="impact">Impact analyzer</TabsTrigger>
+          <TabsTrigger value="security">Security</TabsTrigger>
         </TabsList>
 
         <TabsContent value="heatmap" className="space-y-6">
@@ -72,6 +74,9 @@ export default function RiskPage() {
         </TabsContent>
         <TabsContent value="impact" className="space-y-6">
           <ImpactTab repoId={repoId} />
+        </TabsContent>
+        <TabsContent value="security" className="space-y-6">
+          <SecurityTab repoId={repoId} />
         </TabsContent>
       </Tabs>
     </div>

--- a/packages/web/src/app/repos/[id]/security/page.tsx
+++ b/packages/web/src/app/repos/[id]/security/page.tsx
@@ -1,89 +1,17 @@
 "use client";
 
-import { useMemo } from "react";
-import useSWR from "swr";
-import { useParams } from "next/navigation";
-import { ShieldAlert } from "lucide-react";
-import { SeverityDistribution } from "@repowise-dev/ui/security/severity-distribution";
-import { SecurityFindingsTable } from "@repowise-dev/ui/security/findings-table";
-import { FindingsByDirectory } from "@repowise-dev/ui/security/findings-by-directory";
-import { Card, CardContent, CardHeader, CardTitle } from "@repowise-dev/ui/ui/card";
-import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
-import { listSecurityFindings, type SecurityFinding } from "@/lib/api/security";
-import { useFileCardHost } from "@/components/shared/file-card-host";
-import type { FileCardData } from "@repowise-dev/ui/shared/file-card";
+import { useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
 
+// Security now lives as a tab under Risk. Keep this route as a redirect so
+// existing links / bookmarks continue to work.
 export default function SecurityPage() {
   const params = useParams<{ id: string }>();
-  const repoId = params.id;
+  const router = useRouter();
 
-  const { data: findings, isLoading, error } = useSWR<SecurityFinding[]>(
-    `security:${repoId}`,
-    () => listSecurityFindings(repoId, { limit: 500 }),
-    { revalidateOnFocus: false },
-  );
+  useEffect(() => {
+    router.replace(`/repos/${params.id}/risk?tab=security`);
+  }, [params.id, router]);
 
-  const { showFile, dialog } = useFileCardHost(repoId);
-
-  const counts = useMemo(() => {
-    const c: Record<string, number> = { high: 0, med: 0, low: 0 };
-    for (const f of findings ?? []) {
-      c[f.severity] = (c[f.severity] ?? 0) + 1;
-    }
-    return c;
-  }, [findings]);
-
-  const handleSelect = (f: SecurityFinding) => {
-    const data: FileCardData = {
-      file_path: f.file_path,
-      summary: `Security: ${f.kind} (${f.severity})`,
-      security: {
-        findings_count: (findings ?? []).filter((x) => x.file_path === f.file_path).length,
-        critical_count: (findings ?? []).filter(
-          (x) => x.file_path === f.file_path && x.severity === "high",
-        ).length,
-      },
-    };
-    showFile(data);
-  };
-
-  return (
-    <div className="p-4 sm:p-6 space-y-6 max-w-[1600px]">
-      <div>
-        <h1 className="text-xl font-semibold text-[var(--color-text-primary)] mb-1 flex items-center gap-2">
-          <ShieldAlert className="h-5 w-5 text-red-400" />
-          Security
-        </h1>
-        <p className="text-sm text-[var(--color-text-secondary)]">
-          Findings detected during ingestion — secrets, dangerous patterns, and policy hits.
-        </p>
-      </div>
-
-      {isLoading ? (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <Skeleton className="h-40 w-full rounded-lg" />
-          <Skeleton className="h-40 w-full rounded-lg" />
-        </div>
-      ) : error ? (
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm">Couldn&apos;t load findings</CardTitle>
-          </CardHeader>
-          <CardContent className="pt-0 text-xs text-[var(--color-text-secondary)]">
-            The security endpoint returned an error. Try re-running ingestion.
-          </CardContent>
-        </Card>
-      ) : (
-        <>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            <SeverityDistribution counts={counts} />
-            <FindingsByDirectory findings={findings ?? []} />
-          </div>
-          <SecurityFindingsTable findings={findings ?? []} onSelect={handleSelect} />
-        </>
-      )}
-
-      {dialog}
-    </div>
-  );
+  return null;
 }

--- a/packages/web/src/components/docs/docs-explorer.tsx
+++ b/packages/web/src/components/docs/docs-explorer.tsx
@@ -29,10 +29,18 @@ export function DocsExplorer({ repoId }: DocsExplorerProps) {
   // link or breadcrumb navigates via <Link href="?page=...">.
   const pageParam = searchParams.get("page");
   useEffect(() => {
-    if (pages.length === 0 || !pageParam) return;
-    if (selectedPage?.id === pageParam) return;
-    const match = pages.find((p) => p.id === pageParam);
-    if (match) setSelectedPage(match);
+    if (pages.length === 0) return;
+    if (pageParam) {
+      if (selectedPage?.id === pageParam) return;
+      const match = pages.find((p) => p.id === pageParam);
+      if (match) setSelectedPage(match);
+      return;
+    }
+    // No ?page= in the URL — open the repo overview by default (falling back
+    // to the first page) so the viewer never lands on an empty state.
+    if (selectedPage) return;
+    const overview = pages.find((p) => p.page_type === "repo_overview");
+    setSelectedPage(overview ?? pages[0]);
   }, [pages, pageParam, selectedPage]);
 
   const handleSelectPage = useCallback((page: PageResponse) => {

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -44,7 +44,7 @@ function repoNavItems(repoId: string) {
   return [
     { label: "Overview", href: `/repos/${repoId}/overview`, icon: Activity },
     { label: "Chat", href: `/repos/${repoId}`, icon: MessageSquare, exact: true },
-    { label: "Docs", href: `/repos/${repoId}/docs`, icon: BookOpen },
+    { label: "Wiki", href: `/repos/${repoId}/docs`, icon: BookOpen },
     { label: "Search", href: `/repos/${repoId}/search`, icon: Search },
     { label: "Graph", href: `/repos/${repoId}/graph`, icon: GitBranch },
     { label: "Symbols", href: `/repos/${repoId}/symbols`, icon: Code2 },

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -282,7 +282,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.1.0</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.12.0</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -332,7 +332,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
       {!isIconOnly && (
         <div className="border-t border-[var(--color-border-default)] px-4 py-3">
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.1.0
+            repowise v0.12.0
           </p>
         </div>
       )}

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -25,9 +25,6 @@ import {
   Users,
   Boxes,
   HeartPulse,
-  TestTubeDiagonal,
-  Wrench,
-  TrendingUp,
 } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { ScrollArea } from "@repowise-dev/ui/ui/scroll-area";
@@ -59,19 +56,15 @@ function repoNavItems(repoId: string): NavItem[] {
   return [
     { label: "Overview", href: `/repos/${repoId}/overview`, icon: Activity },
     { label: "Chat", href: `/repos/${repoId}`, icon: MessageSquare, exact: true },
+    { label: "Wiki", href: `/repos/${repoId}/docs`, icon: BookOpen },
     { label: "Risk", href: `/repos/${repoId}/risk`, icon: ShieldAlert },
     { label: "Health", href: `/repos/${repoId}/health`, icon: HeartPulse, exact: true },
-    { label: "Trend", href: `/repos/${repoId}/health/trend`, icon: TrendingUp },
-    { label: "Coverage", href: `/repos/${repoId}/health/coverage`, icon: TestTubeDiagonal },
-    { label: "Refactoring", href: `/repos/${repoId}/health/refactoring-targets`, icon: Wrench },
     { label: "Graph", href: `/repos/${repoId}/graph`, icon: GitBranch },
     { label: "Knowledge Graph", href: `/repos/${repoId}/c4`, icon: Boxes },
     { label: "Symbols", href: `/repos/${repoId}/symbols`, icon: Code2 },
     { label: "Contributors", href: `/repos/${repoId}/owners`, icon: Users },
     { label: "Decisions", href: `/repos/${repoId}/decisions`, icon: Lightbulb },
-    { label: "Docs", href: `/repos/${repoId}/docs`, icon: BookOpen },
     { label: "Costs", href: `/repos/${repoId}/costs`, icon: DollarSign },
-    { label: "Security", href: `/repos/${repoId}/security`, icon: ShieldAlert },
     { label: "Settings", href: `/repos/${repoId}/settings`, icon: Settings },
   ];
 }

--- a/packages/web/src/components/layout/swr-provider.tsx
+++ b/packages/web/src/components/layout/swr-provider.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { SWRConfig } from "swr";
+
+/**
+ * App-wide SWR defaults. Without this, SWR refetches every active key whenever
+ * the window regains focus or the network reconnects — which makes pages
+ * flicker and feel sluggish each time you tab back in. Most call sites already
+ * opt into these flags individually; setting them globally covers the rest and
+ * keeps behaviour consistent. `dedupingInterval` collapses duplicate requests
+ * for the same key fired close together (e.g. several widgets on one page).
+ */
+export function SWRProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <SWRConfig
+      value={{
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+        dedupingInterval: 60_000,
+      }}
+    >
+      {children}
+    </SWRConfig>
+  );
+}

--- a/packages/web/src/components/risk/security-tab.tsx
+++ b/packages/web/src/components/risk/security-tab.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useMemo } from "react";
+import useSWR from "swr";
+import { SeverityDistribution } from "@repowise-dev/ui/security/severity-distribution";
+import { SecurityFindingsTable } from "@repowise-dev/ui/security/findings-table";
+import { FindingsByDirectory } from "@repowise-dev/ui/security/findings-by-directory";
+import { Card, CardContent, CardHeader, CardTitle } from "@repowise-dev/ui/ui/card";
+import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
+import { listSecurityFindings, type SecurityFinding } from "@/lib/api/security";
+import { useFileCardHost } from "@/components/shared/file-card-host";
+import type { FileCardData } from "@repowise-dev/ui/shared/file-card";
+
+export function SecurityTab({ repoId }: { repoId: string }) {
+  const { data: findings, isLoading, error } = useSWR<SecurityFinding[]>(
+    `security:${repoId}`,
+    () => listSecurityFindings(repoId, { limit: 500 }),
+    { revalidateOnFocus: false },
+  );
+
+  const { showFile, dialog } = useFileCardHost(repoId);
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = { high: 0, med: 0, low: 0 };
+    for (const f of findings ?? []) {
+      c[f.severity] = (c[f.severity] ?? 0) + 1;
+    }
+    return c;
+  }, [findings]);
+
+  const handleSelect = (f: SecurityFinding) => {
+    const data: FileCardData = {
+      file_path: f.file_path,
+      summary: `Security: ${f.kind} (${f.severity})`,
+      security: {
+        findings_count: (findings ?? []).filter((x) => x.file_path === f.file_path).length,
+        critical_count: (findings ?? []).filter(
+          (x) => x.file_path === f.file_path && x.severity === "high",
+        ).length,
+      },
+    };
+    showFile(data);
+  };
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-[var(--color-text-secondary)]">
+        Findings detected during ingestion — secrets, dangerous patterns, and policy hits.
+      </p>
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <Skeleton className="h-40 w-full rounded-lg" />
+          <Skeleton className="h-40 w-full rounded-lg" />
+        </div>
+      ) : error ? (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm">Couldn&apos;t load findings</CardTitle>
+          </CardHeader>
+          <CardContent className="pt-0 text-xs text-[var(--color-text-secondary)]">
+            The security endpoint returned an error. Try re-running ingestion.
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <SeverityDistribution counts={counts} />
+            <FindingsByDirectory findings={findings ?? []} />
+          </div>
+          <SecurityFindingsTable findings={findings ?? []} onSelect={handleSelect} />
+        </>
+      )}
+
+      {dialog}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Navigation restructure, docs landing cleanup, a perf pass on the docs/wiki pages, and a fix so chat picks up the provider key written by `repowise init`.

## Navigation & UI
- Fold **Trend / Coverage / Refactoring** back into Health (drop the standalone sidebar entries — they already live under Health).
- Move **Security** from a standalone sidebar item to a tab under **Risk**; the old `/security` route now redirects to `/risk?tab=security` so bookmarks keep working.
- Rename **Docs → Wiki** and surface it near the top of the repo nav.
- Docs landing: remove the redundant outer "Start here" container, make the panel collapsible (collapsed by default) and more compact, and open the repo **overview** page by default instead of the empty "Select a page" state.
- Remove the noisy floating **Health risks** overlay from the graph view.
- Bump the sidebar / mobile footer to **v0.12.0**.

## Performance
- Add a global `SWRConfig`: disable revalidate-on-focus/reconnect and dedupe requests, so pages stop refetching every time the window regains focus.
- Docs: share a single SWR key for the full page list instead of fetching it twice (it already carries full content).
- Memoize rendered wiki markdown on `(content, components)` so sidebar/persona toggles no longer re-parse the whole document.

## Chat provider fix
`repowise serve` auto-detected the local `.repowise/wiki.db` but never loaded the API key from `.repowise/.env` or the provider/model from `.repowise/config.yaml`, so the in-process API server started with no usable chat provider — chat failed even though `init` had saved a key.
- `serve_cmd` now loads `.repowise/.env` and seeds `REPOWISE_PROVIDER` / `REPOWISE_MODEL` / `REPOWISE_EMBEDDER` from `config.yaml` before startup (existing env vars win).
- `provider_config` honours `REPOWISE_PROVIDER` / `REPOWISE_MODEL` when no provider has been explicitly selected, before falling back to auto-detect.

Verified by simulating `serve` startup from a clean env: OpenAI loads, is auto-selected as active (`gpt-5.4-nano`), and shows as configured.

## Test plan
- [ ] Sidebar shows Overview / Chat / Wiki / Risk / Health / … without Trend/Coverage/Refactoring/Security standalone entries
- [ ] Security renders as a tab under Risk; `/security` redirects there
- [ ] Docs opens on the overview page; "Start here" is collapsed by default and compact
- [ ] `repowise serve` (from a repo with `.repowise/.env` + `config.yaml`) → chat works, OpenAI auto-selected, no "add key"
