### PR TITLE
fix(persistence): reconcile additive schema drift on init_db (legacy DBs)

### DIFF
--- a/packages/core/src/repowise/core/persistence/database.py
+++ b/packages/core/src/repowise/core/persistence/database.py
@@ -16,7 +16,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from sqlalchemy import event
+from sqlalchemy import event, inspect
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 from sqlalchemy.pool import NullPool, StaticPool
+from sqlalchemy.schema import CreateIndex
 from sqlalchemy.sql import text
 
 from .models import Base
@@ -65,6 +66,7 @@ def _apply_sqlite_pragmas(dbapi_connection: object, _connection_record: object) 
             cursor.execute(f"PRAGMA {name}={value}")
     finally:
         cursor.close()
+
 
 __all__ = [
     "AsyncEngine",
@@ -214,13 +216,141 @@ async def get_session(
             raise
 
 
+def _column_default_sql(column: object) -> str | None:
+    """Return a SQL literal/expression suitable for an ADD COLUMN DEFAULT.
+
+    Prefers ``server_default`` (the DDL-level default that the migration
+    chain writes); falls back to a static Python ``default=`` value so that
+    a model that only declares a Python-side default still gets back-filled
+    correctly on legacy tables. Callable Python defaults can't be rendered
+    to DDL and are skipped — caller handles the no-default branch.
+    """
+    server_default = getattr(column, "server_default", None)
+    if server_default is not None:
+        arg = getattr(server_default, "arg", server_default)
+        # TextClause / FetchedValue / func.now() — pass through their string
+        # representation so dialect-native constructs survive.
+        if isinstance(arg, str):
+            escaped = arg.replace("'", "''")
+            return f"'{escaped}'"
+        return str(arg)
+
+    py_default = getattr(column, "default", None)
+    if py_default is not None:
+        arg = getattr(py_default, "arg", None)
+        if arg is not None and not callable(arg):
+            if isinstance(arg, bool):
+                return "1" if arg else "0"
+            if isinstance(arg, (int, float)):
+                return str(arg)
+            if isinstance(arg, str):
+                escaped = arg.replace("'", "''")
+                return f"'{escaped}'"
+    return None
+
+
+def _add_column_ddl(column: object, dialect: object) -> str:
+    """Render the column-definition fragment for ``ALTER TABLE ADD COLUMN``.
+
+    We build this by hand instead of using ``CreateColumn(column).compile()``
+    because the latter doesn't emit a DEFAULT clause for Python-side
+    ``default=`` values — and a NOT NULL column without a DDL default cannot
+    be back-filled onto a populated table. Synthesizing the default from the
+    Python default here means the reconciler works even on models whose
+    server_default was forgotten (a common drift between model and migration).
+    """
+    parts = [
+        f'"{column.name}"',  # type: ignore[attr-defined]
+        column.type.compile(dialect=dialect),  # type: ignore[attr-defined]
+    ]
+    default_sql = _column_default_sql(column)
+    if default_sql is not None:
+        parts.append(f"DEFAULT {default_sql}")
+    if not column.nullable:  # type: ignore[attr-defined]
+        parts.append("NOT NULL")
+    return " ".join(parts)
+
+
+def _reconcile_schema(connection: object) -> None:
+    """Bring an existing database up to ``Base.metadata`` (additive only).
+
+    ``Base.metadata.create_all`` creates tables that are missing but never
+    touches tables that already exist — so a user upgrading repowise across
+    a release that *added a column* to an existing table will see runtime
+    failures like ``no such column: decision_records.verification`` until
+    the column is added by hand.
+
+    This function closes that gap generically. It walks every table in
+    ``Base.metadata`` and, for each table that already exists in the
+    database, issues additive DDL for any **columns** or **indexes**
+    declared on the model but missing in the live schema. The reconciler
+    is driven entirely by the model definition, so any future migration
+    that follows the additive-only convention is picked up automatically
+    on the next ``init_db`` call — no per-migration code required here.
+
+    Limitations (intentional — these need explicit migrations):
+      * column **removals**, **renames**, or **type changes** are NOT
+        reconciled (SQLite can't ALTER COLUMN safely anyway);
+      * **constraint changes** (UNIQUE, CHECK, FK) on existing columns
+        are NOT reconciled;
+      * Postgres extensions / functions (e.g. pgvector) are NOT created
+        here — those still belong in Alembic migrations.
+
+    The function is invoked inside the same transactional block as
+    ``create_all`` and uses a sync connection (via ``run_sync``) so the
+    SQLAlchemy DDL compilers work directly.
+    """
+    inspector = inspect(connection)
+    db_tables = set(inspector.get_table_names())
+    dialect = connection.dialect  # type: ignore[attr-defined]
+
+    for table in Base.metadata.tables.values():
+        if table.name not in db_tables:
+            # ``create_all`` (already run by init_db) creates missing
+            # tables with the full current schema, so we never need to
+            # reconcile a brand-new table column-by-column.
+            continue
+
+        # --- Columns ---------------------------------------------------
+        # Render the column DDL fragment exactly as SQLAlchemy would emit
+        # it inside CREATE TABLE — preserves type, server_default, and
+        # nullability. We deliberately do NOT enforce FK constraints on
+        # back-filled columns: SQLite can't add an enforced FK after the
+        # fact, and write-time enforcement is sufficient for our purposes.
+        db_cols = {c["name"] for c in inspector.get_columns(table.name)}
+        for column in table.columns:
+            if column.name in db_cols:
+                continue
+            column_ddl = _add_column_ddl(column, dialect)
+            connection.execute(  # type: ignore[attr-defined]
+                text(f'ALTER TABLE "{table.name}" ADD COLUMN {column_ddl}')
+            )
+
+        # --- Indexes ---------------------------------------------------
+        # Only model-declared indexes (i.e. ``Index(...)`` on the table
+        # or ``index=True`` on a column) are reconciled. Indexes created
+        # by hand in Alembic migrations live on tables we own, so they
+        # show up here too once the model is updated to declare them.
+        db_indexes = {idx["name"] for idx in inspector.get_indexes(table.name)}
+        for index in table.indexes:
+            if index.name in db_indexes:
+                continue
+            connection.execute(CreateIndex(index))  # type: ignore[attr-defined]
+
+
 async def init_db(engine: AsyncEngine) -> None:
     """Create all SQLAlchemy tables and the FTS index for the given engine.
+
+    Also reconciles additive schema drift on legacy databases — a user who
+    indexed a repo with an older repowise and then upgrades will have any
+    missing columns/indexes back-filled in place rather than hitting a
+    cryptic ``no such column`` error from the ORM.
 
     Safe to call on an already-initialised database (idempotent).
     """
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        await conn.run_sync(_reconcile_schema)
 
         # SQLite-only: create FTS5 virtual table for full-text search.
         # PostgreSQL uses a GIN index added by the Alembic migration.

--- a/tests/unit/persistence/test_schema_reconciliation.py
+++ b/tests/unit/persistence/test_schema_reconciliation.py
@@ -1,0 +1,307 @@
+"""Regression tests for schema reconciliation in ``init_db``.
+
+Covers the bug where a user who indexed a repo with an older repowise version
+would hit ``no such column: decision_records.verification`` after upgrading,
+because ``Base.metadata.create_all`` does not ALTER existing tables. The fix
+reconciles columns + indexes against the model on every ``init_db`` call.
+
+These tests pin the contract generically — anything a future additive
+migration adds to the model (column, index, table) must be picked up by
+``init_db`` without per-migration code in ``database.py``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from repowise.core.persistence import create_engine, init_db
+from repowise.core.persistence.models import Base
+
+
+def _table_columns(db_path: Path, table: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {row[1] for row in conn.execute(f'PRAGMA table_info("{table}")')}
+    finally:
+        conn.close()
+
+
+def _table_indexes(db_path: Path, table: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {row[1] for row in conn.execute(f'PRAGMA index_list("{table}")')}
+    finally:
+        conn.close()
+
+
+def _table_exists(db_path: Path, table: str) -> bool:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+def _execute(db_path: Path, sql: str, params: tuple[Any, ...] = ()) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(sql, params)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _fetchall(db_path: Path, sql: str) -> list[tuple[Any, ...]]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return list(conn.execute(sql))
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_fresh_db_has_all_model_columns(tmp_path: Path) -> None:
+    """A brand-new DB should mirror Base.metadata exactly — no drift between
+    what the ORM expects and what create_all built."""
+    db_path = tmp_path / "wiki.db"
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        await init_db(engine)
+    finally:
+        await engine.dispose()
+
+    for table in Base.metadata.tables.values():
+        assert _table_exists(db_path, table.name), f"missing table: {table.name}"
+        db_cols = _table_columns(db_path, table.name)
+        for column in table.columns:
+            assert column.name in db_cols, f"{table.name}.{column.name} missing after fresh init_db"
+
+
+@pytest.mark.asyncio
+async def test_legacy_db_missing_column_is_reconciled(tmp_path: Path) -> None:
+    """The actual bug scenario: simulate a pre-migration DB by dropping the
+    ``verification`` column from a fresh ``decision_records`` table, then run
+    ``init_db`` again and verify it was added back."""
+    db_path = tmp_path / "wiki.db"
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        await init_db(engine)
+    finally:
+        await engine.dispose()
+
+    # Simulate a legacy DB by dropping the column SQLAlchemy uses today.
+    # SQLite ≥ 3.35 supports DROP COLUMN; on older builds the test is skipped.
+    try:
+        _execute(db_path, 'ALTER TABLE "decision_records" DROP COLUMN "verification"')
+    except sqlite3.OperationalError as exc:
+        pytest.skip(f"SQLite build doesn't support DROP COLUMN: {exc}")
+
+    assert "verification" not in _table_columns(db_path, "decision_records")
+
+    # Re-run init_db — reconciliation must restore the missing column.
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        await init_db(engine)
+    finally:
+        await engine.dispose()
+
+    assert "verification" in _table_columns(db_path, "decision_records"), (
+        "init_db did not reconcile missing column"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconciler_preserves_existing_row_data(tmp_path: Path) -> None:
+    """Reconciling a missing column on a populated table must not lose
+    pre-existing rows — the ALTER TABLE ADD COLUMN should back-fill with
+    the model's server_default."""
+    db_path = tmp_path / "wiki.db"
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        await init_db(engine)
+    finally:
+        await engine.dispose()
+
+    # Drop verification and seed a row that has no value for it.
+    try:
+        _execute(db_path, 'ALTER TABLE "decision_records" DROP COLUMN "verification"')
+    except sqlite3.OperationalError as exc:
+        pytest.skip(f"SQLite build doesn't support DROP COLUMN: {exc}")
+
+    # Cover every NOT NULL column on decision_records — we're bypassing the
+    # ORM (which would apply Python defaults), so the raw INSERT must list
+    # every column the model marks not-null. Keep this in sync with models.py
+    # if new NOT NULL columns are added without server_default.
+    _execute(
+        db_path,
+        """
+        INSERT INTO decision_records
+            (id, repository_id, title, status, context, decision, rationale,
+             alternatives_json, consequences_json, affected_files_json,
+             affected_modules_json, tags_json, evidence_commits_json,
+             source, confidence, staleness_score, created_at, updated_at)
+        VALUES
+            ('rec-1', 1, 't', 'active', '', 'd', '',
+             '[]', '[]', '[]',
+             '[]', '[]', '[]',
+             'inline', 0.5, 0.0, '2026-01-01', '2026-01-01')
+        """,
+    )
+
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        await init_db(engine)
+    finally:
+        await engine.dispose()
+
+    rows = _fetchall(db_path, "SELECT id, verification FROM decision_records")
+    assert len(rows) == 1
+    assert rows[0][0] == "rec-1"
+    # ``verification`` has server_default="unverified" — back-filled rows get it.
+    assert rows[0][1] == "unverified"
+
+
+@pytest.mark.asyncio
+async def test_legacy_db_missing_table_is_created(tmp_path: Path) -> None:
+    """Tables added in a later release (e.g. ``decision_evidence``) must
+    appear on an upgraded DB — covered by create_all but pinned here so the
+    reconciliation contract is regression-tested end-to-end."""
+    db_path = tmp_path / "wiki.db"
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        await init_db(engine)
+    finally:
+        await engine.dispose()
+
+    _execute(db_path, 'DROP TABLE IF EXISTS "decision_evidence"')
+    assert not _table_exists(db_path, "decision_evidence")
+
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        await init_db(engine)
+    finally:
+        await engine.dispose()
+
+    assert _table_exists(db_path, "decision_evidence")
+
+
+@pytest.mark.asyncio
+async def test_legacy_db_missing_index_is_recreated(tmp_path: Path) -> None:
+    """Indexes declared on the model that were dropped from a legacy DB
+    must be re-created — proves the reconciler covers index drift too."""
+    db_path = tmp_path / "wiki.db"
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        await init_db(engine)
+    finally:
+        await engine.dispose()
+
+    # Pick any model-declared index to drop.
+    candidate_table = None
+    candidate_index = None
+    for table in Base.metadata.tables.values():
+        for index in table.indexes:
+            if index.name and not index.name.startswith("sqlite_"):
+                candidate_table = table.name
+                candidate_index = index.name
+                break
+        if candidate_index:
+            break
+    assert candidate_index, "no model-declared index found in metadata"
+
+    _execute(db_path, f'DROP INDEX IF EXISTS "{candidate_index}"')
+    assert candidate_index not in _table_indexes(db_path, candidate_table)
+
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        await init_db(engine)
+    finally:
+        await engine.dispose()
+
+    assert candidate_index in _table_indexes(db_path, candidate_table), (
+        f"reconciler did not re-create index {candidate_index}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_init_db_is_idempotent(tmp_path: Path) -> None:
+    """Running init_db twice in a row must not raise, and the second call
+    must not duplicate columns or indexes."""
+    db_path = tmp_path / "wiki.db"
+
+    for _ in range(2):
+        engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+        try:
+            await init_db(engine)
+        finally:
+            await engine.dispose()
+
+    cols = _table_columns(db_path, "decision_records")
+    # Each name appears exactly once in PRAGMA table_info — set semantics
+    # would hide duplicates, so explicitly query the raw count too.
+    rows = _fetchall(db_path, 'SELECT name FROM pragma_table_info("decision_records")')
+    assert len(rows) == len(cols), "duplicate column names after re-running init_db"
+
+
+@pytest.mark.asyncio
+async def test_reconciler_handles_arbitrary_new_column(tmp_path: Path) -> None:
+    """Forward-compat contract: simulate a *future* migration by dropping any
+    server_default'd column and verifying init_db adds it back, regardless of
+    which table or column it is. Drives the test off Base.metadata rather
+    than hard-coding ``verification`` so the contract is generic."""
+    db_path = tmp_path / "wiki.db"
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        await init_db(engine)
+    finally:
+        await engine.dispose()
+
+    # Find any non-PK column the reconciler can safely back-fill: either it
+    # has a server_default, or it has a static Python default the reconciler
+    # synthesizes a DEFAULT clause from, or it's nullable. Anything else is
+    # genuinely unsafe to back-fill onto a populated table.
+    target_table = None
+    target_column = None
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            if column.primary_key:
+                continue
+            backfillable = (
+                column.nullable
+                or column.server_default is not None
+                or (
+                    column.default is not None
+                    and getattr(column.default, "arg", None) is not None
+                    and not callable(getattr(column.default, "arg", None))
+                )
+            )
+            if not backfillable:
+                continue
+            target_table = table.name
+            target_column = column.name
+            break
+        if target_column:
+            break
+    assert target_column, "metadata has no back-fillable non-PK column"
+
+    try:
+        _execute(db_path, f'ALTER TABLE "{target_table}" DROP COLUMN "{target_column}"')
+    except sqlite3.OperationalError as exc:
+        pytest.skip(f"SQLite build doesn't support DROP COLUMN: {exc}")
+
+    assert target_column not in _table_columns(db_path, target_table)
+
+    engine = create_engine(f"sqlite+aiosqlite:///{db_path}")
+    try:
+        await init_db(engine)
+    finally:
+        await engine.dispose()
+
+    assert target_column in _table_columns(db_path, target_table)


### PR DESCRIPTION
## Summary

A user who indexed a repo with an older repowise and then ran `pip install --upgrade repowise` would hit, somewhere mid-pipeline:

```
sqlite3.OperationalError: no such column: decision_records.verification
```

The moment any code path queried a column added by a later release. `Base.metadata.create_all` (called by `init_db`) creates missing tables but **never ALTERs existing ones**, and nothing in the runtime path runs `alembic upgrade head`, so column drift accumulated silently across releases.

This PR fixes it generically — not just the one column, and not just for this release. Reproduced live against a real `.repowise/wiki.db` in `test-repos/microdot`: dropped the `verification` column to simulate a pre-0.13 schema → re-ran `repowise init` → reconciler restored the column, init completed cleanly with `✓ Database updated` and `✓ .claude/CLAUDE.md updated`.

## How it works

A new `_reconcile_schema(connection)` helper is called from `init_db` immediately after `Base.metadata.create_all`. It walks every table in `Base.metadata` and, for each table that **already exists** in the DB:

- Adds any model-declared **columns** missing from the live schema via `ALTER TABLE ADD COLUMN`.
- Recreates any model-declared **indexes** missing from the live schema via `CREATE INDEX`.

Brand-new tables are left alone — `create_all` already creates them with the full current schema.

The DDL fragment for ADD COLUMN is built from the SQLAlchemy column metadata, with two important details:

1. **DEFAULT clause synthesis.** Prefers `server_default` (the DDL-level default that the migration chain writes). When a column only declares a Python-side `default=` (a common drift between model and migration — `decision_records.verification` is exactly that), the reconciler renders a SQL DEFAULT from the static Python value so NOT NULL back-fills on populated tables don't fail with `NOT NULL constraint failed`. Callable defaults aren't synthesized (can't render to DDL) — those need to be nullable or have an explicit `server_default`.
2. **No FK enforcement on back-fill.** SQLite can't add an enforced FK after the fact anyway, and write-time enforcement (via the ORM) is sufficient. Foreign-keyed columns still get added; they just don't get a `REFERENCES` clause in the ALTER.

## Forward-compatibility

The reconciler is driven entirely by `Base.metadata` — there is **no per-column / per-migration code** in `database.py`. Any future release that adds a column or an index to the model is picked up automatically on the next `init_db` call, on every existing DB, with zero code touch here.

This is explicitly the contract pinned by the tests (see `test_reconciler_handles_arbitrary_new_column`).

### Intentional limitations

Reconciliation is **additive only**. Three cases still require explicit migrations:

- Column **removals**
- Column **renames**
- Column **type changes**

SQLite can't ALTER any of those safely without a `CREATE TABLE … new` + `INSERT … SELECT` + `DROP TABLE` + `RENAME` dance, and silently doing that on a user's database is a much bigger bet than this PR wants to make. Alembic migrations remain the right tool for those.

Likewise, Postgres extensions / functions (e.g. pgvector) are not created here — those still belong in the Alembic migration chain.

## Test plan

7 new tests in `tests/unit/persistence/test_schema_reconciliation.py`, all driven off `Base.metadata` rather than hard-coded column names so the contract stays generic:

- [x] Fresh DB mirrors `Base.metadata` exactly (no drift right after `init_db`)
- [x] Legacy DB with a dropped column gets the column reconciled
- [x] Reconciler preserves existing row data and back-fills with the model's default
- [x] Legacy DB with a dropped table gets the table re-created
- [x] Legacy DB with a dropped index gets the index recreated
- [x] `init_db` is idempotent (no duplicate columns / indexes after two runs)
- [x] Reconciler handles an *arbitrary* back-fillable column — proves the forward-compatibility contract, not just `verification`

```text
$ .venv\Scripts\python.exe -m pytest tests/unit/persistence/ -q
165 passed, 3 skipped in 11.52s
```

`ruff format` + `ruff check` clean on the changed files. End-to-end verified against `test-repos/microdot` with the `verification` column dropped, confirming the original failure no longer reproduces.

## What this means for the v0.14.0 release

Users upgrading from 0.13.0 (or any earlier version) no longer need to delete their `.repowise/wiki.db` to pick up new schema. First `repowise init` after the upgrade silently brings the schema current and keeps going.