### PR TITLE
fix(cli): use shared database engine for reindex

### DIFF
--- a/packages/cli/src/repowise/cli/commands/reindex_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/reindex_cmd.py
@@ -45,9 +45,9 @@ async def _reindex(repo_path, embedder_name: str, batch_size: int) -> None:
     from pathlib import Path
 
     from sqlalchemy import select
-    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-    from repowise.core.persistence.database import init_db
+    from repowise.core.persistence.database import create_engine, init_db
     from repowise.core.persistence.models import Page
 
     # --- Resolve embedder ---
@@ -85,10 +85,7 @@ async def _reindex(repo_path, embedder_name: str, batch_size: int) -> None:
 
     # --- Open database ---
     db_url = get_db_url_for_repo(repo_path)
-    connect_args = {}
-    if db_url.startswith("sqlite"):
-        connect_args["check_same_thread"] = False
-    engine = create_async_engine(db_url, connect_args=connect_args)
+    engine = create_engine(db_url)
     await init_db(engine)
     factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 

--- a/tests/unit/cli/test_reindex_cmd.py
+++ b/tests/unit/cli/test_reindex_cmd.py
@@ -1,0 +1,71 @@
+"""Tests for the reindex CLI command internals."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from repowise.cli.commands import reindex_cmd
+
+
+class _DummyEngine:
+    def __init__(self) -> None:
+        self.disposed = False
+
+    async def dispose(self) -> None:
+        self.disposed = True
+
+
+class _EmptyResult:
+    def scalars(self) -> _EmptyResult:
+        return self
+
+    def all(self) -> list[Any]:
+        return []
+
+
+class _Session:
+    async def __aenter__(self) -> _Session:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def execute(self, _stmt: object) -> _EmptyResult:
+        return _EmptyResult()
+
+
+def _sessionmaker(*_args: object, **_kwargs: object):
+    return _Session
+
+
+async def test_reindex_uses_shared_database_engine(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'wiki.db'}"
+    created: dict[str, object] = {}
+
+    def fake_create_engine(url: str):
+        engine = _DummyEngine()
+        created["url"] = url
+        created["engine"] = engine
+        return engine
+
+    async def fake_init_db(engine: object) -> None:
+        created["init_engine"] = engine
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(reindex_cmd, "get_db_url_for_repo", lambda _repo_path: db_url)
+    monkeypatch.setattr(
+        "repowise.core.persistence.database.create_engine",
+        fake_create_engine,
+    )
+    monkeypatch.setattr("repowise.core.persistence.database.init_db", fake_init_db)
+    monkeypatch.setattr("sqlalchemy.ext.asyncio.async_sessionmaker", _sessionmaker)
+
+    await reindex_cmd._reindex(tmp_path, "openai", batch_size=20)
+
+    assert created["url"] == db_url
+    assert created["init_engine"] is created["engine"]
+    assert created["engine"].disposed is True


### PR DESCRIPTION
# PR 3: Reindex SQLite Engine Pragmas

## Title

fix(cli): use shared database engine for reindex

## Branch

`codex/reindex-sqlite-engine-pragmas`

## Summary

Makes `repowise reindex` use the shared persistence `create_engine()` helper instead of constructing a SQLAlchemy async engine directly.

- Replaces direct `create_async_engine()` usage in `reindex_cmd.py`.
- Routes reindex through `repowise.core.persistence.database.create_engine()`.
- Ensures reindex gets the same SQLite WAL, busy-timeout, foreign-key, and pooling behavior as the rest of the CLI.
- Adds a regression test proving reindex calls the shared engine factory.

## Why

The shared database helper already centralizes SQLite lock hardening. `reindex` bypassed it, so it could miss the busy-timeout and WAL pragmas that reduce local `database is locked` failures during heavier indexing or concurrent checks.

## Testing

```powershell
.\.venv\Scripts\python.exe -m pytest tests\unit\cli\test_reindex_cmd.py
.\.venv\Scripts\python.exe -m pytest tests\unit\persistence\test_database_pragmas.py
.\.venv\Scripts\python.exe -m pytest tests\unit\cli tests\unit\persistence\test_database_pragmas.py
.\.venv\Scripts\python.exe -m ruff check packages\cli\src\repowise\cli\commands\reindex_cmd.py tests\unit\cli\test_reindex_cmd.py
.\.venv\Scripts\python.exe -m ruff format --check packages\cli\src\repowise\cli\commands\reindex_cmd.py tests\unit\cli\test_reindex_cmd.py
```

The broader CLI plus SQLite pragma run passed: `329 passed`.

## Risk

Low. This aligns `reindex` with existing database setup behavior instead of introducing a separate locking strategy.
