### PR TITLE
release: v0.16.0 — Codex CLI provider, Ollama embedder, resumable init

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.16.0] — 2026-06-03
+
+### Added
+- **Codex CLI provider and project integration.** A new local Codex CLI LLM provider runs documentation generation through authenticated `codex exec` sessions (argv-based subprocess, JSONL parsing tolerant of non-JSON noise, async concurrency cap, exec timeout, and zero-cost subscription usage tracking). Adds project-local Codex setup — a `.codex/config.toml` MCP server, `.codex` lifecycle hooks, `.codex-plugin` metadata and marketplace entry, and managed `AGENTS.md` generation. Reasoning effort is now wired across all LLM providers with per-provider model discovery and supported reasoning modes (#348).
+- **Native Ollama embedder.** Semantic indexing can now embed through a local Ollama instance directly, without routing through an OpenAI-compatible shim (#331).
+- **`repowise init --resume` actually resumes.** Persistence is split into per-phase persisters (ingestion, git, analysis, generation) so a re-run skips phases that already completed instead of redoing the whole pipeline. Public API and end-state are unchanged (#343).
+- **Advisory CLI-version check in `repowise doctor`.** `doctor` now shows current vs. latest published version and the exact install-method-aware upgrade command (uv tool / pipx / pip / editable). Advisory only — it never auto-updates, never flips doctor's pass/fail, and swallows network errors (#346, closes #338).
+
+### Fixed
+- **Owner "last touched" reflects your own last commit.** Previously a teammate's commit to a file you co-own bumped your "last touched" timestamp. Each author's own first/last commit timestamps are now recorded and aggregated, and author identity is read through git's `.mailmap` so one person's multiple names/emails fold into a single contributor (#349).
+- **`repowise update` re-runs health when config changes even if git is unchanged.** Editing `exclude_patterns` or `health-rules.json` used to have no effect until a code change touched each file. `update` now fingerprints the config and triggers a full health rescore when it changes (#337).
+- **Minified/generated bundles can no longer wedge `init`.** Duplication detection's O(k²) window comparison could explode on checked-in minified chunks, leaving `init` stuck at `health 0/N`. New layered resource guards skip minified files, cap per-file tokens and the repo-wide window budget, and drop degenerate hash buckets (#342, closes #341).
+- **`exclude_patterns` are enforced in MCP tool responses at query time.** Rows that predate an `exclude_patterns` change are now filtered out of every structured tool (context, answer, search, health, overview, dead_code, risk, and the rest) and out of aggregate KPIs, so excluded files never leak back into results or numbers (#339, #340).
+- **User-added MCP `env` survives re-registration.** `repowise init`/`update` re-registration did a shallow replace of the `repowise` MCP server entry, silently wiping any user-added `env` block (BYOK provider/embedder keys) and degrading semantic search to the mock embedder. Server definitions are now deep-merged (#336, fixes #307).
+- **Cost tracking no longer wedges `repowise update` on `database is locked`.** A second cost-tracking engine inserting per LLM call lost WAL's single-writer race against the doc-generation writer, blocking the full busy-timeout per call and turning `update` into an effectively non-terminating run. Persistence is now best-effort, plus a `--no-cost-tracking` flag and `REPOWISE_NO_COST_TRACKING` env var to opt out entirely (#330, closes #326).
+- **Rust sibling test modules are kept live** in dead-code reachability instead of being flagged as unused (#332).
+- **`reindex` uses the shared database engine** rather than opening its own (#333).
+
+### Documentation
+- **README and linked docs revamped** for accuracy, with a sharpened tagline, reframed layer positioning, and fixed README/CONTRIBUTING links (#334, #335, #345).
+
+---
+
 ## [0.15.2] — 2026-05-31
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.15.2"
+__version__ = "0.16.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.15.2"
+__version__ = "0.16.0"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.15.2"
+__version__ = "0.16.0"

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -284,7 +284,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.15.2</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.16.0</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -334,7 +334,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
       {!isIconOnly && (
         <div className="border-t border-[var(--color-border-default)] px-4 py-3">
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.15.2
+            repowise v0.16.0
           </p>
         </div>
       )}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.15.2"
+version = "0.16.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.15.1"
+version = "0.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Release **v0.16.0**. Branch cut from latest `main`; contains only the version bump, lockfile sync, and changelog.

## Highlights

**Added**
- Codex CLI provider and project integration — local `codex exec`-based LLM provider plus project-local Codex setup (MCP server, lifecycle hooks, managed `AGENTS.md`); reasoning effort wired across all providers (#348)
- Native Ollama embedder (#331)
- `repowise init --resume` now actually resumes completed phases (#343)
- Advisory CLI-version check in `repowise doctor` (#346)

**Fixed**
- Owner "last touched" now reflects your own last commit and honors `.mailmap` (#349)
- `repowise update` re-runs health on config change even when git is unchanged (#337)
- Duplication detection bounded so minified bundles can't wedge `init` (#342)
- `exclude_patterns` enforced in MCP tool responses at query time (#339, #340)
- User-added MCP `env` survives re-registration (#336)
- Cost tracking no longer wedges `repowise update` on `database is locked`; adds `--no-cost-tracking` (#330)
- Rust sibling test modules kept live in dead-code (#332); reindex uses shared DB engine (#333)

**Documentation**
- README and linked docs revamped for accuracy (#334, #335, #345)

Full detail in `docs/CHANGELOG.md`.

## Version bump
- `pyproject.toml`, `packages/{cli,core,server}/src/repowise/.../__init__.py` → `0.16.0`
- Web footers (`sidebar.tsx`, `mobile-nav.tsx`) → `repowise v0.16.0`
- `uv.lock` self-entry resynced (`0.15.1` → `0.16.0`; was stale)

## Test plan
- [x] `uv build --wheel` → `repowise-0.16.0-py3-none-any.whl` clean; contains all `cli/commands`, tree-sitter `.scm`, and Jinja `.j2` assets
- [x] No version drift — `git grep "0.15.2"` clean across pyproject / `__init__.py` / uv.lock / web footers
- [x] `npm ci` + `npm run build --workspace packages/web` → all routes built, standalone `server.js` emitted, workspace-package code compiled inline, footer renders `v0.16.0`
- [ ] End-user smoke test (`pip install`, `repowise serve`) after publish
- [ ] Tag + `publish.yml` after merge

## Merge convention
Merge with a **regular merge commit — not squash** — so the tag points at a real merge of the bump-only diff and artifact provenance stays traceable.
