### PR TITLE
fix(exclude-patterns): enforce exclude_patterns in git indexer and dynamic edges

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd.py
@@ -224,6 +224,17 @@ def _workspace_update(
 # ---------------------------------------------------------------------------
 
 
+def _build_filtered_changed_paths(file_diffs: list, exclude_patterns: list[str]) -> list[str]:
+    """Extract paths from file_diffs, filtering out excluded patterns."""
+    paths = [fd.path for fd in file_diffs]
+    if not exclude_patterns:
+        return paths
+    import pathspec
+
+    spec = pathspec.PathSpec.from_lines("gitwildmatch", exclude_patterns)
+    return [p for p in paths if not spec.match_file(p)]
+
+
 def _rebuild_graph_and_git(
     repo_path: Any,
     file_diffs: list,
@@ -248,7 +259,7 @@ def _rebuild_graph_and_git(
     parser = ASTParser()
     parsed_files: list = []
     source_map: dict[str, bytes] = {}
-    graph_builder = GraphBuilder(repo_path)
+    graph_builder = GraphBuilder(repo_path, exclude_patterns=exclude_patterns)
 
     for fi in file_infos:
         try:
@@ -283,8 +294,9 @@ def _rebuild_graph_and_git(
             repo_path,
             commit_limit=_commit_limit,
             follow_renames=_follow_renames,
+            exclude_patterns=exclude_patterns or None,
         )
-        changed_paths = [fd.path for fd in file_diffs]
+        changed_paths = _build_filtered_changed_paths(file_diffs, exclude_patterns)
         updated_meta = run_async(git_indexer.index_changed_files(changed_paths))
         git_meta_map = {m["file_path"]: m for m in updated_meta}
         graph_builder.update_co_change_edges(git_meta_map)

--- a/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
@@ -57,11 +57,16 @@ class GitIndexer:
         commit_limit: int | None = None,
         follow_renames: bool = False,
         tier: GitIndexTier = GitIndexTier.FULL,
+        exclude_patterns: list[str] | None = None,
     ) -> None:
         self.repo_path = Path(repo_path)
         self.commit_limit = commit_limit or _DEFAULT_COMMIT_LIMIT
         self.follow_renames = follow_renames
         self.tier = tier
+
+        import pathspec
+
+        self._exclude = pathspec.PathSpec.from_lines("gitwildmatch", exclude_patterns or [])
 
     async def index_repo(
         self,
@@ -350,7 +355,10 @@ class GitIndexer:
     def _get_tracked_files(self, repo: Any) -> list[str]:
         try:
             output = repo.git.ls_files()
-            return [f for f in output.splitlines() if f.strip()]
+            paths = [f for f in output.splitlines() if f.strip()]
+            if self._exclude.patterns:
+                paths = [p for p in paths if not self._exclude.match_file(p)]
+            return paths
         except Exception as exc:
             logger.warning("Failed to list tracked files", error=str(exc))
             return []

--- a/packages/core/src/repowise/core/ingestion/graph/_edges.py
+++ b/packages/core/src/repowise/core/ingestion/graph/_edges.py
@@ -79,6 +79,8 @@ class EdgesMixin:
             if e.source not in self._graph:
                 continue
             if e.target not in self._graph:
+                if self._exclude.patterns and self._exclude.match_file(e.target):
+                    continue
                 self._graph.add_node(e.target)
             sub_type = e.edge_type or "dynamic"
             graph_edge_type = (

--- a/packages/core/src/repowise/core/ingestion/graph/builder.py
+++ b/packages/core/src/repowise/core/ingestion/graph/builder.py
@@ -40,12 +40,21 @@ class GraphBuilder(MetricsMixin, ResolveMixin, EdgesMixin, SerializeMixin, Rehyd
         pr = builder.pagerank()
     """
 
-    def __init__(self, repo_path: Path | str | None = None) -> None:
+    def __init__(
+        self,
+        repo_path: Path | str | None = None,
+        *,
+        exclude_patterns: list[str] | None = None,
+    ) -> None:
         self._graph: nx.DiGraph = nx.DiGraph()
         self._parsed_files: dict[str, ParsedFile] = {}  # path → ParsedFile
         self._built = False
         self._repo_path: Path | None = Path(repo_path) if repo_path else None
         self._tsconfig_resolver: Any | None = None  # TsconfigResolver (lazy import)
+
+        import pathspec
+
+        self._exclude = pathspec.PathSpec.from_lines("gitwildmatch", exclude_patterns or [])
 
         # Community / flow / metric caches (invalidated on build)
         self._community_cache: dict[str, int] | None = None

--- a/packages/core/src/repowise/core/pipeline/orchestrator.py
+++ b/packages/core/src/repowise/core/pipeline/orchestrator.py
@@ -247,6 +247,7 @@ async def run_pipeline(
             commit_depth=commit_depth,
             follow_renames=follow_renames,
             tier=git_tier,
+            exclude_patterns=exclude_patterns,
             progress=progress,
         )
 

--- a/packages/core/src/repowise/core/pipeline/phases/git.py
+++ b/packages/core/src/repowise/core/pipeline/phases/git.py
@@ -25,6 +25,7 @@ async def _run_git_indexing(
     commit_depth: int,
     follow_renames: bool,
     tier: GitIndexTier = GitIndexTier.FULL,
+    exclude_patterns: list[str] | None = None,
     progress: ProgressCallback | None,
 ) -> tuple[Any | None, list[dict], dict[str, dict]]:
     """Run git history indexing.
@@ -39,6 +40,7 @@ async def _run_git_indexing(
             commit_limit=commit_depth,
             follow_renames=follow_renames,
             tier=tier,
+            exclude_patterns=exclude_patterns,
         )
 
         def _on_start(total: int) -> None:

--- a/packages/core/src/repowise/core/pipeline/phases/ingestion.py
+++ b/packages/core/src/repowise/core/pipeline/phases/ingestion.py
@@ -169,7 +169,7 @@ async def _run_ingestion(
 
     parsed_files: list[Any] = []
     source_map: dict[str, bytes] = {}
-    graph_builder = GraphBuilder(repo_path=repo_path)
+    graph_builder = GraphBuilder(repo_path=repo_path, exclude_patterns=exclude_patterns)
 
     loop = asyncio.get_running_loop()
     workers = max(1, os.cpu_count() or 4)

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -122,3 +122,27 @@ class TestErrorCases:
         (tmp_path / ".repowise").mkdir()
         result = runner.invoke(cli, ["update", str(tmp_path)])
         assert result.exit_code != 0
+
+
+class TestBuildFilteredChangedPaths:
+    def test_excludes_matching_patterns(self):
+        from unittest.mock import MagicMock
+
+        from repowise.cli.commands.update_cmd import _build_filtered_changed_paths
+
+        fds = [
+            MagicMock(path="src/main.py"),
+            MagicMock(path=".claude/config.yml"),
+            MagicMock(path="tools/build.sh"),
+        ]
+        result = _build_filtered_changed_paths(fds, [".claude/", "tools/"])
+        assert result == ["src/main.py"]
+
+    def test_no_patterns_returns_all(self):
+        from unittest.mock import MagicMock
+
+        from repowise.cli.commands.update_cmd import _build_filtered_changed_paths
+
+        fds = [MagicMock(path="src/main.py"), MagicMock(path=".claude/config.yml")]
+        result = _build_filtered_changed_paths(fds, [])
+        assert result == ["src/main.py", ".claude/config.yml"]

--- a/tests/unit/ingestion/test_graph.py
+++ b/tests/unit/ingestion/test_graph.py
@@ -954,3 +954,28 @@ class TestGoImports:
         b.build()
         g = b.graph()
         assert g.has_edge("main.go", "calculator/calculator.go")
+
+
+class TestDynamicEdgeExcludeFilter:
+    def _edge(self, target: str):
+        from repowise.core.ingestion.dynamic_hints import DynamicEdge
+
+        return DynamicEdge(
+            source="src/main.py",
+            target=target,
+            edge_type="co_change",
+            hint_source="git",
+            weight=1.0,
+        )
+
+    def test_skips_excluded_targets(self):
+        gb = GraphBuilder("/tmp/fake", exclude_patterns=[".claude/"])
+        gb._graph.add_node("src/main.py")
+        gb.add_dynamic_edges([self._edge(".claude/config.yml")])
+        assert ".claude/config.yml" not in gb._graph
+
+    def test_allows_non_excluded_targets(self):
+        gb = GraphBuilder("/tmp/fake", exclude_patterns=[".claude/"])
+        gb._graph.add_node("src/main.py")
+        gb.add_dynamic_edges([self._edge("src/utils.py")])
+        assert "src/utils.py" in gb._graph

--- a/tests/unit/test_git_indexer.py
+++ b/tests/unit/test_git_indexer.py
@@ -651,3 +651,25 @@ class TestBlameOwnershipComputed:
         assert name == "Alice"
         assert email == "alice@example.com"
         assert pct == pytest.approx(0.8)
+
+
+class TestExcludePatterns:
+    def test_get_tracked_files_respects_exclude_patterns(self) -> None:
+        indexer = GitIndexer("/tmp/fake", exclude_patterns=[".claude/", "tools/"])
+
+        fake_repo = MagicMock()
+        fake_repo.git.ls_files.return_value = (
+            "src/main.py\n.claude/config.yml\ntools/build.sh\nsrc/utils.py"
+        )
+
+        result = indexer._get_tracked_files(fake_repo)
+        assert result == ["src/main.py", "src/utils.py"]
+
+    def test_get_tracked_files_no_exclude_patterns(self) -> None:
+        indexer = GitIndexer("/tmp/fake")
+
+        fake_repo = MagicMock()
+        fake_repo.git.ls_files.return_value = "src/main.py\n.claude/config.yml"
+
+        result = indexer._get_tracked_files(fake_repo)
+        assert result == ["src/main.py", ".claude/config.yml"]


### PR DESCRIPTION
## What

Make `exclude_patterns` actually exclude files from the git indexer and from dynamic-edge graph construction.

## Why

`exclude_patterns` was honored by file traversal but bypassed in two places (issues 1 and 2 of #296):

1. The git indexer ran `git ls-files` and indexed every tracked file, so excluded paths still produced git metadata (churn, ownership, hotspots).
2. Dynamic-edge creation added a graph node for any co-change/hint target, so excluded files reappeared as phantom nodes even though traversal skipped them.

## How

- `GitIndexer` accepts `exclude_patterns` and filters them out of `git ls-files`. Threaded through `_run_git_indexing` and the orchestrator's git stage (init path).
- The incremental update path (`_rebuild_graph_and_git`) passes `exclude_patterns` to `GitIndexer` and filters changed paths via a new `_build_filtered_changed_paths` helper.
- `GraphBuilder` accepts `exclude_patterns`; `add_dynamic_edges` no longer creates phantom nodes for excluded targets. Threaded into the ingestion pipeline phase and the update rebuild path.

All filtering uses `pathspec` (gitwildmatch), consistent with how traversal already applies `exclude_patterns`.

## Tests

- `tests/unit/test_git_indexer.py::TestExcludePatterns`: `_get_tracked_files` filters excluded paths and is a no-op without patterns.
- `tests/unit/cli/test_commands.py::TestBuildFilteredChangedPaths`: changed-path filtering.
- `tests/unit/ingestion/test_graph.py::TestDynamicEdgeExcludeFilter`: excluded dynamic-edge targets do not create phantom nodes; non-excluded targets still do.
- Full ingestion + git-indexer + cli suites pass (874 passed, 2 xfailed).

This change is Python-only and does not touch `packages/web`.

Closes #296 (issues 1 and 2; the remaining issues 3 and 5 are separate follow-up PRs).