### PR TITLE
fix(health): suppress primitive obsession in tiny modules

### DIFF
--- a/docs/CODE_HEALTH.md
+++ b/docs/CODE_HEALTH.md
@@ -98,7 +98,9 @@ so it is excluded — the trigger is about length-with-substance, not raw line
 count.
 
 **primitive_obsession** — Many primitive parameters in one signature. A
-dataclass or parameter object would name the inputs.
+dataclass or parameter object would name the inputs. Suppressed in very small
+modules (under ~60 non-blank lines), where a wide signature is an idiomatic
+config/builder/forwarder rather than a design smell.
 
 **dry_violation** — Cross-file code clones, detected by a native Rabin–Karp
 rolling hash over tree-sitter tokens (variable renames don't hide a clone).

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/README.md
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/README.md
@@ -26,7 +26,8 @@ Structural complexity (cap −2.5):
 Size & complexity (cap −1.5):
 - `complex_method` — functions with CCN ≥ 9.
 - `large_method` — functions exceeding the NLOC threshold.
-- `primitive_obsession` — many primitive parameters in a single signature.
+- `primitive_obsession` — many primitive parameters in a single signature
+  (suppressed in very small modules, where a wide signature is idiomatic).
 
 Duplication (cap −1.0):
 - `dry_violation` — Rabin–Karp clone pairs, weighted by co-change.

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/primitive_obsession.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/primitive_obsession.py
@@ -9,6 +9,15 @@ default.
 
 Constructors (`__init__`, `init`) get a small grace allowance — wide
 dataclass-style ctors are an idiomatic pattern, not a smell.
+
+A wide signature only counts as obsession in a file with enough substance to
+*have* a design (`_MIN_FILE_NLOC`). In a tiny module a long parameter list is
+almost always an idiomatic config/builder/forwarder entry point rather than a
+value object that wants extracting — and an empirical defect-prediction analysis
+across a 13-repo corpus confirmed the firing is anti-predictive there (it flags
+clean small utility files), inverting discrimination on the small-file size
+band. The floor keeps the smell where it carries signal without touching its
+scoring weight; larger modules and the per-function param logic are unchanged.
 """
 
 from __future__ import annotations
@@ -19,6 +28,10 @@ from .base import BiomarkerResult, FileContext
 _PARAM_THRESHOLD = 5
 _CTOR_GRACE = 2  # constructors get +2 free params before the smell trips
 _CTOR_NAMES = frozenset({"__init__", "init", "constructor"})
+# A wide signature in a module below this many non-blank lines is idiomatic
+# (config/builder/DTO), not a design smell — empirically anti-predictive of
+# defects on small files. Tuned on the defect benchmark's small-file size band.
+_MIN_FILE_NLOC = 60
 
 
 class PrimitiveObsessionDetector:
@@ -26,6 +39,8 @@ class PrimitiveObsessionDetector:
     category = "size_and_complexity"
 
     def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        if ctx.nloc < _MIN_FILE_NLOC:
+            return []
         out: list[BiomarkerResult] = []
         for fn in ctx.function_metrics.values():
             threshold = _PARAM_THRESHOLD

--- a/tests/unit/health/test_structural_biomarkers.py
+++ b/tests/unit/health/test_structural_biomarkers.py
@@ -65,11 +65,19 @@ def test_large_method_severity_grades():
 # ---- primitive_obsession -------------------------------------------------
 
 
+# A filler function that lifts the enclosing file above the _MIN_FILE_NLOC floor
+# so primitive_obsession is evaluated (a wide signature in a tiny module is
+# idiomatic and suppressed — see test_primitive_obsession_skips_tiny_files).
+_FILLER = FunctionComplexity(
+    "filler", 1, 70, ccn=1, max_nesting=0, cognitive=0, nloc=70, param_count=0
+)
+
+
 def test_primitive_obsession_flags_wide_signature():
     fn = FunctionComplexity(
-        "do_things", 1, 5, ccn=1, max_nesting=0, cognitive=0, nloc=3, param_count=7
+        "do_things", 1, 30, ccn=1, max_nesting=0, cognitive=0, nloc=24, param_count=7
     )
-    out = PrimitiveObsessionDetector().detect(_ctx([fn]))
+    out = PrimitiveObsessionDetector().detect(_ctx([fn, _FILLER]))
     assert len(out) == 1
     assert out[0].details["param_count"] == 7
 
@@ -77,18 +85,30 @@ def test_primitive_obsession_flags_wide_signature():
 def test_primitive_obsession_grace_for_constructors():
     # 6 params on a regular fn fires; on __init__ it doesn't (grace = 2).
     regular = FunctionComplexity(
-        "build", 1, 5, ccn=1, max_nesting=0, cognitive=0, nloc=3, param_count=6
+        "build", 1, 20, ccn=1, max_nesting=0, cognitive=0, nloc=14, param_count=6
     )
     ctor = FunctionComplexity(
-        "__init__", 1, 5, ccn=1, max_nesting=0, cognitive=0, nloc=3, param_count=6
+        "__init__", 1, 20, ccn=1, max_nesting=0, cognitive=0, nloc=14, param_count=6
     )
     d = PrimitiveObsessionDetector()
-    assert d.detect(_ctx([regular]))
-    assert d.detect(_ctx([ctor])) == []
+    assert d.detect(_ctx([regular, _FILLER]))
+    assert d.detect(_ctx([ctor, _FILLER])) == []
 
 
 def test_primitive_obsession_ignores_small_signatures():
     fn = FunctionComplexity(
-        "narrow", 1, 5, ccn=1, max_nesting=0, cognitive=0, nloc=3, param_count=3
+        "narrow", 1, 20, ccn=1, max_nesting=0, cognitive=0, nloc=14, param_count=3
+    )
+    assert PrimitiveObsessionDetector().detect(_ctx([fn, _FILLER])) == []
+
+
+def test_primitive_obsession_skips_tiny_files():
+    # A wide signature in a module below the file-NLOC floor is idiomatic
+    # (config/builder/forwarder), not a design smell — suppressed. (Phase-9
+    # failure-forensics: anti-predictive on the small-file size band.)
+    fn = FunctionComplexity(
+        "configure", 1, 12, ccn=1, max_nesting=0, cognitive=0, nloc=10, param_count=8
     )
     assert PrimitiveObsessionDetector().detect(_ctx([fn])) == []
+    # The same wide signature in a substantial module still fires.
+    assert PrimitiveObsessionDetector().detect(_ctx([fn, _FILLER]))


### PR DESCRIPTION
A wide parameter list in a very small module (under 60 non-blank lines) is almost always an idiomatic config/builder/forwarder entry point, not a value object waiting to be extracted. Firing the `primitive_obsession` smell there flags clean small utility files and adds noise without predictive value.

This gates the detector on a minimal file size so the smell only fires where it carries signal.

**Scope**
- Scoring weights, categories and caps are unchanged; larger modules and the per-function parameter logic behave exactly as before.
- The detector simply returns no findings in modules below the size floor.

**Validation**
- A defect-prediction analysis across a 13-repo, 5-language corpus showed `primitive_obsession` firing on small files is anti-predictive (it flags clean small utility files), inverting discrimination on the small-file size band. Suppressing it there improves that band and leaves overall discrimination and cost-effectiveness unchanged — a precision/noise fix with no regression.
- Added a regression test for tiny-file suppression; existing cases updated to substantial modules. Full health suite green (212 passed); lint + format clean; scoring snapshot unchanged.