### PR TITLE
fix(mcp): preserve user-added `env` on MCP re-registration

### DIFF
--- a/packages/cli/src/repowise/cli/mcp_config.py
+++ b/packages/cli/src/repowise/cli/mcp_config.py
@@ -35,6 +35,27 @@ def save_mcp_config(repo_path: Path) -> Path:
     return config_path
 
 
+def _merge_server_entries(servers: dict, new_entry: dict) -> dict:
+    """Deep-merge *new_entry* server definitions into *servers* in place.
+
+    For each server key, the generated ``command``/``args``/``description``
+    overwrite the stored values (so path/command changes take effect), but any
+    other keys the user added to the entry — most importantly an ``env`` block
+    carrying BYOK provider keys — are preserved. A shallow ``servers.update()``
+    would replace the whole entry and silently wipe ``env`` on every
+    re-registration (``repowise init`` / ``update``). See issue #307.
+    """
+    for name, entry in new_entry.items():
+        current = servers.get(name)
+        if isinstance(current, dict) and isinstance(entry, dict):
+            merged_entry = dict(current)
+            merged_entry.update(entry)
+            servers[name] = merged_entry
+        else:
+            servers[name] = entry
+    return servers
+
+
 def save_root_mcp_config(repo_path: Path) -> Path:
     """Write .mcp.json at repo root for MCP clients that support discovery.
 
@@ -47,7 +68,7 @@ def save_root_mcp_config(repo_path: Path) -> Path:
     if config_path.exists():
         existing = load_existing_config(config_path)
         servers = dict(existing.get("mcpServers", {}))
-        servers.update(new_entry)
+        _merge_server_entries(servers, new_entry)
         existing["mcpServers"] = servers
         merged = existing
     else:
@@ -61,6 +82,10 @@ def merge_mcp_entry(config_path: Path, new_entry: dict) -> bool:
     """Merge *new_entry* into the mcpServers block of *config_path*.
 
     Creates the file if it doesn't exist. Returns True on success.
+
+    The per-server merge is deep: generated fields overwrite stored ones, but
+    user-added keys such as an ``env`` block are preserved across
+    re-registration (see :func:`_merge_server_entries`).
     """
     try:
         if config_path.exists():
@@ -70,7 +95,7 @@ def merge_mcp_entry(config_path: Path, new_entry: dict) -> bool:
             existing = {}
 
         servers = dict(existing.get("mcpServers", {}))
-        servers.update(new_entry)
+        _merge_server_entries(servers, new_entry)
         existing["mcpServers"] = servers
         config_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
         return True

--- a/tests/unit/cli/test_mcp_config.py
+++ b/tests/unit/cli/test_mcp_config.py
@@ -98,6 +98,64 @@ def test_merge_mcp_entry_rejects_invalid_existing_file(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Re-registration must not wipe user-added per-server keys (issue #307)
+# ---------------------------------------------------------------------------
+
+
+def test_merge_mcp_entry_preserves_user_env_block(tmp_path: Path) -> None:
+    """A user-added ``env`` block (BYOK keys) survives re-registration."""
+    config_path = tmp_path / "settings.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "repowise": {
+                        "command": "old-command",
+                        "args": ["stale"],
+                        "env": {"OPENAI_API_KEY": "sk-secret"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert mcp_config.merge_mcp_entry(config_path, _repowise_entry(tmp_path))
+
+    repowise = json.loads(config_path.read_text(encoding="utf-8"))["mcpServers"]["repowise"]
+    # User env preserved...
+    assert repowise["env"] == {"OPENAI_API_KEY": "sk-secret"}
+    # ...while generated fields are refreshed to the current values.
+    assert repowise["command"] == "repowise"
+    assert repowise["args"][:2] == ["mcp", str(tmp_path.resolve()).replace("\\", "/")]
+
+
+def test_save_root_mcp_config_preserves_user_env_block(tmp_path: Path) -> None:
+    """``.mcp.json`` re-write keeps a user ``env`` block on the repowise entry."""
+    config_path = tmp_path / ".mcp.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "repowise": {
+                        "command": "old-command",
+                        "args": ["stale"],
+                        "env": {"DEEPSEEK_API_KEY": "dk-secret"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    mcp_config.save_root_mcp_config(tmp_path)
+
+    repowise = json.loads(config_path.read_text(encoding="utf-8"))["mcpServers"]["repowise"]
+    assert repowise["env"] == {"DEEPSEEK_API_KEY": "dk-secret"}
+    assert repowise["command"] == "repowise"
+
+
+# ---------------------------------------------------------------------------
 # install_claude_code_hooks — fresh installs
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Re-registering the repowise MCP server silently wiped any user-added `env` block on the `repowise` entry. `merge_mcp_entry()` and `save_root_mcp_config()` updated the client config with a shallow `servers.update(new_entry)`, replacing the *entire* per-server value. Because `generate_mcp_config()` emits no `env` key, the user's `env` block was dropped on every re-registration — `repowise init`, `update`, and anything calling `register_with_claude_desktop()` / `register_with_claude_code()`.

This bites BYOK setups hard: provider/embedder keys are read only from `os.environ`, and the standard way to supply them to a stdio MCP server is an `env` block in the client config. Once it's wiped, the configured embedder can't initialize and silently falls back to a mock, so semantic search returns garbage while the server still reports healthy.

## Fix

Deep-merge each server definition instead of replacing it. Generated `command`/`args`/`description` are refreshed (so path/command changes still take effect), but any other keys the user added to the entry — most importantly `env` — are preserved across re-registration.

## Tests

Added coverage for both entry points that re-register:
- `merge_mcp_entry` preserves a user `env` block while refreshing generated fields.
- `save_root_mcp_config` preserves a user `env` block on the `.mcp.json` entry.

Full `test_mcp_config.py` suite passes (26/26); ruff format + check clean.

Fixes #307. Related: #306, #277.
