### PR TITLE
fix(update): re-run health on config change even when git is unchanged

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd.py
@@ -23,6 +23,7 @@ from repowise.cli.editor_setup import (
     write_editor_project_files,
 )
 from repowise.cli.helpers import (
+    config_fingerprint,
     console,
     ensure_repowise_dir,
     get_head_commit,
@@ -1344,6 +1345,10 @@ def _save_full_state_and_config(
         reasoning=resolved_reasoning,
     )
 
+    # Re-save state with the fingerprint now that config.yaml is written.
+    state["config_fingerprint"] = config_fingerprint(repo_path)
+    save_state(repo_path, state)
+
 
 def _show_completion(
     *,
@@ -2018,6 +2023,8 @@ def init_command(
             exclude_patterns=exclude_patterns if exclude_patterns else None,
             commit_limit=resolved_commit_limit if commit_limit is not None else None,
         )
+        # Fingerprint after config writes so the first update doesn't false-positive.
+        base_state["config_fingerprint"] = config_fingerprint(repo_path)
         save_state(repo_path, base_state)
 
     # ---- State + config (full mode only) ----

--- a/packages/cli/src/repowise/cli/commands/update_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd.py
@@ -277,6 +277,69 @@ def _build_filtered_changed_paths(file_diffs: list, exclude_patterns: list[str])
     return [p for p in paths if not spec.match_file(p)]
 
 
+def _build_repo_graph(
+    repo_path: Any,
+    exclude_patterns: list[str],
+    *,
+    collect_sources: bool = False,
+) -> tuple[list, dict[str, bytes], Any, Any, int]:
+    """Traverse + parse the repo and build the graph (+ framework-aware edges).
+
+    Shared by the incremental rebuild path (:func:`_rebuild_graph_and_git`) and
+    the config-triggered re-score path (:func:`_run_full_health_rescore`) so both
+    build the same graph from the same parser and the same synthetic edge step.
+
+    Files that fail to read/parse are skipped and reported as a count rather than
+    swallowed silently. ``source_map`` is populated only when ``collect_sources``
+    is set (the re-score path doesn't need the raw bytes).
+
+    Returns ``(parsed_files, source_map, graph_builder, repo_structure,
+    file_count)``.
+    """
+    from pathlib import Path as PathlibPath
+
+    from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
+
+    traverser = FileTraverser(repo_path, extra_exclude_patterns=exclude_patterns or None)
+    file_infos = list(traverser.traverse())
+    repo_structure = traverser.get_repo_structure()
+
+    parser = ASTParser()
+    parsed_files: list = []
+    source_map: dict[str, bytes] = {}
+    graph_builder = GraphBuilder(repo_path, exclude_patterns=exclude_patterns)
+
+    skipped = 0
+    for fi in file_infos:
+        try:
+            source = PathlibPath(fi.abs_path).read_bytes()
+            parsed = parser.parse_file(fi, source)
+        except Exception:
+            skipped += 1
+            continue
+        parsed_files.append(parsed)
+        if collect_sources:
+            source_map[fi.path] = source
+        graph_builder.add_file(parsed)
+    graph_builder.build()
+
+    if skipped:
+        console.print(f"[yellow]Skipped {skipped} file(s) that failed to parse.[/yellow]")
+
+    # Add framework-aware synthetic edges (conftest, Django, FastAPI, Flask).
+    try:
+        from repowise.core.generation.editor_files.tech_stack import detect_tech_stack
+
+        tech_items = detect_tech_stack(repo_path)
+        fw_count = graph_builder.add_framework_edges([item.name for item in tech_items])
+        if fw_count:
+            console.print(f"Framework edges added: [cyan]{fw_count}[/cyan]")
+    except Exception:
+        pass  # framework edge detection is best-effort
+
+    return parsed_files, source_map, graph_builder, repo_structure, len(file_infos)
+
+
 def _rebuild_graph_and_git(
     repo_path: Any,
     file_diffs: list,
@@ -289,41 +352,10 @@ def _rebuild_graph_and_git(
     Returns ``(parsed_files, source_map, graph_builder, repo_structure,
     file_count, git_meta_map)``.
     """
-    from pathlib import Path as PathlibPath
-
-    from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
-
     # Full re-ingest for graph (needed for cascade analysis)
-    traverser = FileTraverser(repo_path, extra_exclude_patterns=exclude_patterns or None)
-    file_infos = list(traverser.traverse())
-    repo_structure = traverser.get_repo_structure()
-
-    parser = ASTParser()
-    parsed_files: list = []
-    source_map: dict[str, bytes] = {}
-    graph_builder = GraphBuilder(repo_path, exclude_patterns=exclude_patterns)
-
-    for fi in file_infos:
-        try:
-            source = PathlibPath(fi.abs_path).read_bytes()
-            parsed = parser.parse_file(fi, source)
-            parsed_files.append(parsed)
-            source_map[fi.path] = source
-            graph_builder.add_file(parsed)
-        except Exception:
-            pass
-    graph_builder.build()
-
-    # Add framework-aware synthetic edges (conftest, Django, FastAPI, Flask)
-    try:
-        from repowise.core.generation.editor_files.tech_stack import detect_tech_stack
-
-        tech_items = detect_tech_stack(repo_path)
-        fw_count = graph_builder.add_framework_edges([item.name for item in tech_items])
-        if fw_count:
-            console.print(f"Framework edges added: [cyan]{fw_count}[/cyan]")
-    except Exception:
-        pass  # framework edge detection is best-effort
+    parsed_files, source_map, graph_builder, repo_structure, file_count = _build_repo_graph(
+        repo_path, exclude_patterns, collect_sources=True
+    )
 
     # Re-index git metadata for changed files
     git_meta_map: dict[str, dict] = {}
@@ -345,7 +377,7 @@ def _rebuild_graph_and_git(
     except Exception as exc:
         console.print(f"[yellow]Git re-index skipped: {exc}[/yellow]")
 
-    return parsed_files, source_map, graph_builder, repo_structure, len(file_infos), git_meta_map
+    return parsed_files, source_map, graph_builder, repo_structure, file_count, git_meta_map
 
 
 def _run_partial_analysis(
@@ -571,7 +603,6 @@ def _git_metadata_to_dict(gm: Any) -> dict[str, Any]:
 
 def _run_full_health_rescore(
     repo_path: Any,
-    cfg: dict,
     exclude_patterns: list[str],
     state: dict,
     head: str | None,
@@ -587,27 +618,14 @@ def _run_full_health_rescore(
     import time
 
     start = time.monotonic()
-    from pathlib import Path as PathlibPath
 
     import pathspec
 
-    from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
-
-    traverser = FileTraverser(repo_path, extra_exclude_patterns=exclude_patterns or None)
-    file_infos = list(traverser.traverse())
-
-    parser = ASTParser()
-    parsed_files: list = []
-    graph_builder = GraphBuilder(repo_path, exclude_patterns=exclude_patterns)
-    for fi in file_infos:
-        try:
-            source = PathlibPath(fi.abs_path).read_bytes()
-            parsed = parser.parse_file(fi, source)
-            parsed_files.append(parsed)
-            graph_builder.add_file(parsed)
-        except Exception:
-            pass
-    graph_builder.build()
+    # Share the rebuild path with the incremental update so both produce the
+    # same graph (same parser, same framework-aware synthetic edges).
+    parsed_files, _source_map, graph_builder, _repo_structure, _file_count = _build_repo_graph(
+        repo_path, exclude_patterns
+    )
 
     exclude_spec = (
         pathspec.PathSpec.from_lines("gitwildmatch", exclude_patterns)
@@ -994,7 +1012,7 @@ def update_command(
             return
         cfg = load_config(repo_path)
         exclude_patterns = list(cfg.get("exclude_patterns") or [])
-        _run_full_health_rescore(repo_path, cfg, exclude_patterns, state, head, curr_config_fp)
+        _run_full_health_rescore(repo_path, exclude_patterns, state, head, curr_config_fp)
         return
 
     console.print(f"Changed files: [yellow]{len(file_diffs)}[/yellow]")

--- a/packages/cli/src/repowise/cli/commands/update_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd.py
@@ -495,7 +495,12 @@ def _persist_index_only_update(
                 console.print(f"[yellow]Graph nodes persist skipped: {exc}[/yellow]")
 
     run_async(_persist_index_only())
-    save_state(repo_path, {**state, "last_sync_commit": head})
+    from repowise.cli.helpers import config_fingerprint
+
+    save_state(
+        repo_path,
+        {**state, "last_sync_commit": head, "config_fingerprint": config_fingerprint(repo_path)},
+    )
     elapsed = time.monotonic() - start
     console.print(
         f"[green]Index-only update complete[/green] in {elapsed:.1f}s — "
@@ -525,6 +530,180 @@ def _render_update_report(
         console.print(
             f"[bold green]Updated {len(generated_pages)} pages in {elapsed:.1f}s[/bold green]"
         )
+
+
+def _git_metadata_to_dict(gm: Any) -> dict[str, Any]:
+    """Convert a GitMetadata ORM row to the dict format HealthAnalyzer expects."""
+    return {
+        "file_path": gm.file_path,
+        "commit_count_total": gm.commit_count_total,
+        "commit_count_90d": gm.commit_count_90d,
+        "commit_count_30d": gm.commit_count_30d,
+        "first_commit_at": gm.first_commit_at,
+        "last_commit_at": gm.last_commit_at,
+        "primary_owner_name": gm.primary_owner_name,
+        "primary_owner_email": gm.primary_owner_email,
+        "primary_owner_commit_pct": gm.primary_owner_commit_pct,
+        "top_authors_json": gm.top_authors_json,
+        "significant_commits_json": gm.significant_commits_json,
+        "co_change_partners_json": gm.co_change_partners_json,
+        "commit_categories_json": gm.commit_categories_json,
+        "is_hotspot": gm.is_hotspot,
+        "is_stable": gm.is_stable,
+        "churn_percentile": gm.churn_percentile,
+        "age_days": gm.age_days,
+        "commit_count_capped": gm.commit_count_capped,
+        "lines_added_90d": gm.lines_added_90d,
+        "lines_deleted_90d": gm.lines_deleted_90d,
+        "avg_commit_size": gm.avg_commit_size,
+        "recent_owner_name": gm.recent_owner_name,
+        "recent_owner_commit_pct": gm.recent_owner_commit_pct,
+        "bus_factor": gm.bus_factor,
+        "contributor_count": gm.contributor_count,
+        "original_path": gm.original_path,
+        "merge_commit_count_90d": gm.merge_commit_count_90d,
+        "temporal_hotspot_score": gm.temporal_hotspot_score,
+        "prior_defect_count": gm.prior_defect_count,
+        "change_entropy": gm.change_entropy,
+        "change_entropy_pct": gm.change_entropy_pct,
+    }
+
+
+def _run_full_health_rescore(
+    repo_path: Any,
+    cfg: dict,
+    exclude_patterns: list[str],
+    state: dict,
+    head: str | None,
+    curr_fingerprint: str,
+) -> None:
+    """Rebuild graph and re-run full health analysis when config changed.
+
+    Uses save_health_metrics / save_health_findings (full replace, not upsert)
+    so rows for newly-excluded files are removed. Loads GitMetadata from the DB
+    (so biomarkers keep accurate churn/ownership/co-change data) and removes
+    excluded rows both from the DB and the analyzer input.
+    """
+    import time
+
+    start = time.monotonic()
+    from pathlib import Path as PathlibPath
+
+    import pathspec
+
+    from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
+
+    traverser = FileTraverser(repo_path, extra_exclude_patterns=exclude_patterns or None)
+    file_infos = list(traverser.traverse())
+
+    parser = ASTParser()
+    parsed_files: list = []
+    graph_builder = GraphBuilder(repo_path, exclude_patterns=exclude_patterns)
+    for fi in file_infos:
+        try:
+            source = PathlibPath(fi.abs_path).read_bytes()
+            parsed = parser.parse_file(fi, source)
+            parsed_files.append(parsed)
+            graph_builder.add_file(parsed)
+        except Exception:
+            pass
+    graph_builder.build()
+
+    exclude_spec = (
+        pathspec.PathSpec.from_lines("gitwildmatch", exclude_patterns)
+        if exclude_patterns
+        else None
+    )
+
+    async def _rescore() -> None:
+        from sqlalchemy import delete, select
+
+        from repowise.cli.helpers import get_db_url_for_repo
+        from repowise.core.analysis.health import HealthAnalyzer
+        from repowise.core.analysis.health.config import HealthConfig
+        from repowise.core.persistence import (
+            create_engine,
+            create_session_factory,
+            get_session,
+            init_db,
+            upsert_repository,
+        )
+        from repowise.core.persistence.crud import save_health_findings, save_health_metrics
+        from repowise.core.persistence.models import GitMetadata
+        from repowise.core.pipeline.persist import persist_graph_nodes
+
+        url = get_db_url_for_repo(repo_path)
+        engine = create_engine(url)
+        await init_db(engine)
+        sf = create_session_factory(engine)
+
+        async with get_session(sf) as session:
+            repo = await upsert_repository(
+                session, name=repo_path.name, local_path=str(repo_path)
+            )
+            repo_id = repo.id
+
+            gm_result = await session.execute(
+                select(GitMetadata).where(GitMetadata.repository_id == repo_id)
+            )
+            git_rows = list(gm_result.scalars().all())
+            excluded_git_paths = [
+                gm.file_path
+                for gm in git_rows
+                if exclude_spec is not None and exclude_spec.match_file(gm.file_path)
+            ]
+            if excluded_git_paths:
+                await session.execute(
+                    delete(GitMetadata).where(
+                        GitMetadata.repository_id == repo_id,
+                        GitMetadata.file_path.in_(excluded_git_paths),
+                    )
+                )
+                await session.flush()
+
+            git_meta_map = {
+                gm.file_path: _git_metadata_to_dict(gm)
+                for gm in git_rows
+                if exclude_spec is None or not exclude_spec.match_file(gm.file_path)
+            }
+
+            analyzer = HealthAnalyzer(
+                graph_builder.graph(),
+                git_meta_map=git_meta_map,
+                parsed_files=parsed_files,
+            )
+            hcfg = HealthConfig.load(repo_path)
+            analyzer_config = (
+                hcfg.to_analyzer_config([pf.file_info.path for pf in parsed_files])
+                if (hcfg.disabled_biomarkers or hcfg.rules)
+                else None
+            )
+            report = analyzer.analyze(analyzer_config)
+
+            console.print(
+                f"Health re-score: [cyan]{len(parsed_files)} files[/cyan], "
+                f"[yellow]{len(report.findings)} findings[/yellow]"
+            )
+
+            await save_health_metrics(session, repo_id, report.metrics or [])
+            await save_health_findings(session, repo_id, list(report.findings or []))
+            await persist_graph_nodes(session, repo_id, graph_builder)
+
+    try:
+        run_async(_rescore())
+    except Exception as exc:
+        # Return without advancing the fingerprint so the next update retries.
+        console.print(f"[yellow]Health re-score failed: {exc}[/yellow]")
+        return
+
+    save_state(
+        repo_path,
+        {**state, "last_sync_commit": head, "config_fingerprint": curr_fingerprint},
+    )
+    elapsed = time.monotonic() - start
+    console.print(
+        f"[green]Config-triggered health re-score complete[/green] in {elapsed:.1f}s"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -713,8 +892,19 @@ def update_command(
             "Run 'repowise init' there first, or pass --since <ref>." + hint
         )
 
-    if head and head == base_ref:
+    # A config.yaml / health-rules.json change warrants a full health re-score
+    # even when git is unchanged. A missing prior fingerprint is backfilled, not
+    # treated as a change. ``config_changed`` gates every "nothing to do" path.
+    from repowise.cli.helpers import config_fingerprint
+
+    prev_config_fp = state.get("config_fingerprint")
+    curr_config_fp = config_fingerprint(repo_path)
+    config_changed = prev_config_fp is not None and prev_config_fp != curr_config_fp
+
+    if head and head == base_ref and not config_changed:
         console.print("[green]Already up to date.[/green]")
+        if prev_config_fp is None and not dry_run:
+            save_state(repo_path, {**state, "config_fingerprint": curr_config_fp})
         return
 
     # --- Single-flight check ------------------------------------------------
@@ -785,9 +975,26 @@ def update_command(
     detector = ChangeDetector(repo_path)
     file_diffs = detector.get_changed_files(base_ref, head or "HEAD")
 
-    if not file_diffs:
+    if not file_diffs and not config_changed:
         console.print("[green]No changed files detected.[/green]")
-        save_state(repo_path, {**state, "last_sync_commit": head})
+        save_state(
+            repo_path,
+            {**state, "last_sync_commit": head, "config_fingerprint": curr_config_fp},
+        )
+        return
+
+    if config_changed:
+        # Full re-score (not the partial update) so unchanged files pick up the
+        # new rules/excludes instead of being left stale.
+        console.print("[yellow]Config files changed — re-running health analysis.[/yellow]")
+        if dry_run:
+            console.print(
+                "[yellow]Dry run — health would be re-scored. No changes made.[/yellow]"
+            )
+            return
+        cfg = load_config(repo_path)
+        exclude_patterns = list(cfg.get("exclude_patterns") or [])
+        _run_full_health_rescore(repo_path, cfg, exclude_patterns, state, head, curr_config_fp)
         return
 
     console.print(f"Changed files: [yellow]{len(file_diffs)}[/yellow]")
@@ -1230,8 +1437,11 @@ def update_command(
         pass  # Editor project-file refresh must never fail the update command
 
     # Update state
+    from repowise.cli.helpers import config_fingerprint
+
     state["last_sync_commit"] = head
     state["total_pages"] = state.get("total_pages", 0) + len(generated_pages)
+    state["config_fingerprint"] = config_fingerprint(repo_path)
     save_state(repo_path, state)
 
     # --- Roll forward to any commit that landed during this run ------------

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -523,6 +523,25 @@ def save_config_partial(
     )
 
 
+def config_fingerprint(repo_path: Path) -> str:
+    """SHA-256 hex of ``.repowise/config.yaml`` + ``health-rules.json`` content.
+
+    Used by ``repowise update`` and ``repowise init`` to detect config changes
+    across runs without relying on filesystem timestamps. Missing files are
+    skipped, so an absent config still yields a stable hash.
+    """
+    import hashlib
+
+    rw_dir = get_repowise_dir(repo_path)
+    h = hashlib.sha256()
+    for name in ("config.yaml", "health-rules.json"):
+        p = rw_dir / name
+        if p.exists():
+            h.update(name.encode())
+            h.update(p.read_bytes())
+    return h.hexdigest()
+
+
 # ---------------------------------------------------------------------------
 # Provider resolution
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -304,6 +304,88 @@ class TestUpdateIndexOnly:
         assert state1["last_sync_commit"] != base_commit
 
 
+class TestUpdateConfigChangeDetection:
+    def _state(self, repo):
+        import json
+
+        return json.loads((repo / ".repowise" / "state.json").read_text(encoding="utf-8"))
+
+    def test_init_stores_fingerprint_and_update_detects_config_change(
+        self, runner, git_work_repo
+    ):
+        """init records a config_fingerprint; an update with no file changes
+        skips rescore when config is unchanged but triggers one when
+        health-rules.json changes (#296, issue 3)."""
+        r0 = runner.invoke(
+            cli, ["init", str(git_work_repo), "--index-only"], catch_exceptions=False
+        )
+        assert r0.exit_code == 0, r0.output
+        assert self._state(git_work_repo).get("config_fingerprint")
+
+        # No new commits, unchanged config -> no rescore.
+        r1 = runner.invoke(
+            cli, ["update", str(git_work_repo), "--index-only"], catch_exceptions=False
+        )
+        assert r1.exit_code == 0, r1.output
+        assert "Already up to date" in r1.output
+
+        # Change health-rules.json (not a git change) -> config-triggered rescore.
+        (git_work_repo / ".repowise" / "health-rules.json").write_text(
+            '{"disabled_biomarkers": ["ungoverned_hotspot"]}', encoding="utf-8"
+        )
+        r2 = runner.invoke(
+            cli, ["update", str(git_work_repo), "--index-only"], catch_exceptions=False
+        )
+        assert r2.exit_code == 0, r2.output
+        assert "Config files changed" in r2.output
+        assert "health re-score complete" in r2.output.lower()
+
+    def test_dry_run_does_not_rescore_or_advance_fingerprint(self, runner, git_work_repo):
+        """`update --dry-run` after a config change must not mutate state/DB."""
+        import json
+
+        runner.invoke(
+            cli, ["init", str(git_work_repo), "--index-only"], catch_exceptions=False
+        )
+        fp_before = self._state(git_work_repo)["config_fingerprint"]
+
+        (git_work_repo / ".repowise" / "health-rules.json").write_text(
+            '{"disabled_biomarkers": ["ungoverned_hotspot"]}', encoding="utf-8"
+        )
+        result = runner.invoke(
+            cli,
+            ["update", str(git_work_repo), "--index-only", "--dry-run"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "Dry run" in result.output
+        assert "complete" not in result.output.lower()
+        # Fingerprint must NOT advance, so a real update still re-scores later.
+        assert self._state(git_work_repo)["config_fingerprint"] == fp_before
+
+    def test_config_change_with_source_diffs_runs_full_rescore(self, runner, git_work_repo):
+        """A config change must take the full re-score path even when there are
+        also source-file commits (not the partial update)."""
+        runner.invoke(
+            cli, ["init", str(git_work_repo), "--index-only"], catch_exceptions=False
+        )
+
+        # New source commit AND a config change in the same update window.
+        (git_work_repo / "new_module.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+        _git(["add", "-A"], git_work_repo)
+        _git(["commit", "-m", "add module"], git_work_repo)
+        (git_work_repo / ".repowise" / "health-rules.json").write_text(
+            '{"disabled_biomarkers": ["ungoverned_hotspot"]}', encoding="utf-8"
+        )
+
+        result = runner.invoke(
+            cli, ["update", str(git_work_repo), "--index-only"], catch_exceptions=False
+        )
+        assert result.exit_code == 0, result.output
+        assert "Config files changed" in result.output
+        assert "health re-score complete" in result.output.lower()
+
+
 class TestUpdatePreservesDeadCode:
     def test_single_file_update_preserves_unchanged_files(self, runner, git_work_repo):
         """A single-file re-index must not wipe the whole dead-code index;

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -221,9 +221,72 @@ class TestRescoreFailureFingerprint:
         (tmp_path / "f.py").write_text("x = 1\n", encoding="utf-8")
 
         update_cmd._run_full_health_rescore(
-            tmp_path, {}, [], {"last_sync_commit": "base"}, "head1", "NEWFP"
+            tmp_path, [], {"last_sync_commit": "base"}, "head1", "NEWFP"
         )
 
         state_file = tmp_path / ".repowise" / "state.json"
         if state_file.exists():
             assert json.loads(state_file.read_text()).get("config_fingerprint") != "NEWFP"
+
+
+class TestBuildRepoGraph:
+    """The shared traverse/parse/build helper used by both the incremental
+    rebuild and the config-triggered re-score paths."""
+
+    def test_reports_parse_skips_instead_of_swallowing(self, tmp_path, monkeypatch):
+        """Files that fail to parse are skipped and surfaced as a count."""
+        from repowise.cli.commands import update_cmd
+        from repowise.core.ingestion import ASTParser
+
+        (tmp_path / "good.py").write_text("x = 1\n", encoding="utf-8")
+        (tmp_path / "bad.py").write_text("y = 2\n", encoding="utf-8")
+
+        real_parse = ASTParser.parse_file
+
+        def _maybe_raise(self, fi, source):
+            if fi.path.endswith("bad.py"):
+                raise ValueError("boom")
+            return real_parse(self, fi, source)
+
+        monkeypatch.setattr(ASTParser, "parse_file", _maybe_raise)
+
+        printed: list[str] = []
+
+        class _FakeConsole:
+            def print(self, *args, **kwargs):
+                printed.append(" ".join(str(a) for a in args))
+
+        monkeypatch.setattr(update_cmd, "console", _FakeConsole())
+
+        parsed_files, _src, _gb, _struct, _count = update_cmd._build_repo_graph(tmp_path, [])
+
+        paths = [pf.file_info.path for pf in parsed_files]
+        assert any(p.endswith("good.py") for p in paths)
+        assert not any(p.endswith("bad.py") for p in paths)
+        assert any("Skipped" in line for line in printed)
+
+    def test_includes_framework_edge_step(self, tmp_path, monkeypatch):
+        """The shared path always runs the framework-aware synthetic edge step,
+        so the re-score graph matches the incremental rebuild graph."""
+        from repowise.cli.commands import update_cmd
+        from repowise.core.ingestion import GraphBuilder
+
+        (tmp_path / "good.py").write_text("x = 1\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            "repowise.core.generation.editor_files.tech_stack.detect_tech_stack",
+            lambda _p: [],
+        )
+
+        calls: list = []
+        real_add = GraphBuilder.add_framework_edges
+
+        def _spy(self, names):
+            calls.append(list(names))
+            return real_add(self, names)
+
+        monkeypatch.setattr(GraphBuilder, "add_framework_edges", _spy)
+
+        update_cmd._build_repo_graph(tmp_path, [])
+
+        assert calls, "framework-edge step must run in the shared rebuild path"

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -152,3 +152,78 @@ class TestBuildFilteredChangedPaths:
         fds = [MagicMock(path="src/main.py"), MagicMock(path=".claude/config.yml")]
         result = _build_filtered_changed_paths(fds, [])
         assert result == ["src/main.py", ".claude/config.yml"]
+
+
+class TestGitMetadataToDict:
+    def test_converts_orm_row_to_dict(self):
+        from types import SimpleNamespace
+
+        from repowise.cli.commands.update_cmd import _git_metadata_to_dict
+
+        gm = SimpleNamespace(
+            file_path="src/main.py",
+            commit_count_total=42,
+            commit_count_90d=10,
+            commit_count_30d=3,
+            first_commit_at=None,
+            last_commit_at=None,
+            primary_owner_name="alice",
+            primary_owner_email="alice@example.com",
+            primary_owner_commit_pct=0.7,
+            top_authors_json="[]",
+            significant_commits_json="[]",
+            co_change_partners_json="[]",
+            commit_categories_json="{}",
+            is_hotspot=True,
+            is_stable=False,
+            churn_percentile=0.9,
+            age_days=100,
+            commit_count_capped=False,
+            lines_added_90d=120,
+            lines_deleted_90d=30,
+            avg_commit_size=15.0,
+            recent_owner_name="alice",
+            recent_owner_commit_pct=0.8,
+            bus_factor=2,
+            contributor_count=4,
+            original_path=None,
+            merge_commit_count_90d=1,
+            temporal_hotspot_score=0.8,
+            prior_defect_count=5,
+            change_entropy=0.42,
+            change_entropy_pct=0.6,
+        )
+
+        d = _git_metadata_to_dict(gm)
+        assert d["file_path"] == "src/main.py"
+        assert d["commit_count_total"] == 42
+        assert d["is_hotspot"] is True
+        assert d["bus_factor"] == 2
+        # Columns added by the newer health biomarkers must flow through too.
+        assert d["prior_defect_count"] == 5
+        assert d["change_entropy"] == 0.42
+        assert d["change_entropy_pct"] == 0.6
+
+
+class TestRescoreFailureFingerprint:
+    def test_failed_rescore_does_not_advance_fingerprint(self, tmp_path, monkeypatch):
+        """A failed re-score must not persist the new fingerprint, so the next
+        update retries instead of treating the config change as handled."""
+        import json
+
+        from repowise.cli.commands import update_cmd
+
+        def _boom(coro):
+            coro.close()  # avoid 'coroutine never awaited' warning
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(update_cmd, "run_async", _boom)
+        (tmp_path / "f.py").write_text("x = 1\n", encoding="utf-8")
+
+        update_cmd._run_full_health_rescore(
+            tmp_path, {}, [], {"last_sync_commit": "base"}, "head1", "NEWFP"
+        )
+
+        state_file = tmp_path / ".repowise" / "state.json"
+        if state_file.exists():
+            assert json.loads(state_file.read_text()).get("config_fingerprint") != "NEWFP"

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -198,6 +198,39 @@ class TestSaveConfigPartial:
         assert cfg["embedder"] == "minilm"
 
 
+class TestConfigFingerprint:
+    def test_config_fingerprint_detects_change(self, tmp_path):
+        """config_fingerprint returns a stable hash that changes with config."""
+        from repowise.cli.helpers import config_fingerprint
+
+        rw_dir = tmp_path / ".repowise"
+        rw_dir.mkdir()
+        (rw_dir / "config.yaml").write_text("exclude_patterns: [.claude/]", encoding="utf-8")
+        (rw_dir / "health-rules.json").write_text(
+            '{"disabled_biomarkers": []}', encoding="utf-8"
+        )
+
+        fp1 = config_fingerprint(tmp_path)
+        assert isinstance(fp1, str)
+        assert len(fp1) == 64  # sha256 hex
+        assert config_fingerprint(tmp_path) == fp1
+
+        (rw_dir / "health-rules.json").write_text(
+            '{"disabled_biomarkers": ["ungoverned_hotspot"]}', encoding="utf-8"
+        )
+        assert config_fingerprint(tmp_path) != fp1
+
+    def test_config_fingerprint_missing_files(self, tmp_path):
+        """config_fingerprint handles missing config files gracefully."""
+        from repowise.cli.helpers import config_fingerprint
+
+        rw_dir = tmp_path / ".repowise"
+        rw_dir.mkdir()
+        fp = config_fingerprint(tmp_path)
+        assert isinstance(fp, str)
+        assert len(fp) == 64
+
+
 # ---------------------------------------------------------------------------
 # Update lock
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`repowise update` now detects changes to `.repowise/config.yaml` (e.g. `exclude_patterns`) and `health-rules.json` and triggers a full health re-score, even when no commits moved HEAD.

## Why

Previously update only re-scored health for files that changed in git. Editing the config or health rules had no effect until a code change happened to touch each file, so newly-excluded files lingered in health views and rule changes never applied to unchanged files. This is issue 3 of #296.

## How

- Add `config_fingerprint(repo_path)` to `cli/helpers.py`: a sha256 of `config.yaml` + `health-rules.json` content. `repowise init` stores it in `state.json` after the config is written, so the first update does not false-positive.
- `repowise update` compares the stored fingerprint to the current one. A real change runs `_run_full_health_rescore`: rebuild the graph with current `exclude_patterns`, load `GitMetadata` from the DB (so biomarkers keep accurate churn/ownership data, including the newer `prior_defect_count` / `change_entropy` columns added since), drop excluded git rows, full-replace health metrics/findings, and refresh graph nodes.
- The graph rebuild is shared with the incremental update path via `_build_repo_graph`, so both build the same graph from the same parser and the same framework-aware synthetic edges.
- A missing prior fingerprint is backfilled, not treated as a change.
- The config-change path takes precedence over the partial update so unchanged files are re-scored under the new rules. It is skipped under `--dry-run`, and does not advance the fingerprint if the re-score fails (so the next update retries).

## Scope note: graph rows

This PR fully replaces **health** metrics/findings (so rows for newly-excluded files are removed) and removes excluded `git_metadata` rows. It **refreshes** `graph_nodes` but does **not** delete stale `graph_nodes` / `graph_edges` rows for newly-excluded files. Hiding excluded files from graph-backed tool responses is handled at query time by the MCP runtime exclude filtering in #339 / #340, not by deleting graph rows here.

## Trade-off

In the rare case where a config change and new source commits land in the same `update`, the full health re-score takes precedence and the incremental doc regeneration for those commits is deferred. For index-only mode (no docs) this loses nothing.

## Tests

Unit: `config_fingerprint`, `_git_metadata_to_dict` (incl. the new columns), a failed-rescore-keeps-old-fingerprint test, and `TestBuildRepoGraph` (parse-skip warning + framework-edge step in the shared rebuild path). Integration: init stores the fingerprint; unchanged config stays "Already up to date"; a `health-rules.json` change triggers the re-score; `--dry-run` does not mutate state/DB; and config-change-with-source-diffs takes the full re-score path.

This change is Python-only and does not touch `packages/web`.

Closes #296 (issue 3)
