### PR TITLE
release: v0.15.0 — code-health biomarker overhaul, change-risk command, commits page

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,10 @@ repowise health --coverage cov.lcov         # ingest coverage, light up untested
 repowise health --refactoring-targets       # ranked by impact / effort
 repowise health --trend                     # last 10 snapshots + declining/predicted-decline alerts
 
+# Change risk
+repowise risk                               # score HEAD's defect risk (0-10)
+repowise risk main..HEAD                    # score a branch / PR range as one change
+
 # Dead code
 repowise dead-code                          # full report
 repowise dead-code --safe-only              # only safe-to-delete findings

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.15.0] — 2026-05-30
+
+### Added
+- **Code-health biomarkers overhaul — calibrated, multi-language, process-aware.** The health model is reworked into a broad biomarker suite whose weights are calibrated against real defect data (#305): class-level cohesion and god-class detection (#302), test-quality smells with hardened size sensitivity (#303), change-entropy and co-change scatter signals (#301), ownership and relative-churn process signals (#300), and a prior-defect process signal (#312). Coverage deductions now scale by the uncovered fraction rather than a flat penalty (#314), primitive-obsession is suppressed in tiny modules to cut false positives (#313), and the biomarkers extend to Kotlin, C++, and C# (#316).
+- **`repowise risk` — just-in-time change-risk scoring.** A new command and scoring pass estimate the risk of changing a file from churn, complexity, ownership, and defect history, surfaced both in the CLI and the dashboard (#315).
+- **Commits change-risk page with per-function blame.** A new commits explorer surfaces per-commit change-risk history (#317), change-complexity and defect-history signals (#318), and a per-function blame view with a coverage-gradient breakdown (#319).
+- **Coverage ingestion.** `repowise` ingests normalized-JSON coverage reports and surfaces coverage metrics across the health surfaces (#309).
+- **`.mts` / `.cts` are treated as TypeScript** for indexing and language detection (#310).
+
+### Fixed
+- **`exclude_patterns` are enforced in the git indexer and dynamic-edge passes** — excluded paths no longer leak back in through commit history or dynamic edges (#308). Index-only runs now persist `exclude_patterns` via `save_config_partial` so subsequent updates honour them (#297).
+- **Single-file re-index no longer wipes all dead-code findings** — an incremental re-index of one file previously cleared the whole findings set (#298).
+- **CommonJS `require()` is resolved** so property-access calls on a required module are no longer mis-flagged as dead (#299).
+- **`@repowise-dev/ui` uses extensionless relative imports** package-wide, fixing a web build failure where `.js`-suffixed relative specifiers failed to resolve (#320).
+
+### Documentation
+- **README header refreshed** with a banner and badges (#311).
+
+---
+
 ## [0.14.0] — 2026-05-28
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -284,7 +284,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.14.0</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.15.0</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -334,7 +334,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
       {!isIconOnly && (
         <div className="border-t border-[var(--color-border-default)] px-4 py-3">
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.14.0
+            repowise v0.15.0
           </p>
         </div>
       )}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.14.0"
+version = "0.15.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Release **v0.15.0**. Headlines: a calibrated, process-aware code-health biomarker overhaul, the new `repowise risk` change-risk command, and a commits change-risk page with per-function blame.

## Version bump
- `pyproject.toml`, `packages/{cli,core,server}/src/.../__init__.py` → `0.15.0`
- `uv.lock` self-entry regenerated → `0.15.0`
- Web footer (`sidebar.tsx`, `mobile-nav.tsx`) → `repowise v0.15.0`

## Changelog & docs
- `docs/CHANGELOG.md` — new `## [0.15.0] — 2026-05-30` section
- `README.md` — added a `repowise risk` command block; refreshed header note

## Test plan
- [x] `uv build --wheel` → `dist/repowise-0.15.0-py3-none-any.whl` built cleanly; structure verified (commands incl. `serve_cmd.py`, `.scm`/`.j2` data files present)
- [x] `uv lock` updated the `repowise` self-entry to `0.15.0`
- [x] `npm run build --workspace packages/web` → compiled successfully, no missing-module errors
- [x] Version-drift check: no `0.14.0` hits across version files
- [ ] Tag `v0.15.0` on the merge commit and push (post-merge)
- [ ] `publish.yml` green; GitHub release + PyPI show `0.15.0` (post-tag)

## Merge convention
**Use a regular merge commit — do not squash.** The tag must point at a real merge commit on `main` so artifact provenance stays traceable.
