### PR TITLE
feat(git): surface change-complexity and defect-history signals

### DIFF
--- a/packages/server/src/repowise/server/routers/git.py
+++ b/packages/server/src/repowise/server/routers/git.py
@@ -64,6 +64,11 @@ def _hotspot_from_row(r: GitMetadata) -> HotspotResponse:
         commit_count_capped=bool(r.commit_count_capped),
         age_days=r.age_days or 0,
         last_commit_at=r.last_commit_at,
+        change_entropy=r.change_entropy or 0.0,
+        # Normalize 0-1 -> 0-100 to match churn_percentile.
+        change_entropy_pct=(r.change_entropy_pct or 0.0) * 100.0,
+        prior_defect_count=r.prior_defect_count or 0,
+        original_path=r.original_path,
     )
 
 

--- a/packages/server/src/repowise/server/schemas/git.py
+++ b/packages/server/src/repowise/server/schemas/git.py
@@ -34,6 +34,15 @@ class GitMetadataResponse(BaseModel):
     avg_commit_size: float
     commit_categories: dict
     merge_commit_count_90d: int
+    # Change-complexity + defect-history signals (computed every index, newly
+    # surfaced). change_entropy_pct is normalized 0-100 like churn_percentile.
+    change_entropy: float = 0.0
+    change_entropy_pct: float = 0.0
+    prior_defect_count: int = 0
+    temporal_hotspot_score: float | None = None
+    commit_count_capped: bool = False
+    # Rename lineage: the file's path before its most recent move, if any.
+    original_path: str | None = None
     test_gap: bool | None = None
 
     @classmethod
@@ -67,6 +76,13 @@ class GitMetadataResponse(BaseModel):
             if obj.commit_categories_json
             else {},  # type: ignore[attr-defined]
             merge_commit_count_90d=obj.merge_commit_count_90d or 0,  # type: ignore[attr-defined]
+            change_entropy=obj.change_entropy or 0.0,  # type: ignore[attr-defined]
+            # Normalize 0-1 -> 0-100 to match churn_percentile's contract.
+            change_entropy_pct=(obj.change_entropy_pct or 0.0) * 100.0,  # type: ignore[attr-defined]
+            prior_defect_count=obj.prior_defect_count or 0,  # type: ignore[attr-defined]
+            temporal_hotspot_score=obj.temporal_hotspot_score,  # type: ignore[attr-defined]
+            commit_count_capped=bool(obj.commit_count_capped),  # type: ignore[attr-defined]
+            original_path=obj.original_path,  # type: ignore[attr-defined]
         )
 
 
@@ -93,6 +109,11 @@ class HotspotResponse(BaseModel):
     commit_count_capped: bool = False
     age_days: int = 0
     last_commit_at: datetime | None = None
+    # Change-complexity + defect-history signals.
+    change_entropy: float = 0.0
+    change_entropy_pct: float = 0.0
+    prior_defect_count: int = 0
+    original_path: str | None = None
 
 
 class OwnershipEntry(BaseModel):

--- a/packages/types/src/git.ts
+++ b/packages/types/src/git.ts
@@ -55,6 +55,16 @@ export interface GitMetadata {
   test_gap?: boolean | null;
   /** v0.2.0+ — combined recency × churn × ownership score. Order hotspots by this when present. */
   temporal_hotspot_score?: number | null;
+  /** Hassan change entropy (History Complexity Metric) — decay-weighted commit scatter. */
+  change_entropy?: number;
+  /** Repo-wide percentile rank of change_entropy, 0–100. */
+  change_entropy_pct?: number;
+  /** Bug-fix commits touching this file in the trailing defect window. */
+  prior_defect_count?: number;
+  /** The file's path before its most recent rename, if any. */
+  original_path?: string | null;
+  /** True when the per-file commit-history cap was hit during indexing. */
+  commit_count_capped?: boolean;
 }
 
 export interface Hotspot {
@@ -83,6 +93,14 @@ export interface Hotspot {
   commit_count_capped?: boolean;
   age_days?: number;
   last_commit_at?: string | null;
+  /** Hassan change entropy (History Complexity Metric) — decay-weighted commit scatter. */
+  change_entropy?: number;
+  /** Repo-wide percentile rank of change_entropy, 0–100. */
+  change_entropy_pct?: number;
+  /** Bug-fix commits touching this file in the trailing defect window. */
+  prior_defect_count?: number;
+  /** The file's path before its most recent rename, if any. */
+  original_path?: string | null;
 }
 
 export interface OwnershipEntry {

--- a/packages/ui/src/git/change-history-card.tsx
+++ b/packages/ui/src/git/change-history-card.tsx
@@ -1,0 +1,101 @@
+import { Activity, Bug, FileSymlink, History } from "lucide-react";
+import { ChurnBar } from "./churn-bar.js";
+
+export interface ChangeHistoryCardProps {
+  /** Repo-wide percentile rank of change entropy, 0–100. */
+  changeEntropyPct?: number | null;
+  /** Bug-fix commits touching this file in the trailing defect window. */
+  priorDefectCount?: number | null;
+  /** The file's path before its most recent rename, if any. */
+  originalPath?: string | null;
+  /** True when the per-file commit-history cap was hit during indexing. */
+  commitCountCapped?: boolean;
+  className?: string;
+}
+
+/**
+ * Surfaces the change-complexity + defect-history signals the indexer captures
+ * on every run but the product never showed: change entropy (how scattered a
+ * file's commits are — Hassan's History Complexity Metric), prior bug-fix
+ * count, and rename lineage.
+ */
+export function ChangeHistoryCard({
+  changeEntropyPct,
+  priorDefectCount,
+  originalPath,
+  commitCountCapped,
+  className,
+}: ChangeHistoryCardProps) {
+  const hasEntropy = changeEntropyPct != null && changeEntropyPct > 0;
+  const hasDefects = priorDefectCount != null && priorDefectCount > 0;
+  const hasRename = !!originalPath;
+
+  // Nothing meaningful to show — let the caller omit the section entirely.
+  if (!hasEntropy && !hasDefects && !hasRename && !commitCountCapped) return null;
+
+  return (
+    <div className={className}>
+      <p className="text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider mb-2">
+        Change Complexity & Defect History
+      </p>
+      <div className="space-y-2.5">
+        {hasEntropy && (
+          <div className="space-y-1">
+            <div className="flex items-center gap-1.5 text-xs">
+              <Activity className="h-3 w-3 text-[var(--color-text-tertiary)]" />
+              <span className="flex-1 text-[var(--color-text-tertiary)]">
+                Change entropy
+              </span>
+              <span
+                className="text-[var(--color-text-secondary)] tabular-nums"
+                title="How scattered this file's commits are across the codebase (Hassan History Complexity Metric), as a repo-wide percentile."
+              >
+                {Math.round(changeEntropyPct as number)}%
+              </span>
+            </div>
+            <ChurnBar percentile={changeEntropyPct as number} />
+          </div>
+        )}
+
+        {priorDefectCount != null && (
+          <div className="flex items-center gap-1.5 text-xs">
+            <Bug
+              className={`h-3 w-3 ${hasDefects ? "text-red-400" : "text-[var(--color-text-tertiary)]"}`}
+            />
+            <span className="flex-1 text-[var(--color-text-tertiary)]">
+              Bug-fix history
+            </span>
+            <span
+              className={`tabular-nums ${hasDefects ? "text-red-400" : "text-[var(--color-text-secondary)]"}`}
+              title="Bug-fix commits that touched this file in the trailing defect window."
+            >
+              {priorDefectCount} {priorDefectCount === 1 ? "fix" : "fixes"}
+            </span>
+          </div>
+        )}
+
+        {hasRename && (
+          <div className="flex items-start gap-1.5 text-xs">
+            <FileSymlink className="h-3 w-3 shrink-0 mt-0.5 text-[var(--color-text-tertiary)]" />
+            <span className="text-[var(--color-text-tertiary)] shrink-0">
+              Renamed from
+            </span>
+            <span
+              className="font-mono text-[10px] text-[var(--color-text-secondary)] break-all"
+              title={originalPath as string}
+            >
+              {originalPath}
+            </span>
+          </div>
+        )}
+
+        {commitCountCapped && (
+          <div className="flex items-center gap-1.5 text-[10px] text-[var(--color-text-tertiary)]">
+            <History className="h-3 w-3 shrink-0" />
+            <span>History capped during indexing — older commits not analysed.</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/git/index.ts
+++ b/packages/ui/src/git/index.ts
@@ -1,4 +1,5 @@
 export * from "./bus-factor-panel.js";
+export * from "./change-history-card.js";
 export * from "./churn-bar.js";
 export * from "./churn-histogram.js";
 export * from "./co-change-list.js";

--- a/packages/ui/src/wiki/git-history-panel.tsx
+++ b/packages/ui/src/wiki/git-history-panel.tsx
@@ -2,6 +2,7 @@ import { GitCommit, User } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { CommitCategorySparkline } from "../git/commit-category-sparkline";
 import { CoChangeList } from "../git/co-change-list";
+import { ChangeHistoryCard } from "../git/change-history-card";
 import { formatRelativeTime, formatDate, formatAgeDays } from "../lib/format";
 import type { GitMetadata } from "@repowise-dev/types/git";
 
@@ -166,6 +167,13 @@ export function GitHistoryPanel({ git }: GitHistoryPanelProps) {
           <CoChangeList partners={git.co_change_partners} />
         </div>
       )}
+
+      <ChangeHistoryCard
+        changeEntropyPct={git.change_entropy_pct ?? null}
+        priorDefectCount={git.prior_defect_count ?? null}
+        originalPath={git.original_path ?? null}
+        commitCountCapped={git.commit_count_capped ?? false}
+      />
 
       {commits.length > 0 && (
         <div>

--- a/packages/web/src/lib/api/types/git.ts
+++ b/packages/web/src/lib/api/types/git.ts
@@ -28,6 +28,12 @@ export interface GitMetadataResponse {
   avg_commit_size: number;
   commit_categories: Record<string, number>;
   merge_commit_count_90d: number;
+  change_entropy?: number;
+  change_entropy_pct?: number;
+  prior_defect_count?: number;
+  temporal_hotspot_score?: number | null;
+  commit_count_capped?: boolean;
+  original_path?: string | null;
   test_gap?: boolean | null;
 }
 
@@ -54,6 +60,10 @@ export interface HotspotResponse {
   commit_count_capped?: boolean;
   age_days?: number;
   last_commit_at?: string | null;
+  change_entropy?: number;
+  change_entropy_pct?: number;
+  prior_defect_count?: number;
+  original_path?: string | null;
 }
 
 export interface OwnershipEntry {

--- a/tests/unit/server/test_git.py
+++ b/tests/unit/server/test_git.py
@@ -34,6 +34,12 @@ async def _insert_git_metadata(session_factory, repo_id: str) -> None:
             is_stable=False,
             churn_percentile=0.85,
             age_days=365,
+            change_entropy=1.5,
+            change_entropy_pct=0.9,
+            prior_defect_count=4,
+            temporal_hotspot_score=12.3,
+            commit_count_capped=True,
+            original_path="src/old_main.py",
         )
         await crud.upsert_git_metadata(
             session,
@@ -67,6 +73,13 @@ async def test_get_git_metadata(client: AsyncClient, app) -> None:
     assert data["commit_count_total"] == 50
     assert data["is_hotspot"] is True
     assert data["primary_owner_name"] == "Alice"
+    # Newly surfaced change-complexity + defect-history signals.
+    assert data["change_entropy"] == 1.5
+    assert data["change_entropy_pct"] == 90.0  # normalized 0-1 -> 0-100
+    assert data["prior_defect_count"] == 4
+    assert data["temporal_hotspot_score"] == 12.3
+    assert data["commit_count_capped"] is True
+    assert data["original_path"] == "src/old_main.py"
 
 
 @pytest.mark.asyncio
@@ -93,6 +106,9 @@ async def test_get_hotspots(client: AsyncClient, app) -> None:
     assert len(data) == 1
     assert data[0]["file_path"] == "src/main.py"
     assert data[0]["is_hotspot"] is True
+    assert data[0]["change_entropy_pct"] == 90.0
+    assert data[0]["prior_defect_count"] == 4
+    assert data[0]["original_path"] == "src/old_main.py"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Surfaces per-file git signals that are computed on every index but were never
exposed by the API or UI:

- **change entropy** (Hassan's History Complexity Metric) + its repo-wide
  percentile — how scattered a file's commits are
- **prior bug-fix count** — bug-fix commits touching the file in the trailing
  defect window
- **rename lineage** (`original_path`) — the file's path before its last move
- **temporal hotspot score** + the **commit-cap flag** on `/git-metadata`
  (both were already on `/hotspots`, just missing here)

## How

- Add the fields to `GitMetadataResponse`/`HotspotResponse` and their row
  mappers (`change_entropy_pct` normalized 0-100 to match `churn_percentile`).
- Thread them through the shared and web TypeScript types.
- New **"Change Complexity & Defect History"** card on the per-file git panel:
  change entropy as a percentile bar (reusing the churn bar), prior bug-fix
  count, and rename lineage when present. The card renders nothing when a file
  has none of these signals, so existing files are unaffected.

Pure read-path — no new capture, no re-index.

## Validation

- All three TypeScript packages type-check clean.
- Response-shape tests assert the new fields on the git-metadata and hotspots
  endpoints, including the 0-1 → 0-100 normalization.

## Notes

- The card is reusable; wiring it into the hotspots-table drill-down is a small
  follow-up.
- The hosted frontend mirrors via the usual package-bump flow (separate repo).
