### PR TITLE
fix(cli): silence structlog/stdlib logs on stdout when --format json or md is used

### DIFF
--- a/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
@@ -12,6 +12,7 @@ from repowise.cli.helpers import (
     resolve_command_target,
     resolve_repo_path,
     run_async,
+    silence_logs_for_machine_output,
 )
 
 
@@ -86,6 +87,9 @@ def dead_code_command(
     --repo <alias> to target a different repo. Cross-repo dead-code
     detection is not yet supported — run once per repo for now.
     """
+    if fmt != "table":
+        silence_logs_for_machine_output()
+
     from pathlib import Path as PathlibPath
 
     from repowise.core.analysis.dead_code import DeadCodeAnalyzer

--- a/packages/cli/src/repowise/cli/commands/health_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/health_cmd.py
@@ -17,6 +17,7 @@ from repowise.cli.helpers import (
     err_console,
     resolve_command_target,
     run_async,
+    silence_logs_for_machine_output,
 )
 
 
@@ -110,6 +111,12 @@ def health_command(
     from repowise.core.analysis.health import HealthAnalyzer
     from repowise.core.analysis.health.coverage import parse as parse_coverage
     from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
+
+    # Silence structlog/stdlib info+debug lines when the user asked for a
+    # machine-readable format so stdout is pure JSON/Markdown and safe to
+    # pipe into jq or other tools (e.g. `repowise health --format json | jq .kpis`).
+    if fmt != "table":
+        silence_logs_for_machine_output()
 
     # Status output goes to stderr when the user asked for a machine-readable
     # format — otherwise rich's banner pollutes stdout and breaks

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -31,6 +31,41 @@ REPOWISE_DIR = ".repowise"
 
 
 # ---------------------------------------------------------------------------
+# Logging / structlog helpers
+# ---------------------------------------------------------------------------
+
+
+def silence_logs_for_machine_output() -> None:
+    """Suppress info/debug log output when stdout is machine-readable (JSON/md).
+
+    Structlog and stdlib loggers write to stdout by default. When a command
+    emits JSON or Markdown, those lines corrupt the output for downstream
+    consumers (e.g. ``repowise health --format json | jq .kpis``).
+
+    Call this at the top of any command that supports ``--format json`` or
+    ``--format md`` before the ingestion pipeline starts.
+    """
+    import logging
+
+    logging.getLogger("httpx").setLevel(logging.ERROR)
+    logging.getLogger("httpcore").setLevel(logging.ERROR)
+    for _name in ("repowise.core", "repowise.server"):
+        logging.getLogger(_name).setLevel(logging.ERROR)
+    try:
+        import structlog
+
+        # cache_logger_on_first_use=False is required: module-level
+        # ``structlog.get_logger`` calls snapshot the logger before configure()
+        # runs and would bypass this filter without it.
+        structlog.configure(
+            wrapper_class=structlog.make_filtering_bound_logger(logging.ERROR),
+            cache_logger_on_first_use=False,
+        )
+    except ImportError:
+        pass
+
+
+# ---------------------------------------------------------------------------
 # Async bridge
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
`repowise health --format json` (and `dead-code --format json`) was polluting stdout with structlog info/debug lines from the ingestion pipeline, making the output unparseable by downstream consumers like jq.

Add `silence_logs_for_machine_output()` to `cli/helpers.py` following the same pattern already used in `init_cmd.py` quiet mode: set httpx/httpcore and repowise.core stdlib loggers to ERROR, then reconfigure structlog with `wrapper_class=make_filtering_bound_logger(logging.ERROR)` and `cache_logger_on_first_use=False` (required to suppress module-level loggers snapshotted before configure() runs).

Call it at the top of `health_command()` and `dead_code_command()` whenever `fmt != 'table'`, before the ingestion pipeline starts.

Closes #227

## Summary

- Added `silence_logs_for_machine_output()` helper to `cli/helpers.py` that suppresses structlog and stdlib info/debug output when stdout is used for machine-readable formats
- Called it in `health_command()` and `dead_code_command()` when `fmt != "table"`, fixing `--format json` and `--format md` for both commands
- `repowise health --format json | jq .kpis` now works without stripping leading log lines

## Related Issues

Closes #227

## Test Plan

- [x] Tests pass (`pytest`)
- [x] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(if frontend changes)*

## Checklist

- [x] My code follows the project's code style
- [ ] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed

Note on the two unchecked boxes: No new tests were added because exercising the fix requires the full ingestion pipeline (traverser, parser, graph builder) which can't be meaningfully unit-tested in isolation. The fix itself is a direct port of the pattern already used and proven in init_cmd.py. No docs needed since the command's --format flag behavior is unchanged from the user's perspective — it just works correctly now.