### PR TITLE
fix(dead-code): keep rust sibling test modules live

### DIFF
--- a/packages/core/src/repowise/core/analysis/dead_code/constants.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/constants.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 from repowise.core.ingestion.languages.registry import REGISTRY as _LANG_REGISTRY
 
-
 # Non-code languages that should never be flagged as dead code.
 # Derived from the centralised LanguageRegistry — passthrough config/infra
 # languages plus "unknown".
@@ -483,6 +482,9 @@ _NEVER_FLAG_PATTERNS: tuple[str, ...] = (
     "**/tests/**/*.rs",
     "tests/*.rs",
     "tests/**/*.rs",
+    # Unit-test sibling modules (e.g. `src/foo/tests.rs`) are loaded by
+    # `#[cfg(test)] mod tests;` and the Cargo test harness, not production imports.
+    "**/src/**/tests.rs",
     # Binary targets (separate executables in a crate)
     "**/src/bin/*.rs",
     "**/src/bin/**/*.rs",
@@ -967,7 +969,6 @@ _NEVER_PACKAGE_DIRS: frozenset[str] = frozenset({
     ".circleci",
     ".buildkite",
     ".cargo",
-    ".husky",
     ".yarn",
     "docs",
     "doc",

--- a/tests/unit/dead_code/test_rust_tests_module.py
+++ b/tests/unit/dead_code/test_rust_tests_module.py
@@ -1,0 +1,47 @@
+"""Rust sibling test modules should not be reported as dead code."""
+
+from __future__ import annotations
+
+from repowise.core.analysis.dead_code import DeadCodeAnalyzer, DeadCodeKind
+from tests.unit.dead_code._helpers import _build_graph
+
+
+def test_rust_sibling_tests_module_never_flagged() -> None:
+    analyzer = DeadCodeAnalyzer(_build_graph(nodes={}), git_meta_map={})
+
+    assert analyzer._should_never_flag("noor-server/src/server/routes/tests.rs", set())
+
+
+def test_rust_sibling_tests_module_not_reported_unreachable() -> None:
+    analyzer = DeadCodeAnalyzer(
+        _build_graph(
+            nodes={
+                "noor-server/src/server/routes/tests.rs": {
+                    "is_entry_point": False,
+                    "language": "rust",
+                    "symbol_count": 1,
+                    "symbols": [],
+                },
+                "noor-server/src/lib.rs": {
+                    "is_entry_point": True,
+                    "language": "rust",
+                    "symbol_count": 1,
+                    "symbols": [],
+                },
+            }
+        ),
+        git_meta_map={},
+    )
+
+    report = analyzer.analyze(
+        {
+            "detect_unused_exports": False,
+            "detect_unused_internal": False,
+            "detect_zombie_packages": False,
+        }
+    )
+
+    unreachable = [
+        finding for finding in report.findings if finding.kind == DeadCodeKind.UNREACHABLE_FILE
+    ]
+    assert unreachable == []


### PR DESCRIPTION
# PR 2: Rust Sibling Test Modules

## Title

fix(dead-code): keep rust sibling test modules live

## Branch

`codex/dead-code-rust-tests-module`

## Summary

Prevents the dead-code analyzer from reporting Rust sibling test modules as unreachable files.

- Adds `**/src/**/tests.rs` to the dead-code never-flag patterns.
- Adds a regression test for the `src/server/routes/tests.rs` shape used by Rust crates that declare `#[cfg(test)] mod tests;`.
- Keeps the change conservative and audit-only: it only suppresses the test module file itself from unreachable-file findings.
- Includes a tiny lint cleanup in the touched constants file by removing a duplicate `.husky` set entry.

## Why

Rust unit-test modules are often compiled into the crate test target through declarations like:

```rust
#[cfg(test)]
mod tests;
```

Those files do not necessarily have ordinary production import edges. Treating `src/**/tests.rs` as an unreachable production file creates false deletion signals.

## Testing

```powershell
.\.venv\Scripts\python.exe -m pytest tests\unit\dead_code\test_rust_tests_module.py
.\.venv\Scripts\python.exe -m pytest tests\unit\dead_code
.\.venv\Scripts\python.exe -m ruff check packages\core\src\repowise\core\analysis\dead_code\constants.py tests\unit\dead_code\test_rust_tests_module.py
```

The full dead-code unit suite passed: `66 passed`.

## Risk

This can hide a truly orphaned Rust `tests.rs` file from the unreachable-file report, but that is preferable to presenting Cargo test modules as safe deletion candidates. The suppression is limited to the conventional `src/**/tests.rs` path.
