### PR TITLE
fix(web): decode breadcrumb path labels

### DIFF
--- a/packages/web/src/components/layout/repo-breadcrumb-label.ts
+++ b/packages/web/src/components/layout/repo-breadcrumb-label.ts
@@ -1,0 +1,28 @@
+const SEGMENT_LABELS: Record<string, string> = {
+  overview: "Overview",
+  docs: "Docs",
+  coverage: "Coverage",
+  search: "Search",
+  graph: "Graph",
+  symbols: "Symbols",
+  ownership: "Ownership",
+  hotspots: "Hotspots",
+  "dead-code": "Dead Code",
+  "blast-radius": "Blast Radius",
+  decisions: "Decisions",
+  costs: "Costs",
+  risk: "Risk",
+  security: "Security",
+  settings: "Settings",
+  c4: "Knowledge Graph",
+};
+
+export function getRepoBreadcrumbSegmentLabel(segment: string): string {
+  if (SEGMENT_LABELS[segment]) return SEGMENT_LABELS[segment];
+
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}

--- a/packages/web/src/components/layout/repo-breadcrumb.test.ts
+++ b/packages/web/src/components/layout/repo-breadcrumb.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getRepoBreadcrumbSegmentLabel } from "./repo-breadcrumb-label";
+
+describe("getRepoBreadcrumbSegmentLabel", () => {
+  it("keeps configured route segment labels", () => {
+    expect(getRepoBreadcrumbSegmentLabel("dead-code")).toBe("Dead Code");
+    expect(getRepoBreadcrumbSegmentLabel("c4")).toBe("Knowledge Graph");
+  });
+
+  it("decodes dynamic path segments for display", () => {
+    expect(getRepoBreadcrumbSegmentLabel("name%40example.com")).toBe("name@example.com");
+    expect(getRepoBreadcrumbSegmentLabel("name%3Ajane%20doe")).toBe("name:jane doe");
+  });
+
+  it("falls back to the raw segment for malformed escapes", () => {
+    expect(getRepoBreadcrumbSegmentLabel("%E0%A4%A")).toBe("%E0%A4%A");
+  });
+});

--- a/packages/web/src/components/layout/repo-breadcrumb.tsx
+++ b/packages/web/src/components/layout/repo-breadcrumb.tsx
@@ -4,25 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Breadcrumb } from "@repowise-dev/ui/shared/breadcrumb";
 import type { BreadcrumbSegment } from "@repowise-dev/ui/shared/breadcrumb";
-
-const SEGMENT_LABELS: Record<string, string> = {
-  overview: "Overview",
-  docs: "Docs",
-  coverage: "Coverage",
-  search: "Search",
-  graph: "Graph",
-  symbols: "Symbols",
-  ownership: "Ownership",
-  hotspots: "Hotspots",
-  "dead-code": "Dead Code",
-  "blast-radius": "Blast Radius",
-  decisions: "Decisions",
-  costs: "Costs",
-  risk: "Risk",
-  security: "Security",
-  settings: "Settings",
-  c4: "Knowledge Graph",
-};
+import { getRepoBreadcrumbSegmentLabel } from "./repo-breadcrumb-label";
 
 export function RepoBreadcrumb({ repoName }: { repoName: string }) {
   const pathname = usePathname();
@@ -41,7 +23,7 @@ export function RepoBreadcrumb({ repoName }: { repoName: string }) {
   for (const seg of rest) {
     currentPath += `/${seg}`;
     segments.push({
-      label: SEGMENT_LABELS[seg] || seg,
+      label: getRepoBreadcrumbSegmentLabel(seg),
       href: currentPath,
     });
   }


### PR DESCRIPTION
## Summary

- Decode dynamic repo breadcrumb path segments for display while preserving encoded hrefs.
- Move breadcrumb label mapping into a testable helper.
- Add regression coverage for encoded owner/email labels and malformed escapes.

## Related Issues

Fixes #351

## Test Plan

- [ ] Tests pass (`pytest`) - not run; frontend-only change
- [ ] Lint passes (`ruff check .`) - not run; no Python changes
- [x] Web build passes (`npm run build`) *(if frontend changes)*

Additional frontend checks:

- [x] `./node_modules/.bin/vitest run packages/web/src/components/layout/repo-breadcrumb.test.ts`
- [x] `node node_modules/typescript/bin/tsc --noEmit -p packages/web/tsconfig.json`
- [x] `node node_modules/next/dist/bin/next build`

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
