### PR TITLE
fix(pipeline): drop transient BlameIndex before serialization

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd.py
@@ -828,6 +828,13 @@ def update_command(
         repo_path, graph_builder, git_meta_map, parsed_files, file_diffs
     )
 
+    # Partial health has consumed the per-file ``BlameIndex``; drop it before
+    # the metadata reaches persistence / regeneration so the transient,
+    # non-serializable object can never leak downstream (mirrors run_pipeline).
+    from repowise.core.pipeline.phases.git import drop_transient_git_signals
+
+    drop_transient_git_signals(list(git_meta_map.values()))
+
     if index_only:
         _persist_index_only_update(
             repo_path,

--- a/packages/core/src/repowise/core/pipeline/orchestrator.py
+++ b/packages/core/src/repowise/core/pipeline/orchestrator.py
@@ -33,7 +33,7 @@ from .phases.analysis import (
     _run_health_analysis,
 )
 from .phases.generation import run_generation
-from .phases.git import _run_git_indexing
+from .phases.git import _run_git_indexing, drop_transient_git_signals
 from .phases.ingestion import _run_ingestion
 
 logger = structlog.get_logger(__name__)
@@ -362,6 +362,12 @@ async def run_pipeline(
     health_report = await _run_health_analysis(
         graph_builder, git_meta_map, parsed_files, repo_path=repo_path, progress=progress
     )
+
+    # Drop the in-memory-only ``BlameIndex`` now that the health biomarkers
+    # have consumed it — before it can leak into ``PipelineResult`` and the
+    # downstream JSON artifact writers / DB persistence. ``git_meta_map`` shares
+    # these dict objects, so this cleans both views.
+    drop_transient_git_signals(git_metadata_list)
 
     decision_report = await _run_decision_extraction(
         repo_path,

--- a/packages/core/src/repowise/core/pipeline/phases/git.py
+++ b/packages/core/src/repowise/core/pipeline/phases/git.py
@@ -19,6 +19,23 @@ from ._common import _phase_done
 logger = structlog.get_logger(__name__)
 
 
+def drop_transient_git_signals(git_metadata_list: list[dict]) -> None:
+    """Strip in-memory-only signals from git metadata dicts.
+
+    The per-file ``BlameIndex`` (attached under ``"blame_index"``) is consumed
+    by the health biomarkers (``function_hotspot`` / ``code_age_volatility``)
+    and is never meant to round-trip through the DB or JSON artifacts —
+    serializing it raises "Object of type BlameIndex is not JSON serializable".
+    Call this once the health phase has run, before the metadata reaches
+    ``PipelineResult`` / persistence / artifact writers.
+
+    Mutates the dicts in place; callers that also hold a ``git_meta_map`` built
+    from the same dict objects see them cleaned too.
+    """
+    for meta in git_metadata_list:
+        meta.pop("blame_index", None)
+
+
 async def _run_git_indexing(
     repo_path: Path,
     *,

--- a/tests/unit/pipeline/test_drop_transient_git_signals.py
+++ b/tests/unit/pipeline/test_drop_transient_git_signals.py
@@ -1,0 +1,58 @@
+"""Regression guard: the transient BlameIndex must not survive into the
+metadata that reaches persistence / JSON artifact writers.
+
+The per-file ``BlameIndex`` is in-memory only (consumed by the health
+biomarkers). If it leaks into ``git_metadata_list`` the hosted backend's
+``json.dumps`` of ``git_metadata.json`` raises "Object of type BlameIndex is
+not JSON serializable", which aborts the whole indexing run and leaves repos
+with missing artifacts.
+"""
+
+from __future__ import annotations
+
+import json
+
+from repowise.core.ingestion.git_indexer.function_blame import BlameIndex
+from repowise.core.pipeline.phases.git import drop_transient_git_signals
+
+
+def test_drop_removes_blame_index_and_keeps_other_fields() -> None:
+    meta = {
+        "file_path": "a.py",
+        "commit_count_total": 12,
+        "blame_index": BlameIndex(lines={1: ("abc", 100)}, authors={"abc": ("A", "a@x")}),
+        "primary_owner_name": "A",
+    }
+    git_metadata_list = [meta]
+
+    drop_transient_git_signals(git_metadata_list)
+
+    assert "blame_index" not in meta
+    # Non-transient fields are preserved.
+    assert meta["file_path"] == "a.py"
+    assert meta["primary_owner_name"] == "A"
+    # The cleaned list is now JSON-serializable — the exact contract the hosted
+    # artifact writer depends on.
+    json.dumps(git_metadata_list)
+
+
+def test_drop_is_idempotent_and_safe_without_blame_index() -> None:
+    meta = {"file_path": "b.py", "commit_count_total": 1}
+    git_metadata_list = [meta]
+
+    drop_transient_git_signals(git_metadata_list)
+    drop_transient_git_signals(git_metadata_list)  # second call must not raise
+
+    assert meta == {"file_path": "b.py", "commit_count_total": 1}
+
+
+def test_drop_cleans_shared_git_meta_map_view() -> None:
+    # git_meta_map is built from the same dict objects as git_metadata_list, so
+    # stripping the list must clean the map view too.
+    meta = {"file_path": "c.py", "blame_index": BlameIndex()}
+    git_metadata_list = [meta]
+    git_meta_map = {m["file_path"]: m for m in git_metadata_list}
+
+    drop_transient_git_signals(git_metadata_list)
+
+    assert "blame_index" not in git_meta_map["c.py"]


### PR DESCRIPTION
## Problem

Indexing FULL-tier repos with real git history crashed with **`Object of type BlameIndex is not JSON serializable`**. The per-file `BlameIndex` is an in-memory-only signal (consumed by the `function_hotspot` / `code_age_volatility` biomarkers) but it was being attached to the git-metadata dicts that escape the pipeline in `PipelineResult.git_metadata_list`. Any JSON serialization of git metadata then raised — aborting the whole artifact build so the repo ended up with no graph/decisions/docs.

## Fix

Strip the transient signal once the health phase has consumed it, in both the full pipeline (`orchestrator`) and the incremental `update` path, via a shared `drop_transient_git_signals()` helper.

- DB persistence already filtered `blame_index` out by column, so this is behaviour-preserving for OSS DB users.
- Fixes any JSON artifact writer that serializes `git_metadata_list`.

## Tests

`tests/unit/pipeline/test_drop_transient_git_signals.py` — verifies the key is dropped, other fields are preserved, the result is JSON-serializable, the shared `git_meta_map` view is cleaned, and the op is idempotent. Full health/pipeline suites pass (264 tests).