### PR TITLE
fix(dead-code): stop single-file re-index from wiping all findings

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd.py
@@ -368,6 +368,7 @@ def _persist_index_only_update(
     state: dict,
     head: str | None,
     start: float,
+    changed_paths: list[str],
 ) -> None:
     """Persist the index-only update (graph + git + dead-code + health), save
     state, and print the completion line. No LLM regeneration."""
@@ -406,10 +407,12 @@ def _persist_index_only_update(
             if dead_code_report is not None:
                 try:
                     from repowise.core.persistence.crud import (
-                        save_dead_code_findings,
+                        upsert_dead_code_findings,
                     )
 
-                    await save_dead_code_findings(session, repo_id, dead_code_report.findings)
+                    await upsert_dead_code_findings(
+                        session, repo_id, dead_code_report.findings, file_paths=changed_paths
+                    )
                 except Exception as exc:
                     console.print(f"[yellow]Dead-code persist skipped: {exc}[/yellow]")
 
@@ -776,6 +779,7 @@ def update_command(
             state,
             head,
             start,
+            [fd.path for fd in file_diffs],
         )
         return
 
@@ -1068,18 +1072,19 @@ def update_command(
             except Exception:
                 pass  # health persistence is best-effort
 
-        # Persist dead code findings (partial)
-        if dead_code_report and dead_code_report.findings:
+        # Scoped to changed files so unchanged files keep their findings (#295).
+        if dead_code_report is not None:
             try:
                 import dataclasses as _dc_dead
 
-                from repowise.core.persistence.crud import save_dead_code_findings
+                from repowise.core.persistence.crud import upsert_dead_code_findings
 
                 async with get_session(sf) as session:
-                    await save_dead_code_findings(
+                    await upsert_dead_code_findings(
                         session,
                         repo_id,
                         [_dc_dead.asdict(f) for f in dead_code_report.findings],
+                        file_paths=[fd.path for fd in file_diffs],
                     )
             except Exception:
                 pass  # dead code persistence is best-effort

--- a/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
@@ -428,37 +428,16 @@ class DeadCodeAnalyzer:
     def analyze_partial(
         self, affected_files: list[str], config: dict | None = None
     ) -> DeadCodeReport:
-        """Partial analysis for incremental updates."""
-        cfg = config or {}
-        findings: list[DeadCodeFindingData] = []
-        dynamic_patterns = cfg.get("dynamic_patterns", _DEFAULT_DYNAMIC_PATTERNS)
-        whitelist = set(cfg.get("whitelist", []))
+        """Run the full detector suite, then narrow findings to ``affected_files``.
 
+        Persisted via the file-scoped ``upsert_dead_code_findings`` so unchanged
+        files keep their findings. Cross-file effects on unchanged files are not
+        recomputed here; the full ``analyze()`` remains authoritative.
+        """
         affected_set = set(affected_files)
-        for node in affected_set:
-            if node not in self.graph:
-                continue
-            node_data = self.graph.nodes.get(node, {})
-            if node_data.get("language", "unknown") in _NON_CODE_LANGUAGES:
-                continue
-            if self._should_never_flag(node, whitelist):
-                continue
+        full = self.analyze(config)
+        findings = [f for f in full.findings if f.file_path in affected_set]
 
-            in_deg = self.graph.in_degree(node)
-            node_data = self.graph.nodes.get(node, {})
-            if (
-                in_deg == 0
-                and not node_data.get("is_entry_point", False)
-                and not node_data.get("is_test", False)
-            ):
-                finding = self._make_unreachable_finding(node, node_data, dynamic_patterns)
-                if finding:
-                    findings.append(finding)
-
-        min_conf = cfg.get("min_confidence", 0.4)
-        findings = [f for f in findings if f.confidence >= min_conf]
-
-        now = datetime.now(UTC)
         deletable = sum(f.lines for f in findings if f.safe_to_delete)
         high = sum(1 for f in findings if f.confidence >= 0.7)
         medium = sum(1 for f in findings if 0.4 <= f.confidence < 0.7)
@@ -466,7 +445,7 @@ class DeadCodeAnalyzer:
 
         return DeadCodeReport(
             repo_id="",
-            analyzed_at=now,
+            analyzed_at=full.analyzed_at,
             total_findings=len(findings),
             findings=findings,
             deletable_lines=deletable,

--- a/packages/core/src/repowise/core/persistence/crud/analysis.py
+++ b/packages/core/src/repowise/core/persistence/crud/analysis.py
@@ -29,6 +29,53 @@ from ._shared import _BATCH_SIZE
 # ---------------------------------------------------------------------------
 
 
+def _finding_file_path(finding: Any) -> str | None:
+    """Read ``file_path`` from a dataclass-like finding or a plain dict."""
+    if isinstance(finding, dict):
+        return finding.get("file_path")
+    return getattr(finding, "file_path", None)
+
+
+def _dead_code_row_kwargs(finding: Any, repository_id: str) -> dict:
+    """Normalize a DeadCodeFindingData-like object or plain dict into kwargs
+    for the ``DeadCodeFinding`` ORM row."""
+    if hasattr(finding, "kind"):
+        data = {
+            "kind": str(finding.kind.value)
+            if hasattr(finding.kind, "value")
+            else str(finding.kind),
+            "file_path": finding.file_path,
+            "symbol_name": finding.symbol_name,
+            "symbol_kind": finding.symbol_kind,
+            "confidence": finding.confidence,
+            "reason": finding.reason,
+            "last_commit_at": finding.last_commit_at,
+            "commit_count_90d": finding.commit_count_90d,
+            "lines": finding.lines,
+            "package": finding.package,
+            "evidence_json": json.dumps(
+                finding.evidence if hasattr(finding, "evidence") else []
+            ),
+            "safe_to_delete": finding.safe_to_delete,
+            "primary_owner": finding.primary_owner,
+            "age_days": finding.age_days,
+        }
+    else:
+        data = dict(finding)
+        if "evidence" in data:
+            data["evidence_json"] = json.dumps(data.pop("evidence"))
+
+    return {
+        "id": _new_uuid(),
+        "repository_id": repository_id,
+        **{
+            k: v
+            for k, v in data.items()
+            if k not in ("id", "repository_id") and hasattr(DeadCodeFinding, k)
+        },
+    }
+
+
 async def save_dead_code_findings(
     session: AsyncSession,
     repository_id: str,
@@ -48,44 +95,45 @@ async def save_dead_code_findings(
     for i in range(0, len(findings), _BATCH_SIZE):
         batch = findings[i : i + _BATCH_SIZE]
         for finding in batch:
-            # Accept both DeadCodeFindingData-like objects and plain dicts
-            if hasattr(finding, "kind"):
-                data = {
-                    "kind": str(finding.kind.value)
-                    if hasattr(finding.kind, "value")
-                    else str(finding.kind),
-                    "file_path": finding.file_path,
-                    "symbol_name": finding.symbol_name,
-                    "symbol_kind": finding.symbol_kind,
-                    "confidence": finding.confidence,
-                    "reason": finding.reason,
-                    "last_commit_at": finding.last_commit_at,
-                    "commit_count_90d": finding.commit_count_90d,
-                    "lines": finding.lines,
-                    "package": finding.package,
-                    "evidence_json": json.dumps(
-                        finding.evidence if hasattr(finding, "evidence") else []
-                    ),
-                    "safe_to_delete": finding.safe_to_delete,
-                    "primary_owner": finding.primary_owner,
-                    "age_days": finding.age_days,
-                }
-            else:
-                data = dict(finding)
-                if "evidence" in data:
-                    data["evidence_json"] = json.dumps(data.pop("evidence"))
+            session.add(DeadCodeFinding(**_dead_code_row_kwargs(finding, repository_id)))
+        await session.flush()
 
-            session.add(
-                DeadCodeFinding(
-                    id=_new_uuid(),
-                    repository_id=repository_id,
-                    **{
-                        k: v
-                        for k, v in data.items()
-                        if k not in ("id", "repository_id") and hasattr(DeadCodeFinding, k)
-                    },
-                )
-            )
+
+async def upsert_dead_code_findings(
+    session: AsyncSession,
+    repository_id: str,
+    findings: list[Any],
+    *,
+    file_paths: list[str],
+) -> None:
+    """Replace open dead-code findings **only for the given file paths**.
+
+    Used by the incremental ``repowise update`` path so unchanged files keep
+    their findings instead of being wiped on every partial re-index. Callers
+    must pass the full set of *changed* file paths (not just paths that
+    produced findings) so a changed-but-now-clean file has its stale findings
+    removed.
+    """
+    if not file_paths:
+        return
+    allowed = set(file_paths)
+    existing = await session.execute(
+        select(DeadCodeFinding).where(
+            DeadCodeFinding.repository_id == repository_id,
+            DeadCodeFinding.status == "open",
+            DeadCodeFinding.file_path.in_(file_paths),
+        )
+    )
+    for row in existing.scalars().all():
+        await session.delete(row)
+    await session.flush()
+
+    # Insert only within the replaced scope (delete is scoped to file_paths).
+    scoped = [f for f in findings if _finding_file_path(f) in allowed]
+    for i in range(0, len(scoped), _BATCH_SIZE):
+        batch = scoped[i : i + _BATCH_SIZE]
+        for finding in batch:
+            session.add(DeadCodeFinding(**_dead_code_row_kwargs(finding, repository_id)))
         await session.flush()
 
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -275,6 +275,55 @@ class TestUpdateIndexOnly:
         assert state1["last_sync_commit"] != base_commit
 
 
+class TestUpdatePreservesDeadCode:
+    def test_single_file_update_preserves_unchanged_files(self, runner, git_work_repo):
+        """A single-file re-index must not wipe the whole dead-code index;
+        unchanged files keep their findings (regression guard for #295)."""
+        import sqlite3
+
+        runner.invoke(
+            cli, ["init", str(git_work_repo), "--index-only"], catch_exceptions=False
+        )
+
+        db = git_work_repo / ".repowise" / "wiki.db"
+
+        def _counts_by_file() -> dict[str, int]:
+            con = sqlite3.connect(db)
+            try:
+                rows = con.execute(
+                    "SELECT file_path, COUNT(*) FROM dead_code_findings "
+                    "WHERE status='open' GROUP BY file_path"
+                ).fetchall()
+            finally:
+                con.close()
+            return {fp: n for fp, n in rows}
+
+        before = _counts_by_file()
+        if sum(before.values()) == 0:
+            pytest.skip("sample repo produced no dead-code findings to preserve")
+
+        # Pick a real file (skip package-level findings whose path is a directory).
+        changed = next((fp for fp in before if (git_work_repo / fp).is_file()), None)
+        if changed is None:
+            pytest.skip("no file-level dead-code findings to exercise scoping")
+        # Append a blank line: a real content change valid in any language.
+        target = git_work_repo / changed
+        target.write_text(target.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+        _git(["add", "-A"], git_work_repo)
+        _git(["commit", "-m", "touch one file"], git_work_repo)
+
+        result = runner.invoke(
+            cli, ["update", str(git_work_repo), "--index-only"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+
+        after = _counts_by_file()
+        assert sum(after.values()) > 0, "dead-code index was wiped to zero"
+        for fp, n in before.items():
+            if fp != changed:
+                assert after.get(fp, 0) == n, f"unchanged file {fp} lost findings"
+
+
 class TestUpdateFullMock:
     def test_regenerates_pages(self, runner, git_work_repo):
         import json

--- a/tests/unit/dead_code/test_partial.py
+++ b/tests/unit/dead_code/test_partial.py
@@ -1,0 +1,62 @@
+"""Tests for DeadCodeAnalyzer.analyze_partial (incremental update path)."""
+
+from __future__ import annotations
+
+from repowise.core.analysis.dead_code import DeadCodeAnalyzer, DeadCodeKind
+from tests.unit.dead_code._helpers import _build_graph
+
+
+def _graph_with_unused_export():
+    """utils.py exports an unused `orphan`; main.py (entry) imports utils
+    but not `orphan` by name."""
+    return _build_graph(
+        nodes={
+            "pkg/utils.py": {
+                "is_entry_point": False,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 1,
+                "symbols": [
+                    {
+                        "name": "orphan",
+                        "kind": "function",
+                        "visibility": "public",
+                        "decorators": [],
+                        "start_line": 1,
+                        "end_line": 10,
+                        "complexity_estimate": 2,
+                    },
+                ],
+            },
+            "pkg/main.py": {
+                "is_entry_point": True,
+                "is_test": False,
+                "is_api_contract": False,
+                "symbol_count": 10,
+                "symbols": [],
+            },
+        },
+        edges=[("pkg/main.py", "pkg/utils.py", {"imported_names": ["other_func"]})],
+    )
+
+
+def test_analyze_partial_reports_unused_export_for_changed_file():
+    """analyze_partial must run all detectors (not just unreachable files),
+    so a changed file's unused export is reported."""
+    analyzer = DeadCodeAnalyzer(_graph_with_unused_export(), git_meta_map={})
+
+    partial = analyzer.analyze_partial(["pkg/utils.py"])
+
+    by_symbol = {(f.file_path, f.symbol_name): f.kind for f in partial.findings}
+    assert ("pkg/utils.py", "orphan") in by_symbol
+    assert by_symbol[("pkg/utils.py", "orphan")] == DeadCodeKind.UNUSED_EXPORT
+
+
+def test_analyze_partial_scopes_findings_to_affected_files():
+    """Findings for files outside the affected set are not returned."""
+    analyzer = DeadCodeAnalyzer(_graph_with_unused_export(), git_meta_map={})
+
+    partial = analyzer.analyze_partial(["pkg/utils.py"])
+
+    assert partial.findings
+    assert all(f.file_path == "pkg/utils.py" for f in partial.findings)

--- a/tests/unit/persistence/test_dead_code_crud.py
+++ b/tests/unit/persistence/test_dead_code_crud.py
@@ -1,0 +1,98 @@
+"""Unit tests for dead-code findings persistence (file-scoped upsert)."""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from repowise.core.persistence.crud import (
+    save_dead_code_findings,
+    upsert_dead_code_findings,
+)
+from repowise.core.persistence.models import DeadCodeFinding
+from tests.unit.persistence.helpers import insert_repo
+
+
+def _finding(file_path: str, symbol: str, kind: str = "unused_export") -> dict:
+    return {
+        "kind": kind,
+        "file_path": file_path,
+        "symbol_name": symbol,
+        "symbol_kind": "function",
+        "confidence": 1.0,
+        "reason": "test",
+        "last_commit_at": None,
+        "commit_count_90d": 0,
+        "lines": 1,
+        "package": None,
+        "evidence": [],
+        "safe_to_delete": True,
+        "primary_owner": None,
+        "age_days": None,
+    }
+
+
+async def _findings_by_file(session, repo_id: str) -> list[tuple[str, str]]:
+    rows = (
+        await session.execute(
+            select(DeadCodeFinding).where(DeadCodeFinding.repository_id == repo_id)
+        )
+    ).scalars().all()
+    return sorted((r.file_path, r.symbol_name) for r in rows)
+
+
+async def test_upsert_dead_code_findings_scopes_by_file(async_session):
+    """Re-indexing one file replaces only that file's findings; others survive."""
+    repo = await insert_repo(async_session)
+    await save_dead_code_findings(
+        async_session, repo.id, [_finding("a.py", "fa"), _finding("b.py", "fb")]
+    )
+    await async_session.commit()
+
+    await upsert_dead_code_findings(
+        async_session, repo.id, [_finding("a.py", "fa2")], file_paths=["a.py"]
+    )
+    await async_session.commit()
+
+    assert await _findings_by_file(async_session, repo.id) == [
+        ("a.py", "fa2"),
+        ("b.py", "fb"),
+    ]
+
+
+async def test_upsert_dead_code_findings_clears_changed_file_with_no_findings(async_session):
+    """A changed file that is now clean must have its old findings removed."""
+    repo = await insert_repo(async_session)
+    await save_dead_code_findings(async_session, repo.id, [_finding("a.py", "fa")])
+    await async_session.commit()
+
+    await upsert_dead_code_findings(async_session, repo.id, [], file_paths=["a.py"])
+    await async_session.commit()
+
+    assert await _findings_by_file(async_session, repo.id) == []
+
+
+async def test_upsert_dead_code_findings_ignores_out_of_scope_findings(async_session):
+    """Findings whose file_path is outside file_paths are not inserted."""
+    repo = await insert_repo(async_session)
+
+    await upsert_dead_code_findings(
+        async_session,
+        repo.id,
+        [_finding("a.py", "fa"), _finding("b.py", "fb")],
+        file_paths=["a.py"],
+    )
+    await async_session.commit()
+
+    assert await _findings_by_file(async_session, repo.id) == [("a.py", "fa")]
+
+
+async def test_upsert_dead_code_findings_noop_without_file_paths(async_session):
+    """Empty file_paths is a no-op (nothing deleted, nothing inserted)."""
+    repo = await insert_repo(async_session)
+    await save_dead_code_findings(async_session, repo.id, [_finding("a.py", "fa")])
+    await async_session.commit()
+
+    await upsert_dead_code_findings(async_session, repo.id, [_finding("a.py", "x")], file_paths=[])
+    await async_session.commit()
+
+    assert await _findings_by_file(async_session, repo.id) == [("a.py", "fa")]


### PR DESCRIPTION
## What

Stop `repowise update` from dropping the entire dead-code index (~979 findings → 0) when a single file changes.

## Why

Two coupled root causes (issue #295):

- `save_dead_code_findings()` was a **full-repo delete-then-insert** (no `file_path` scope).
- `analyze_partial()` returned a **sparse** report — only the unreachable-file detector, only for changed files.

Together, a single-file incremental update deleted every finding and reinserted a near-empty set.

## How

- **File-scoped persistence:** add `upsert_dead_code_findings(..., file_paths=...)` mirroring the existing `upsert_health_findings` — deletes and inserts only within the changed paths, so unchanged files keep their findings and a now-clean changed file has its stale findings cleared. Inserts are filtered to `file_paths` to enforce the scope contract.
- **Complete partial analysis:** rewrite `analyze_partial()` to run the full detector suite (it needs the complete graph for accurate caller in-degrees anyway) and narrow the result to the affected files, so all finding kinds are recomputed — not just unreachable files.
- **Wire-up:** thread changed paths into both update persistence paths (index-only and full) and use the scoped upsert.

## Known limitation

Incremental analysis is scoped to *changed* files. An edit to file X that makes a symbol in unchanged file Y dead is not recomputed until the next full analysis (`repowise init`/full re-score). This matches the existing incremental-health behavior; the full `analyze()` remains authoritative.

## Tests

- Unit (`tests/unit/persistence/test_dead_code_crud.py`): scoped replace preserves other files; changed-but-clean file is cleared; out-of-scope findings are not inserted; empty `file_paths` is a no-op.
- Unit (`tests/unit/dead_code/test_partial.py`): `analyze_partial` reports an unused *export* on a changed file and scopes findings to affected files.
- Integration (`tests/integration/test_cli.py::TestUpdatePreservesDeadCode`): a single-file update preserves unchanged files' findings and does not wipe the index.

This change is Python-only and does not touch `packages/web`.

Closes #295 (findings-reset half; the CommonJS property-access false-positive half is a separate follow-up PR).