### PR TITLE
feat(health): add test-quality smells and harden size sensitivity

### DIFF
--- a/docs/CODE_HEALTH.md
+++ b/docs/CODE_HEALTH.md
@@ -1,10 +1,11 @@
 # Code Health
 
-Repowise computes a 1–10 health score for every file in your repo from twenty-one
+Repowise computes a 1–10 health score for every file in your repo from twenty-three
 deterministic biomarkers — McCabe complexity, deep nesting, brain methods,
 class cohesion (LCOM4), god classes, clone detection, untested hotspots,
 function-level churn, code-age volatility,
-ownership dispersion, relative churn, change entropy, co-change scatter, and more. **No LLM calls, no cloud requirement.** Pure
+ownership dispersion, relative churn, change entropy, co-change scatter,
+test-quality smells, and more. **No LLM calls, no cloud requirement.** Pure
 Python over tree-sitter + git data, designed to finish in under 30 seconds on a
 3 000-file repo.
 
@@ -32,8 +33,9 @@ most:
 | Test coverage          | −2.0  | untested_hotspot, coverage_gap |
 | Size & complexity      | −1.5  | complex_method, large_method, primitive_obsession |
 | Duplication            | −1.0  | dry_violation |
+| Test quality           | −0.5  | large_assertion_block, duplicated_assertion_block |
 
-Twenty-one biomarkers across five categories. `function_hotspot` and
+Twenty-three biomarkers across six categories. `function_hotspot` and
 `code_age_volatility` are blame-based and sit in the organizational bucket —
 both are tier-aware and stay silent on ESSENTIAL-tier repos until the per-line
 blame index is built.
@@ -80,8 +82,11 @@ sign the function is doing several jobs that should be split.
 **complex_method** — Cyclomatic complexity ≥ 9. Each branch is a path the
 test suite has to cover.
 
-**large_method** — Functions that exceed the NLOC threshold. Length on its
-own is not always a bug, so this is a milder signal.
+**large_method** — Long functions that also carry at least some branching.
+A long-but-perfectly-flat body (a big config/data literal, a wall of
+sequential assignments) is a layout artefact rather than a complexity smell,
+so it is excluded — the trigger is about length-with-substance, not raw line
+count.
 
 **primitive_obsession** — Many primitive parameters in one signature. A
 dataclass or parameter object would name the inputs.
@@ -162,6 +167,22 @@ editing it tends to ripple across the codebase (shotgun surgery). This is the
 breadth complement to `hidden_coupling`, which flags *specific* undeclared
 coupled pairs. Fires on actively-changing files (≥ 3 recent commits) coupled to
 ≥ 8 distinct partners. Tier-aware: silent on ESSENTIAL-tier repos.
+
+## Test quality
+
+These two fire **only on test files** and live in a deliberately small
+category (cap −0.5), so a noisy test never dominates its own health score.
+
+**large_assertion_block** — A test that fires 15 or more assertions in one
+uninterrupted run. Such a test usually checks several behaviours at once: when
+it fails it points at a line, not a cause, and it's brittle to unrelated
+changes. Splitting it into focused cases makes failures legible.
+
+**duplicated_assertion_block** — The same run of assertions copy-pasted across
+tests. Reuses the Rabin–Karp clone detector and keeps only the clone regions
+that overlap an assertion block on a test file. A change to the asserted
+behaviour then has to be edited in several places — and usually isn't, so the
+copies drift.
 
 ## Test coverage
 
@@ -257,7 +278,7 @@ Health: 7.4 (avg) · 6.2 (hotspots) · 2.1 (worst: payments/processor.ts)
 
 | Feature                          | Repowise | CodeScene | DeepSource | Sourcery |
 |----------------------------------|:--:|:--:|:--:|:--:|
-| Code health score (1–10)         | ✅ 21 biomarkers | ✅ 25–30 | ❌ | ❌ |
+| Code health score (1–10)         | ✅ 23 biomarkers | ✅ 25–30 | ❌ | ❌ |
 | Brain Method detection           | ✅ | ✅ | ❌ | ❌ |
 | Low cohesion (LCOM4) / god class  | ✅ | ✅ | ❌ | ❌ |
 | Test coverage intelligence       | ✅ LCOV/Cobertura/Clover | ❌ | ❌ | ❌ |

--- a/docs/LANGUAGE_SUPPORT.md
+++ b/docs/LANGUAGE_SUPPORT.md
@@ -346,13 +346,15 @@ without touching the shared pipeline files:
   (`LanguageNodeMap`), independent of the ingestion `.scm` queries. Add a
   map for a language to get McCabe complexity, nesting, cognitive
   complexity, and the per-function biomarkers; optionally set
-  `class_kinds` / `self_identifiers` / `member_access_kinds` on that map
-  to also get class-level metrics (LCOM4 cohesion, god-class). Both tiers
-  are purely additive and degrade safely — an unmapped language simply
-  produces no health findings rather than wrong ones. Control-flow maps
-  ship for Python, TypeScript, JavaScript, Go, Java, Rust; class-level
-  maps for all of those except Go. See `complexity/README.md` for the
-  extension recipe and the LCOM4 heuristic's limits.
+  `class_kinds` / `self_identifiers` / `member_access_kinds` to also get
+  class-level metrics (LCOM4 cohesion, god-class), and
+  `assert_kinds` / `assert_call_kinds` to get test-quality assertion-block
+  smells. All tiers are purely additive and degrade safely — an unmapped
+  language simply produces no health findings rather than wrong ones.
+  Control-flow maps ship for Python, TypeScript, JavaScript, Go, Java,
+  Rust; class-level maps for all of those except Go; assertion maps for all
+  six. See `complexity/README.md` for the extension recipe and the LCOM4
+  heuristic's limits.
 
 ---
 

--- a/docs/architecture/code-health.md
+++ b/docs/architecture/code-health.md
@@ -316,7 +316,7 @@ higher than dormant ones.
 
 ---
 
-## 5. The 21 biomarkers and their categories
+## 5. The 23 biomarkers and their categories
 
 Each biomarker is a stateless class implementing the `Biomarker` Protocol
 from `biomarkers/base.py`:
@@ -335,6 +335,14 @@ class Biomarker(Protocol):
 | Test coverage          | −2.0 | untested_hotspot, coverage_gap |
 | Size & complexity      | −1.5 | complex_method, large_method, primitive_obsession |
 | Duplication            | −1.0 | dry_violation |
+| Test quality           | −0.5 | large_assertion_block, duplicated_assertion_block |
+
+`large_assertion_block` and `duplicated_assertion_block` are the two
+**test-quality** smells (see §5.3). They fire only on test files and sit in
+a deliberately small category so a noisy test can't dominate its own score.
+`large_method` is now gated on a minimal CCN floor (≥ 2) so a long-but-flat
+body (a big data literal) reads as layout, not a complexity smell — a small
+step toward decoupling the score from raw file size.
 
 `ownership_risk` (long-run minor-contributor dispersion, Bird et al.) and
 `churn_risk` (size-normalized relative churn, Nagappan-Ball) are git-only
@@ -384,6 +392,20 @@ references (a static utility, or an unmapped language) reports `lcom4 = 1`
 ("no signal") rather than `len(methods)`, so adding a language can only
 turn signal on — never produce a false-positive flood. See
 `complexity/README.md` for the full heuristic and its limits.
+
+### 5.3 Assertion-block walker metrics (test-quality)
+
+The same single walker pass records `assertion_blocks` on each
+`FunctionComplexity`: runs of ≥ 2 consecutive assertion statements, each
+`(start_line, end_line, count)`. A statement counts as an assertion when it
+is a bare `assert` (`LanguageNodeMap.assert_kinds`) or its expression is a
+call (`assert_call_kinds`) whose callee name starts with `assert` or
+`expect` — covering `assertEqual` / `assert_eq!` / `expect(...).toBe(...)`
+across xUnit and BDD styles. Opt-in per language (Python, TS/JS, Java, Rust,
+Go are mapped); a language that maps neither field simply emits no blocks.
+`large_assertion_block` flags a single run ≥ 15; `duplicated_assertion_block`
+intersects the clone report with assertion spans. Both gate on
+`coverage.is_test_file(path)` so production code is never touched.
 
 `biomarkers/registry.py` is an **explicit list**, not auto-discovery —
 keeps the registration order deterministic and lets tests inject extras

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/README.md
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/README.md
@@ -9,7 +9,7 @@ class Biomarker(Protocol):
     def detect(self, ctx: FileContext) -> list[BiomarkerResult]: ...
 ```
 
-## Registered detectors (21)
+## Registered detectors (23)
 
 Structural complexity (cap −2.5):
 - `brain_method` — symbols simultaneously long, complex, and central. The
@@ -56,6 +56,12 @@ Organizational (cap −3.5):
 - `co_change_scatter` — breadth of co-change coupling: a file coupled to
   many others (shotgun surgery). Complements `hidden_coupling`, which
   flags specific undeclared pairs.
+
+Test quality (cap −0.5, test files only):
+- `large_assertion_block` — a test function with a run of ≥ 15 consecutive
+  assertions (one case testing many behaviours at once).
+- `duplicated_assertion_block` — copy-pasted assertion runs across tests,
+  found by intersecting the clone detector with assertion spans.
 
 Caps were recalibrated to lift `organizational` (was −1.0) and de-rate
 `size_and_complexity` / `duplication` per plan §3.1. A per-biomarker

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/duplicated_assertion_block.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/duplicated_assertion_block.py
@@ -1,0 +1,73 @@
+"""Duplicated Assertion Block — copy-pasted assertion sequences in tests.
+
+When the same run of assertions appears in more than one test, a change to
+the asserted behaviour has to be edited in several places — and usually
+isn't, so the copies drift. This biomarker reuses the engine's Rabin-Karp
+clone detector (``ctx.clones``) and keeps only the clone regions that
+overlap an assertion block on a **test file**.
+
+It complements ``dry_violation`` (which flags clones anywhere, weighted by
+co-change): this one is scoped to test assertions and lands in the milder
+``test_quality`` category so a duplicated test never tanks a file's score.
+"""
+
+from __future__ import annotations
+
+from ..coverage import is_test_file
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+
+def _overlaps(a_start: int, a_end: int, b_start: int, b_end: int) -> bool:
+    return a_start <= b_end and b_start <= a_end
+
+
+class DuplicatedAssertionBlockDetector:
+    name = "duplicated_assertion_block"
+    category = "test_quality"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        if not is_test_file(ctx.file_path) or not ctx.clones:
+            return []
+        blocks = [
+            (start, end)
+            for fn in ctx.function_metrics.values()
+            for start, end, _count in fn.assertion_blocks
+        ]
+        if not blocks:
+            return []
+
+        out: list[BiomarkerResult] = []
+        seen: set[tuple[int, int]] = set()
+        for clone in ctx.clones:
+            spans: list[tuple[int, int]] = []
+            if clone.file_a == ctx.file_path:
+                spans.append((clone.a_start_line, clone.a_end_line))
+            if clone.file_b == ctx.file_path:
+                spans.append((clone.b_start_line, clone.b_end_line))
+            partner = clone.file_b if clone.file_a == ctx.file_path else clone.file_a
+            for cs, ce in spans:
+                for bs, be in blocks:
+                    if not _overlaps(cs, ce, bs, be) or (bs, be) in seen:
+                        continue
+                    seen.add((bs, be))
+                    out.append(
+                        BiomarkerResult(
+                            biomarker_type=self.name,
+                            severity=Severity.MEDIUM,
+                            function_name=None,
+                            line_start=bs,
+                            line_end=be,
+                            details={
+                                "assertion_lines": [bs, be],
+                                "partner_file": partner,
+                            },
+                            reason=(
+                                f"assertion block at lines {bs}-{be} is duplicated in {partner}"
+                            ),
+                        )
+                    )
+        return out
+
+
+BIOMARKER = DuplicatedAssertionBlockDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/large_assertion_block.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/large_assertion_block.py
@@ -1,0 +1,50 @@
+"""Large Assertion Block — a single test packed with too many assertions.
+
+A test function that fires 15+ assertions in one uninterrupted run is
+usually testing several behaviours at once: when it fails it points at a
+line, not a cause, and it's brittle to unrelated changes. Splitting it
+into focused cases makes failures legible.
+
+Fires **only on test files** (so production code that happens to use
+``assert`` for invariants is never flagged) and only on a *consecutive*
+run of assertions — the walker records these as ``assertion_blocks`` on
+each ``FunctionComplexity``.
+"""
+
+from __future__ import annotations
+
+from ..coverage import is_test_file
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+
+class LargeAssertionBlockDetector:
+    name = "large_assertion_block"
+    category = "test_quality"
+
+    _MIN_COUNT = 15
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        if not is_test_file(ctx.file_path):
+            return []
+        out: list[BiomarkerResult] = []
+        for fn in ctx.function_metrics.values():
+            for start, end, count in fn.assertion_blocks:
+                if count < self._MIN_COUNT:
+                    continue
+                severity = Severity.HIGH if count >= 30 else Severity.MEDIUM
+                out.append(
+                    BiomarkerResult(
+                        biomarker_type=self.name,
+                        severity=severity,
+                        function_name=fn.name,
+                        line_start=start,
+                        line_end=end,
+                        details={"function": fn.name, "assertion_count": count},
+                        reason=f"{fn.name} runs {count} assertions in one block",
+                    )
+                )
+        return out
+
+
+BIOMARKER = LargeAssertionBlockDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/large_method.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/large_method.py
@@ -1,9 +1,13 @@
 """Large Method — function bodies that exceed a healthy line budget.
 
-Fires on raw NLOC, independent of complexity. A 200-line function with
-CCN 2 still hurts readability and tests; a 60-line function with CCN 12
-is the `complex_method` case. Both can fire on the same function — the
-scorer caps the size_and_complexity category so they don't double-count.
+Fires on NLOC once a function carries *some* branching, so it measures
+length-with-substance rather than pure size. A long but perfectly flat
+body (a big config/data literal, a wall of sequential assignments — CCN 1)
+is a layout artefact, not a maintainability smell, and is excluded by the
+``_CCN_FLOOR`` gate. The complementary case — a short-but-tangled 60-line
+function with CCN 12 — is handled by ``complex_method``. Both can fire on
+the same function; the scorer caps the size_and_complexity category so
+they don't double-count.
 """
 
 from __future__ import annotations
@@ -17,11 +21,16 @@ class LargeMethodDetector:
     category = "size_and_complexity"
 
     _NLOC_THRESHOLD = 60
+    # Minimal branching required so a long-but-flat body (CCN 1, e.g. a big
+    # config dict) doesn't read as a complexity smell. Anything with even a
+    # single branch clears this floor. Keeps the trigger about substance,
+    # not raw line count — directly targeting the size-confound critique.
+    _CCN_FLOOR = 2
 
     def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
         out: list[BiomarkerResult] = []
         for fn in ctx.function_metrics.values():
-            if fn.nloc < self._NLOC_THRESHOLD:
+            if fn.nloc < self._NLOC_THRESHOLD or fn.ccn < self._CCN_FLOOR:
                 continue
             severity = (
                 Severity.CRITICAL

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/registry.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/registry.py
@@ -23,10 +23,12 @@ from .complex_method import ComplexMethodDetector
 from .coverage_gap import CoverageGapDetector
 from .developer_congestion import DeveloperCongestionDetector
 from .dry_violation import DryViolationDetector
+from .duplicated_assertion_block import DuplicatedAssertionBlockDetector
 from .function_hotspot import FunctionHotspotDetector
 from .god_class import GodClassDetector
 from .hidden_coupling import HiddenCouplingDetector
 from .knowledge_loss import KnowledgeLossDetector
+from .large_assertion_block import LargeAssertionBlockDetector
 from .large_method import LargeMethodDetector
 from .low_cohesion import LowCohesionDetector
 from .nested_complexity import NestedComplexityDetector
@@ -56,6 +58,8 @@ _DETECTOR_FACTORIES: list[type[Biomarker]] = [
     ChurnRiskDetector,  # type: ignore[list-item]
     ChangeEntropyDetector,  # type: ignore[list-item]
     CoChangeScatterDetector,  # type: ignore[list-item]
+    LargeAssertionBlockDetector,  # type: ignore[list-item]
+    DuplicatedAssertionBlockDetector,  # type: ignore[list-item]
 ]
 
 

--- a/packages/core/src/repowise/core/analysis/health/complexity/README.md
+++ b/packages/core/src/repowise/core/analysis/health/complexity/README.md
@@ -13,6 +13,10 @@ Tree-sitter AST walker. Single AST pass per file computes:
   sibling branches. Feeds `bumpy_road`.
 - **param_count** — formal parameter count. Feeds `primitive_obsession`.
 - **nloc** — non-comment lines of code per function.
+- **assertion_blocks** — runs of ≥ 2 consecutive assertion statements,
+  each `(start_line, end_line, count)`. Opt-in per language via
+  `assert_kinds` / `assert_call_kinds`. Feeds the test-quality biomarkers
+  (`large_assertion_block`, `duplicated_assertion_block`).
 
 It also emits **class-level** aggregates (`ClassComplexity`) for languages
 that opt in — see "Class-level metrics" below.
@@ -121,7 +125,21 @@ the node-type names above. Get one wrong and the safety valve degrades the
 class to "no signal" rather than emitting a false positive, so it's cheap
 to add a language speculatively and refine later.
 
+For **assertion-block** detection (test-quality smells), set two more
+opt-in fields:
+
+- `assert_kinds` — statement node type(s) that are assertions on their own
+  (Python/Java `assert_statement`).
+- `assert_call_kinds` — call node type(s) to inspect for an assertion
+  *call*. A statement counts when its expression is a call of one of these
+  kinds whose callee name starts with `assert` or `expect` (covers
+  `assertEqual` / `assert_eq!` / `expect(...).toBe(...)`).
+
+A language that maps neither produces no assertion blocks — never a false
+positive.
+
 Ships control-flow mappings for Python, TypeScript, JavaScript, Go, Java,
 Rust; class-level mappings for Python, TypeScript, JavaScript, Java, Rust
-(Go has no class-grouping node). Adding more languages — either tier — is
-purely additive in `languages.py`.
+(Go has no class-grouping node); assertion mappings for Python, TypeScript,
+JavaScript, Java, Rust, Go. Adding more languages — any tier — is purely
+additive in `languages.py`.

--- a/packages/core/src/repowise/core/analysis/health/complexity/languages.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/languages.py
@@ -21,6 +21,9 @@ names to the walker's abstract categories:
                   class-level metrics (LCOM4 / god-class). Opt-in per
                   language via ``class_kinds`` / ``self_identifiers`` /
                   ``member_access_kinds`` — see the dataclass below.
+- ``ASSERT``    — (optional) statement / call node type(s) used to detect
+                  test-assertion runs (test-quality smells). Opt-in per
+                  language via ``assert_kinds`` / ``assert_call_kinds``.
 
 Control-flow maps cover Python, TypeScript, JavaScript, Go, Java, Rust;
 class-level maps cover all of those except Go (no class-grouping node).
@@ -84,6 +87,24 @@ class LanguageNodeMap:
     # reference for cohesion).
     member_access_kinds: frozenset[str] = frozenset()
 
+    # ------------------------------------------------------------------
+    # Assertion detection (test-quality smells). Both fields default to
+    # empty, making assertion-block detection OPT-IN per language:
+    #
+    #   * ``assert_kinds`` — statement node types that ARE assertions on
+    #     their own (Python/Java ``assert_statement``).
+    #   * ``assert_call_kinds`` — call node types to inspect for an
+    #     assertion *call* (``assertEqual`` / ``expect`` / ``assert_eq!``).
+    #     A statement counts as an assertion when its expression is a call
+    #     of one of these kinds whose callee name starts with ``assert`` or
+    #     ``expect`` (see ``walker._ASSERT_CALL_PREFIXES``).
+    #
+    # Consumed by ``large_assertion_block`` / ``duplicated_assertion_block``
+    # (both fire only on test files). A language that maps neither field
+    # simply produces no assertion blocks — never a false positive.
+    assert_kinds: frozenset[str] = frozenset()
+    assert_call_kinds: frozenset[str] = frozenset()
+
 
 _PY = LanguageNodeMap(
     function_kinds=frozenset({"function_definition", "async_function_definition"}),
@@ -98,6 +119,10 @@ _PY = LanguageNodeMap(
     class_kinds=frozenset({"class_definition"}),
     self_identifiers=frozenset({"self", "cls"}),
     member_access_kinds=frozenset({"attribute"}),
+    # ``assert x == y`` is a bare statement; ``self.assertEqual(...)`` is a
+    # call.
+    assert_kinds=frozenset({"assert_statement"}),
+    assert_call_kinds=frozenset({"call"}),
 )
 
 _TS = LanguageNodeMap(
@@ -130,6 +155,9 @@ _TS = LanguageNodeMap(
     class_kinds=frozenset({"class_declaration", "class", "abstract_class_declaration"}),
     self_identifiers=frozenset({"this"}),
     member_access_kinds=frozenset({"member_expression"}),
+    # ``expect(x).toBe(y)`` / ``assert.equal(...)`` — best-effort: any call
+    # whose callee chain mentions ``expect`` / ``assert*``.
+    assert_call_kinds=frozenset({"call_expression"}),
 )
 
 _JS = _TS  # identical control-flow nodes; tree-sitter-javascript shares shape.
@@ -149,6 +177,8 @@ _GO = LanguageNodeMap(
     # receiver (``func (r T) m()``) rather than nesting in a class body,
     # so there is no single node that groups a type's methods. Left for a
     # future receiver-aware grouping pass; until then Go emits no classes.
+    # ``assert.Equal(t, ...)`` (testify) — best-effort call detection.
+    assert_call_kinds=frozenset({"call_expression"}),
 )
 
 _JAVA = LanguageNodeMap(
@@ -174,6 +204,9 @@ _JAVA = LanguageNodeMap(
     # ``field_access`` covers ``this.field``; ``method_invocation`` covers
     # ``this.foo()`` (its ``name`` field is the called method).
     member_access_kinds=frozenset({"field_access", "method_invocation"}),
+    # ``assert x`` (JUnit ``assert`` keyword) + ``assertEquals(...)`` calls.
+    assert_kinds=frozenset({"assert_statement"}),
+    assert_call_kinds=frozenset({"method_invocation"}),
 )
 
 _RUST = LanguageNodeMap(
@@ -197,6 +230,8 @@ _RUST = LanguageNodeMap(
     class_kinds=frozenset({"impl_item"}),
     self_identifiers=frozenset({"self"}),
     member_access_kinds=frozenset({"field_expression"}),
+    # ``assert!`` / ``assert_eq!`` / ``assert_ne!`` are macro invocations.
+    assert_call_kinds=frozenset({"macro_invocation"}),
 )
 
 

--- a/packages/core/src/repowise/core/analysis/health/complexity/walker.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/walker.py
@@ -68,10 +68,17 @@ class FunctionComplexity:
     # Per-condition boolean-operator counts collected during the walk.
     # Empty when no branch/loop carries compound boolean expressions.
     complex_conditions: list[ConditionComplexity] = None  # type: ignore[assignment]
+    # Runs of ≥2 consecutive assertion statements within the body, each
+    # ``(start_line, end_line, count)``. Populated only for languages whose
+    # ``LanguageNodeMap`` opts into assertion detection (``assert_kinds`` /
+    # ``assert_call_kinds``). Consumed by the test-quality biomarkers.
+    assertion_blocks: list[tuple[int, int, int]] = None  # type: ignore[assignment]
 
     def __post_init__(self) -> None:
         if self.complex_conditions is None:
             self.complex_conditions = []
+        if self.assertion_blocks is None:
+            self.assertion_blocks = []
 
 
 @dataclass
@@ -418,6 +425,115 @@ def _walk_function_body(
     return ccn, max_nesting, cognitive, bumps, conditions
 
 
+# ----------------------------------------------------------------------
+# Assertion-block detection (test-quality smells)
+# ----------------------------------------------------------------------
+
+# Callee-name prefixes that mark a call as a test assertion. Matched
+# case-insensitively against every identifier in the call's callee chain,
+# so ``assertEqual`` / ``assert_eq`` / ``Assert.assertTrue`` / ``expect``
+# all qualify. Deliberately small — these two prefixes cover xUnit-family
+# (``assert*``) and the BDD/expect family (``expect(...)``).
+_ASSERT_CALL_PREFIXES = ("assert", "expect")
+_EXPRESSION_STATEMENT = "expression_statement"
+_AWAIT_WRAPPER_KINDS = ("await_expression", "await", "parenthesized_expression")
+
+
+def _callee_matches_assert(call_node: Node) -> bool:
+    """True if any identifier in *call_node*'s callee chain is assert-ish.
+
+    Only the callee (the ``function`` / ``macro`` field) is inspected, not
+    the arguments — so ``foo(assertion)`` does not match while
+    ``expect(x).toBe(y)`` and ``self.assertEqual(...)`` do.
+    """
+    callee = call_node.child_by_field_name("function") or call_node.child_by_field_name("macro")
+    # Fallback when no ``function``/``macro`` field is exposed: the first
+    # named child is usually the callee.
+    roots = [callee] if callee is not None else [c for c in call_node.children if c.is_named][:1]
+    stack: list[Node] = list(roots)
+    while stack:
+        node = stack.pop()
+        if node.type.endswith(_IDENTIFIER_SUFFIX) and node.text is not None:
+            name = node.text.decode("utf-8", errors="replace").lower()
+            if any(name.startswith(p) for p in _ASSERT_CALL_PREFIXES):
+                return True
+        for child in node.children:
+            stack.append(child)
+    return False
+
+
+def _find_assert_call(stmt: Node, kinds: frozenset[str]) -> Node | None:
+    """Find an assertion-call node that is *stmt*'s own expression.
+
+    Searches direct named children and one level deeper (to see through
+    ``await`` / parenthesis wrappers) — but no further, so a call buried in
+    an argument or a nested block is not mistaken for the statement's
+    expression.
+    """
+    for child in stmt.children:
+        if not child.is_named:
+            continue
+        if child.type in kinds:
+            return child
+        if child.type in _AWAIT_WRAPPER_KINDS:
+            for gc in child.children:
+                if gc.is_named and gc.type in kinds:
+                    return gc
+    return None
+
+
+def _is_assertion_statement(stmt: Node, lmap: LanguageNodeMap) -> bool:
+    """True if *stmt* is a test assertion (bare ``assert`` or assert call)."""
+    if stmt.type in lmap.assert_kinds:
+        return True
+    if not lmap.assert_call_kinds or stmt.type != _EXPRESSION_STATEMENT:
+        return False
+    call = _find_assert_call(stmt, lmap.assert_call_kinds)
+    return call is not None and _callee_matches_assert(call)
+
+
+def _collect_assertion_blocks(body_node: Node, lmap: LanguageNodeMap) -> list[tuple[int, int, int]]:
+    """Runs of ≥2 consecutive assertion statements within a function body.
+
+    Each run is recorded as ``(start_line, end_line, count)``. Runs are
+    found per statement-list (a block's direct children), so an assertion
+    sequence broken by a non-assertion statement starts a new run. Nested
+    function bodies are skipped — their assertions belong to them.
+    """
+    if not lmap.assert_kinds and not lmap.assert_call_kinds:
+        return []
+    blocks: list[tuple[int, int, int]] = []
+
+    def _scan_siblings(parent: Node) -> None:
+        run_start = 0
+        run_end = 0
+        run_count = 0
+        for child in parent.children:
+            if not child.is_named:
+                continue
+            if _is_assertion_statement(child, lmap):
+                if run_count == 0:
+                    run_start = child.start_point[0] + 1
+                run_end = child.end_point[0] + 1
+                run_count += 1
+            else:
+                if run_count >= 2:
+                    blocks.append((run_start, run_end, run_count))
+                run_count = 0
+        if run_count >= 2:
+            blocks.append((run_start, run_end, run_count))
+
+    def _visit(node: Node) -> None:
+        _scan_siblings(node)
+        for child in node.children:
+            if child.type in lmap.function_kinds:
+                continue  # nested fn — walked as its own entry
+            _visit(child)
+
+    _visit(body_node)
+    return blocks
+
+
 def _collect_function_nodes(root: Node, lmap: LanguageNodeMap) -> list[Node]:
     """All function / method definition nodes in the file.
 
@@ -725,6 +841,7 @@ def walk_file(
             bumps=bumps,
             param_count=_count_parameters(fn_node),
             complex_conditions=conditions,
+            assertion_blocks=_collect_assertion_blocks(body, lmap),
         )
         functions.append(fc)
         fc_by_node_id[fn_node.id] = fc

--- a/packages/core/src/repowise/core/analysis/health/scoring.py
+++ b/packages/core/src/repowise/core/analysis/health/scoring.py
@@ -31,6 +31,9 @@ CATEGORY_CAPS: dict[str, float] = {
     "test_coverage": 2.0,
     "size_and_complexity": 1.5,
     "duplication": 1.0,
+    # Test-quality smells are mild, advisory signals — a small cap keeps a
+    # noisy test file from dominating its own health score.
+    "test_quality": 0.5,
 }
 
 # Per-biomarker deduction by severity. The scorer caps the per-category
@@ -93,6 +96,8 @@ _BIOMARKER_CATEGORY: dict[str, str] = {
     "churn_risk": "organizational",
     "change_entropy": "organizational",
     "co_change_scatter": "organizational",
+    "large_assertion_block": "test_quality",
+    "duplicated_assertion_block": "test_quality",
     # Governance biomarkers — written by the additive governance pass
     "ungoverned_hotspot": "organizational",
     "stale_governance": "organizational",

--- a/packages/core/src/repowise/core/analysis/health/suggestions.py
+++ b/packages/core/src/repowise/core/analysis/health/suggestions.py
@@ -136,6 +136,18 @@ _TEMPLATES: dict[str, str] = {
         "shared concerns behind a stable boundary, or split it so callers "
         "depend on smaller, more cohesive units."
     ),
+    "large_assertion_block": (
+        "Split this test. A long run of assertions in one case tests "
+        "several behaviours at once — when it fails it names a line, not a "
+        "cause. Break it into focused cases (one behaviour each), or factor "
+        "shared setup into a fixture so each assertion's intent is clear."
+    ),
+    "duplicated_assertion_block": (
+        "De-duplicate this assertion block. The same checks are copy-pasted "
+        "across tests, so a behaviour change must be edited in several "
+        "places and usually isn't. Extract the shared assertions into a "
+        "helper or parametrize the cases over the varying inputs."
+    ),
     "knowledge_loss": (
         "Document the surviving knowledge. The primary author(s) of "
         "this file are no longer active — pair-program with someone "

--- a/tests/fixtures/lang_samples/python/assertions.py
+++ b/tests/fixtures/lang_samples/python/assertions.py
@@ -1,0 +1,45 @@
+"""Fixture for assertion-block detection (test-quality smells)."""
+
+
+def test_many_bare_asserts():
+    x = 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+    assert x == 1
+
+
+class _Case:
+    def test_unittest_calls(self):
+        self.assertEqual(1, 1)
+        self.assertEqual(2, 2)
+        self.assertTrue(True)
+
+    def test_few_asserts(self):
+        assert 1 == 1
+        x = 2
+        assert x == 2
+
+
+def test_split_runs():
+    assert 1 == 1
+    assert 2 == 2
+    do_work()
+    assert 3 == 3
+    assert 4 == 4
+
+
+def do_work():
+    return None

--- a/tests/fixtures/lang_samples/typescript/assertions.ts
+++ b/tests/fixtures/lang_samples/typescript/assertions.ts
@@ -1,0 +1,27 @@
+// Fixture for assertion-block detection (test-quality smells).
+
+function testManyExpects(): void {
+  const x = 1;
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+  expect(x).toBe(1);
+}
+
+function testFewExpects(): void {
+  expect(1).toBe(1);
+  const y = 2;
+  expect(y).toBe(2);
+}

--- a/tests/unit/health/test_complexity_walker.py
+++ b/tests/unit/health/test_complexity_walker.py
@@ -156,3 +156,47 @@ def test_unsupported_language_has_no_classes():
     fcx = walk_file("/tmp/x.unknown", "klingon", b"")
     assert fcx.classes == []
     assert fcx.functions == []
+
+
+# ---- assertion-block detection (test-quality) ----------------------------
+
+
+def test_python_assertion_blocks():
+    results = _walk("python/assertions.py", "python")
+    many = _find(results, "test_many_bare_asserts")
+    assert many is not None
+    # One uninterrupted run of 16 bare asserts.
+    assert len(many.assertion_blocks) == 1
+    assert many.assertion_blocks[0][2] == 16
+
+    calls = _find(results, "test_unittest_calls")
+    assert calls is not None
+    # self.assertEqual / assertTrue calls counted as assertions.
+    assert calls.assertion_blocks[0][2] == 3
+
+
+def test_python_assertion_runs_split_on_non_assert():
+    results = _walk("python/assertions.py", "python")
+    split = _find(results, "test_split_runs")
+    assert split is not None
+    # A non-assert statement between the asserts breaks the run into two.
+    assert [b[2] for b in split.assertion_blocks] == [2, 2]
+
+
+def test_python_single_assert_is_not_a_block():
+    results = _walk("python/assertions.py", "python")
+    few = _find(results, "test_few_asserts")
+    assert few is not None
+    # Two asserts separated by an assignment → no run of ≥2.
+    assert few.assertion_blocks == []
+
+
+def test_typescript_expect_blocks():
+    results = _walk("typescript/assertions.ts", "typescript")
+    many = _find(results, "testManyExpects")
+    if many is None:
+        pytest.skip("typescript function not detected")
+    assert many.assertion_blocks[0][2] == 16
+    few = _find(results, "testFewExpects")
+    assert few is not None
+    assert few.assertion_blocks == []

--- a/tests/unit/health/test_scoring_snapshot.py
+++ b/tests/unit/health/test_scoring_snapshot.py
@@ -28,6 +28,7 @@ _EXPECTED_CATEGORY_CAPS = {
     "test_coverage": 2.0,
     "size_and_complexity": 1.5,
     "duplication": 1.0,
+    "test_quality": 0.5,
 }
 
 _EXPECTED_SEVERITY_DEDUCTION = {
@@ -77,6 +78,8 @@ _EXPECTED_BIOMARKER_CATEGORY = {
     "churn_risk": "organizational",
     "change_entropy": "organizational",
     "co_change_scatter": "organizational",
+    "large_assertion_block": "test_quality",
+    "duplicated_assertion_block": "test_quality",
     # Phase 4B governance biomarkers.
     "ungoverned_hotspot": "organizational",
     "stale_governance": "organizational",

--- a/tests/unit/health/test_test_quality_biomarkers.py
+++ b/tests/unit/health/test_test_quality_biomarkers.py
@@ -1,0 +1,155 @@
+"""Tests for the test-quality biomarkers + large_method size hardening.
+
+- ``large_assertion_block`` / ``duplicated_assertion_block`` fire only on
+  test files and live in the mild ``test_quality`` category.
+- ``large_method`` now requires a minimal CCN floor so a long-but-flat
+  body (a big data literal) no longer reads as a complexity smell.
+"""
+
+from __future__ import annotations
+
+from repowise.core.analysis.health.biomarkers import FileContext
+from repowise.core.analysis.health.biomarkers.duplicated_assertion_block import (
+    DuplicatedAssertionBlockDetector,
+)
+from repowise.core.analysis.health.biomarkers.large_assertion_block import (
+    LargeAssertionBlockDetector,
+)
+from repowise.core.analysis.health.biomarkers.large_method import LargeMethodDetector
+from repowise.core.analysis.health.complexity import FunctionComplexity
+from repowise.core.analysis.health.duplication import ClonePair
+from repowise.core.analysis.health.models import Severity
+
+
+def _fn(
+    name: str,
+    *,
+    nloc: int = 5,
+    ccn: int = 1,
+    assertion_blocks: list[tuple[int, int, int]] | None = None,
+) -> FunctionComplexity:
+    return FunctionComplexity(
+        name=name,
+        start_line=1,
+        end_line=1 + nloc,
+        ccn=ccn,
+        max_nesting=0,
+        cognitive=0,
+        nloc=nloc,
+        assertion_blocks=assertion_blocks or [],
+    )
+
+
+def _ctx(
+    *,
+    file_path: str,
+    functions: list[FunctionComplexity],
+    clones: list[ClonePair] | None = None,
+) -> FileContext:
+    return FileContext(
+        file_path=file_path,
+        language="python",
+        nloc=200,
+        has_test_file=False,
+        module=None,
+        function_metrics={fn.name: fn for fn in functions},
+        clones=clones or [],
+    )
+
+
+# ---- large_assertion_block -----------------------------------------------
+
+
+def test_large_assertion_block_fires_on_test_file():
+    fn = _fn("test_x", assertion_blocks=[(10, 30, 18)])
+    out = LargeAssertionBlockDetector().detect(_ctx(file_path="tests/test_x.py", functions=[fn]))
+    assert len(out) == 1
+    assert out[0].details["assertion_count"] == 18
+    assert out[0].severity == Severity.MEDIUM  # 15 <= count < 30
+
+
+def test_large_assertion_block_high_severity():
+    fn = _fn("test_x", assertion_blocks=[(10, 60, 35)])
+    out = LargeAssertionBlockDetector().detect(_ctx(file_path="tests/test_x.py", functions=[fn]))
+    assert out[0].severity == Severity.HIGH  # count >= 30
+
+
+def test_large_assertion_block_ignores_small_runs():
+    fn = _fn("test_x", assertion_blocks=[(10, 18, 8)])
+    assert (
+        LargeAssertionBlockDetector().detect(_ctx(file_path="tests/test_x.py", functions=[fn]))
+        == []
+    )
+
+
+def test_large_assertion_block_silent_on_production_file():
+    # Same big block, but the file is not a test → never fires.
+    fn = _fn("validate", assertion_blocks=[(10, 30, 18)])
+    assert (
+        LargeAssertionBlockDetector().detect(_ctx(file_path="src/validate.py", functions=[fn]))
+        == []
+    )
+
+
+# ---- duplicated_assertion_block ------------------------------------------
+
+
+def _clone(path: str, a: tuple[int, int], partner: str, b: tuple[int, int]) -> ClonePair:
+    return ClonePair(
+        file_a=path,
+        file_b=partner,
+        a_start_line=a[0],
+        a_end_line=a[1],
+        b_start_line=b[0],
+        b_end_line=b[1],
+        token_count=80,
+    )
+
+
+def test_duplicated_assertion_block_fires_when_clone_overlaps_block():
+    fn = _fn("test_x", assertion_blocks=[(10, 20, 6)])
+    clone = _clone("tests/test_x.py", (12, 19), "tests/test_y.py", (5, 12))
+    out = DuplicatedAssertionBlockDetector().detect(
+        _ctx(file_path="tests/test_x.py", functions=[fn], clones=[clone])
+    )
+    assert len(out) == 1
+    assert out[0].severity == Severity.MEDIUM
+    assert out[0].details["partner_file"] == "tests/test_y.py"
+
+
+def test_duplicated_assertion_block_ignores_clone_outside_block():
+    fn = _fn("test_x", assertion_blocks=[(10, 20, 6)])
+    clone = _clone("tests/test_x.py", (40, 48), "tests/test_y.py", (5, 12))
+    assert (
+        DuplicatedAssertionBlockDetector().detect(
+            _ctx(file_path="tests/test_x.py", functions=[fn], clones=[clone])
+        )
+        == []
+    )
+
+
+def test_duplicated_assertion_block_silent_on_production_file():
+    fn = _fn("run", assertion_blocks=[(10, 20, 6)])
+    clone = _clone("src/run.py", (12, 19), "src/other.py", (5, 12))
+    assert (
+        DuplicatedAssertionBlockDetector().detect(
+            _ctx(file_path="src/run.py", functions=[fn], clones=[clone])
+        )
+        == []
+    )
+
+
+# ---- large_method size hardening -----------------------------------------
+
+
+def test_large_method_skips_long_flat_body():
+    # 150 lines but zero branching (a big config dict) → not a smell.
+    flat = _fn("CONFIG", nloc=150, ccn=1)
+    assert LargeMethodDetector().detect(_ctx(file_path="src/x.py", functions=[flat])) == []
+
+
+def test_large_method_fires_with_any_branching():
+    branchy = _fn("process", nloc=150, ccn=2)
+    out = LargeMethodDetector().detect(_ctx(file_path="src/x.py", functions=[branchy]))
+    assert len(out) == 1
+    assert out[0].details["nloc"] == 150


### PR DESCRIPTION
## What

Adds a **test-quality** biomarker category and reduces the health score's sensitivity to raw file size. Biomarker roster grows 21 → 23.

### Test-quality smells (new `test_quality` category, cap −0.5)

Both fire **only on test files** and live in a deliberately small category, so a noisy test never dominates its own file score.

- **`large_assertion_block`** — a test function with a run of ≥15 consecutive assertions (one case checking many behaviours at once). HIGH at ≥30.
- **`duplicated_assertion_block`** — copy-pasted assertion runs across tests, found by intersecting the existing Rabin–Karp clone detector with assertion spans. Complements `dry_violation` (repo-wide, co-change-weighted).

To support these, the complexity walker now records per-function `assertion_blocks` (runs of ≥2 consecutive assertion statements) via two opt-in `LanguageNodeMap` fields (`assert_kinds` / `assert_call_kinds`), covering bare `assert` and `assertEqual` / `assert_eq!` / `expect(...).toBe(...)` styles. Mapped for Python, TS/JS, Java, Rust, Go; an unmapped language simply emits no blocks (never a false positive).

### Size-normalization hardening

- **`large_method`** now requires a minimal cyclomatic-complexity floor, so a long-but-perfectly-flat body (a big config/data literal, a wall of sequential assignments) reads as a layout artefact rather than a complexity smell. The trigger becomes length-with-substance rather than raw line count.

## Validation

- **Unit tests:** `tests/unit/health/` 201 passed (+13: walker assertion detection, both new biomarkers, and a `large_method` regression). Adjacent git-indexer + persistence suites green (additive walker change, no ripple).
- **Performance:** the `-m slow` 30s / 3,000-file walker budget still holds.
- **Defect benchmark (anchor repos):** holds or improves with no regression.
  - clap: Spearman −0.415 → **−0.423**, partial-Spearman (ctrl NLOC) −0.189 → **−0.217**, ROC AUC 0.843 → **0.850**, P@20 60%.
  - pydantic: flat (ρ −0.228, AUC 0.742, P@20 20%).
  - `large_method` still fires strongly after the CCN floor (clap δ = +0.410, n=24), confirming the change only drops pure-straight-line bodies.

The test-quality biomarkers are a factor-parity / maintainability signal rather than a defect-lift signal; their weights stay on hand-set priors (the −0.5 cap bounds their blast radius).

## Docs

`docs/CODE_HEALTH.md`, `docs/architecture/code-health.md`, `docs/LANGUAGE_SUPPORT.md`, and the `biomarkers/` + `complexity/` READMEs updated for the new category, counts, and the assertion-detection extension recipe.