### PR TITLE
fix(serve): auto-fallback to next free port when 3000/7337 is taken

### DIFF
--- a/packages/cli/src/repowise/cli/commands/serve_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/serve_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import socket
 import subprocess
 import tarfile
 import tempfile
@@ -187,6 +188,45 @@ def _load_local_provider_config() -> None:
     embedder = cfg.get("embedder")
     if embedder and embedder != "mock" and not os.environ.get("REPOWISE_EMBEDDER"):
         os.environ["REPOWISE_EMBEDDER"] = str(embedder)
+
+
+def _is_port_free(host: str, port: int) -> bool:
+    """Return True if *port* can be bound on *host* right now."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, port))
+        except OSError:
+            return False
+    return True
+
+
+def _find_free_port(host: str, preferred: int, label: str, max_attempts: int = 20) -> int:
+    """Return *preferred* if free, otherwise the next free port within range.
+
+    Falls back to an OS-assigned port if a contiguous slot can't be found.
+    Prints a notice when the preferred port is unavailable so the user knows
+    the bind moved.
+    """
+    if _is_port_free(host, preferred):
+        return preferred
+
+    for offset in range(1, max_attempts + 1):
+        candidate = preferred + offset
+        if candidate > 65535:
+            break
+        if _is_port_free(host, candidate):
+            console.print(
+                f"[yellow]Port {preferred} for {label} is in use — using {candidate} instead.[/yellow]"
+            )
+            return candidate
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        candidate = sock.getsockname()[1]
+    console.print(
+        f"[yellow]Port {preferred} for {label} and nearby ports busy — using {candidate}.[/yellow]"
+    )
+    return candidate
 
 
 _GITHUB_REPO = "repowise-dev/repowise"
@@ -449,9 +489,18 @@ def serve_command(
             os.environ["REPOWISE_DB_URL"] = f"sqlite+aiosqlite:///{local_db.as_posix()}"
             console.print(f"[dim]Using local database: {local_db}[/dim]")
 
+    # Resolve a usable API port up front — uvicorn would otherwise crash later
+    # with a bare OSError, and the chosen port needs to flow into the frontend
+    # via REPOWISE_API_URL.
+    port = _find_free_port(host, port, "API server")
+
     frontend_proc: subprocess.Popen | None = None
 
     if not no_ui:
+        # The Next.js server binds to 0.0.0.0 (see HOSTNAME below), so probe
+        # there — a port can be free on 127.0.0.1 but taken on the wildcard.
+        ui_port = _find_free_port("0.0.0.0", ui_port, "web UI")
+
         node = _node_available()
         npm = _npm_available()
 

--- a/tests/unit/cli/test_serve_port_fallback.py
+++ b/tests/unit/cli/test_serve_port_fallback.py
@@ -1,0 +1,70 @@
+"""Regression tests for `repowise serve` port auto-fallback (issue #232).
+
+When the user's project already occupies the default UI port (3000) or the
+default API port (7337), `repowise serve` should pick the next available
+port instead of crashing with EADDRINUSE.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from repowise.cli.commands import serve_cmd
+
+
+def _bind_listener(host: str = "127.0.0.1") -> tuple[socket.socket, int]:
+    """Bind a listening socket on an OS-assigned port and return (sock, port)."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind((host, 0))
+    sock.listen(1)
+    return sock, sock.getsockname()[1]
+
+
+def test_is_port_free_detects_free_port() -> None:
+    sock, port = _bind_listener()
+    sock.close()
+    assert serve_cmd._is_port_free("127.0.0.1", port) is True
+
+
+def test_is_port_free_detects_busy_port() -> None:
+    sock, port = _bind_listener()
+    try:
+        assert serve_cmd._is_port_free("127.0.0.1", port) is False
+    finally:
+        sock.close()
+
+
+def test_find_free_port_returns_preferred_when_free() -> None:
+    sock, port = _bind_listener()
+    sock.close()
+    assert serve_cmd._find_free_port("127.0.0.1", port, "test") == port
+
+
+def test_find_free_port_falls_back_to_next_available() -> None:
+    """The exact scenario from issue #232: preferred port already taken."""
+    sock, busy_port = _bind_listener()
+    try:
+        chosen = serve_cmd._find_free_port("127.0.0.1", busy_port, "web UI")
+        assert chosen != busy_port
+        assert chosen > busy_port
+        # Chosen port must actually be bindable.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", chosen))
+    finally:
+        sock.close()
+
+
+def test_find_free_port_handles_contiguous_busy_block(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the preferred port and the scan window are all busy, fall back
+    to an OS-assigned ephemeral port instead of raising."""
+    # Pretend every port in the scan range is busy; the function should still
+    # produce a usable port via the wildcard bind path.
+    monkeypatch.setattr(serve_cmd, "_is_port_free", lambda host, port: False)
+
+    chosen = serve_cmd._find_free_port("127.0.0.1", 3000, "web UI", max_attempts=5)
+    assert isinstance(chosen, int)
+    assert 1024 <= chosen <= 65535


### PR DESCRIPTION
Closes #232.

## Summary

`repowise serve` crashes with `EADDRINUSE` whenever the user's own project is already bound to port `3000` (the default Next.js dev port — a very common collision). The error only surfaces *after* the API server has finished starting, so the user sees a clean startup followed by a stack trace from the Node frontend.

Now both ports are probed before anything binds:

- API server (`--port`, default `7337`) — probed on `--host`.
- Web UI (`--ui-port`, default `3000`) — probed on `0.0.0.0` because the bundled Next.js server binds via `HOSTNAME=0.0.0.0`. A port can be free on `127.0.0.1` but taken on the wildcard, so probing on `0.0.0.0` matches the actual bind.

If the requested port is busy, the next available port within a 20-port scan window is used; if that whole block is busy too, the OS assigns an ephemeral port. Either way the user gets a clear notice (`Port 3000 for web UI is in use — using 3001 instead.`) and the rest of startup proceeds normally. The chosen API port flows through to `REPOWISE_API_URL` so the frontend points at the right backend.

## Test plan

5 new tests in `tests/unit/cli/test_serve_port_fallback.py`:

- [x] `_is_port_free` correctly detects free vs busy ports
- [x] `_find_free_port` returns the preferred port when it is free
- [x] `_find_free_port` walks past a busy port to the next available one (the issue #232 scenario)
- [x] `_find_free_port` falls back to an OS-assigned port when the whole scan window is busy

```text
$ .venv\Scripts\python.exe -m pytest tests/unit/cli/test_serve_port_fallback.py -v
============================== 5 passed in 0.06s ==============================
```

`ruff format` + `ruff check` clean on the changed files.

## Notes

- Behavior change is opt-out-free by design: matches what `next dev` and most local dev servers already do, and is what the issue reporter explicitly asked for. Users who want to fail loudly on a specific port can still pass `--port`/`--ui-port` and watch for the yellow "using N instead" line in output.
- Scan window is 20 ports, which keeps the message ranges predictable (3000 → 3001..3020). Anything past that falls back to ephemeral.