### PR TITLE
fix(providers): await cost recording inline to avoid event-loop-closed teardown

### DIFF
--- a/packages/core/src/repowise/core/providers/llm/anthropic.py
+++ b/packages/core/src/repowise/core/providers/llm/anthropic.py
@@ -12,6 +12,7 @@ Recommended models (as of 2026):
 
 from __future__ import annotations
 
+import contextlib
 import os
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
@@ -184,20 +185,20 @@ class AnthropicProvider(BaseProvider):
         )
 
         if self._cost_tracker is not None:
-            import asyncio
-
-            try:
-                asyncio.get_event_loop().create_task(
-                    self._cost_tracker.record(
-                        model=self._model,
-                        input_tokens=result.input_tokens,
-                        output_tokens=result.output_tokens,
-                        operation="doc_generation",
-                        file_path=None,
-                    )
+            # Await the cost record inline rather than spawning a detached
+            # task. A fire-and-forget create_task can still be flushing its
+            # aiosqlite write when the event loop is torn down (e.g. the
+            # asyncio.run teardown after doc generation), which surfaces as a
+            # noisy "Event loop is closed" worker-thread traceback. record()
+            # swallows its own persistence errors, so generation is unaffected.
+            with contextlib.suppress(Exception):
+                await self._cost_tracker.record(
+                    model=self._model,
+                    input_tokens=result.input_tokens,
+                    output_tokens=result.output_tokens,
+                    operation="doc_generation",
+                    file_path=None,
                 )
-            except RuntimeError:
-                pass  # No running event loop — skip async record
 
         return result
 

--- a/packages/core/src/repowise/core/providers/llm/deepseek.py
+++ b/packages/core/src/repowise/core/providers/llm/deepseek.py
@@ -181,17 +181,19 @@ class DeepSeekProvider(BaseProvider):
         )
 
         if self._cost_tracker is not None:
-            import asyncio
-
-            with contextlib.suppress(RuntimeError):
-                asyncio.get_event_loop().create_task(
-                    self._cost_tracker.record(
-                        model=self._model,
-                        input_tokens=result.input_tokens,
-                        output_tokens=result.output_tokens,
-                        operation="doc_generation",
-                        file_path=None,
-                    )
+            # Await the cost record inline rather than spawning a detached
+            # task. A fire-and-forget create_task can still be flushing its
+            # aiosqlite write when the event loop is torn down (e.g. the
+            # asyncio.run teardown after doc generation), which surfaces as a
+            # noisy "Event loop is closed" worker-thread traceback. record()
+            # swallows its own persistence errors, so generation is unaffected.
+            with contextlib.suppress(Exception):
+                await self._cost_tracker.record(
+                    model=self._model,
+                    input_tokens=result.input_tokens,
+                    output_tokens=result.output_tokens,
+                    operation="doc_generation",
+                    file_path=None,
                 )
 
         return result

--- a/packages/core/src/repowise/core/providers/llm/gemini.py
+++ b/packages/core/src/repowise/core/providers/llm/gemini.py
@@ -11,6 +11,7 @@ Recommended models:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 
@@ -224,18 +225,20 @@ class GeminiProvider(BaseProvider):
         )
 
         if self._cost_tracker is not None:
-            try:
-                asyncio.get_event_loop().create_task(
-                    self._cost_tracker.record(
-                        model=self._model,
-                        input_tokens=result.input_tokens,
-                        output_tokens=result.output_tokens,
-                        operation="doc_generation",
-                        file_path=None,
-                    )
+            # Await the cost record inline rather than spawning a detached
+            # task. A fire-and-forget create_task can still be flushing its
+            # aiosqlite write when the event loop is torn down (e.g. the
+            # asyncio.run teardown after doc generation), which surfaces as a
+            # noisy "Event loop is closed" worker-thread traceback. record()
+            # swallows its own persistence errors, so generation is unaffected.
+            with contextlib.suppress(Exception):
+                await self._cost_tracker.record(
+                    model=self._model,
+                    input_tokens=result.input_tokens,
+                    output_tokens=result.output_tokens,
+                    operation="doc_generation",
+                    file_path=None,
                 )
-            except RuntimeError:
-                pass  # No running event loop — skip async record
 
         return result
 

--- a/packages/core/src/repowise/core/providers/llm/litellm.py
+++ b/packages/core/src/repowise/core/providers/llm/litellm.py
@@ -19,6 +19,7 @@ Reference: https://docs.litellm.ai/docs/providers
 
 from __future__ import annotations
 
+import contextlib
 import os
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
@@ -182,20 +183,20 @@ class LiteLLMProvider(BaseProvider):
         )
 
         if self._cost_tracker is not None:
-            import asyncio
-
-            try:
-                asyncio.get_event_loop().create_task(
-                    self._cost_tracker.record(
-                        model=self._model,
-                        input_tokens=result.input_tokens,
-                        output_tokens=result.output_tokens,
-                        operation="doc_generation",
-                        file_path=None,
-                    )
+            # Await the cost record inline rather than spawning a detached
+            # task. A fire-and-forget create_task can still be flushing its
+            # aiosqlite write when the event loop is torn down (e.g. the
+            # asyncio.run teardown after doc generation), which surfaces as a
+            # noisy "Event loop is closed" worker-thread traceback. record()
+            # swallows its own persistence errors, so generation is unaffected.
+            with contextlib.suppress(Exception):
+                await self._cost_tracker.record(
+                    model=self._model,
+                    input_tokens=result.input_tokens,
+                    output_tokens=result.output_tokens,
+                    operation="doc_generation",
+                    file_path=None,
                 )
-            except RuntimeError:
-                pass  # No running event loop — skip async record
 
         return result
 

--- a/packages/core/src/repowise/core/providers/llm/openai.py
+++ b/packages/core/src/repowise/core/providers/llm/openai.py
@@ -12,6 +12,7 @@ Recommended models (as of 2026):
 
 from __future__ import annotations
 
+import contextlib
 import os
 from typing import TYPE_CHECKING, Any, AsyncIterator
 
@@ -255,20 +256,20 @@ class OpenAIProvider(BaseProvider):
         )
 
         if self._cost_tracker is not None:
-            import asyncio
-
-            try:
-                asyncio.get_event_loop().create_task(
-                    self._cost_tracker.record(
-                        model=self._model,
-                        input_tokens=result.input_tokens,
-                        output_tokens=result.output_tokens,
-                        operation="doc_generation",
-                        file_path=None,
-                    )
+            # Await the cost record inline rather than spawning a detached
+            # task. A fire-and-forget create_task can still be flushing its
+            # aiosqlite write when the event loop is torn down (e.g. the
+            # asyncio.run teardown after doc generation), which surfaces as a
+            # noisy "Event loop is closed" worker-thread traceback. record()
+            # swallows its own persistence errors, so generation is unaffected.
+            with contextlib.suppress(Exception):
+                await self._cost_tracker.record(
+                    model=self._model,
+                    input_tokens=result.input_tokens,
+                    output_tokens=result.output_tokens,
+                    operation="doc_generation",
+                    file_path=None,
                 )
-            except RuntimeError:
-                pass  # No running event loop — skip async record
 
         return result
 


### PR DESCRIPTION
## Problem

Running `repowise init` (after wiki generation completes) emitted a noisy
`RuntimeError: Event loop is closed` traceback originating from an aiosqlite
worker thread. Init still finished successfully, so the error was cosmetic —
but alarming and repeated.

## Root cause

All five LLM providers record per-generation token cost as a fire-and-forget
task:

```python
asyncio.get_event_loop().create_task(self._cost_tracker.record(...))
```

Doc generation runs under `asyncio.run(...)`. When generation finishes, that
event loop is torn down immediately — but a detached `record()` task may still
be flushing its aiosqlite write on a worker thread. The write then races
against loop teardown and surfaces as `Event loop is closed`.

## Fix

Await `CostTracker.record()` inline in each provider instead of spawning a
detached task. `record()` already swallows its own persistence failures
(`cost_tracker.persist_failed`), and the call is additionally wrapped in
`contextlib.suppress(Exception)`, so generation behavior is unchanged — but the
write now completes (or fails quietly) *before* the loop closes.

Applied uniformly to `anthropic`, `openai`, `gemini`, `deepseek`, and
`litellm`. Removed the now-unused local `import asyncio` from the four
providers that only used it for this call.

## Testing

- `pytest tests/unit -k "provider or cost"` → **148 passed**
- `ruff check` on the five files → no new findings (remaining E402/UP035/UP037/F401 are pre-existing)
