### PR TITLE
feat(health): extend code-health biomarkers to Kotlin, C++, and C#

### DIFF
--- a/docs/LANGUAGE_SUPPORT.md
+++ b/docs/LANGUAGE_SUPPORT.md
@@ -21,8 +21,18 @@ pipeline stages produce meaningful output.
 | Call graph edges | Y | partial | -- | -- | -- |
 | Heritage (extends/implements) | Y | partial | -- | -- | -- |
 | Named bindings | Y | -- | -- | -- | -- |
+| Code-health biomarkers | Y¹ | -- | -- | -- | -- |
 | Dead code detection | Y | Y | Y | Y | -- |
 | Semantic search & wiki pages | Y | Y | Y | Y | Y |
+
+¹ **Code-health biomarkers** require a per-language complexity-walker map
+(`analysis/health/complexity/languages.py`), independent of `.scm` parsing.
+A language is only listed **Full** once it clears the
+[code-health checklist](#code-health-biomarker-coverage) below — except
+**Go**, whose class-level metrics (LCOM4 / god-class) are not computable
+because Go methods attach to a type via an external receiver rather than
+nesting in a class body; Go gets the function- and assertion-level
+biomarkers but is footnoted on the class-level ones.
 
 ---
 
@@ -60,6 +70,43 @@ All nine languages support:
 - For TypeScript / JavaScript only: a workspace-granular index (`TsWorkspaceIndex`) built as a warmup phase that surfaces every file reachable through a `package.json` `exports` map (including `"./locales/*"`-style wildcards) as an entry point so downstream npm consumers don't read as unreachable; type-reference resolution emits `type_use` edges for parameter / field / return / generic-constraint / type-alias-RHS / heritage clauses (unwrapping `Promise<T>`, `T[]`, `Pick<T,K>`, union/intersection, conditional/mapped types) so interfaces consumed only as types are not flagged dead; same-file rescue exempts symbols whose only consumer is another declaration in the same module; convention never-flag globs for `*.test.*` / `*.spec.*` / `*.stories.*` / `*.bench.*` / `__tests__/**` / `__mocks__/**` / Next.js app-router files (`page.tsx`, `layout.tsx`, `route.ts`, `middleware.ts`, `instrumentation.ts`, route segment configs) / SvelteKit `+page` / `+layout` / `+server` / Remix `entry.client` / `entry.server` / `next-env.d.ts` / `*.gen.ts` / `generated/**`; experimental sub-package rescue marks every source file in directories named `bench` / `benchmarks` / `treeshake` / `examples` / `demos` / `samples` / `playground` / `scratch` / `scripts` as a live entry (these dirs invoke their files via runtime CLI arguments no static scan can follow); npm-script entry detection — parses every `package.json` `scripts.*` command for paths (`tsx X.ts` / `bun run X.mts` / `rollup -c X.js`), quoted glob arguments (prettier / eslint scopes), and bare directory tokens; MDX `import` scan + `vitest.config` `include` glob scan as belt-and-suspenders for entry surfaces the static parser can't see; framework edges for Next.js App Router (`app/**/{page,layout,route,middleware,…}`), Hono / Fastify / Koa / Elysia router DSLs (`.get('/x', handler)`), Remix / SvelteKit / Astro filesystem-convention routes, and tRPC procedure registries (`.query(handler)` / `.mutation(handler)`); JSX-namespace types declared inside a `namespace JSX` file are exempt from `unused_export` (consumed by tsc via `jsxImportSource`, never imported as values)
 - For XAML only: `<ResourceDictionary Source="..."/>` and `MergedDictionaries` entries resolve across `pack://application:,,,/`, `ms-appx:///`, repo-rooted and relative URIs, emitting xaml→xaml `dynamic_uses` edges
 - For JVM (Java + Kotlin together) only: a unified `JvmWorkspaceIndex` warmup parsing Maven `pom.xml` reactors and Gradle `settings.gradle(.kts)` + source-sets + `gradle/libs.versions.toml` version catalogs; one walk groups every `.java` and `.kt` file by package directory so `import com.foo.Bar` fans out to every defining file in the package (siblings share importers), `import com.foo.*` / `import static com.foo.Bar.*` expand to all matching files, same-package implicit identifier access is honoured, and Kotlin↔Java cross-language resolution links callers across both source-roots (including `.kt` files hosted under `src/main/java`); type-reference resolution emits `type_use` edges for parameter / field / return / generic / `new T()` types (unwrapping arrays, generics, nullables), plus Kotlin `companion object` / `object` singleton / method-reference (`Foo::bar`) / `sealed … permits` resolution; source-generator-equivalent synthesis emits the symbols Lombok (`@Data` / `@Value` / `@Builder` / `@RequiredArgsConstructor` / `@Slf4j` / `@UtilityClass` / friends), Java `record`, Kotlin `data class` / `enum class` / `object`, and MapStruct / AutoValue / Immutables would produce at compile time — so a Lombok-only Spring service no longer reads its injected fields as unused; framework edges cover Spring (stereotypes with meta-annotation resolution; `@RequestMapping` family routing; Spring Data `JpaRepository` / `Crud` / `Mongo` / `R2dbc` / `Elasticsearch` / `Neo4j` / `Couchbase` / `Cassandra` interfaces and their derived-query methods as entry points; `@Bean` factories; single-constructor + `@Autowired` / `@Inject` / `@Resource` DI; Lombok-RAC/AAC constructor inference), Jakarta (JAX-RS `@Path`, CDI scopes, Servlet 3+ `@WebServlet`/`@WebFilter`/`@WebListener`, JPA `@Entity` + `@OneToMany`/`@ManyToOne`/`@ManyToMany`/`@OneToOne` association edges; both `javax.*` and `jakarta.*`), Quarkus (entry stereotypes + SmallRye `@Incoming("topic")` ↔ `@Outgoing("topic")` cross-linking), Micronaut (DI / routing, gated on Micronaut imports to disambiguate Spring's collisions), and Android (`AndroidManifest.xml` `android:name` references emit edges to the named class); JVM dynamic hints capture `Class.forName`, Mockito / mockk, MapStruct `Mappers.getMapper`, `SpringApplication.run` and Kotlin `runApplication<>`, Jackson / Gson `readValue` / `fromJson` / `treeToValue`; package-aware dead-code reachability rescues sibling-rescued packages, stereotype-annotated classes, `main(String[])` carriers, and FQNs listed in `META-INF/services/*` / `META-INF/spring.factories` (Boot 2) / `META-INF/spring/...AutoConfiguration.imports` (Boot 3) / JPMS `provides … with …` — all resolved during the workspace warmup; JVM never-flag patterns cover `module-info.java`, `package-info.java`, every conventional test source-set (`src/test/**`, `src/integrationTest/**`, `src/intTest/**`, `src/it/**`, `src/jmh/**`, generic `src/*Test/**`), generated source roots (`build/generated/**`, KAPT/KSP, `target/generated-sources/**`, GraalVM `aotSources`), generated suffix conventions (`Dagger*`, `AutoValue_*`, JPA `*_.java` metamodel, `*Grpc.java`, protoc `*OuterClass.java`), JUnit / TestNG / Spock / ArchUnit test-naming + annotation-marked entry points (`@Test` / `@PostConstruct` / `@EventListener` / `@Scheduled` / `@JmsListener` / `@KafkaListener` / `@RabbitListener` / `@SqsListener` / `@Incoming` / `@Outgoing` / `@Mojo` / `@Bean` / …), and JVM contract methods (`equals` / `hashCode` / `toString` / `compareTo` / `clone` / serialization `readObject` / `writeObject` / `serialVersionUID` / Lombok `canEqual` / Kotlin `componentN` / `copy` / enum `values` / `valueOf`)
+
+#### Code-health biomarker coverage
+
+The code-health layer scores every source file from deterministic
+biomarkers (complexity, cohesion, test-quality, …). These run off a
+per-language complexity-walker map
+(`analysis/health/complexity/languages.py`) that is **independent** of the
+`.scm` ingestion queries — a language can parse perfectly for the graph yet
+still need this map before health biomarkers fire. To keep "Full" meaning
+"health works", a language must clear this checklist (each item has a green
+fixture under `tests/fixtures/lang_samples/<lang>/` + a walker test):
+
+1. **Control flow** — `if` / loop / `switch`/`match`/`when` / `try`-`catch`
+   nodes mapped → McCabe CCN, nesting depth, cognitive complexity.
+2. **Boolean operators** — `&&` / `||` (or their text form) counted toward
+   CCN and `complex_conditional`.
+3. **Class metrics** — `class_kinds` set so `method_count` / `total_nloc` /
+   `max_method_ccn` aggregate (feeds `god_class`). *(N/A for Go — no
+   class-grouping node.)*
+4. **LCOM4 cohesion** — `self_identifiers` + `member_access_kinds` set so
+   explicit-receiver member access is detected (feeds `low_cohesion`).
+   Receiver-less idioms degrade to "no signal", never a false positive.
+   *(N/A for Go.)*
+5. **Assertion blocks** — `assert_kinds` / `assert_call_kinds` set so runs
+   of consecutive assertions are detected on test files (feeds
+   `large_assertion_block` / `duplicated_assertion_block`).
+
+| Language | Control flow | Class metrics | LCOM4 | Assertions |
+|----------|:---:|:---:|:---:|:---:|
+| Python | Y | Y | Y | Y |
+| TypeScript / JavaScript | Y | Y | Y | Y |
+| Java | Y | Y | Y | Y |
+| Kotlin | Y | Y | Y | Y |
+| Go | Y | — | — | Y |
+| Rust | Y | Y | Y | Y |
+| C++ | Y | Y | Y | Y |
+| C# | Y | Y | Y | Y |
 
 ### Good
 
@@ -351,9 +398,10 @@ without touching the shared pipeline files:
   `assert_kinds` / `assert_call_kinds` to get test-quality assertion-block
   smells. All tiers are purely additive and degrade safely — an unmapped
   language simply produces no health findings rather than wrong ones.
-  Control-flow maps ship for Python, TypeScript, JavaScript, Go, Java,
-  Rust; class-level maps for all of those except Go; assertion maps for all
-  six. See `complexity/README.md` for the extension recipe and the LCOM4
+  Control-flow and assertion maps ship for all nine full-tier languages
+  (Python, TypeScript, JavaScript, Go, Java, Kotlin, Rust, C++, C#);
+  class-level maps for all of those except Go (no class-grouping node).
+  See `complexity/README.md` for the extension recipe and the LCOM4
   heuristic's limits.
 
 ---

--- a/docs/architecture/code-health.md
+++ b/docs/architecture/code-health.md
@@ -421,7 +421,7 @@ them on legacy DBs.
 
 The complexity walker emits a `ClassComplexity` per class-like node for
 languages that opt in (`LanguageNodeMap.class_kinds` non-empty: Python,
-TS/JS, Java, Rust `impl`; Go has no grouping node). LCOM4 is the number of
+TS/JS, Java, Kotlin, Rust `impl`, C++, C#; Go has no grouping node). LCOM4 is the number of
 connected components in the graph whose nodes are the class's methods and
 whose edges link methods that share an instance field or call one another.
 Member references are detected per-language via `self`/`this`/`$this`
@@ -439,8 +439,9 @@ The same single walker pass records `assertion_blocks` on each
 is a bare `assert` (`LanguageNodeMap.assert_kinds`) or its expression is a
 call (`assert_call_kinds`) whose callee name starts with `assert` or
 `expect` — covering `assertEqual` / `assert_eq!` / `expect(...).toBe(...)`
-across xUnit and BDD styles. Opt-in per language (Python, TS/JS, Java, Rust,
-Go are mapped); a language that maps neither field simply emits no blocks.
+across xUnit and BDD styles. Opt-in per language (all nine full-tier
+languages — Python, TS/JS, Java, Kotlin, Go, Rust, C++, C# — are mapped);
+a language that maps neither field simply emits no blocks.
 `large_assertion_block` flags a single run ≥ 15; `duplicated_assertion_block`
 intersects the clone report with assertion spans. Both gate on
 `coverage.is_test_file(path)` so production code is never touched.

--- a/packages/core/src/repowise/core/analysis/health/complexity/README.md
+++ b/packages/core/src/repowise/core/analysis/health/complexity/README.md
@@ -70,10 +70,13 @@ Consumed by `low_cohesion` and `god_class`.
 
 - **Member detection is best-effort and per-language.** A method's field
   reads and intra-class calls are found by scanning for `self.x` /
-  `this.x` / `$this->x` member-access nodes whose receiver token is in the
-  language's `self_identifiers`. Members accessed without an explicit
-  receiver (Python has none; Ruby's `@ivar`, implicit-`this` in some
-  languages) are not counted.
+  `this.x` / `this->x` / `$this->x` member-access nodes whose receiver
+  token is in the language's `self_identifiers`. Members accessed without
+  an explicit receiver are not counted — and this is the common idiom in
+  **Kotlin, C++, C#, and Java** (bare `field`, not `this.field`), so on
+  receiver-less code those languages fall through to the "no signal" valve
+  below rather than over-reporting cohesion. (Ruby's `@ivar` is the same
+  shape.)
 - **Safety valve.** If a class yields *zero* detected member references
   (a pure-static utility class, or a language whose member-access node
   type isn't mapped yet), `lcom4` falls back to `1` ("no signal") rather
@@ -119,9 +122,10 @@ fields on its `LanguageNodeMap` (all default to empty = opt-out):
 
 The receiver and member-name children are extracted by a generic
 field-name probe (`walker._self_member_name`), which tries the
-`object`/`value` and `property`/`attribute`/`field`/`name` fields and then
-falls back to positional children — so most tree-sitter grammars need only
-the node-type names above. Get one wrong and the safety valve degrades the
+`object`/`value`/`argument`/`expression` (receiver) and
+`property`/`attribute`/`field`/`name` (member) fields and then falls back
+to positional children — so most tree-sitter grammars need only the
+node-type names above. Get one wrong and the safety valve degrades the
 class to "no signal" rather than emitting a false positive, so it's cheap
 to add a language speculatively and refine later.
 
@@ -136,10 +140,13 @@ opt-in fields:
   `assertEqual` / `assert_eq!` / `expect(...).toBe(...)`).
 
 A language that maps neither produces no assertion blocks — never a false
-positive.
+positive. (Languages without an `expression_statement` wrapper — e.g.
+Kotlin, where the call node sits directly in the statement list — are
+handled too: the call node is matched as the statement itself.)
 
-Ships control-flow mappings for Python, TypeScript, JavaScript, Go, Java,
-Rust; class-level mappings for Python, TypeScript, JavaScript, Java, Rust
-(Go has no class-grouping node); assertion mappings for Python, TypeScript,
-JavaScript, Java, Rust, Go. Adding more languages — any tier — is purely
-additive in `languages.py`.
+Ships control-flow + assertion mappings for **all nine full-tier
+languages** — Python, TypeScript, JavaScript, Go, Java, Kotlin, Rust, C++,
+C# — plus the `tsx`/`jsx` aliases; class-level (LCOM4 / god-class)
+mappings for all of those except **Go** (methods attach to a type via an
+external receiver, so there is no single grouping node). Adding more
+languages — any tier — is purely additive in `languages.py`.

--- a/packages/core/src/repowise/core/analysis/health/complexity/languages.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/languages.py
@@ -25,9 +25,17 @@ names to the walker's abstract categories:
                   test-assertion runs (test-quality smells). Opt-in per
                   language via ``assert_kinds`` / ``assert_call_kinds``.
 
-Control-flow maps cover Python, TypeScript, JavaScript, Go, Java, Rust;
-class-level maps cover all of those except Go (no class-grouping node).
-Adding a language — either tier — is purely additive here.
+Control-flow maps cover all nine full-tier languages — Python, TypeScript,
+JavaScript, Go, Java, Kotlin, Rust, C++, C# — plus their aliases; class-level
+maps cover all of those except Go (no class-grouping node). Adding a language —
+either tier — is purely additive here.
+
+Two cross-language heuristic limits worth noting (both degrade to "no signal",
+never a false positive): (1) instance members accessed without an explicit
+receiver (idiomatic Kotlin/C++/C#/Java bare ``field`` rather than
+``this.field``) are not counted toward LCOM4 cohesion, so ``low_cohesion``
+stays silent on receiver-less code; (2) flat ``switch``/``when``/``match``
+arms count once for the dispatch, not per arm.
 """
 
 from __future__ import annotations
@@ -235,6 +243,83 @@ _RUST = LanguageNodeMap(
 )
 
 
+_KOTLIN = LanguageNodeMap(
+    function_kinds=frozenset({"function_declaration"}),
+    lambda_kinds=frozenset({"lambda_literal", "anonymous_function"}),
+    branch_kinds=frozenset({"if_expression"}),
+    loop_kinds=frozenset({"for_statement", "while_statement", "do_while_statement"}),
+    try_kinds=frozenset({"try_expression"}),
+    catch_kinds=frozenset({"catch_block"}),
+    switch_kinds=frozenset({"when_expression"}),
+    case_kinds=frozenset({"when_entry"}),
+    boolean_operator_kinds=frozenset(),
+    boolean_operator_text_kinds=frozenset({"binary_expression"}),
+    # Methods group under a ``class_body``; ``object_declaration`` (singletons
+    # / companion objects) groups them the same way. Member access is
+    # ``receiver.member`` via ``navigation_expression``; the instance receiver
+    # is a ``this_expression`` whose text is ``this``. NOTE: idiomatic Kotlin
+    # accesses members WITHOUT an explicit ``this.`` receiver — those bare
+    # references are not counted (the documented implicit-receiver limit), so
+    # ``low_cohesion`` stays at the "no signal" value rather than mis-firing.
+    class_kinds=frozenset({"class_declaration", "object_declaration"}),
+    self_identifiers=frozenset({"this"}),
+    member_access_kinds=frozenset({"navigation_expression"}),
+    # Kotlin has no bare ``assert`` keyword; ``assertEquals(...)`` /
+    # ``assertTrue(...)`` are plain calls placed directly in the statement
+    # list (no ``expression_statement`` wrapper).
+    assert_call_kinds=frozenset({"call_expression"}),
+)
+
+_CPP = LanguageNodeMap(
+    function_kinds=frozenset({"function_definition"}),
+    lambda_kinds=frozenset({"lambda_expression"}),
+    branch_kinds=frozenset({"if_statement", "conditional_expression"}),
+    loop_kinds=frozenset({"for_statement", "while_statement", "do_statement", "for_range_loop"}),
+    try_kinds=frozenset({"try_statement"}),
+    catch_kinds=frozenset({"catch_clause"}),
+    switch_kinds=frozenset({"switch_statement"}),
+    case_kinds=frozenset({"case_statement"}),
+    boolean_operator_kinds=frozenset(),
+    boolean_operator_text_kinds=frozenset({"binary_expression"}),
+    # ``class_specifier`` / ``struct_specifier`` group methods in a
+    # ``field_declaration_list``. ``field_expression`` covers both
+    # ``this->member`` and ``obj.member``; the instance receiver is the
+    # ``this`` node. Same implicit-receiver limit as Kotlin — bare member
+    # access (no ``this->``) is not counted.
+    class_kinds=frozenset({"class_specifier", "struct_specifier"}),
+    self_identifiers=frozenset({"this"}),
+    member_access_kinds=frozenset({"field_expression"}),
+    # GoogleTest / Catch2 / Boost.Test macros: ``EXPECT_EQ`` / ``ASSERT_EQ`` /
+    # ``ASSERT_TRUE`` are ordinary calls (``expect``/``assert`` prefix matched
+    # case-insensitively).
+    assert_call_kinds=frozenset({"call_expression"}),
+)
+
+_CSHARP = LanguageNodeMap(
+    function_kinds=frozenset(
+        {"method_declaration", "constructor_declaration", "local_function_statement"}
+    ),
+    lambda_kinds=frozenset({"lambda_expression"}),
+    branch_kinds=frozenset({"if_statement", "conditional_expression"}),
+    loop_kinds=frozenset({"for_statement", "while_statement", "foreach_statement", "do_statement"}),
+    try_kinds=frozenset({"try_statement"}),
+    catch_kinds=frozenset({"catch_clause"}),
+    switch_kinds=frozenset({"switch_statement", "switch_expression"}),
+    case_kinds=frozenset({"switch_section", "switch_expression_arm"}),
+    boolean_operator_kinds=frozenset(),
+    boolean_operator_text_kinds=frozenset({"binary_expression"}),
+    # ``class``/``struct``/``record`` declarations group methods in a
+    # ``declaration_list``. ``member_access_expression`` covers
+    # ``this.member`` (and ``obj.member``); ``this`` is the receiver token.
+    class_kinds=frozenset({"class_declaration", "struct_declaration", "record_declaration"}),
+    self_identifiers=frozenset({"this"}),
+    member_access_kinds=frozenset({"member_access_expression"}),
+    # xUnit / NUnit / MSTest: ``Assert.Equal(...)`` / ``Assert.True(...)`` are
+    # invocations whose callee chain begins with ``Assert``.
+    assert_call_kinds=frozenset({"invocation_expression"}),
+)
+
+
 LANGUAGE_MAPS: dict[str, LanguageNodeMap] = {
     "python": _PY,
     "typescript": _TS,
@@ -244,6 +329,9 @@ LANGUAGE_MAPS: dict[str, LanguageNodeMap] = {
     "go": _GO,
     "java": _JAVA,
     "rust": _RUST,
+    "kotlin": _KOTLIN,
+    "cpp": _CPP,
+    "csharp": _CSHARP,
 }
 
 

--- a/packages/core/src/repowise/core/analysis/health/complexity/walker.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/walker.py
@@ -120,6 +120,13 @@ class FileComplexity:
     classes: list[ClassComplexity]
 
 
+# Leaf node types that carry a declared name at the bottom of a C/C++
+# ``declarator`` chain.
+_DECLARATOR_NAME_KINDS = frozenset(
+    {"identifier", "field_identifier", "type_identifier", "qualified_identifier"}
+)
+
+
 def _find_name(node: Node) -> str:
     """Best-effort: return the text of the first identifier child."""
     # Search a couple of common field names first.
@@ -127,6 +134,16 @@ def _find_name(node: Node) -> str:
         child = node.child_by_field_name(field_name)
         if child is not None and child.text is not None:
             return child.text.decode("utf-8", errors="replace")
+    # C / C++: the function name is not a direct child but nested inside a
+    # ``declarator`` chain (``function_definition → function_declarator →
+    # field_identifier``). Languages with a ``name`` field never reach here.
+    decl = node.child_by_field_name("declarator")
+    hops = 0
+    while decl is not None and hops < 6:
+        if decl.type in _DECLARATOR_NAME_KINDS and decl.text is not None:
+            return decl.text.decode("utf-8", errors="replace")
+        decl = decl.child_by_field_name("declarator") or decl.child_by_field_name("name")
+        hops += 1
     for child in node.children:
         if (
             child.type in ("identifier", "property_identifier", "field_identifier")
@@ -486,7 +503,16 @@ def _is_assertion_statement(stmt: Node, lmap: LanguageNodeMap) -> bool:
     """True if *stmt* is a test assertion (bare ``assert`` or assert call)."""
     if stmt.type in lmap.assert_kinds:
         return True
-    if not lmap.assert_call_kinds or stmt.type != _EXPRESSION_STATEMENT:
+    if not lmap.assert_call_kinds:
+        return False
+    # Some grammars (Kotlin) have no ``expression_statement`` wrapper — the
+    # call node sits directly in the statement list. Match it as the
+    # statement itself. (Wrapper languages never hit this: their call nodes
+    # only ever appear as the single child of an ``expression_statement``,
+    # so they can't form a run of ≥2 at this level.)
+    if stmt.type in lmap.assert_call_kinds:
+        return _callee_matches_assert(stmt)
+    if stmt.type != _EXPRESSION_STATEMENT:
         return False
     call = _find_assert_call(stmt, lmap.assert_call_kinds)
     return call is not None and _callee_matches_assert(call)
@@ -562,7 +588,9 @@ def _collect_function_nodes(root: Node, lmap: LanguageNodeMap) -> list[Node]:
 # ----------------------------------------------------------------------
 
 _PROP_FIELD_NAMES = ("property", "attribute", "field", "name")
-_OBJECT_FIELD_NAMES = ("object", "value", "argument", "operand")
+# ``expression`` is C#'s receiver field on ``member_access_expression`` (its
+# ``this`` token is unnamed, so the positional fallback would pick the member).
+_OBJECT_FIELD_NAMES = ("object", "value", "argument", "operand", "expression")
 _IDENTIFIER_SUFFIX = "identifier"
 
 

--- a/tests/fixtures/lang_samples/cpp/assertions.cpp
+++ b/tests/fixtures/lang_samples/cpp/assertions.cpp
@@ -1,0 +1,27 @@
+// Fixture for assertion-block detection (test-quality smells).
+// GoogleTest-style EXPECT_*/ASSERT_* macros are ordinary call expressions.
+
+void testManyAsserts() {
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, 1);
+}
+
+void testFewAsserts() {
+    EXPECT_EQ(1, 1);
+    int x = 2;
+    EXPECT_EQ(x, 2);
+}

--- a/tests/fixtures/lang_samples/cpp/classes.cpp
+++ b/tests/fixtures/lang_samples/cpp/classes.cpp
@@ -1,0 +1,54 @@
+// Fixtures for class-level (LCOM4 / god-class) walker tests.
+//
+// Uses explicit `this->` so the member-access node type is exercised; bare
+// member access (idiomatic C++) is the documented "no signal" path.
+
+class Cohesive {
+    int total;
+    int count;
+
+public:
+    void add(int n) {
+        this->total += n;
+        this->count += 1;
+    }
+
+    int average() {
+        return this->count ? this->total / this->count : 0;
+    }
+
+    void reset() {
+        this->total = 0;
+        this->count = 0;
+    }
+
+    int describe() {
+        return this->count;
+    }
+};
+
+class Splintered {
+    int a;
+    int b;
+
+public:
+    void setA(int v) {
+        this->a = v;
+    }
+
+    int getA() {
+        return this->a;
+    }
+
+    void setB(int v) {
+        this->b = v;
+    }
+
+    int getB() {
+        return this->b;
+    }
+
+    int loner() {
+        return 42;
+    }
+};

--- a/tests/fixtures/lang_samples/cpp/nested.cpp
+++ b/tests/fixtures/lang_samples/cpp/nested.cpp
@@ -1,0 +1,28 @@
+// Fixtures for nesting / cyclomatic-complexity walker tests.
+
+int deeplyNested(int x) {
+    if (x > 0) {
+        for (int i = 0; i < x; i++) {
+            while (i > 0) {
+                if (i == 5) {
+                    return i;
+                }
+            }
+        }
+    }
+    return x;
+}
+
+int shallow(int x) {
+    return x + 1;
+}
+
+int manyBranches(int x) {
+    if (x == 1) return 1;
+    if (x == 2 && x > 0) return 2;
+    if (x == 3 || x < 0) return 3;
+    if (x == 4) return 4;
+    if (x == 5) return 5;
+    if (x == 6) return 6;
+    return x;
+}

--- a/tests/fixtures/lang_samples/csharp/assertions.cs
+++ b/tests/fixtures/lang_samples/csharp/assertions.cs
@@ -1,0 +1,32 @@
+// Fixture for assertion-block detection (test-quality smells).
+// xUnit-style Assert.* invocations.
+
+class Tests
+{
+    void TestManyAsserts()
+    {
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+        Assert.Equal(1, 1);
+    }
+
+    void TestFewAsserts()
+    {
+        Assert.Equal(1, 1);
+        int x = 2;
+        Assert.Equal(x, 2);
+    }
+}

--- a/tests/fixtures/lang_samples/csharp/classes.cs
+++ b/tests/fixtures/lang_samples/csharp/classes.cs
@@ -1,0 +1,61 @@
+// Fixtures for class-level (LCOM4 / god-class) walker tests.
+// Explicit `this.` exercises the member-access node type.
+
+class Cohesive
+{
+    int total;
+    int count;
+
+    public void Add(int n)
+    {
+        this.total += n;
+        this.count += 1;
+    }
+
+    public int Average()
+    {
+        return this.count != 0 ? this.total / this.count : 0;
+    }
+
+    public void Reset()
+    {
+        this.total = 0;
+        this.count = 0;
+    }
+
+    public int Describe()
+    {
+        return this.count;
+    }
+}
+
+class Splintered
+{
+    int a;
+    int b;
+
+    public void SetA(int v)
+    {
+        this.a = v;
+    }
+
+    public int GetA()
+    {
+        return this.a;
+    }
+
+    public void SetB(int v)
+    {
+        this.b = v;
+    }
+
+    public int GetB()
+    {
+        return this.b;
+    }
+
+    public int Loner()
+    {
+        return 42;
+    }
+}

--- a/tests/fixtures/lang_samples/csharp/nested.cs
+++ b/tests/fixtures/lang_samples/csharp/nested.cs
@@ -1,0 +1,38 @@
+// Fixtures for nesting / cyclomatic-complexity walker tests.
+
+class Sample
+{
+    int DeeplyNested(int x)
+    {
+        if (x > 0)
+        {
+            for (int i = 0; i < x; i++)
+            {
+                while (i > 0)
+                {
+                    if (i == 5)
+                    {
+                        return i;
+                    }
+                }
+            }
+        }
+        return x;
+    }
+
+    int Shallow(int x)
+    {
+        return x + 1;
+    }
+
+    int ManyBranches(int x)
+    {
+        if (x == 1) return 1;
+        if (x == 2 && x > 0) return 2;
+        if (x == 3 || x < 0) return 3;
+        if (x == 4) return 4;
+        if (x == 5) return 5;
+        if (x == 6) return 6;
+        return x;
+    }
+}

--- a/tests/fixtures/lang_samples/kotlin/assertions.kt
+++ b/tests/fixtures/lang_samples/kotlin/assertions.kt
@@ -1,0 +1,26 @@
+// Fixture for assertion-block detection (test-quality smells).
+
+fun testManyAsserts() {
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+    assertEquals(1, 1)
+}
+
+fun testFewAsserts() {
+    assertEquals(1, 1)
+    val x = 2
+    assertEquals(x, 2)
+}

--- a/tests/fixtures/lang_samples/kotlin/classes.kt
+++ b/tests/fixtures/lang_samples/kotlin/classes.kt
@@ -1,0 +1,53 @@
+// Fixtures for class-level (LCOM4 / god-class) walker tests.
+//
+// Kotlin accesses instance members WITHOUT a receiver idiomatically; these
+// fixtures use an explicit `this.` so the member-access node type is
+// exercised. The implicit-receiver case is the documented "no signal" path.
+
+class Cohesive {
+    var total = 0
+    var count = 0
+
+    fun add(n: Int) {
+        this.total += n
+        this.count += 1
+    }
+
+    fun average(): Int {
+        return if (this.count != 0) this.total / this.count else 0
+    }
+
+    fun reset() {
+        this.total = 0
+        this.count = 0
+    }
+
+    fun describe(): Int {
+        return this.count
+    }
+}
+
+class Splintered {
+    var a = 0
+    var b = 0
+
+    fun setA(v: Int) {
+        this.a = v
+    }
+
+    fun getA(): Int {
+        return this.a
+    }
+
+    fun setB(v: Int) {
+        this.b = v
+    }
+
+    fun getB(): Int {
+        return this.b
+    }
+
+    fun loner(): Int {
+        return 42
+    }
+}

--- a/tests/fixtures/lang_samples/kotlin/nested.kt
+++ b/tests/fixtures/lang_samples/kotlin/nested.kt
@@ -1,0 +1,28 @@
+// Fixtures for nesting / cyclomatic-complexity walker tests.
+
+fun deeplyNested(x: Int): Int {
+    if (x > 0) {
+        for (i in 0..x) {
+            while (i > 0) {
+                if (i == 5) {
+                    return i
+                }
+            }
+        }
+    }
+    return x
+}
+
+fun shallow(x: Int): Int {
+    return x + 1
+}
+
+fun manyBranches(x: Int): Int {
+    if (x == 1) return 1
+    if (x == 2 && x > 0) return 2
+    if (x == 3 || x < 0) return 3
+    if (x == 4) return 4
+    if (x == 5) return 5
+    if (x == 6) return 6
+    return x
+}

--- a/tests/unit/health/test_complexity_walker.py
+++ b/tests/unit/health/test_complexity_walker.py
@@ -200,3 +200,103 @@ def test_typescript_expect_blocks():
     few = _find(results, "testFewExpects")
     assert few is not None
     assert few.assertion_blocks == []
+
+
+# ---- full-tier language coverage: Kotlin / C++ / C# ----------------------
+#
+# Each new full-tier language is validated end-to-end against the walker:
+# control-flow (nesting + CCN), class-level cohesion (LCOM4), and
+# assertion-block detection — mirroring the Python/TypeScript fixtures.
+
+
+def test_kotlin_nesting_and_ccn():
+    results = _walk("kotlin/nested.kt", "kotlin")
+    deep = _find(results, "deeplyNested")
+    assert deep is not None
+    assert deep.max_nesting >= 4, f"expected ≥4 nesting, got {deep.max_nesting}"
+    many = _find(results, "manyBranches")
+    assert many is not None
+    # 6 ifs + 2 boolean operators over the base path.
+    assert many.ccn >= 9, f"expected CCN ≥ 9, got {many.ccn}"
+    shallow = _find(results, "shallow")
+    assert shallow is not None and shallow.max_nesting == 0
+
+
+def test_kotlin_class_cohesion():
+    classes = _walk_classes("kotlin/classes.kt", "kotlin")
+    cohesive = classes.get("Cohesive")
+    splintered = classes.get("Splintered")
+    assert cohesive is not None and splintered is not None
+    assert cohesive.lcom4 == 1
+    assert splintered.lcom4 == 3
+    assert splintered.method_count == 5
+    assert splintered.field_count == 2
+
+
+def test_kotlin_assertion_blocks():
+    results = _walk("kotlin/assertions.kt", "kotlin")
+    many = _find(results, "testManyAsserts")
+    assert many is not None
+    assert many.assertion_blocks[0][2] == 16
+    few = _find(results, "testFewAsserts")
+    assert few is not None and few.assertion_blocks == []
+
+
+def test_cpp_nesting_and_ccn():
+    results = _walk("cpp/nested.cpp", "cpp")
+    deep = _find(results, "deeplyNested")
+    assert deep is not None
+    assert deep.max_nesting >= 4, f"expected ≥4 nesting, got {deep.max_nesting}"
+    many = _find(results, "manyBranches")
+    assert many is not None
+    assert many.ccn >= 9, f"expected CCN ≥ 9, got {many.ccn}"
+
+
+def test_cpp_class_cohesion():
+    classes = _walk_classes("cpp/classes.cpp", "cpp")
+    cohesive = classes.get("Cohesive")
+    splintered = classes.get("Splintered")
+    assert cohesive is not None and splintered is not None
+    assert cohesive.lcom4 == 1
+    assert splintered.lcom4 == 3
+    assert splintered.method_count == 5
+    assert splintered.field_count == 2
+
+
+def test_cpp_assertion_blocks():
+    results = _walk("cpp/assertions.cpp", "cpp")
+    many = _find(results, "testManyAsserts")
+    assert many is not None
+    assert many.assertion_blocks[0][2] == 16
+    few = _find(results, "testFewAsserts")
+    assert few is not None and few.assertion_blocks == []
+
+
+def test_csharp_nesting_and_ccn():
+    results = _walk("csharp/nested.cs", "csharp")
+    deep = _find(results, "DeeplyNested")
+    assert deep is not None
+    assert deep.max_nesting >= 4, f"expected ≥4 nesting, got {deep.max_nesting}"
+    many = _find(results, "ManyBranches")
+    assert many is not None
+    assert many.ccn >= 9, f"expected CCN ≥ 9, got {many.ccn}"
+
+
+def test_csharp_class_cohesion():
+    classes = _walk_classes("csharp/classes.cs", "csharp")
+    cohesive = classes.get("Cohesive")
+    splintered = classes.get("Splintered")
+    assert cohesive is not None and splintered is not None
+    assert cohesive.lcom4 == 1
+    assert splintered.lcom4 == 3
+    assert splintered.method_count == 5
+    assert splintered.field_count == 2
+
+
+def test_csharp_assertion_blocks():
+    results = _walk("csharp/assertions.cs", "csharp")
+    many = _find(results, "TestManyAsserts")
+    assert many is not None
+    assert many.assertion_blocks[0][2] == 16
+    few = _find(results, "TestFewAsserts")
+    assert few is not None and few.assertion_blocks == []


### PR DESCRIPTION
## Summary

The code-health complexity walker computes its biomarkers (McCabe complexity, nesting, cognitive complexity, LCOM4 cohesion, god-class, test-quality assertion smells) off a per-language node-type map that is independent of the `.scm` ingestion queries. That map shipped for Python, TypeScript, JavaScript, Go, Java, and Rust — but **Kotlin, C++, and C# had no map**, so files in those languages produced *no* health findings even though they are listed as Full-tier languages.

This adds the missing maps so all nine Full-tier languages compute the same biomarker set, and turns "Full tier" into a claim the health layer is verified to honor.

## What's included

- **Kotlin / C++ / C# `LanguageNodeMap` entries** — control-flow, class-level (LCOM4 / god-class), and assertion-block node types, with handcrafted fixtures under `tests/fixtures/lang_samples/{kotlin,cpp,csharp}/` and walker tests asserting nesting depth, cyclomatic complexity, class cohesion, and assertion-run detection. Node types were verified against the installed grammars, not guessed.
- **Three additive walker generalizations** (existing languages unchanged — each only triggers on a node shape the previously-mapped languages never produce):
  - follow C/C++ `declarator` chains to recover the nested function name;
  - match an assertion call that is itself the statement, for grammars without an `expression_statement` wrapper (Kotlin);
  - consult the `expression` receiver field used by C# member access (its `this` token is unnamed).
- **Documented heuristic limit** — instance members accessed without an explicit receiver (idiomatic Kotlin/C++/C#/Java) are not counted toward cohesion; `low_cohesion` degrades to "no signal" rather than producing a false positive.
- **`LANGUAGE_SUPPORT.md`** gains a code-health-biomarker support row, a per-language coverage table, and a checklist a language must clear to be listed Full. **Go is reconciled as the one documented gap** — its methods attach to a type via an external receiver with no class-grouping node, so class-level metrics aren't computable; it gets the function- and assertion-level biomarkers.

## Validation

- Health unit suite **228 passed** (+9 new walker tests); health + git-indexer **252 passed**.
- Perf benchmark (`-m slow`, walker hot path) passes within budget.
- `ruff check` + `ruff format` clean on changed files.
- **No scoring constants change** — the scoring snapshot test is untouched.