### PR TITLE
fix(decisions): discover changelogs under docs/, doc/, .github/

### DIFF
--- a/packages/core/src/repowise/core/analysis/decision_extractor.py
+++ b/packages/core/src/repowise/core/analysis/decision_extractor.py
@@ -1001,13 +1001,28 @@ class DecisionExtractor:
         return decisions
 
     def _find_changelog(self) -> Path | None:
-        """Locate a top-level CHANGELOG/HISTORY/NEWS file (any extension)."""
-        for p in sorted(self._repo_path.glob("*")):
-            if not p.is_file():
+        """Locate a CHANGELOG/HISTORY/NEWS file (any extension).
+
+        Checks the repo root first, then the conventional documentation
+        subdirectories (``docs/``, ``doc/``, ``.github/``). Many projects keep
+        their changelog under ``docs/`` rather than at the root, so a root-only
+        scan silently skips this source.
+        """
+        search_dirs = [
+            self._repo_path,
+            self._repo_path / "docs",
+            self._repo_path / "doc",
+            self._repo_path / ".github",
+        ]
+        for directory in search_dirs:
+            if not directory.is_dir():
                 continue
-            stem = re.sub(r"[^a-z]", "", p.stem.lower())
-            if stem in _CHANGELOG_NAMES:
-                return p
+            for p in sorted(directory.glob("*")):
+                if not p.is_file():
+                    continue
+                stem = re.sub(r"[^a-z]", "", p.stem.lower())
+                if stem in _CHANGELOG_NAMES:
+                    return p
         return None
 
     def _parse_changelog(self, content: str) -> list[tuple[str, str]]:

--- a/tests/unit/analysis/test_decision_sources.py
+++ b/tests/unit/analysis/test_decision_sources.py
@@ -106,6 +106,20 @@ async def test_mine_changelog_extracts_decision_sections(tmp_path):
     assert all(d.source == "changelog" for d in decisions)
 
 
+async def test_mine_changelog_finds_changelog_under_docs(tmp_path):
+    # Many projects keep the changelog under docs/ rather than at the root.
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "CHANGELOG.md").write_text(_CHANGELOG, encoding="utf-8")
+
+    ex = DecisionExtractor(repo_path=tmp_path)  # no provider → raw bullets
+    decisions = await ex.mine_changelog()
+
+    texts = [d.decision for d in decisions]
+    assert any("Migrate the auth layer" in t for t in texts)
+    assert all(d.source == "changelog" for d in decisions)
+
+
 async def test_extract_all_runs_deterministic_sources_and_gates(tmp_path):
     adr_dir = tmp_path / "docs" / "adr"
     adr_dir.mkdir(parents=True)


### PR DESCRIPTION
## Problem

`DecisionExtractor._find_changelog()` globbed only the repository root:

```python
for p in sorted(self._repo_path.glob("*")):  # root only
```

Many projects keep their changelog under `docs/` (this repo's lives at
`docs/CHANGELOG.md`). For those, the changelog decision source was silently
skipped — `mine_changelog()` returned zero decisions even though
`_parse_changelog()` handles the file perfectly when handed it directly. A
keep-a-changelog with rich `Changed`/`Removed`/`Deprecated` sections produced
no decisions at all.

## Fix

Search the conventional documentation subdirectories — `docs/`, `doc/`,
`.github/` — in addition to the repo root, returning the first match. The root
is still checked first, so existing behavior is preserved; this only *adds*
discovery locations.

## Testing

- New regression test `test_mine_changelog_finds_changelog_under_docs` places
  the changelog under `docs/` and asserts decisions are extracted.
- `pytest tests/unit/analysis/test_decision_sources.py` → **5 passed**
- `ruff check` on both files → clean
