### PR TITLE
feat(embeddings): add native ollama embedder

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd.py
@@ -1495,8 +1495,8 @@ def _show_completion(
     "--embedder",
     "embedder_name",
     default=None,
-    type=click.Choice(["gemini", "openai", "mock"]),
-    help="Embedder for RAG: gemini | openai | mock (default: auto-detect).",
+    type=click.Choice(["gemini", "openai", "openrouter", "ollama", "mock"]),
+    help="Embedder for RAG: gemini | openai | openrouter | ollama | mock (default: auto-detect).",
 )
 @click.option("--skip-tests", is_flag=True, default=False, help="Skip test files.")
 @click.option("--skip-infra", is_flag=True, default=False, help="Skip infrastructure files.")

--- a/packages/cli/src/repowise/cli/commands/reindex_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/reindex_cmd.py
@@ -18,7 +18,7 @@ from repowise.cli.helpers import (
 @click.argument("path", required=False, default=None)
 @click.option(
     "--embedder",
-    type=click.Choice(["gemini", "openai", "auto"]),
+    type=click.Choice(["gemini", "openai", "openrouter", "ollama", "mock", "auto"]),
     default="auto",
     help="Embedder to use. 'auto' detects from env vars / config.",
 )
@@ -47,30 +47,28 @@ async def _reindex(repo_path, embedder_name: str, batch_size: int) -> None:
     from sqlalchemy import select
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+    from repowise.cli.providers.embedders import build_embedder
     from repowise.core.persistence.database import create_engine, init_db
     from repowise.core.persistence.models import Page
+    from repowise.core.providers.embedding.base import MockEmbedder
 
     # --- Resolve embedder ---
+    requested_embedder = embedder_name
     if embedder_name == "auto":
         from repowise.cli.commands.init_cmd import _resolve_embedder
 
         embedder_name = _resolve_embedder(None)
 
-    if embedder_name == "gemini":
-        from repowise.core.providers.embedding.gemini import GeminiEmbedder
-
-        embedder_impl = GeminiEmbedder()
-        console.print("[green]Using Gemini embedder[/green]")
-    elif embedder_name == "openai":
-        from repowise.core.providers.embedding.openai import OpenAIEmbedder
-
-        embedder_impl = OpenAIEmbedder()
-        console.print("[green]Using OpenAI embedder[/green]")
-    else:
+    embedder_impl = build_embedder(embedder_name)
+    if isinstance(embedder_impl, MockEmbedder) and requested_embedder != "mock":
         console.print(
-            "[red]No real embedder available. Set GEMINI_API_KEY or OPENAI_API_KEY.[/red]"
+            "[red]No real embedder available. Set a real embedder key, configure Ollama, or pass --embedder mock for test vectors.[/red]"
         )
         raise click.Abort()
+    if embedder_name == "mock":
+        console.print("[yellow]Using mock embedder (deterministic test vectors)[/yellow]")
+    else:
+        console.print(f"[green]Using {embedder_name} embedder[/green]")
 
     # --- Create LanceDB vector store ---
     lance_dir = Path(repo_path) / ".repowise" / "lancedb"

--- a/packages/cli/src/repowise/cli/commands/search_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/search_cmd.py
@@ -10,7 +10,6 @@ from repowise.cli.helpers import (
     ensure_repowise_dir,
     get_db_url_for_repo,
     resolve_command_target,
-    resolve_repo_path,
     run_async,
 )
 
@@ -71,9 +70,7 @@ def search_command(
     if target.is_workspace:
         assert target.ws_root is not None and target.ws_config is not None
         if search_all:
-            repo_paths = [
-                (target.ws_root / e.path).resolve() for e in target.ws_config.repos
-            ]
+            repo_paths = [(target.ws_root / e.path).resolve() for e in target.ws_config.repos]
         elif target.repo_filter is not None:
             picked = target.resolve_repo_alias(target.repo_filter)
             if picked is None:
@@ -152,26 +149,16 @@ def _search_semantic(repo_path, query: str, limit: int) -> None:
     async def _run():
         from pathlib import Path
 
-        from repowise.core.persistence import MockEmbedder
-
         # Try LanceDB first (populated during repowise init)
         lance_dir = Path(repo_path) / ".repowise" / "lancedb"
         if lance_dir.exists():
             try:
                 from repowise.cli.commands.init_cmd import _resolve_embedder
+                from repowise.cli.providers.embedders import build_embedder
                 from repowise.core.persistence.vector_store import LanceDBVectorStore
 
                 embedder_name = _resolve_embedder(None)
-                if embedder_name == "gemini":
-                    from repowise.core.providers.embedding.gemini import GeminiEmbedder
-
-                    embedder = GeminiEmbedder()
-                elif embedder_name == "openai":
-                    from repowise.core.providers.embedding.openai import OpenAIEmbedder
-
-                    embedder = OpenAIEmbedder()
-                else:
-                    embedder = MockEmbedder()
+                embedder = build_embedder(embedder_name)
                 store = LanceDBVectorStore(str(lance_dir), embedder=embedder)
                 results = await store.search(query, limit=limit)
                 await store.close()
@@ -280,25 +267,17 @@ def _collect_semantic(repo_path, query: str, limit: int):
     async def _run():
         from pathlib import Path
 
-        from repowise.core.persistence import FullTextSearch, MockEmbedder, create_engine
+        from repowise.core.persistence import FullTextSearch, create_engine
 
         lance_dir = Path(repo_path) / ".repowise" / "lancedb"
         if lance_dir.exists():
             try:
                 from repowise.cli.commands.init_cmd import _resolve_embedder
+                from repowise.cli.providers.embedders import build_embedder
                 from repowise.core.persistence.vector_store import LanceDBVectorStore
 
                 embedder_name = _resolve_embedder(None)
-                if embedder_name == "gemini":
-                    from repowise.core.providers.embedding.gemini import GeminiEmbedder
-
-                    embedder = GeminiEmbedder()
-                elif embedder_name == "openai":
-                    from repowise.core.providers.embedding.openai import OpenAIEmbedder
-
-                    embedder = OpenAIEmbedder()
-                else:
-                    embedder = MockEmbedder()
+                embedder = build_embedder(embedder_name)
                 store = LanceDBVectorStore(str(lance_dir), embedder=embedder)
                 results = await store.search(query, limit=limit)
                 await store.close()

--- a/packages/cli/src/repowise/cli/providers/embedders.py
+++ b/packages/cli/src/repowise/cli/providers/embedders.py
@@ -6,16 +6,43 @@ import os
 from typing import Any
 
 
+def _embedder_kwargs(embedder_name: str) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    model = os.environ.get("REPOWISE_EMBEDDING_MODEL")
+    if embedder_name == "ollama":
+        model = os.environ.get("OLLAMA_EMBEDDING_MODEL") or model
+        base_url = os.environ.get("OLLAMA_BASE_URL")
+        dimensions = os.environ.get("OLLAMA_EMBEDDING_DIMS") or os.environ.get(
+            "REPOWISE_EMBEDDING_DIMS"
+        )
+        if base_url:
+            kwargs["base_url"] = base_url
+        if dimensions:
+            kwargs["dimensions"] = int(dimensions)
+    elif embedder_name == "gemini":
+        dimensions = os.environ.get("REPOWISE_EMBEDDING_DIMS")
+        if dimensions:
+            kwargs["output_dimensionality"] = int(dimensions)
+    if model:
+        kwargs["model"] = model
+    return kwargs
+
+
 def resolve_embedder(embedder_flag: str | None) -> str:
     """Auto-detect embedder from env vars, or use the flag value."""
     if embedder_flag:
         return embedder_flag
+    configured = os.environ.get("REPOWISE_EMBEDDER", "").strip().lower()
+    if configured:
+        return configured
     if os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY"):
         return "gemini"
     if os.environ.get("OPENAI_API_KEY"):
         return "openai"
     if os.environ.get("OPENROUTER_API_KEY"):
         return "openrouter"
+    if os.environ.get("OLLAMA_EMBEDDING_MODEL"):
+        return "ollama"
     return "mock"
 
 
@@ -27,19 +54,11 @@ def build_embedder(embedder_name_resolved: str) -> Any:
     back to the deterministic mock when their SDK/credentials are unavailable.
     """
     from repowise.core.providers.embedding.base import MockEmbedder
+    from repowise.core.providers.embedding.registry import get_embedder
 
-    if embedder_name_resolved == "gemini":
-        try:
-            from repowise.core.providers.embedding.gemini import GeminiEmbedder
-
-            return GeminiEmbedder()
-        except Exception:
-            return MockEmbedder()
-    if embedder_name_resolved == "openai":
-        try:
-            from repowise.core.providers.embedding.openai import OpenAIEmbedder
-
-            return OpenAIEmbedder()
-        except Exception:
-            return MockEmbedder()
-    return MockEmbedder()
+    if embedder_name_resolved == "mock":
+        return MockEmbedder()
+    try:
+        return get_embedder(embedder_name_resolved, **_embedder_kwargs(embedder_name_resolved))
+    except Exception:
+        return MockEmbedder()

--- a/packages/cli/src/repowise/cli/ui/mode_selection.py
+++ b/packages/cli/src/repowise/cli/ui/mode_selection.py
@@ -259,7 +259,7 @@ def _prompt_generation(
 
     # Embedder selection
     detected_embedder = _resolve_embedder_from_env()
-    embedder_choices = ["gemini", "openai", "mock"]
+    embedder_choices = ["gemini", "openai", "openrouter", "ollama", "mock"]
     result["embedder"] = click.prompt(
         "  Embedder for RAG",
         default=detected_embedder,
@@ -374,6 +374,10 @@ def _resolve_embedder_from_env() -> str:
         return "gemini"
     if os.environ.get("OPENAI_API_KEY"):
         return "openai"
+    if os.environ.get("OPENROUTER_API_KEY"):
+        return "openrouter"
+    if os.environ.get("OLLAMA_EMBEDDING_MODEL"):
+        return "ollama"
     return "mock"
 
 

--- a/packages/core/src/repowise/core/providers/embedding/ollama.py
+++ b/packages/core/src/repowise/core/providers/embedding/ollama.py
@@ -1,0 +1,114 @@
+"""Ollama embedding support for repowise semantic search.
+
+Uses Ollama's native ``/api/embed`` endpoint, so local embedding models do not
+need to be exposed through the OpenAI-compatible API.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Any
+
+import httpx
+
+_DEFAULT_BASE_URL = "http://localhost:11434"
+_DEFAULT_MODEL = "embeddinggemma"
+_DEFAULT_TIMEOUT = 30.0
+
+
+def _normalize_base_url(url: str) -> str:
+    return url.rstrip("/")
+
+
+def _infer_dimensions(model: str) -> int:
+    """Best-effort dimension hint for common Ollama embedding models."""
+    name = model.lower()
+    if "qwen3-embedding" in name:
+        if "4b" in name:
+            return 2560
+        if "8b" in name:
+            return 4096
+        return 1024
+    if "all-minilm" in name or "minilm" in name:
+        return 384
+    if "mxbai-embed-large" in name or "bge-m3" in name:
+        return 1024
+    if "nomic-embed-text" in name or "embeddinggemma" in name:
+        return 768
+    return 768
+
+
+class OllamaEmbedder:
+    """Ollama embedding adapter implementing the repowise Embedder protocol.
+
+    Args:
+        model: Ollama embedding model name. Defaults to ``embeddinggemma``.
+        base_url: Ollama server URL. Defaults to ``http://localhost:11434``.
+        dimensions: Optional output dimension hint. Also sent to Ollama as
+            ``dimensions`` when provided.
+    """
+
+    def __init__(
+        self,
+        model: str | None = None,
+        base_url: str | None = None,
+        dimensions: int | None = None,
+        timeout: float = _DEFAULT_TIMEOUT,
+    ) -> None:
+        self._model = (
+            model
+            or os.environ.get("OLLAMA_EMBEDDING_MODEL")
+            or os.environ.get("REPOWISE_EMBEDDING_MODEL")
+            or _DEFAULT_MODEL
+        )
+        self._base_url = _normalize_base_url(
+            base_url or os.environ.get("OLLAMA_BASE_URL") or _DEFAULT_BASE_URL
+        )
+        env_dimensions = os.environ.get("OLLAMA_EMBEDDING_DIMS") or os.environ.get(
+            "REPOWISE_EMBEDDING_DIMS"
+        )
+        self._requested_dimensions = dimensions or (int(env_dimensions) if env_dimensions else None)
+        self._dimensions = self._requested_dimensions or _infer_dimensions(self._model)
+        self._timeout = timeout
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts using Ollama's native API."""
+        if not texts:
+            return []
+
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "input": texts,
+        }
+        if self._requested_dimensions is not None:
+            payload["dimensions"] = self._requested_dimensions
+
+        async with httpx.AsyncClient(timeout=self._timeout) as client:
+            response = await client.post(f"{self._base_url}/api/embed", json=payload)
+            response.raise_for_status()
+            data = response.json()
+
+        raw_vectors = data.get("embeddings")
+        if raw_vectors is None and "embedding" in data:
+            raw_vectors = [data["embedding"]]
+        if not isinstance(raw_vectors, list):
+            raise ValueError("Ollama embedding response did not include embeddings.")
+        if len(raw_vectors) != len(texts):
+            raise ValueError(
+                f"Ollama returned {len(raw_vectors)} embeddings for {len(texts)} inputs."
+            )
+
+        return [_l2_normalize([float(value) for value in vector]) for vector in raw_vectors]
+
+
+def _l2_normalize(vec: list[float]) -> list[float]:
+    """L2-normalize a vector to unit length."""
+    norm = math.sqrt(sum(x * x for x in vec))
+    if norm == 0.0:
+        norm = 1.0
+    return [x / norm for x in vec]

--- a/packages/core/src/repowise/core/providers/embedding/registry.py
+++ b/packages/core/src/repowise/core/providers/embedding/registry.py
@@ -18,15 +18,17 @@ Custom embedder registration:
 from __future__ import annotations
 
 import importlib
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from repowise.core.providers.embedding.base import Embedder
 
 _BUILTIN_EMBEDDERS: dict[str, tuple[str, str]] = {
     "openai": ("repowise.core.providers.embedding.openai", "OpenAIEmbedder"),
-    "gemini":     ("repowise.core.providers.embedding.gemini",     "GeminiEmbedder"),
+    "gemini": ("repowise.core.providers.embedding.gemini", "GeminiEmbedder"),
+    "ollama": ("repowise.core.providers.embedding.ollama", "OllamaEmbedder"),
     "openrouter": ("repowise.core.providers.embedding.openrouter", "OpenRouterEmbedder"),
-    "mock":       ("repowise.core.providers.embedding.base",       "MockEmbedder"),
+    "mock": ("repowise.core.providers.embedding.base", "MockEmbedder"),
 }
 
 _custom_embedders: dict[str, Callable[..., Embedder]] = {}
@@ -44,9 +46,7 @@ def register_embedder(name: str, factory: Callable[..., Embedder]) -> None:
         ValueError: If name conflicts with a built-in embedder.
     """
     if name in _BUILTIN_EMBEDDERS:
-        raise ValueError(
-            f"Cannot register {name!r}: conflicts with a built-in embedder."
-        )
+        raise ValueError(f"Cannot register {name!r}: conflicts with a built-in embedder.")
     _custom_embedders[name] = factory
 
 
@@ -73,14 +73,13 @@ def get_embedder(name: str, **kwargs: Any) -> Embedder:
 
     if name not in _BUILTIN_EMBEDDERS:
         available = sorted(set(_BUILTIN_EMBEDDERS) | set(_custom_embedders))
-        raise ValueError(
-            f"Unknown embedder: {name!r}. Available embedders: {available}"
-        )
+        raise ValueError(f"Unknown embedder: {name!r}. Available embedders: {available}")
 
     module_path, class_name = _BUILTIN_EMBEDDERS[name]
     _missing = {
         "openai": "openai",
         "gemini": "google-genai",
+        "ollama": "httpx",
         "openrouter": "openai",  # openrouter uses the openai package
     }
     try:

--- a/packages/server/src/repowise/server/app.py
+++ b/packages/server/src/repowise/server/app.py
@@ -67,6 +67,10 @@ def _build_embedder():
         openrouter — OpenRouterEmbedder via OPENROUTER_API_KEY env var
     """
     name = os.environ.get("REPOWISE_EMBEDDER", "mock").lower()
+    if name == "ollama":
+        from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+        return OllamaEmbedder()
     if name == "gemini":
         from repowise.core.providers.embedding.gemini import GeminiEmbedder
 
@@ -82,7 +86,9 @@ def _build_embedder():
 
         model = os.environ.get("REPOWISE_EMBEDDING_MODEL", "google/gemini-embedding-001")
         return OpenRouterEmbedder(model=model)
-    logger.warning("embedder.mock_active — set REPOWISE_EMBEDDER=gemini, openai, or openrouter for real RAG")
+    logger.warning(
+        "embedder.mock_active: set REPOWISE_EMBEDDER=gemini, openai, openrouter, or ollama for real RAG"
+    )
     return MockEmbedder()
 
 

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -35,6 +35,7 @@ _EMBEDDER_REMEDIATION: dict[str, str] = {
         "set GEMINI_API_KEY (or GOOGLE_API_KEY) in the MCP server's environment "
         "(and `pip install google-genai`)"
     ),
+    "ollama": "start Ollama, pull an embedding model, and set OLLAMA_BASE_URL if not local",
     "openrouter": "set OPENROUTER_API_KEY in the MCP server's environment (and `pip install openai`)",
 }
 

--- a/packages/web/src/components/settings/provider-section.tsx
+++ b/packages/web/src/components/settings/provider-section.tsx
@@ -15,7 +15,7 @@ import {
 } from "@repowise-dev/ui/ui/select";
 
 const PROVIDERS = ["gemini", "openai", "anthropic", "deepseek", "ollama", "litellm", "mock"] as const;
-const EMBEDDERS = ["mock", "gemini", "openai"] as const;
+const EMBEDDERS = ["mock", "gemini", "openai", "openrouter", "ollama"] as const;
 
 const MODEL_PLACEHOLDERS: Record<string, string> = {
   gemini: "gemini-3.1-flash-lite-preview",
@@ -40,6 +40,8 @@ const PROVIDER_ENV_VARS: Record<string, { vars: string[]; installHint: string }>
 const EMBEDDER_ENV_VARS: Record<string, string[]> = {
   gemini: ["GEMINI_API_KEY"],
   openai: ["OPENAI_API_KEY"],
+  openrouter: ["OPENROUTER_API_KEY"],
+  ollama: ["OLLAMA_BASE_URL"],
   mock: [],
 };
 

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -50,6 +50,12 @@ class TestCliBasics:
         assert result.exit_code == 0
         assert "--mode" in result.output
 
+    def test_reindex_help(self, runner):
+        result = runner.invoke(cli, ["reindex", "--help"])
+        assert result.exit_code == 0
+        assert "--embedder" in result.output
+        assert "mock" in result.output
+
     def test_export_help(self, runner):
         result = runner.invoke(cli, ["export", "--help"])
         assert result.exit_code == 0

--- a/tests/unit/cli/test_shared_helpers.py
+++ b/tests/unit/cli/test_shared_helpers.py
@@ -8,6 +8,7 @@ implementation (no divergent copies) and pin the behavior of the pure helpers.
 from __future__ import annotations
 
 import types
+from typing import ClassVar
 
 import pytest
 
@@ -44,6 +45,9 @@ def test_resolve_embedder_explicit_flag_wins(monkeypatch: pytest.MonkeyPatch) ->
         ({"GOOGLE_API_KEY": "x"}, "gemini"),
         ({"OPENAI_API_KEY": "x"}, "openai"),
         ({"OPENROUTER_API_KEY": "x"}, "openrouter"),
+        ({"OLLAMA_BASE_URL": "http://localhost:11434"}, "mock"),
+        ({"OLLAMA_EMBEDDING_MODEL": "embeddinggemma"}, "ollama"),
+        ({"REPOWISE_EMBEDDER": "ollama"}, "ollama"),
         ({}, "mock"),
     ],
 )
@@ -55,6 +59,9 @@ def test_resolve_embedder_env_detection(
         "GOOGLE_API_KEY",
         "OPENAI_API_KEY",
         "OPENROUTER_API_KEY",
+        "OLLAMA_BASE_URL",
+        "OLLAMA_EMBEDDING_MODEL",
+        "REPOWISE_EMBEDDER",
     ):
         monkeypatch.delenv(key, raising=False)
     for key, val in env.items():
@@ -70,6 +77,15 @@ def test_build_embedder_falls_back_to_mock() -> None:
     assert isinstance(providers.build_embedder("mock"), MockEmbedder)
 
 
+def test_build_embedder_supports_ollama(monkeypatch: pytest.MonkeyPatch) -> None:
+    from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+    monkeypatch.setenv("OLLAMA_EMBEDDING_MODEL", "qwen3-embedding:0.6b")
+    embedder = providers.build_embedder("ollama")
+    assert isinstance(embedder, OllamaEmbedder)
+    assert embedder._model == "qwen3-embedding:0.6b"
+
+
 def test_build_vector_store_returns_a_store(tmp_path) -> None:
     from repowise.core.providers.embedding.base import MockEmbedder
 
@@ -80,9 +96,9 @@ def test_build_vector_store_returns_a_store(tmp_path) -> None:
 
 
 class _FakeKG:
-    nodes = [{"summary": "s"}, {"summary": ""}]
-    layers = [1, 2, 3]
-    tour = [1, 2]
+    nodes: ClassVar[list[dict[str, str]]] = [{"summary": "s"}, {"summary": ""}]
+    layers: ClassVar[list[int]] = [1, 2, 3]
+    tour: ClassVar[list[int]] = [1, 2]
     fingerprint = "abc123"
 
     def to_dict(self) -> dict:

--- a/tests/unit/server/mcp/test_embedder_resolution.py
+++ b/tests/unit/server/mcp/test_embedder_resolution.py
@@ -29,6 +29,9 @@ _EMBEDDER_ENV_VARS = (
     "GEMINI_API_KEY",
     "GOOGLE_API_KEY",
     "OPENROUTER_API_KEY",
+    "OLLAMA_BASE_URL",
+    "OLLAMA_EMBEDDING_MODEL",
+    "OLLAMA_EMBEDDING_DIMS",
 )
 
 
@@ -86,6 +89,23 @@ def test_openrouter_without_key_degrades(monkeypatch):
     assert status["degraded"] is True
     assert status["requested"] == "openrouter"
     assert "OPENROUTER_API_KEY" in status["reason"]
+
+
+def test_ollama_resolves_without_api_key(monkeypatch):
+    """Local Ollama embeddings do not require a cloud API key at construction."""
+    from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+    monkeypatch.setenv("REPOWISE_EMBEDDER", "ollama")
+    monkeypatch.setenv("OLLAMA_EMBEDDING_MODEL", "qwen3-embedding:0.6b")
+
+    embedder = _server._resolve_embedder()
+
+    assert isinstance(embedder, OllamaEmbedder)
+    assert _state._embedder_status == {
+        "active": "ollama",
+        "requested": "ollama",
+        "degraded": False,
+    }
 
 
 def test_unknown_embedder_name_degrades(monkeypatch):

--- a/tests/unit/test_persistence/test_ollama_embedder.py
+++ b/tests/unit/test_persistence/test_ollama_embedder.py
@@ -1,0 +1,120 @@
+"""Unit tests for OllamaEmbedder.
+
+All tests mock httpx.AsyncClient, so no local Ollama daemon is required.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, ClassVar
+
+import pytest
+
+from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+
+def test_registry_keeps_mock_and_adds_ollama() -> None:
+    from repowise.core.providers.embedding.base import MockEmbedder
+    from repowise.core.providers.embedding.registry import get_embedder, list_embedders
+
+    embedders = list_embedders()
+
+    assert "mock" in embedders
+    assert "ollama" in embedders
+    assert isinstance(get_embedder("mock"), MockEmbedder)
+    assert isinstance(get_embedder("ollama", model="embeddinggemma"), OllamaEmbedder)
+
+
+class _FakeResponse:
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._data
+
+
+class _FakeAsyncClient:
+    calls: ClassVar[list[dict[str, Any]]] = []
+    response_data: ClassVar[dict[str, Any]] = {"embeddings": [[1.0, 0.0]]}
+
+    def __init__(self, *, timeout: float) -> None:
+        self.timeout = timeout
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def post(self, url: str, *, json: dict[str, Any]) -> _FakeResponse:
+        self.calls.append({"url": url, "json": json, "timeout": self.timeout})
+        return _FakeResponse(self.response_data)
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_client(monkeypatch: pytest.MonkeyPatch):
+    _FakeAsyncClient.calls = []
+    _FakeAsyncClient.response_data = {"embeddings": [[1.0, 0.0]]}
+    monkeypatch.setattr(
+        "repowise.core.providers.embedding.ollama.httpx.AsyncClient",
+        _FakeAsyncClient,
+    )
+
+
+async def test_embed_empty_returns_empty() -> None:
+    embedder = OllamaEmbedder(model="embeddinggemma")
+    assert await embedder.embed([]) == []
+
+
+async def test_embed_posts_batch_to_native_endpoint() -> None:
+    _FakeAsyncClient.response_data = {"embeddings": [[1.0, 0.0], [0.0, 2.0]]}
+    embedder = OllamaEmbedder(
+        model="qwen3-embedding:0.6b",
+        base_url="http://localhost:11434/",
+        dimensions=1024,
+    )
+
+    vectors = await embedder.embed(["first", "second"])
+
+    assert _FakeAsyncClient.calls == [
+        {
+            "url": "http://localhost:11434/api/embed",
+            "json": {
+                "model": "qwen3-embedding:0.6b",
+                "input": ["first", "second"],
+                "dimensions": 1024,
+            },
+            "timeout": 30.0,
+        }
+    ]
+    assert len(vectors) == 2
+    assert all(abs(math.sqrt(sum(x * x for x in vec)) - 1.0) < 1e-6 for vec in vectors)
+
+
+async def test_embed_supports_legacy_single_embedding_response() -> None:
+    _FakeAsyncClient.response_data = {"embedding": [3.0, 4.0]}
+    embedder = OllamaEmbedder(model="embeddinggemma")
+
+    result = await embedder.embed(["one"])
+
+    assert result == [[0.6, 0.8]]
+
+
+def test_model_and_base_url_can_come_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://ollama.local:11434/")
+    monkeypatch.setenv("OLLAMA_EMBEDDING_MODEL", "all-minilm")
+
+    embedder = OllamaEmbedder()
+
+    assert embedder._base_url == "http://ollama.local:11434"
+    assert embedder._model == "all-minilm"
+    assert embedder.dimensions == 384
+
+
+def test_qwen3_dimensions_are_inferred() -> None:
+    assert OllamaEmbedder(model="qwen3-embedding:0.6b").dimensions == 1024
+    assert OllamaEmbedder(model="qwen3-embedding:4b").dimensions == 2560
+    assert OllamaEmbedder(model="qwen3-embedding:8b").dimensions == 4096


### PR DESCRIPTION
# PR 1: Native Ollama Embeddings

## Title

feat(embeddings): add native ollama embedder

## Branch

`codex/ollama-embedding-provider`

## Summary

Adds first-class Ollama embedding support without requiring users to alias an Ollama model through the OpenAI-compatible endpoint.

- Adds `OllamaEmbedder` backed by Ollama's native `/api/embed` endpoint.
- Registers `ollama` in the embedding registry while preserving `mock`.
- Wires Ollama through CLI embedder resolution, `init`, `reindex`, semantic `search`, server startup, MCP remediation text, and the settings UI embedder list.
- Supports `OLLAMA_EMBEDDING_MODEL`, `REPOWISE_EMBEDDING_MODEL`, `OLLAMA_EMBEDDING_DIMS`, `REPOWISE_EMBEDDING_DIMS`, and `OLLAMA_BASE_URL`.
- Keeps `mock` available, including explicit `repowise reindex --embedder mock` for deterministic test vectors.
- Avoids selecting Ollama embeddings from `OLLAMA_BASE_URL` alone, since that variable can mean "Ollama LLM provider" rather than "use Ollama for embeddings".

## Why

Local users can already use Ollama for generation, but embedding required the OpenAI-compatible workaround:

```powershell
ollama cp qwen3-embedding:0.6b text-embedding-3-small
repowise reindex --embedder openai
```

This PR lets users configure the embedding provider directly:

```powershell
$env:REPOWISE_EMBEDDER = "ollama"
$env:OLLAMA_EMBEDDING_MODEL = "qwen3-embedding:0.6b"
repowise reindex --embedder ollama
```

## Safety Notes

- The registry change only makes `ollama` resolvable by name through the existing lazy provider registry.
- `mock` remains registered and has a regression test.
- `OLLAMA_BASE_URL` configures the endpoint but does not auto-select the Ollama embedder by itself.
- Pointing `OLLAMA_BASE_URL` at a remote host sends indexed source/wiki text to that host; local loopback remains the default.
- If a real embedder fails and the user did not explicitly request `mock`, `reindex` still aborts instead of silently writing mock vectors.

## Testing

```powershell
.\.venv\Scripts\python.exe -m pytest tests\unit\test_persistence\test_ollama_embedder.py
.\.venv\Scripts\python.exe -m pytest tests\unit\cli\test_shared_helpers.py
.\.venv\Scripts\python.exe -m pytest tests\unit\cli\test_commands.py
.\.venv\Scripts\python.exe -m pytest tests\unit\server\mcp\test_embedder_resolution.py
.\.venv\Scripts\python.exe -m ruff check packages\core\src\repowise\core\providers\embedding\ollama.py packages\core\src\repowise\core\providers\embedding\registry.py packages\cli\src\repowise\cli\providers\embedders.py packages\cli\src\repowise\cli\commands\reindex_cmd.py packages\cli\src\repowise\cli\commands\search_cmd.py packages\cli\src\repowise\cli\ui\mode_selection.py packages\server\src\repowise\server\mcp_server\_server.py tests\unit\test_persistence\test_ollama_embedder.py tests\unit\cli\test_shared_helpers.py tests\unit\cli\test_commands.py tests\unit\server\mcp\test_embedder_resolution.py
.\.venv\Scripts\python.exe -m ruff format --check packages\core\src\repowise\core\providers\embedding\ollama.py packages\core\src\repowise\core\providers\embedding\registry.py packages\cli\src\repowise\cli\providers\embedders.py packages\cli\src\repowise\cli\commands\reindex_cmd.py packages\cli\src\repowise\cli\commands\search_cmd.py packages\cli\src\repowise\cli\ui\mode_selection.py packages\server\src\repowise\server\mcp_server\_server.py tests\unit\test_persistence\test_ollama_embedder.py tests\unit\cli\test_shared_helpers.py tests\unit\cli\test_commands.py tests\unit\server\mcp\test_embedder_resolution.py
```
