### PR TITLE
docs: fix broken README and CONTRIBUTING links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,8 +18,8 @@ Thanks for your interest in contributing to Repowise! This guide will help you g
 git clone https://github.com/repowise-dev/repowise.git
 cd repowise
 
-# Install Python dependencies
-uv sync --all-extras
+# Install Python dependencies (uv workspace — installs all packages)
+uv sync --all-packages
 
 # Install web frontend dependencies
 npm install
@@ -27,8 +27,11 @@ npm install
 # Build the web frontend
 npm run build
 
+# Verify the CLI runs
+uv run repowise --version
+
 # Run tests
-pytest
+uv run pytest tests/unit/
 ```
 
 ## Development Workflow
@@ -41,7 +44,7 @@ pytest
 3. **Make your changes** — keep commits focused and well-described
 4. **Run tests** before pushing:
    ```bash
-   pytest
+   uv run pytest tests/unit/
    npm run lint
    npm run type-check
    ```
@@ -58,6 +61,13 @@ Use descriptive prefixes:
 | `chore/` | Maintenance, CI, docs |
 | `refactor/` | Code restructuring |
 
+## Commit Messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/) with an
+optional scope, e.g. `feat(cli): add --resume to init` or `fix(health): bound
+duplication detection`. Keep the subject line in the imperative mood and under
+~72 characters.
+
 ## Project Structure
 
 ```
@@ -66,6 +76,8 @@ repowise/
     core/     # Ingestion pipeline, analysis, generation engine
     cli/      # CLI commands (click-based)
     server/   # FastAPI API + MCP server
+    types/    # Shared TypeScript types
+    ui/       # Shared React UI components
     web/      # Next.js frontend
   tests/      # Unit and integration tests
   docs/       # Documentation
@@ -74,15 +86,18 @@ repowise/
 ## Code Style
 
 - **Python**: Formatted with [ruff](https://docs.astral.sh/ruff/) (`ruff format .`, `ruff check .`)
-- **TypeScript**: Linted with ESLint (`npm run lint`)
+- **TypeScript**: Linted with ESLint (`npm run lint`) and type-checked (`npm run type-check`)
 - Keep functions small and focused
 - Write docstrings for public APIs
+
+Adding a new language or LLM provider has a dedicated recipe — see
+[docs/LANGUAGE_SUPPORT.md](../docs/LANGUAGE_SUPPORT.md).
 
 ## Testing
 
 - Add tests for new features and bug fixes
 - Place tests in `tests/unit/` or `tests/integration/`
-- Run the full suite with `pytest`
+- Run the full suite with `uv run pytest`
 
 ## Pull Request Guidelines
 
@@ -96,7 +111,8 @@ repowise/
 
 - Use [GitHub Issues](https://github.com/repowise-dev/repowise/issues) for bugs and feature requests
 - For security vulnerabilities, see [SECURITY.md](SECURITY.md)
+- For questions and discussion, join us on [Discord](https://discord.gg/cQVpuDB6rh)
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the [AGPL-3.0](LICENSE) license.
+By contributing, you agree that your contributions will be licensed under the [AGPL-3.0](../LICENSE) license.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ scored at the same leakage-free commit against the same defect labels:
 
 Ranking by repowise health surfaces **2.3× the defects under a fixed review
 budget** (Popt Δ +0.144, recall Δ +0.098, density Δ p = 0.003 — all paired,
-significant). [Full methodology & CIs →](https://github.com/repowise-dev/repowise-bench/blob/main/health-defect/COMPARISON_REPORT.md)
+significant). [Full methodology & CIs →](https://github.com/repowise-dev/repowise-bench/blob/master/health-defect/COMPARISON_REPORT.md)
 
 User guide & per-biomarker reference: **[docs/CODE_HEALTH.md](docs/CODE_HEALTH.md)**
 
@@ -139,7 +139,7 @@ repositories (same model, same harness, with vs without repowise's MCP tools):
 Best case shown; across the two benchmarks the range is −49% to −70% tool calls,
 −69% to −89% file reads, and −29% to −36% cost. Bonus: feeding an agent a commit
 via `get_context` costs **2,391 tokens vs 64,039** for the raw changed files —
-**~27× fewer**. Reports: [flask48](https://github.com/repowise-dev/repowise-bench/blob/main/BENCHMARK_REPORT_FLASK48.md) · [sklearn48](https://github.com/repowise-dev/repowise-bench/blob/main/BENCHMARK_REPORT_SKLEARN48.md)
+**~27× fewer**. Reports: [flask48](https://github.com/repowise-dev/repowise-bench/blob/master/BENCHMARK_REPORT_FLASK48.md) · [sklearn48](https://github.com/repowise-dev/repowise-bench/blob/master/BENCHMARK_REPORT_SKLEARN48.md)
 
 ### 2 · Code health predicts real defects
 
@@ -157,7 +157,7 @@ languages**:
 - Holds up on an **external published dataset it has never seen** (PROMISE/jEdit
   CK-metrics: AUC 0.76–0.78, within ~0.03 of the dataset's own tuned model).
 
-Full report: **[health-defect/BENCHMARK_REPORT.md →](https://github.com/repowise-dev/repowise-bench/blob/main/health-defect/BENCHMARK_REPORT.md)**
+Full report: **[health-defect/BENCHMARK_REPORT.md →](https://github.com/repowise-dev/repowise-bench/blob/master/health-defect/BENCHMARK_REPORT.md)**
 
 ---
 
@@ -393,7 +393,7 @@ uv run pytest tests/unit/
 ```
 
 Full guide, including how to add languages and LLM providers:
-[CONTRIBUTING.md](CONTRIBUTING.md).
+[CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ---
 


### PR DESCRIPTION
## What

Fixes the dead links flagged in the README plus a sweep of nearby link/staleness issues.

### README.md — bench report 404s
The `repowise-bench` repo's default branch is `master`, but the README linked its reports via `/blob/main/`. All four resolved to 404s:

- Code-health `COMPARISON_REPORT.md` (Full methodology & CIs)
- `BENCHMARK_REPORT_FLASK48.md` and `BENCHMARK_REPORT_SKLEARN48.md`
- `health-defect/BENCHMARK_REPORT.md`

All repointed to `/blob/master/` and confirmed present on `origin/master`.

### README.md — CONTRIBUTING link
`[CONTRIBUTING.md](CONTRIBUTING.md)` pointed at repo root, where no such file exists. The file lives at `.github/CONTRIBUTING.md`; link corrected.

### .github/CONTRIBUTING.md — fixes + refresh
- `uv sync --all-extras` → `uv sync --all-packages` (this is a uv workspace; `--all-packages` is the documented command and matches the root README).
- Test commands now use `uv run pytest` so they work without an activated venv.
- Project-structure tree now lists the `types` and `ui` packages that were missing.
- `[AGPL-3.0](LICENSE)` resolved to `.github/LICENSE` (nonexistent); fixed to `../LICENSE`.
- Added a Conventional Commits section, a language/provider recipe pointer, and a Discord link.

## Verification
- Every relative link in both files checked against the working tree.
- All four bench targets verified to exist on `repowise-bench@master`.