### PR TITLE
release: v0.15.1 — embedder fail-fast + BlameIndex serialization fix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.15.1] — 2026-05-30
+
+### Fixed
+- **Misconfigured embedders no longer fail silently.** When an embedder is explicitly configured (`REPOWISE_EMBEDDER` or `.repowise/config.yaml`) but can't initialise — most often a missing API key — the MCP server used to fall back to the mock embedder with only a `WARNING`, then report healthy while semantic search (`search_codebase`, `get_answer`) ran on vectors that can't match the real index. The failure is now logged at `ERROR` with the missing key and remediation, and surfaced in every tool's `_meta` envelope (`embedder_degraded: true`) so it's detectable instead of masquerading as a healthy server. Embedder resolution also goes through the shared registry, so `openrouter` and custom-registered embedders are honoured — not just `openai`/`gemini` (#324).
+- **Indexing artifacts serialize reliably.** A transient blame index is dropped before artifact serialization, fixing a failure that could corrupt published index artifacts (#323).
+
+---
+
 ## [0.15.0] — 2026-05-30
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -284,7 +284,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.15.0</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.15.1</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -334,7 +334,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
       {!isIconOnly && (
         <div className="border-t border-[var(--color-border-default)] px-4 py-3">
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.15.0
+            repowise v0.15.1
           </p>
         </div>
       )}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.15.0"
+version = "0.15.1"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## v0.15.1 — patch release

Two fixes shipped since v0.15.0:

- **mcp: surface embedder init failure instead of silent mock fallback (#324).** An explicitly-configured embedder that fails to initialise (usually a missing API key) no longer silently degrades to mock vectors while reporting healthy — it logs at ERROR with remediation and surfaces `embedder_degraded` in every tool's `_meta`. Resolution now goes through the shared embedder registry, so openrouter and custom embedders work too.
- **pipeline: drop transient BlameIndex before serialization (#323).**

### Version bump
- `pyproject.toml`, `packages/{cli,core,server}/__init__.py`, web footer (`sidebar.tsx`, `mobile-nav.tsx`), and `uv.lock` all bumped to `0.15.1`.
- `docs/CHANGELOG.md` updated.

### Test plan
- [x] `uv build --wheel` → `dist/repowise-0.15.1-py3-none-any.whl` built cleanly
- [x] `uv lock` regenerated; no `0.15.0` drift anywhere
- [x] MCP + server unit suites green (332 tests)
- [ ] Tag `v0.15.1` on `main` after merge → `publish.yml`
- [ ] Post-release: verify PyPI + GitHub release assets

> Merge convention: **regular merge commit, not squash** — the tag must point at a real merge commit on `main` for artifact provenance.
