### PR TITLE
release: v0.15.2 — on_page_ready streaming callback

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.15.2] — 2026-05-31
+
+### Added
+- **`on_page_ready` streaming callback.** `run_pipeline` / `run_generation` / `PageGenerator.generate_all` now accept an optional `on_page_ready` callback, invoked with each page the moment it is generated (alongside the existing `on_page_done`, which only receives the page type). Lets callers persist or stream pages incrementally — e.g. flush pages to storage per page so a generation cut-off yields a partial-but-usable set rather than nothing. Additive and backward-compatible; best-effort (a sink error is logged and never aborts a run) (#328).
+
+---
+
 ## [0.15.1] — 2026-05-30
 
 ### Fixed

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -284,7 +284,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.15.1</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.15.2</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -334,7 +334,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
       {!isIconOnly && (
         <div className="border-t border-[var(--color-border-default)] px-4 py-3">
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.15.1
+            repowise v0.15.2
           </p>
         </div>
       )}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.15.1"
+version = "0.15.2"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Patch release cutting the `on_page_ready` streaming callback (#328) to PyPI. Version bumped 0.15.1 -> 0.15.2 across the four source-of-truth files + `uv.lock` + the web UI footer; changelog entry added.

## Changes

- `pyproject.toml`, `packages/{cli,core,server}/src/.../__init__.py` -> `0.15.2`
- `uv.lock` regenerated (self-entry 0.15.1 -> 0.15.2)
- `packages/web/.../{sidebar,mobile-nav}.tsx` footer -> `repowise v0.15.2`
- `docs/CHANGELOG.md` -> `## [0.15.2]` entry

## Build validation

`uv build --wheel` was run locally on this branch and produced `dist/repowise-0.15.2-py3-none-any.whl`. Inspecting that wheel: 23 CLI command modules present, 37 `.scm`/`.j2` package-data files bundled, and `on_page_ready` appears in the wheel's `generation.py`. The generation suite (`tests/unit/generation` + `tests/integration/test_generation_pipeline.py`) was green — 441 passed — on the merged main prior to cutting this branch.

## Merge convention

Regular merge commit — NOT squash. The tag must point at a real merge commit so artifact provenance is traceable.

## Post-merge (maintainer)

- git checkout main && git pull --ff-only
- git tag v0.15.2 && git push origin v0.15.2 (triggers publish.yml)
- verify PyPI shows 0.15.2 and the GitHub release has all 3 assets