### PR TITLE
fix(serve): detect old Node.js and fall back gracefully

### DIFF
--- a/packages/cli/src/repowise/cli/commands/serve_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/serve_cmd.py
@@ -234,9 +234,37 @@ _WEB_CACHE_DIR = Path.home() / ".repowise" / "web"
 _MARKER_FILE = _WEB_CACHE_DIR / ".version"
 
 
+_NODE_MIN_MAJOR = 20  # Next.js 15 (see packages/web/package.json engines.node)
+
+
 def _node_available() -> str | None:
     """Return the path to node binary, or None."""
     return shutil.which("node")
+
+
+def _node_major_version(node: str) -> int | None:
+    """Return the major version of the *node* binary, or None if it can't be read.
+
+    A failure to invoke or parse is treated as "unknown" rather than fatal — the
+    caller decides whether to proceed or fall back.
+    """
+    try:
+        result = subprocess.run(
+            [node, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    raw = result.stdout.strip().lstrip("v")
+    head = raw.split(".", 1)[0]
+    try:
+        return int(head)
+    except ValueError:
+        return None
 
 
 def _npm_available() -> str | None:
@@ -504,11 +532,25 @@ def serve_command(
         node = _node_available()
         npm = _npm_available()
 
+        # Reject Node versions older than what the bundled Next.js needs.
+        # Without this check, an old node silently produces cryptic syntax
+        # errors from inside the Next.js runtime (e.g. `Unexpected token '?'`
+        # on `??`) once the frontend tries to start — see issue #276.
+        node_major = _node_major_version(node) if node else None
+        node_too_old = node is not None and node_major is not None and node_major < _NODE_MIN_MAJOR
+
         if not node:
             console.print(
-                "[yellow]Node.js not found — starting API server only.[/yellow]\n"
-                "[dim]To get the web UI, install Node.js 20+ or use Docker:\n"
-                "  docker run -p 7337:7337 -p 3000:3000 -v .repowise:/data repowise[/dim]"
+                f"[yellow]Node.js not found — starting API server only.[/yellow]\n"
+                f"[dim]To get the web UI, install Node.js {_NODE_MIN_MAJOR}+ or use Docker:\n"
+                f"  docker run -p 7337:7337 -p 3000:3000 -v .repowise:/data repowise[/dim]"
+            )
+        elif node_too_old:
+            console.print(
+                f"[yellow]Node.js {node_major} is too old for the bundled web UI "
+                f"(requires {_NODE_MIN_MAJOR}+) — starting API server only.[/yellow]\n"
+                f"[dim]Upgrade Node.js to {_NODE_MIN_MAJOR}+ or use Docker:\n"
+                f"  docker run -p 7337:7337 -p 3000:3000 -v .repowise:/data repowise[/dim]"
             )
         else:
             # Try to get the frontend running

--- a/tests/unit/cli/test_serve_node_version.py
+++ b/tests/unit/cli/test_serve_node_version.py
@@ -1,0 +1,86 @@
+"""Regression tests for Node.js version detection in `repowise serve` (issue #276).
+
+When the user has an old Node.js on PATH, the bundled Next.js runtime crashes
+with a cryptic syntax error (e.g. `Unexpected token '?'` on `??`) after the UI
+appears to start. Detect the version up front and fall back to API-only mode
+with a clear message instead.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any
+
+import pytest
+
+from repowise.cli.commands import serve_cmd
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+        self.returncode = 0
+
+
+def test_node_major_version_parses_standard_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*_args: Any, **_kwargs: Any) -> _FakeCompleted:
+        return _FakeCompleted("v20.11.1\n")
+
+    monkeypatch.setattr(serve_cmd.subprocess, "run", fake_run)
+    assert serve_cmd._node_major_version("/usr/bin/node") == 20
+
+
+def test_node_major_version_parses_old_release(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The exact scenario from issue #276 — Node 12 (pre-nullish-coalescing)."""
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> _FakeCompleted:
+        return _FakeCompleted("v12.22.12\n")
+
+    monkeypatch.setattr(serve_cmd.subprocess, "run", fake_run)
+    assert serve_cmd._node_major_version("/usr/bin/node") == 12
+
+
+def test_node_major_version_handles_missing_v_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(*_args: Any, **_kwargs: Any) -> _FakeCompleted:
+        return _FakeCompleted("18.20.3\n")
+
+    monkeypatch.setattr(serve_cmd.subprocess, "run", fake_run)
+    assert serve_cmd._node_major_version("/usr/bin/node") == 18
+
+
+def test_node_major_version_returns_none_on_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(*_args: Any, **_kwargs: Any) -> _FakeCompleted:
+        raise subprocess.CalledProcessError(1, "node")
+
+    monkeypatch.setattr(serve_cmd.subprocess, "run", fake_run)
+    assert serve_cmd._node_major_version("/usr/bin/node") is None
+
+
+def test_node_major_version_returns_none_on_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(*_args: Any, **_kwargs: Any) -> _FakeCompleted:
+        raise OSError("not executable")
+
+    monkeypatch.setattr(serve_cmd.subprocess, "run", fake_run)
+    assert serve_cmd._node_major_version("/missing/node") is None
+
+
+def test_node_major_version_returns_none_on_garbage_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(*_args: Any, **_kwargs: Any) -> _FakeCompleted:
+        return _FakeCompleted("not a version string\n")
+
+    monkeypatch.setattr(serve_cmd.subprocess, "run", fake_run)
+    assert serve_cmd._node_major_version("/usr/bin/node") is None
+
+
+def test_minimum_node_major_matches_next_engines() -> None:
+    """If this trips, packages/web/package.json `engines.node` bumped and the
+    constant in serve_cmd needs to be updated to match."""
+    assert serve_cmd._NODE_MIN_MAJOR == 20


### PR DESCRIPTION
Closes #276.

## Summary

`repowise serve` only checked whether `node` was on PATH, not its version. When the user had an old Node.js installed (e.g. Node 12 on the WSL Debian setup from the issue), the gate let it through and the bundled Next.js 15 runtime then crashed with cryptic syntax errors like:

```
SyntaxError: Unexpected token '?'
```

— Node choking on the nullish coalescing operator (`??`) inside `next/dist/lib/picocolors.js`. The frontend never reaches the browser, so the user sees the API start up cleanly and then `localhost:3000` refuses connections.

Now `_node_major_version` parses `node --version` (with timeout, treating any parse/exec failure as "unknown" rather than fatal) and the serve command compares it against `_NODE_MIN_MAJOR = 20`, which matches `engines.node` in `packages/web/package.json`. If Node is too old, we take the same "API server only" fallback path used when Node is missing, but with a message that explains *why*:

```
Node.js 12 is too old for the bundled web UI (requires 20+) — starting API server only.
Upgrade Node.js to 20+ or use Docker:
  docker run -p 7337:7337 -p 3000:3000 -v .repowise:/data repowise
```

Unknown-version (couldn't run or parse `node --version`) still attempts the frontend — better than refusing to try, and matches existing behavior.

## Test plan

7 new tests in `tests/unit/cli/test_serve_node_version.py`:

- [x] Parses standard `v20.11.1` output → major `20`
- [x] Parses old `v12.22.12` output → major `12` (the issue #276 scenario)
- [x] Handles output without leading `v` (`18.20.3`)
- [x] Returns `None` on `CalledProcessError`
- [x] Returns `None` on `OSError` (binary not executable)
- [x] Returns `None` on garbage output
- [x] Pinning test: `_NODE_MIN_MAJOR == 20` matches `packages/web/package.json` `engines.node` — trips if that requirement bumps

```text
$ .venv\Scripts\python.exe -m pytest tests/unit/cli/test_serve_node_version.py -v
============================== 7 passed in 0.06s ==============================
```

`ruff format` + `ruff check` clean on the changed files.

## Notes

- 5-second timeout on `node --version` so a wedged binary can't hang `serve` startup.
- The minimum-major constant lives next to the version helper with a comment pointing at `packages/web/package.json` so the two stay in sync.