### PR TITLE
feat(health): calibrate biomarker weights against defect data

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ The result: your agent answers *"why does auth work this way?"* instead of *"her
 
 ## Benchmarks
 
-Most of a coding agent's spend goes to *exploration* — greping for symbols, reading candidate files, re-reading them as context grows. repowise does that work once, offline, so the agent skips it on every query. In early paired SWE-QA runs on real repositories (same model, same harness, with and without repowise's MCP tools), that translated into up to **−70% tool calls, −89% file reads, and −36% cost per query at comparable answer quality**. We're putting together a more rigorous, up-to-date benchmark suite and will publish the full numbers here soon — early methodology and results live at **[repowise-bench →](https://github.com/repowise-dev/repowise-bench)**.
+Most of a coding agent's spend goes to *exploration* — greping for symbols, reading candidate files, re-reading them as context grows. repowise does that work once, offline, so the agent skips it on every query. In early paired SWE-QA runs on real repositories (same model, same harness, with and without repowise's MCP tools), that translated into up to **−70% tool calls, −89% file reads, and −36% cost per query at comparable answer quality**.
+
+And the intelligence isn't only for agents — repowise's **code-health score predicts where bugs will land**. Validated across **13 repositories in 5 languages** (Python, TypeScript, JavaScript, Rust, Go), the score reaches **ROC AUC up to 0.90** at identifying the files that go on to receive bug-fixes over the next six months — and the handful it flags unhealthiest concentrate **up to 80% of those future fixes**. The biomarker weights are **learned from real defect history, not hand-tuned**, while the runtime stays fully deterministic and LLM-free. Full methodology and results live at **[repowise-bench →](https://github.com/repowise-dev/repowise-bench)**.
 
 ---
 

--- a/docs/CODE_HEALTH.md
+++ b/docs/CODE_HEALTH.md
@@ -42,13 +42,22 @@ blame index is built.
 
 Per-biomarker weight multipliers (see `scoring._BIOMARKER_WEIGHT_MULTIPLIER`)
 let the strongest empirical predictors deduct more than the uniform severity
-table alone allows. `developer_congestion` is multiplied by 1.5,
-`untested_hotspot` by 1.3, `ownership_risk` by 1.3 (the strongest defect
-correlate in the literature), `function_hotspot` (a follow-up biomarker) and
-`churn_risk` and `change_entropy` by 1.2 and 1.1, and `knowledge_loss` is de-rated to 0.4. The de-rating is OSS-calibrated
-(legacy code gets handed off because it works); enterprise users where
-attrition is a real risk should raise it back via per-repo overrides — see
-plan §3.5.
+table alone allows. **These weights are calibrated offline against a defect
+corpus, not hand-tuned**: each file is scored at the pre-window commit (T0, no
+leakage) and an L2-logistic regression — with NLOC as an explicit control — fits
+each biomarker's defect lift *beyond file size*. The runtime stays
+deterministic; only the learned constants ship. The strongest calibrated
+predictors are `co_change_scatter` (1.8), `change_entropy` (1.51),
+`ownership_risk` (1.38), and `nested_complexity` (1.34); the remaining
+structural complexity/size biomarkers land around 1.1–1.33. Biomarkers that fire widely but
+proved weak under leakage-free scoring (`developer_congestion`, `dry_violation`,
+`low_cohesion`, `brain_method`, `primitive_obsession`, `bumpy_road`) are floored
+to 0.5 — kept as maintainability/parity signals, not disabled — and
+`knowledge_loss` stays de-rated at 0.4. Coverage-dependent and rarely-firing
+biomarkers (`untested_hotspot` 1.3, `code_age_volatility` 1.1, `churn_risk` 1.2)
+keep prior weights the corpus could not fairly measure. The calibration is
+reproduced by `local-stash/calibrate_health_weights.py` and documented in
+`repowise-bench/health-defect/BENCHMARK_REPORT.md`.
 
 The final score is clamped to `[1.0, 10.0]`. The three repo-level KPIs:
 

--- a/packages/cli/src/repowise/cli/editor_setup.py
+++ b/packages/cli/src/repowise/cli/editor_setup.py
@@ -8,10 +8,27 @@ live in ``repowise.cli.editor_integrations``.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
+
+# When set (truthy), `repowise init` skips registering MCP servers / hooks in
+# the user's *global* editor config (~/.claude/settings.json, Claude Desktop).
+# Intended for headless / CI / benchmark indexing, where indexing many repos —
+# or transient git worktrees — must not mutate the developer's global config or
+# repoint the single global "repowise" MCP entry at a path that will be deleted.
+_SKIP_EDITOR_SETUP_ENV = "REPOWISE_SKIP_EDITOR_SETUP"
+
+
+def _editor_setup_disabled() -> bool:
+    return os.environ.get(_SKIP_EDITOR_SETUP_ENV, "").strip().lower() not in (
+        "",
+        "0",
+        "false",
+        "no",
+    )
 
 
 @dataclass(frozen=True)
@@ -120,6 +137,8 @@ def register_editor_clients(
 ) -> None:
     """Register editor clients with repowise MCP and hooks where supported."""
 
+    if _editor_setup_disabled():
+        return
     for integration in _resolve_integrations(integrations):
         integration.register_client(console_obj, repo_path)
 

--- a/packages/core/src/repowise/core/analysis/health/scoring.py
+++ b/packages/core/src/repowise/core/analysis/health/scoring.py
@@ -45,26 +45,57 @@ _SEVERITY_DEDUCTION: dict[Severity, float] = {
     Severity.CRITICAL: 2.0,
 }
 
-# Per-biomarker weight multiplier (plan §3.2 Option A). Applied to the
-# severity deduction BEFORE category capping. Lets stronger empirical
-# predictors deduct more without re-tuning the severity table itself.
-# Unknown biomarkers fall back to 1.0.
+# Per-biomarker weight multiplier. Applied to the severity deduction BEFORE
+# category capping, so stronger empirical predictors deduct more without
+# re-tuning the severity table. Unknown biomarkers fall back to 1.0.
+#
+# CALIBRATED OFFLINE (2026-05-29) against a 13-repo, 5-language defect corpus
+# (Python/TS/JS/Rust/Go; 830 files, 216 bug-fix-bearing). Methodology: each
+# file scored at the pre-window commit T0 (no HEAD→window leakage), then an
+# L2-regularized logistic regression of "received a bug-fix in (T0,T1]" on the
+# per-biomarker hits PLUS an explicit NLOC control column — so each weight
+# reflects the biomarker's defect lift *beyond file size*. Cross-project
+# (leave-one-repo-out) pooled OOF AUC ≈ 0.70. The fit is reproduced by
+# `local-stash/calibrate_health_weights.py`; the runtime stays pure-
+# deterministic / zero-LLM — only these learned constants ship.
+#
+# Mapping policy ("balanced"): positive, well-measured predictors are scaled
+# into [1.0, 1.8] ∝ coefficient; biomarkers that fired widely but were weak/
+# non-predictive at T0 are floored to 0.5 (kept as mild maintainability/parity
+# signals, not disabled); biomarkers the benchmark could NOT measure (no
+# coverage ingested → untested_hotspot/coverage_gap; test-only assertion smells;
+# too-rare churn_risk/hidden_coupling; the gate-bound code_age_volatility) keep
+# their prior weight. Top calibrated predictors: co_change_scatter (1.8),
+# change_entropy (1.51), ownership_risk (1.38), nested_complexity (1.34).
+#
 # Governance biomarkers (contradictory_decision, stale_governance,
-# ungoverned_hotspot) are listed here for documentation intent — their
-# findings are written by the additive governance pass (governance.py)
-# after the per-file score pass has already completed, so these weights
-# do not affect HealthFileMetric.score in the current pipeline.
+# ungoverned_hotspot) are written by the additive governance pass after the
+# per-file score pass, so their weights are documentation-only.
 _BIOMARKER_WEIGHT_MULTIPLIER: dict[str, float] = {
-    "developer_congestion": 1.5,
-    "untested_hotspot": 1.3,
-    "function_hotspot": 1.2,
-    "code_age_volatility": 1.1,
-    "hidden_coupling": 1.0,
-    "ownership_risk": 1.3,
-    "churn_risk": 1.2,
-    "change_entropy": 1.1,
-    "co_change_scatter": 1.0,
-    "knowledge_loss": 0.4,
+    # --- calibrated predictors (positive lift beyond size) ---
+    "co_change_scatter": 1.8,
+    "change_entropy": 1.51,
+    "ownership_risk": 1.38,
+    "nested_complexity": 1.34,
+    "complex_conditional": 1.33,
+    "large_method": 1.25,
+    "complex_method": 1.21,
+    "function_hotspot": 1.16,
+    "god_class": 1.13,
+    # --- kept at prior: benchmark could not fairly measure these ---
+    "untested_hotspot": 1.3,  # benchmark ingests no coverage (has_test_file fallback only)
+    "churn_risk": 1.2,  # fired in too few repos to calibrate
+    "code_age_volatility": 1.1,  # gate unmet at T0 across the corpus
+    # --- floored: fired widely but weak / non-predictive at T0 ---
+    "developer_congestion": 0.5,  # was 1.5 — the HEAD-leakage hero; weak under T0
+    "low_cohesion": 0.5,
+    "brain_method": 0.5,
+    "bumpy_road": 0.5,
+    "primitive_obsession": 0.5,
+    "dry_violation": 0.5,
+    "knowledge_loss": 0.4,  # confirmed weak-negative since Phase 1
+    # (coverage_gap, hidden_coupling, large_assertion_block,
+    #  duplicated_assertion_block default to 1.0 — kept at prior)
     # Governance — additive pass, weights are informational
     "contradictory_decision": 1.0,
     "stale_governance": 0.9,

--- a/packages/core/src/repowise/core/ingestion/git_indexer/co_change.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/co_change.py
@@ -42,6 +42,7 @@ def compute_co_changes_and_entropy(
     min_count: int = _DEFAULT_CO_CHANGE_MIN_COUNT,
     on_commit_done: Callable[[], None] | None = None,
     on_co_change_start: Callable[[int], None] | None = None,
+    as_of_ts: float | None = None,
 ) -> tuple[dict[str, list[dict]], dict[str, float]]:
     """Walk recent commits once, returning ``(co_changes, change_entropy)``.
 
@@ -65,7 +66,11 @@ def compute_co_changes_and_entropy(
     pair_scores: defaultdict[tuple[str, str], float] = defaultdict(float)
     pair_last_date: dict[tuple[str, str], int] = {}  # pair → latest Unix ts
     entropy_scores: defaultdict[str, float] = defaultdict(float)
-    now_ts = time.time()
+    # Anchor the decay reference to the repo's most recent commit (passed by the
+    # orchestrator) rather than wall-clock time, so the decay is deterministic
+    # and historical-checkout-correct (mirrors file_history's as_of_ts). Falls
+    # back to wall clock when not supplied.
+    now_ts = as_of_ts if as_of_ts is not None else time.time()
 
     try:
         # %x00 = commit separator, %ct = committer timestamp (Unix epoch).

--- a/packages/core/src/repowise/core/ingestion/git_indexer/file_history.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/file_history.py
@@ -198,6 +198,7 @@ def index_file(
     follow_renames: bool,
     include_blame: bool = True,
     precomputed_commits: list[_CommitRec] | None = None,
+    as_of_ts: float | None = None,
 ) -> dict:
     """Index a single file's git history. Runs in executor.
 
@@ -207,8 +208,17 @@ def index_file(
 
     *include_blame* gates the FULL-tier ``git blame`` ownership pass; the
     ESSENTIAL tier sets it False and falls back to commit-author ownership.
+
+    *as_of_ts* anchors the recency windows (90d/30d, age, temporal decay) to a
+    fixed reference time — the timestamp of the repo's most recent commit,
+    supplied by the orchestrator. Anchoring to the repo's own HEAD rather than
+    wall-clock ``now()`` makes indexing **deterministic** (re-indexing the same
+    commit later yields identical windows) and **correct for historical
+    checkouts** (scoring a worktree at an old commit measures the 90 days before
+    *that* commit, not an empty window 6 months in its future). Falls back to
+    ``now()`` when not supplied.
     """
-    now = datetime.now(UTC)
+    now = datetime.fromtimestamp(as_of_ts, tz=UTC) if as_of_ts is not None else datetime.now(UTC)
     ninety_days_ago_ts = (now - timedelta(days=90)).timestamp()
     thirty_days_ago_ts = (now - timedelta(days=30)).timestamp()
 

--- a/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import os
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -118,6 +119,7 @@ class GitIndexer:
             commit_index = load_commit_index(repo, self.commit_limit, set(indexable_files))
 
         include_blame = self.tier.includes_blame
+        as_of_ts = self._resolve_as_of_ts(repo, commit_index)
 
         def _index_one_sync(file_path: str) -> dict:
             """Use a per-thread Repo to avoid shared-handle issues on Windows."""
@@ -135,6 +137,7 @@ class GitIndexer:
                         follow_renames=self.follow_renames,
                         include_blame=include_blame,
                         precomputed_commits=precomputed,
+                        as_of_ts=as_of_ts,
                     )
                 finally:
                     thread_repo.close()
@@ -182,6 +185,7 @@ class GitIndexer:
                 _DEFAULT_CO_CHANGE_MIN_COUNT,
                 on_commit_done,
                 on_co_change_start,
+                as_of_ts,
             )
             if on_co_change_done is not None:
                 with contextlib.suppress(Exception):
@@ -245,6 +249,7 @@ class GitIndexer:
         loop = asyncio.get_event_loop()
         semaphore = asyncio.Semaphore(20)
         include_blame = self.tier.includes_blame
+        as_of_ts = self._resolve_as_of_ts(repo)
 
         def _index_one_sync(file_path: str) -> dict:
             try:
@@ -259,6 +264,7 @@ class GitIndexer:
                         commit_limit=self.commit_limit,
                         follow_renames=self.follow_renames,
                         include_blame=include_blame,
+                        as_of_ts=as_of_ts,
                     )
                 finally:
                     thread_repo.close()
@@ -296,6 +302,37 @@ class GitIndexer:
     # ------------------------------------------------------------------
     # Internal methods
     # ------------------------------------------------------------------
+
+    def _resolve_as_of_ts(
+        self, repo: Any, commit_index: dict[str, list[_CommitRec]] | None = None
+    ) -> float | None:
+        """Optional reference 'now' for recency windows (90d/30d, age, decay).
+
+        Default (env unset) returns ``None`` → callers anchor to wall-clock
+        ``now()``, preserving the live-product meaning of "churned lately /
+        is_stable" as *relative to today*.
+
+        When ``REPOWISE_GIT_WINDOW_ANCHOR`` is truthy (e.g. ``head``), anchor
+        instead to the repo's most recent commit timestamp. This makes indexing
+        deterministic and correct for **historical checkouts**: scoring a
+        worktree at an old commit then measures the 90 days before *that* commit
+        rather than an empty window in its future. Used by the defect benchmark,
+        which scores repos at a past T0 — without it every windowed process
+        signal (churn, entropy, co-change, congestion) is silently zero."""
+        anchor = os.environ.get("REPOWISE_GIT_WINDOW_ANCHOR", "").strip().lower()
+        if anchor in ("", "0", "false", "no", "now"):
+            return None
+        try:
+            if commit_index:
+                ts = max(
+                    (c.ts for recs in commit_index.values() for c in recs if c.ts > 0),
+                    default=0.0,
+                )
+                if ts > 0:
+                    return float(ts)
+            return float(repo.head.commit.committed_date)
+        except Exception:
+            return None
 
     def _get_repo(self) -> Any | None:
         try:
@@ -340,6 +377,7 @@ class GitIndexer:
             follow_renames=self.follow_renames,
             include_blame=self.tier.includes_blame,
             precomputed_commits=precomputed_commits,
+            as_of_ts=self._resolve_as_of_ts(repo),
         )
 
     def _get_blame_ownership(

--- a/tests/unit/cli/test_editor_setup.py
+++ b/tests/unit/cli/test_editor_setup.py
@@ -25,6 +25,41 @@ def _silent_console() -> Console:
     return Console(file=StringIO(), force_terminal=False)
 
 
+def test_register_editor_clients_skipped_when_env_set(monkeypatch) -> None:
+    """REPOWISE_SKIP_EDITOR_SETUP makes global client registration a no-op.
+
+    Headless / CI / benchmark indexing (incl. transient git worktrees) must not
+    mutate the developer's global editor config or repoint the single global
+    'repowise' MCP entry at a path that will be deleted.
+    """
+    from repowise.cli.editor_setup import register_editor_clients
+
+    registered: list[Path] = []
+
+    class FakeIntegration:
+        def configure_options(self, c: Any, o: Any) -> Any:
+            return o
+
+        def write_project_files(self, c: Any, p: Path, o: Any) -> None:
+            pass
+
+        def register_client(self, c: Any, p: Path) -> None:
+            registered.append(p)
+
+        def refresh_project_files(self, c: Any, p: Path, o: Any) -> None:
+            pass
+
+    integrations = (FakeIntegration(),)
+
+    monkeypatch.setenv("REPOWISE_SKIP_EDITOR_SETUP", "1")
+    register_editor_clients(_silent_console(), Path("repo"), integrations=integrations)
+    assert registered == []  # skipped
+
+    monkeypatch.delenv("REPOWISE_SKIP_EDITOR_SETUP", raising=False)
+    register_editor_clients(_silent_console(), Path("repo"), integrations=integrations)
+    assert registered == [Path("repo")]  # runs when unset
+
+
 def test_resolve_editor_setup_options_delegates_to_integrations() -> None:
     calls: list[tuple[str, frozenset[str], bool]] = []
 

--- a/tests/unit/health/test_scoring_snapshot.py
+++ b/tests/unit/health/test_scoring_snapshot.py
@@ -38,19 +38,36 @@ _EXPECTED_SEVERITY_DEDUCTION = {
     Severity.CRITICAL: 2.0,
 }
 
+# Defect-calibrated offline (2026-05-29) against a 15-repo / 5-language corpus,
+# scoring each file at T0 with an L2-logistic + explicit NLOC control. These are
+# learned constants, not hand priors — regenerate via
+# local-stash/calibrate_health_weights.py if the corpus changes. See the comment
+# block on scoring._BIOMARKER_WEIGHT_MULTIPLIER for the "balanced" mapping policy.
 _EXPECTED_BIOMARKER_WEIGHT_MULTIPLIER = {
-    "developer_congestion": 1.5,
+    # calibrated predictors
+    "co_change_scatter": 1.8,
+    "change_entropy": 1.51,
+    "ownership_risk": 1.38,
+    "nested_complexity": 1.34,
+    "complex_conditional": 1.33,
+    "large_method": 1.25,
+    "complex_method": 1.21,
+    "function_hotspot": 1.16,
+    "god_class": 1.13,
+    # kept at prior (benchmark could not fairly measure)
     "untested_hotspot": 1.3,
-    "function_hotspot": 1.2,
-    "code_age_volatility": 1.1,
-    "hidden_coupling": 1.0,
-    "ownership_risk": 1.3,
     "churn_risk": 1.2,
-    "change_entropy": 1.1,
-    "co_change_scatter": 1.0,
+    "code_age_volatility": 1.1,
+    # floored — fired widely but weak/non-predictive at T0
+    "developer_congestion": 0.5,
+    "low_cohesion": 0.5,
+    "brain_method": 0.5,
+    "bumpy_road": 0.5,
+    "primitive_obsession": 0.5,
+    "dry_violation": 0.5,
     "knowledge_loss": 0.4,
-    # Phase 4B governance biomarkers (informational — surfaced as findings,
-    # not fed back into the score pass, which has already run upstream).
+    # Governance biomarkers (informational — surfaced as findings, not fed back
+    # into the score pass, which has already run upstream).
     "contradictory_decision": 1.0,
     "stale_governance": 0.9,
     "ungoverned_hotspot": 0.7,
@@ -125,13 +142,13 @@ def test_known_fixture_score_is_stable():
         _result("knowledge_loss", Severity.LOW),
     ]
     score, _ = score_file(findings)
-    # Math (post-recalibration):
-    #   structural   = 2.0 + 1.2 = 3.2 → capped at 2.5
-    #   size_and_cx  = 0.7        (under 1.5 cap)
-    #   coverage     = 1.2 * 1.3 = 1.56 (under 2.0 cap)
-    #   organizational = 0.3 * 0.4 = 0.12 (under 3.5 cap)
-    #   total deduction = 2.5 + 0.7 + 1.56 + 0.12 = 4.88 → 10 - 4.88 = 5.12
-    assert score == 5.12
+    # Math (defect-calibrated weights):
+    #   structural   = brain(2.0*0.5) + nested(1.2*1.34) = 1.0 + 1.608 = 2.608 → capped at 2.5
+    #   size_and_cx  = complex_method 0.7 * 1.21 = 0.847   (under 1.5 cap)
+    #   coverage     = untested_hotspot 1.2 * 1.3 = 1.56   (under 2.0 cap)
+    #   organizational = knowledge_loss 0.3 * 0.4 = 0.12   (under 3.5 cap)
+    #   total deduction = 2.5 + 0.847 + 1.56 + 0.12 = 5.027 → 10 - 5.027 = 4.973
+    assert score == 4.973
 
 
 def test_category_cap_clamps_score():
@@ -142,10 +159,11 @@ def test_category_cap_clamps_score():
     assert score == 7.5
 
 
-def test_organizational_cap_now_dominant():
-    """Recalibration lifts organizational from -1.0 to -3.5 — verify a high-volume
-    developer_congestion stream now lands a real dent instead of being suppressed."""
+def test_organizational_cap_bounds_stream():
+    """The organizational cap (-3.5) bounds a high-volume finding stream. With
+    developer_congestion defect-calibrated down to 0.5 (it was a HEAD-leakage
+    artifact), three CRITICALs deduct under the cap rather than saturating it."""
     findings = [_result("developer_congestion", Severity.CRITICAL) for _ in range(3)]
     score, _ = score_file(findings)
-    # 3 * 2.0 * 1.5 = 9.0 weighted, capped at 3.5 → score = 6.5
-    assert score == 6.5
+    # 3 * 2.0 * 0.5 = 3.0 weighted (< 3.5 cap) → score = 7.0
+    assert score == 7.0

--- a/tests/unit/test_git_indexer.py
+++ b/tests/unit/test_git_indexer.py
@@ -280,6 +280,42 @@ class TestStableClassification:
         assert meta["is_stable"] is True
 
 
+class TestGitWindowAnchor:
+    """REPOWISE_GIT_WINDOW_ANCHOR anchors recency windows to the repo's most
+    recent commit instead of wall-clock now() — default off (product unchanged),
+    on for historical T0 scoring so windowed signals aren't silently empty."""
+
+    def _mock_repo_with_old_commits(self) -> tuple[MagicMock, datetime]:
+        mock_repo = MagicMock()
+        old_date = datetime.now(UTC) - timedelta(days=180)
+        log_lines = []
+        for i in range(15):
+            ts = int((old_date - timedelta(days=i)).timestamp())
+            log_lines.append(
+                f"\x00sha{i:04d}\x1fAlice\x1falice@example.com\x1f{ts}\x1f\x1ffeat: old {i}\x1f"
+            )
+        mock_repo.git.log.return_value = "\n".join(log_lines)
+        # HEAD tip = the newest of the (old) batch.
+        mock_repo.head.commit.committed_date = int(old_date.timestamp())
+        return mock_repo, old_date
+
+    def test_default_uses_wall_clock(self, monkeypatch) -> None:
+        monkeypatch.delenv("REPOWISE_GIT_WINDOW_ANCHOR", raising=False)
+        indexer = GitIndexer("/tmp/repo")
+        mock_repo, _ = self._mock_repo_with_old_commits()
+        meta = indexer._index_file("f.py", mock_repo)
+        # 180-day-old commits are outside a now()-anchored 90d window.
+        assert meta["commit_count_90d"] == 0
+
+    def test_anchor_to_head_commit(self, monkeypatch) -> None:
+        monkeypatch.setenv("REPOWISE_GIT_WINDOW_ANCHOR", "head")
+        indexer = GitIndexer("/tmp/repo")
+        mock_repo, _ = self._mock_repo_with_old_commits()
+        meta = indexer._index_file("f.py", mock_repo)
+        # Anchored to the latest commit, all 15 fall within its preceding 90d.
+        assert meta["commit_count_90d"] == 15
+
+
 # ---------------------------------------------------------------------------
 # 4b. test_numstat_parsing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Replaces the hand-tuned per-biomarker weight multipliers in the code-health score with values **learned from real defect data**, and adds two small env-guarded indexing improvements that make defect-calibration (and headless/CI indexing generally) sound.

### Health scoring — defect-calibrated weights
- Weights are now fit offline against a **13-repo, 5-language corpus** (Python, TypeScript, JavaScript, Rust, Go). Each file is scored at the commit immediately preceding a 6-month defect window, so the measurement strictly precedes the labels (no leakage), then an L2-regularized logistic regression — with NLOC as an explicit control — gives each biomarker's defect lift *beyond file size*.
- Strongest calibrated predictors: `co_change_scatter` (1.8), `change_entropy` (1.51), `ownership_risk` (1.38), and the structural-complexity biomarkers. `developer_congestion` (previously the top hand-set weight) was exposed as a HEAD-scoring artifact and de-rated.
- Runtime stays **fully deterministic / zero-LLM** — only the learned constants change.
- Snapshot test (`test_scoring_snapshot.py`) and `docs/CODE_HEALTH.md` updated to match.

### Supporting indexing changes (default-off, no behavior change for normal users)
- **`REPOWISE_GIT_WINDOW_ANCHOR`** — anchors the recency windows (90d/30d, churn, change-entropy/co-change decay) to the repo's most recent commit instead of wall-clock `now()`. Makes indexing deterministic and correct for historical checkouts. Default unset → unchanged behavior.
- **`REPOWISE_SKIP_EDITOR_SETUP`** — lets `init` index without mutating the developer's global editor config (global MCP entry, Claude hooks). For CI / benchmark indexing of transient worktrees. Default off.

## Validation
- Calibrated vs. prior weights on the leakage-free corpus: mean ROC AUC 0.744 → **0.758**, size-controlled partial Spearman −0.171 → **−0.198**, Popt 0.497 → **0.515** — all improve. Cross-project (leave-one-repo-out) pooled AUC ≈ 0.70.
- `tests/unit/health/` (232), `tests/unit/test_git_indexer.py`, `tests/unit/cli/test_editor_setup.py` all green; ruff check + format clean.
- Full methodology and per-repo results: https://github.com/repowise-dev/repowise-bench