### PR TITLE
fix(init): persist exclude_patterns in index-only mode

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd.py
@@ -33,6 +33,7 @@ from repowise.cli.helpers import (
     resolve_repo_path,
     run_async,
     save_config,
+    save_config_partial,
     save_state,
 )
 from repowise.cli.providers import (
@@ -2000,6 +2001,12 @@ def init_command(
         base_state["knowledge_graph"] = build_kg_state(kg)
         save_knowledge_graph_json(repo_path, kg)
     if effective_index_only or provider is None:
+        # Index-only mode skips save_config(); persist exclude_patterns/commit_limit here.
+        save_config_partial(
+            repo_path,
+            exclude_patterns=exclude_patterns if exclude_patterns else None,
+            commit_limit=resolved_commit_limit if commit_limit is not None else None,
+        )
         save_state(repo_path, base_state)
 
     # ---- State + config (full mode only) ----

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -491,6 +491,38 @@ def save_config(
         config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def save_config_partial(
+    repo_path: Path,
+    *,
+    exclude_patterns: list[str] | None = None,
+    commit_limit: int | None = None,
+) -> None:
+    """Merge optional keys into ``.repowise/config.yaml``, preserving existing keys.
+
+    No scalar-only fallback like :func:`save_config`: it would silently drop
+    ``exclude_patterns``, and PyYAML is a hard dependency anyway.
+    """
+    import yaml  # type: ignore[import-untyped]
+
+    updates: dict[str, Any] = {}
+    if exclude_patterns is not None:
+        updates["exclude_patterns"] = exclude_patterns
+    if commit_limit is not None:
+        updates["commit_limit"] = commit_limit
+    if not updates:
+        return
+
+    ensure_repowise_dir(repo_path)
+    config_path = get_repowise_dir(repo_path) / CONFIG_FILENAME
+    existing = load_config(repo_path)
+    existing.update(updates)
+
+    config_path.write_text(
+        yaml.dump(existing, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Provider resolution
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -144,6 +144,35 @@ class TestInitIndexOnly:
         # No pages generated in index-only mode.
         assert state.get("total_pages", 0) == 0
 
+    def test_index_only_persists_clamped_commit_limit_and_excludes(self, runner, work_repo):
+        from repowise.cli.helpers import load_config
+
+        result = runner.invoke(
+            cli,
+            ["init", str(work_repo), "--index-only", "-x", "vendor/", "--commit-limit", "99999"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+        cfg = load_config(work_repo)
+        assert cfg["exclude_patterns"] == ["vendor/"]
+        assert cfg["commit_limit"] == 5000  # 99999 clamped to the 5000 max
+
+    def test_index_only_omits_excludes_when_none_given(self, runner, work_repo):
+        from repowise.cli.helpers import load_config
+
+        result = runner.invoke(
+            cli,
+            ["init", str(work_repo), "--index-only"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+        cfg = load_config(work_repo)
+        # Empty excludes and unset commit-limit must not be written as [] / default.
+        assert "exclude_patterns" not in cfg
+        assert "commit_limit" not in cfg
+
 
 class TestInitDefaultDbLocation:
     def test_creates_repo_local_db_without_env_override(

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -138,6 +138,67 @@ class TestStateFile:
 
 
 # ---------------------------------------------------------------------------
+# save_config_partial
+# ---------------------------------------------------------------------------
+
+
+class TestSaveConfigPartial:
+    def test_save_config_partial_persists_exclude_patterns(self, tmp_path):
+        """save_config_partial should merge keys into existing config.yaml."""
+        from repowise.cli.helpers import load_config, save_config_partial
+
+        rw_dir = tmp_path / ".repowise"
+        rw_dir.mkdir()
+        (rw_dir / "config.yaml").write_text("embedder: minilm\n", encoding="utf-8")
+
+        save_config_partial(tmp_path, exclude_patterns=[".claude/", "tools/"])
+
+        cfg = load_config(tmp_path)
+        assert cfg["exclude_patterns"] == [".claude/", "tools/"]
+        assert cfg["embedder"] == "minilm"  # existing keys preserved
+
+    def test_save_config_partial_noop_when_no_values(self, tmp_path):
+        """save_config_partial with no values should not modify config."""
+        from repowise.cli.helpers import load_config, save_config_partial
+
+        rw_dir = tmp_path / ".repowise"
+        rw_dir.mkdir()
+        (rw_dir / "config.yaml").write_text("embedder: minilm\n", encoding="utf-8")
+
+        save_config_partial(tmp_path)  # no kwargs
+
+        cfg = load_config(tmp_path)
+        assert "exclude_patterns" not in cfg
+        assert cfg["embedder"] == "minilm"
+
+    def test_save_config_partial_creates_config_if_missing(self, tmp_path):
+        """save_config_partial should create config.yaml if it doesn't exist."""
+        from repowise.cli.helpers import load_config, save_config_partial
+
+        rw_dir = tmp_path / ".repowise"
+        rw_dir.mkdir()
+
+        save_config_partial(tmp_path, exclude_patterns=[".claude/"])
+
+        cfg = load_config(tmp_path)
+        assert cfg["exclude_patterns"] == [".claude/"]
+
+    def test_save_config_partial_persists_commit_limit(self, tmp_path):
+        """save_config_partial should persist commit_limit alongside other keys."""
+        from repowise.cli.helpers import load_config, save_config_partial
+
+        rw_dir = tmp_path / ".repowise"
+        rw_dir.mkdir()
+        (rw_dir / "config.yaml").write_text("embedder: minilm\n", encoding="utf-8")
+
+        save_config_partial(tmp_path, commit_limit=500)
+
+        cfg = load_config(tmp_path)
+        assert cfg["commit_limit"] == 500
+        assert cfg["embedder"] == "minilm"
+
+
+# ---------------------------------------------------------------------------
 # Update lock
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Persist `exclude_patterns` and `commit_limit` to `.repowise/config.yaml` when `repowise init` runs in **index-only mode**.

## Why

Index-only init never calls `save_config()`, so `-x/--exclude` and `--commit-limit` flags were silently dropped. That left `repowise update` and the MCP tools with no record of the user's excludes, causing excluded paths to be re-indexed on subsequent runs. This is Issue 4 of #296.

## How

- Add `save_config_partial()` to `cli/helpers.py` — merges optional keys into `config.yaml`, preserving existing keys. Unlike `save_config()`, it has **no scalar-only YAML fallback**, since that fallback would silently drop the `exclude_patterns` list (and PyYAML is a hard dependency anyway).
- Call it from the index-only branch of `init_command`, matching full mode's behavior: clamp `commit_limit` via `resolved_commit_limit` and omit empty excludes (pass `None`).

## Tests

- Unit tests for `save_config_partial` (persist, no-op, create-if-missing, commit_limit).
- Command-level integration tests asserting an index-only `init -x vendor/ --commit-limit 99999` writes `exclude_patterns: ["vendor/"]` and the clamped `commit_limit: 5000`, and that an exclude-less run writes neither key.

This change is Python-only and does not touch `packages/web`.

Closes #296 (Issue 4)