### PR TITLE
fix(init): repair What's next spacing and lead with `repowise serve`

### DIFF
--- a/packages/cli/src/repowise/cli/ui/result_panels.py
+++ b/packages/cli/src/repowise/cli/ui/result_panels.py
@@ -62,6 +62,17 @@ def build_analysis_summary_panel(
     )
 
 
+def _render_what_next_lines(next_steps: list[tuple[str, str]]) -> list[str]:
+    """Format the ``What's next:`` rows for the completion panel.
+
+    Pads short commands to a 28-column gutter for alignment, but always
+    inserts at least one space between command and description so a long
+    command like ``repowise init --provider gemini`` (>28 chars) doesn't
+    run straight into its description text.
+    """
+    return [f"  {cmd:<28} {desc}" for cmd, desc in next_steps]
+
+
 def build_completion_panel(
     title: str,
     metrics: list[tuple[str, str]],
@@ -85,8 +96,8 @@ def build_completion_panel(
     if next_steps:
         parts.append(Text(""))
         parts.append(Text("  What's next:", style="bold"))
-        for cmd, desc in next_steps:
-            parts.append(Text(f"  {cmd:<28}{desc}", style="dim"))
+        for line in _render_what_next_lines(next_steps):
+            parts.append(Text(line, style="dim"))
 
     return Panel(
         Group(*parts),
@@ -119,7 +130,11 @@ def build_contextual_next_steps(
         steps.append(("repowise init", "run full mode: complete git history + generate docs"))
         steps.append(("repowise mcp .", "start MCP server for AI assistants now"))
     elif index_only:
-        steps.append(("repowise mcp .", "start MCP server for AI assistants"))
+        # MCP is already auto-registered by `init`, so `repowise serve` is a
+        # more useful headline next step — it launches the dashboard where the
+        # graph, hotspots, dead code, and decisions are easier to browse than
+        # via the CLI.
+        steps.append(("repowise serve", "launch the dashboard at http://localhost:3000"))
         steps.append(("repowise init --provider gemini", "generate full documentation"))
     else:
         steps.append(("repowise mcp .", "start MCP server for AI assistants"))

--- a/tests/unit/cli/test_fast_mode_offer.py
+++ b/tests/unit/cli/test_fast_mode_offer.py
@@ -42,7 +42,34 @@ def test_next_steps_index_only_without_fast():
     assert any("--provider" in c for c in cmds)  # the existing generate hint
 
 
+def test_next_steps_index_only_recommends_serve_as_first_step():
+    """`repowise serve` (the dashboard) is the headline next step after an
+    index-only run — MCP is already auto-registered by init."""
+    steps = build_contextual_next_steps(index_only=True, fast_mode=False)
+    assert steps[0][0] == "repowise serve"
+
+
 def test_next_steps_full_mode():
     steps = build_contextual_next_steps(index_only=False)
     cmds = [c for c, _ in steps]
     assert any("search" in c for c in cmds)
+
+
+def test_next_steps_rendered_lines_have_space_before_description():
+    """Regression: long commands like ``repowise init --provider gemini``
+    (>28 chars) used to run straight into the description because the format
+    spec only padded *up to* 28 columns. Every rendered line must have at
+    least one space between the command and its description."""
+    from repowise.cli.ui.result_panels import _render_what_next_lines
+
+    steps = build_contextual_next_steps(index_only=True, fast_mode=False)
+    lines = _render_what_next_lines(steps)
+    for cmd, desc in steps:
+        matching = [line for line in lines if cmd in line and desc in line]
+        assert matching, f"expected a rendered line for ({cmd!r}, {desc!r})"
+        line = matching[0]
+        idx_cmd_end = line.index(cmd) + len(cmd)
+        idx_desc = line.index(desc, idx_cmd_end)
+        gap = line[idx_cmd_end:idx_desc]
+        assert gap.strip() == "", f"unexpected non-space chars between cmd and desc: {gap!r}"
+        assert len(gap) >= 1, f"no separator between {cmd!r} and {desc!r}: {line!r}"


### PR DESCRIPTION
Two small post-init UX fixes spotted while validating the v0.14.0 release candidate against a real repo.

## Summary

### 1. `geminigenerate` — missing space between command and description

The completion panel's "What's next" rows were rendered with `f"  {cmd:<28}{desc}"`. The `<28` only *left-pads* short commands to the gutter — it doesn't *insert* any separator. So `repowise init --provider gemini` (31 chars) overflowed the gutter and ran straight into its description:

```
repowise init --provider geminigenerate full documentation
                                ^^^ no space
```

Changed to `f"  {cmd:<28} {desc}"` so there's always at least one space between command and description. Short commands stay column-aligned (gutter pad), long commands still get a separator. Extracted the formatter as `_render_what_next_lines` so the spacing rule is unit-testable.

### 2. Lead with `repowise serve` after an index-only run

MCP is already auto-registered by `init` (the panel above the next-steps block shows `✓ Claude Code MCP registered`), so the existing `repowise mcp .` suggestion was pointing the user at something they already had. Replaced it with `repowise serve` — the dashboard at `http://localhost:3000` shows the graph, hotspots, dead code, and decisions in a form that's much easier to browse than the CLI.

Before (index-only):
```
What's next:
  repowise mcp .                   start MCP server for AI assistants
  repowise init --provider geminigenerate full documentation
  repowise dead-code               explore 122 dead code findings
  repowise risk conf.py            assess risk for top hotspot
```

After:
```
What's next:
  repowise serve                   launch the dashboard at http://localhost:3000
  repowise init --provider gemini  generate full documentation
  repowise dead-code               explore 122 dead code findings
  repowise risk conf.py            assess risk for top hotspot
```

## Test plan

9 tests in `tests/unit/cli/test_fast_mode_offer.py` pass, including two new ones:

- [x] `test_next_steps_index_only_recommends_serve_as_first_step` — pins `repowise serve` as the headline next step after an index-only run
- [x] `test_next_steps_rendered_lines_have_space_before_description` — regression test for the spacing bug; iterates over every rendered line and asserts at least one whitespace gap between command and description, with no garbage chars in between

```text
$ .venv\Scripts\python.exe -m pytest tests/unit/cli/test_fast_mode_offer.py -q
9 passed in 0.42s
```

Existing tests around fast-mode offering and full-mode hints unchanged. `ruff format` + `ruff check` clean.