### PR TITLE
fix(cli): register workspace root in Claude MCP config when inside a workspace

### DIFF
--- a/packages/cli/src/repowise/cli/editor_integrations/claude_config.py
+++ b/packages/cli/src/repowise/cli/editor_integrations/claude_config.py
@@ -11,6 +11,7 @@ from repowise.cli.mcp_config import (
     load_existing_config,
     merge_mcp_entry,
 )
+from repowise.core.workspace.config import find_workspace_root
 
 
 def _claude_desktop_config_path() -> Path | None:
@@ -35,8 +36,30 @@ def _claude_code_settings_path() -> Path:
     return Path.home() / ".claude" / "settings.json"
 
 
+def _resolve_mcp_target(repo_path: Path) -> Path:
+    """Pick the right path to register as the MCP server target.
+
+    The Claude Desktop / Claude Code MCP config is global — there is only one
+    ``"repowise"`` server key. When the user is operating inside a workspace,
+    registering the per-repo path means every ``repowise init`` against a
+    sibling repo silently overwrites the entry to point at whichever repo was
+    indexed last, breaking workspace mode.
+
+    If ``repo_path`` lives inside a workspace (``.repowise-workspace.yaml`` in
+    any ancestor), return the workspace root instead so the MCP server is
+    invoked in workspace mode and ``repo="<alias>"`` queries work across all
+    repos. Otherwise fall back to the per-repo path, preserving single-repo
+    behavior.
+    """
+    workspace_root = find_workspace_root(repo_path)
+    return workspace_root if workspace_root is not None else repo_path
+
+
 def register_with_claude_desktop(repo_path: Path) -> Path | None:
     """Add repowise MCP server to Claude Desktop's config.
+
+    When ``repo_path`` is inside a workspace, the registration targets the
+    workspace root so the MCP server starts in workspace mode.
 
     Returns the config path if successful, None if Claude Desktop is not
     present or the platform is unsupported.
@@ -47,17 +70,23 @@ def register_with_claude_desktop(repo_path: Path) -> Path | None:
     if not config_path.parent.exists():
         # Claude Desktop not installed
         return None
-    entry = generate_mcp_config(repo_path)["mcpServers"]
+    target = _resolve_mcp_target(repo_path)
+    entry = generate_mcp_config(target)["mcpServers"]
     return config_path if merge_mcp_entry(config_path, entry) else None
 
 
 def register_with_claude_code(repo_path: Path) -> Path | None:
     """Add repowise MCP server to global Claude Code settings (~/.claude/settings.json).
 
+    When ``repo_path`` is inside a workspace, the registration targets the
+    workspace root so the MCP server starts in workspace mode and subsequent
+    inits against sibling repos do not overwrite the entry.
+
     Returns the settings path if successful, None on failure.
     """
     settings_path = _claude_code_settings_path()
-    entry = generate_mcp_config(repo_path)["mcpServers"]
+    target = _resolve_mcp_target(repo_path)
+    entry = generate_mcp_config(target)["mcpServers"]
     return settings_path if merge_mcp_entry(settings_path, entry) else None
 
 
@@ -148,9 +177,7 @@ def _migrate_legacy_hook(hook_list: list) -> bool:
                 hook["command"] = "repowise-augment"
                 changed = True
         matcher = entry.get("matcher", "")
-        only_repowise = entry.get("hooks") and all(
-            _is_repowise_hook(h) for h in entry["hooks"]
-        )
+        only_repowise = entry.get("hooks") and all(_is_repowise_hook(h) for h in entry["hooks"])
         if only_repowise and matcher == "Bash":
             entry["matcher"] = "Bash|Grep|Glob"
             changed = True
@@ -188,9 +215,7 @@ def migrate_claude_code_hooks() -> bool:
         return False
 
     try:
-        settings_path.write_text(
-            json.dumps(existing, indent=2) + "\n", encoding="utf-8"
-        )
+        settings_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
     except OSError:
         return False
     return True

--- a/tests/unit/cli/test_mcp_config.py
+++ b/tests/unit/cli/test_mcp_config.py
@@ -1,5 +1,6 @@
 import json
 import re
+import sys
 from pathlib import Path
 
 import click
@@ -183,17 +184,13 @@ def test_install_claude_code_hooks_migrates_pre_0_6_1_command(
                     "PreToolUse": [
                         {
                             "matcher": "Grep|Glob",
-                            "hooks": [
-                                {"type": "command", "command": "repowise augment"}
-                            ],
+                            "hooks": [{"type": "command", "command": "repowise augment"}],
                         }
                     ],
                     "PostToolUse": [
                         {
                             "matcher": "Bash",
-                            "hooks": [
-                                {"type": "command", "command": "repowise augment"}
-                            ],
+                            "hooks": [{"type": "command", "command": "repowise augment"}],
                         }
                     ],
                 }
@@ -225,17 +222,13 @@ def test_install_claude_code_hooks_migrates_pre_0_6_2_matcher(
                     "PreToolUse": [
                         {
                             "matcher": "Grep|Glob",
-                            "hooks": [
-                                {"type": "command", "command": "repowise-augment"}
-                            ],
+                            "hooks": [{"type": "command", "command": "repowise-augment"}],
                         }
                     ],
                     "PostToolUse": [
                         {
                             "matcher": "Bash",
-                            "hooks": [
-                                {"type": "command", "command": "repowise-augment"}
-                            ],
+                            "hooks": [{"type": "command", "command": "repowise-augment"}],
                         }
                     ],
                 }
@@ -283,17 +276,13 @@ def test_migrate_claude_code_hooks_handles_full_legacy_payload(
                     "PreToolUse": [
                         {
                             "matcher": "Grep|Glob",
-                            "hooks": [
-                                {"type": "command", "command": "repowise augment"}
-                            ],
+                            "hooks": [{"type": "command", "command": "repowise augment"}],
                         }
                     ],
                     "PostToolUse": [
                         {
                             "matcher": "Bash",
-                            "hooks": [
-                                {"type": "command", "command": "repowise augment"}
-                            ],
+                            "hooks": [{"type": "command", "command": "repowise augment"}],
                         }
                     ],
                 }
@@ -403,3 +392,145 @@ def test_install_claude_code_hooks_rejects_invalid_existing_file(
         claude_config.install_claude_code_hooks()
 
     assert settings_path.read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# Workspace-aware MCP target resolution
+#
+# Regression coverage for the case where ``repowise init`` is run inside a
+# multi-repo workspace. Without workspace-aware resolution, each init
+# overwrites ``~/.claude/settings.json`` with the per-repo path, so the
+# global MCP server can only see whichever repo was indexed most recently.
+# These tests pin the "register the workspace root" behavior in place.
+# ---------------------------------------------------------------------------
+
+
+def _write_workspace_yaml(workspace_root: Path) -> None:
+    """Create a minimal valid ``.repowise-workspace.yaml`` at *workspace_root*."""
+    (workspace_root / ".repowise-workspace.yaml").write_text(
+        "version: 1\nrepos: []\n", encoding="utf-8"
+    )
+
+
+def _registered_repowise_args(settings_path: Path) -> list[str]:
+    saved = json.loads(settings_path.read_text(encoding="utf-8"))
+    return saved["mcpServers"]["repowise"]["args"]
+
+
+def test_resolve_mcp_target_returns_repo_path_without_workspace(tmp_path: Path) -> None:
+    """Single-repo usage is unchanged: target is the repo path itself."""
+    repo = tmp_path / "solo-repo"
+    repo.mkdir()
+    assert claude_config._resolve_mcp_target(repo) == repo
+
+
+def test_resolve_mcp_target_returns_workspace_root_when_present(tmp_path: Path) -> None:
+    """Inside a workspace, target collapses to the workspace root."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    _write_workspace_yaml(workspace)
+    repo = workspace / "child-repo"
+    repo.mkdir()
+
+    assert claude_config._resolve_mcp_target(repo) == workspace
+
+
+def test_resolve_mcp_target_finds_workspace_through_multiple_ancestors(
+    tmp_path: Path,
+) -> None:
+    """``find_workspace_root`` walks up arbitrarily deep, not just one level."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    _write_workspace_yaml(workspace)
+    deep = workspace / "a" / "b" / "c" / "repo"
+    deep.mkdir(parents=True)
+
+    assert claude_config._resolve_mcp_target(deep) == workspace
+
+
+def test_register_with_claude_code_uses_workspace_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``register_with_claude_code`` against a workspace member targets the root."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    _write_workspace_yaml(workspace)
+    repo = workspace / "engine"
+    repo.mkdir()
+
+    settings_path = claude_config.register_with_claude_code(repo)
+    assert settings_path is not None
+
+    args = _registered_repowise_args(settings_path)
+    # ``mcp <path> --transport stdio`` — second element is the target path
+    registered_path = Path(args[1])
+    assert registered_path == workspace.resolve()
+
+
+def test_register_with_claude_code_sibling_inits_dont_clobber(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bug this fix targets: indexing two sibling repos in a workspace
+    must converge on a single registration pointing at the workspace root,
+    not flip-flop between per-repo paths."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    _write_workspace_yaml(workspace)
+    engine = workspace / "engine"
+    engine.mkdir()
+    ops = workspace / "ops"
+    ops.mkdir()
+
+    claude_config.register_with_claude_code(engine)
+    first_args = _registered_repowise_args(tmp_path / "home" / ".claude" / "settings.json")
+
+    claude_config.register_with_claude_code(ops)
+    second_args = _registered_repowise_args(tmp_path / "home" / ".claude" / "settings.json")
+
+    assert first_args == second_args
+    assert Path(first_args[1]) == workspace.resolve()
+
+
+def test_register_with_claude_code_no_workspace_uses_repo_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without a workspace yaml in any ancestor, behavior is unchanged."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+    solo = tmp_path / "solo"
+    solo.mkdir()
+
+    settings_path = claude_config.register_with_claude_code(solo)
+    assert settings_path is not None
+
+    args = _registered_repowise_args(settings_path)
+    assert Path(args[1]) == solo.resolve()
+
+
+def test_register_with_claude_desktop_uses_workspace_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``register_with_claude_desktop`` mirrors the workspace-aware behavior."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    # Pre-create the Claude Desktop parent dir so the registration proceeds
+    desktop_parent = tmp_path / "home" / "Library" / "Application Support" / "Claude"
+    desktop_parent.mkdir(parents=True)
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    _write_workspace_yaml(workspace)
+    repo = workspace / "engine"
+    repo.mkdir()
+
+    config_path = claude_config.register_with_claude_desktop(repo)
+    assert config_path is not None
+
+    saved = json.loads(config_path.read_text(encoding="utf-8"))
+    args = saved["mcpServers"]["repowise"]["args"]
+    assert Path(args[1]) == workspace.resolve()


### PR DESCRIPTION
Closes #277. Smaller piece of #88.

## Summary

`repowise init` against any repo inside a multi-repo workspace was overwriting `~/.claude/settings.json` (and Claude Desktop's config) with the per-repo path. Because the MCP config has a single `"repowise"` server key, indexing two sibling repos in sequence flipped the global MCP registration to whichever was indexed last — workspace mode worked for the first repo, then silently broke when another sibling was indexed.

`register_with_claude_code` and `register_with_claude_desktop` now route through a new `_resolve_mcp_target` helper that calls `find_workspace_root` (already exported by `repowise.core.workspace.config`). When a `.repowise-workspace.yaml` is found in any ancestor of `repo_path`, the registration targets the workspace root, so subsequent inits against sibling repos converge on the same entry and the MCP server starts in workspace mode where `repo="<alias>"` queries work across all repos. Single-repo usage is unchanged: no ancestor yaml, no behavior change.

The repo-local `.repowise/mcp.json` and root-of-repo `.mcp.json` writers are left alone — those files are per-repo by design (Cursor/Cline discovery, repo-local tooling). Only the global Claude Desktop / Claude Code registration is workspace-aware.

## Test plan

7 new tests in `tests/unit/cli/test_mcp_config.py` pin the behavior, including a regression test that simulates the exact two-sibling-init scenario from #277:

- [x] `_resolve_mcp_target` resolves to repo_path when no workspace exists
- [x] `_resolve_mcp_target` resolves to the workspace root when one does
- [x] `_resolve_mcp_target` finds workspace through multiple intermediate directories
- [x] `register_with_claude_code` against a workspace member writes the workspace root path
- [x] two sibling inits converge on the same registered path (regression for #277)
- [x] `register_with_claude_code` without a workspace preserves the per-repo path
- [x] `register_with_claude_desktop` mirrors the same behavior

```bash
$ uv run pytest tests/unit/cli/test_mcp_config.py -v
...
============================= 24 passed in 0.78s ==============================
```

`ruff format` + `ruff check` both clean on the changed files.

## Discovered the bug

Hit it bootstrapping a 4-repo workspace and seeing `~/.claude/settings.json` change to the path of whichever repo I had just indexed. Read through `claude_config.py` and `mcp_config.py` to confirm the root cause, then found `find_workspace_root` already doing the right walk in `workspace/config.py:261` — fix slotted in cleanly.

## Out of scope

- Larger refactor toward multi-tenant MCP server architecture (tracked in #88).
- SSE port auto-discovery and SQLite WAL + busy_timeout (also called out in #88 as cherry-pickable; happy to take a stab at those in follow-up PRs if useful).