### PR TITLE
fix(cli): force UTF-8 stdio so cp1252 Windows shells don't crash on '↳'/'✓'

### DIFF
--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -6,4 +6,14 @@ git signals, dead code detection, architectural decisions, and
 AI-generated documentation.
 """
 
+from repowise.cli._stdio import _ensure_utf8_stdio
+
+# Reconfigure stdout/stderr to UTF-8 with ``errors="replace"`` before any
+# Rich Console is constructed downstream. Without this, Windows shells
+# defaulting to cp1252 crash ``repowise init`` (and any other Rich-driven
+# command) mid-pipeline when a non-ASCII glyph like ``↳`` or ``✓`` is
+# printed — see issue #271. Safe and silent on Linux/macOS where stdio
+# is already UTF-8.
+_ensure_utf8_stdio()
+
 __version__ = "0.13.0"

--- a/packages/cli/src/repowise/cli/_stdio.py
+++ b/packages/cli/src/repowise/cli/_stdio.py
@@ -1,0 +1,48 @@
+"""Standard I/O hardening for the repowise CLI.
+
+Imported at the top of :mod:`repowise.cli` so it runs before any Rich
+``Console`` is built. Centralised here (rather than inlined in
+``__init__.py``) so the behavior is unit-testable.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+from typing import IO
+
+
+def _ensure_utf8_stdio() -> None:
+    """Reconfigure ``sys.stdout``/``sys.stderr`` to UTF-8 with replacement.
+
+    Windows shells (``cmd.exe``, default PowerShell) ship with a cp1252
+    code page. Rich falls back to its legacy Windows renderer, which
+    encodes every printed line through the active code page — any
+    non-ASCII glyph in repowise's progress UI (``↳``, ``✓``) then raises
+    ``UnicodeEncodeError`` and aborts the run mid-pipeline (issue #271).
+
+    Reconfiguring with ``errors="replace"`` means even if the underlying
+    console can't render a glyph, the write succeeds (substituting a
+    placeholder) and the pipeline keeps running. ``errors="replace"`` is
+    chosen over ``"backslashreplace"`` because the output is
+    user-visible — a single ``?`` is friendlier than ``\\u21b3``.
+
+    No-op on streams that lack ``reconfigure`` (e.g. when the CLI is
+    embedded and stdout has been swapped for an arbitrary writer) and
+    silently tolerant of any reconfigure failure — the original behavior
+    is preserved in that case rather than masked by an exception.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        _reconfigure(stream)
+
+
+def _reconfigure(stream: IO[str] | None) -> None:
+    if stream is None:
+        return
+    reconfigure = getattr(stream, "reconfigure", None)
+    if reconfigure is None:
+        return
+    # OSError: stream is detached or closed.
+    # ValueError: unsupported argument on a non-text wrapper.
+    with contextlib.suppress(OSError, ValueError):
+        reconfigure(encoding="utf-8", errors="replace")

--- a/tests/unit/cli/test_stdio.py
+++ b/tests/unit/cli/test_stdio.py
@@ -1,0 +1,98 @@
+"""Regression tests for stdio UTF-8 reconfiguration (issue #271).
+
+The bug: Windows shells default to cp1252 and `repowise init` crashes with
+`UnicodeEncodeError: 'charmap' codec can't encode character '↳'` when Rich
+tries to render progress sub-step glyphs. The CLI now reconfigures stdout
+and stderr to UTF-8 with `errors="replace"` at import time so the legacy
+Windows renderer never raises.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+import pytest
+
+from repowise.cli import _stdio
+
+
+class _RecordingStream:
+    """Minimal stand-in for sys.stdout with a `reconfigure` method."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def reconfigure(self, **kwargs: Any) -> None:
+        self.calls.append(kwargs)
+
+
+class _NoReconfigureStream:
+    """Stream without `reconfigure` (e.g. a swapped-in StringIO)."""
+
+    def write(self, _data: str) -> int:
+        return 0
+
+
+class _RaisingStream:
+    def reconfigure(self, **_kwargs: Any) -> None:
+        raise OSError("stream is detached")
+
+
+def test_reconfigure_sets_utf8_with_replace() -> None:
+    stream = _RecordingStream()
+    _stdio._reconfigure(stream)
+    assert stream.calls == [{"encoding": "utf-8", "errors": "replace"}]
+
+
+def test_reconfigure_tolerates_missing_method() -> None:
+    """A StringIO has no `reconfigure` — must not raise."""
+    _stdio._reconfigure(_NoReconfigureStream())
+    _stdio._reconfigure(io.StringIO())
+
+
+def test_reconfigure_swallows_oserror() -> None:
+    """Detached or closed streams raise OSError — must be silent."""
+    _stdio._reconfigure(_RaisingStream())
+
+
+def test_reconfigure_tolerates_none_stream() -> None:
+    _stdio._reconfigure(None)
+
+
+def test_ensure_utf8_stdio_handles_swapped_streams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`pytest -s` and `capsys` swap stdout for buffers without `reconfigure`.
+    The hardening function must not raise in either case — otherwise importing
+    the CLI under test would crash."""
+    monkeypatch.setattr("sys.stdout", io.StringIO())
+    monkeypatch.setattr("sys.stderr", io.StringIO())
+    _stdio._ensure_utf8_stdio()
+
+
+def test_ensure_utf8_stdio_reconfigures_both_streams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    out = _RecordingStream()
+    err = _RecordingStream()
+    monkeypatch.setattr("sys.stdout", out)
+    monkeypatch.setattr("sys.stderr", err)
+
+    _stdio._ensure_utf8_stdio()
+
+    assert out.calls == [{"encoding": "utf-8", "errors": "replace"}]
+    assert err.calls == [{"encoding": "utf-8", "errors": "replace"}]
+
+
+def test_replace_errors_actually_survives_cp1252_glyph() -> None:
+    """End-to-end: a TextIOWrapper around a BytesIO using cp1252+replace
+    must accept the `↳` glyph without raising — proving the chosen error
+    handler is the right one."""
+    raw = io.BytesIO()
+    wrapper = io.TextIOWrapper(raw, encoding="cp1252", errors="replace")
+    wrapper.write("  ↳ betweenness centrality ✓\n")
+    wrapper.flush()
+    # The exact replacement char varies, but the important property is
+    # no exception was raised and *some* bytes were written.
+    assert raw.getvalue()


### PR DESCRIPTION
Closes #271.

## Summary

On Windows shells defaulting to cp1252 (`cmd.exe`, default PowerShell sessions without WT_SESSION), Rich falls back to its legacy Windows renderer which encodes every printed line through the active code page. The first non-ASCII glyph in repowise's progress UI — `↳` in `_timed_step`, `✓` in the sub-step ticks — raises `UnicodeEncodeError: 'charmap' codec can't encode character '↳'` and aborts the run mid-pipeline. Partial state has already been written by the time it triggers, so recovery depends on `--resume` working.

The fix reconfigures `sys.stdout` and `sys.stderr` to UTF-8 with `errors="replace"` at the top of `repowise.cli`, before any Rich `Console` is constructed downstream. `errors="replace"` means even a stream that genuinely can't render a glyph still writes a placeholder rather than crashing, so the pipeline always reaches completion. Streams that are already UTF-8 (Linux, macOS, Windows Terminal with WT_SESSION) are unaffected.

Adopted the reporter's suggested fix (option 1) — cheapest, broad-stroke, doesn't touch Rich internals.

## Implementation notes

- New helper module `repowise/cli/_stdio.py` exposes `_ensure_utf8_stdio()`, called from `repowise/cli/__init__.py` so it runs on any CLI import path.
- Tolerant of swapped-in streams without a `reconfigure` method (e.g. `pytest -s`, embedding harnesses that pass a `StringIO`) and silent on `OSError`/`ValueError` from detached or non-text wrappers — the goal is never to *introduce* a crash while fixing one.

## Test plan

7 new tests in `tests/unit/cli/test_stdio.py`:

- [x] `_reconfigure` passes `encoding="utf-8", errors="replace"` to the stream
- [x] tolerates streams without a `reconfigure` method (`StringIO`)
- [x] swallows `OSError` from detached streams
- [x] tolerates `None` stream
- [x] `_ensure_utf8_stdio` doesn't raise when both stdout/stderr are swapped `StringIO`
- [x] `_ensure_utf8_stdio` reconfigures both stdout and stderr
- [x] End-to-end: a cp1252 `TextIOWrapper` with `errors="replace"` accepts the exact `↳ … ✓` line from the bug report without raising

```text
$ .venv\Scripts\python.exe -m pytest tests/unit/cli/ -q
============================= 287 passed in 6.42s =============================
```

`ruff format` + `ruff check` clean on the changed files.

## Why not the other suggested fixes

The reporter listed three other options. Skipped because:

- **Option 2 (build the Console with a UTF-8 file)** — would only fix the shared `console` in `helpers.py`; any other module that constructs its own `Console()` would still hit the same trap. Reconfiguring stdio fixes them all at once.
- **Option 3 (ASCII-only fallback for `↳`/`✓`)** — would have to be applied at every print site, and Windows Terminal users would lose the nicer glyphs unnecessarily.
- **Option 4 (just document the env var)** — leaves the crash in place for users who don't read README first.