### PR TITLE
feat(cli): owl mascot init banner with repo-seeded heatmap wordmark

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -47,6 +47,8 @@ from repowise.cli.providers import resolve_embedder
 from repowise.cli.state_persistence import build_kg_state, save_knowledge_graph_json
 from repowise.cli.ui import (
     BRAND,
+    BRAND_STYLE,
+    OWL_SPINNER,
     MaybeCountColumn,
     RichProgressCallback,
     interactive_advanced_config,
@@ -455,7 +457,7 @@ def init_command(
     scan_info = None
     if is_interactive:
         print_banner(console, repo_name=repo_path.name)
-        with console.status("  Scanning repository…", spinner="dots"):
+        with console.status("  Scanning repository…", spinner=OWL_SPINNER):
             scan_info = quick_repo_scan(repo_path)
         print_scan_summary(console, scan_info)
         mode = interactive_mode_select(console)
@@ -616,7 +618,7 @@ def init_command(
         # Validate provider connection
         from repowise.core.providers.llm.base import ProviderError
 
-        with console.status("  Verifying provider connection…", spinner="dots"):
+        with console.status("  Verifying provider connection…", spinner=OWL_SPINNER):
             try:
                 run_async(
                     provider.generate(
@@ -645,7 +647,7 @@ def init_command(
     orchestrator_mode = OrchestratorMode.FAST if run_mode == "fast" else OrchestratorMode.STANDARD
 
     with Progress(
-        SpinnerColumn(),
+        SpinnerColumn(spinner_name=OWL_SPINNER, style=BRAND_STYLE),
         TextColumn("[progress.description]{task.description}"),
         BarColumn(),
         MaybeCountColumn(),
@@ -708,9 +710,11 @@ def init_command(
             with cancellation_scope():
                 result = run_async(_index_with_resume())
         except (PipelineCancelled, KeyboardInterrupt):
+            from repowise.cli.ui.mascot import EYES_SLEEPY, mini
+
             console.print(
-                "\n[yellow]Interrupted.[/] Indexed work so far has been saved — "
-                "run [bold]repowise init --resume[/] to continue where it stopped."
+                f"\n{mini(EYES_SLEEPY)} [yellow]Interrupted.[/] Indexed work so far has been "
+                "saved — run [bold]repowise init --resume[/] to continue where it stopped."
             )
             return
 
@@ -757,7 +761,7 @@ def init_command(
             console, 4, total_phases, "Persistence", "Saving to database and building search index"
         )
 
-    with console.status("  Persisting to database…", spinner="dots"):
+    with console.status("  Persisting to database…", spinner=OWL_SPINNER):
         run_async(persist_result(result, repo_path))
     console.print("  [green]✓[/green] Database updated")
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -457,7 +457,9 @@ def init_command(
     scan_info = None
     if is_interactive:
         print_banner(console, repo_name=repo_path.name)
-        with console.status("  Scanning repository…", spinner=OWL_SPINNER):
+        with console.status(
+            "  Scanning repository…", spinner=OWL_SPINNER, spinner_style=BRAND_STYLE
+        ):
             scan_info = quick_repo_scan(repo_path)
         print_scan_summary(console, scan_info)
         mode = interactive_mode_select(console)
@@ -618,7 +620,9 @@ def init_command(
         # Validate provider connection
         from repowise.core.providers.llm.base import ProviderError
 
-        with console.status("  Verifying provider connection…", spinner=OWL_SPINNER):
+        with console.status(
+            "  Verifying provider connection…", spinner=OWL_SPINNER, spinner_style=BRAND_STYLE
+        ):
             try:
                 run_async(
                     provider.generate(
@@ -761,7 +765,9 @@ def init_command(
             console, 4, total_phases, "Persistence", "Saving to database and building search index"
         )
 
-    with console.status("  Persisting to database…", spinner=OWL_SPINNER):
+    with console.status(
+        "  Persisting to database…", spinner=OWL_SPINNER, spinner_style=BRAND_STYLE
+    ):
         run_async(persist_result(result, repo_path))
     console.print("  [green]✓[/green] Database updated")
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -457,9 +457,7 @@ def init_command(
     scan_info = None
     if is_interactive:
         print_banner(console, repo_name=repo_path.name)
-        with console.status(
-            "  Scanning repository…", spinner=OWL_SPINNER, spinner_style=BRAND_STYLE
-        ):
+        with console.status("  Scanning repository…", spinner=OWL_SPINNER):
             scan_info = quick_repo_scan(repo_path)
         print_scan_summary(console, scan_info)
         mode = interactive_mode_select(console)
@@ -620,9 +618,7 @@ def init_command(
         # Validate provider connection
         from repowise.core.providers.llm.base import ProviderError
 
-        with console.status(
-            "  Verifying provider connection…", spinner=OWL_SPINNER, spinner_style=BRAND_STYLE
-        ):
+        with console.status("  Verifying provider connection…", spinner=OWL_SPINNER):
             try:
                 run_async(
                     provider.generate(
@@ -765,9 +761,7 @@ def init_command(
             console, 4, total_phases, "Persistence", "Saving to database and building search index"
         )
 
-    with console.status(
-        "  Persisting to database…", spinner=OWL_SPINNER, spinner_style=BRAND_STYLE
-    ):
+    with console.status("  Persisting to database…", spinner=OWL_SPINNER):
         run_async(persist_result(result, repo_path))
     console.print("  [green]✓[/green] Database updated")
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -27,7 +27,7 @@ from repowise.cli.providers import (
     build_vector_store,
     flush_cost_tracker,
 )
-from repowise.cli.ui import MaybeCountColumn, RichProgressCallback
+from repowise.cli.ui import BRAND_STYLE, OWL_SPINNER, MaybeCountColumn, RichProgressCallback
 
 # The LLM-cost confirmation threshold. A run whose estimate exceeds this asks
 # for confirmation (unless ``--yes``); below it generation proceeds silently.
@@ -187,7 +187,7 @@ def _enrich_knowledge_graph(
             result.knowledge_graph_result = _run()
         return
 
-    with console.status("  Enriching knowledge graph (layers + tour)…", spinner="dots"):
+    with console.status("  Enriching knowledge graph (layers + tour)…", spinner=OWL_SPINNER):
         try:
             result.knowledge_graph_result = _run()
             enriched = result.knowledge_graph_result
@@ -237,7 +237,7 @@ def run_repo_generation(
     provider._cost_tracker = cost_tracker
 
     with Progress(
-        SpinnerColumn(),
+        SpinnerColumn(spinner_name=OWL_SPINNER, style=BRAND_STYLE),
         TextColumn("[progress.description]{task.description}"),
         BarColumn(),
         MaybeCountColumn(),

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -187,7 +187,11 @@ def _enrich_knowledge_graph(
             result.knowledge_graph_result = _run()
         return
 
-    with console.status("  Enriching knowledge graph (layers + tour)…", spinner=OWL_SPINNER):
+    with console.status(
+        "  Enriching knowledge graph (layers + tour)…",
+        spinner=OWL_SPINNER,
+        spinner_style=BRAND_STYLE,
+    ):
         try:
             result.knowledge_graph_result = _run()
             enriched = result.knowledge_graph_result

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -187,11 +187,7 @@ def _enrich_knowledge_graph(
             result.knowledge_graph_result = _run()
         return
 
-    with console.status(
-        "  Enriching knowledge graph (layers + tour)…",
-        spinner=OWL_SPINNER,
-        spinner_style=BRAND_STYLE,
-    ):
+    with console.status("  Enriching knowledge graph (layers + tour)…", spinner=OWL_SPINNER):
         try:
             result.knowledge_graph_result = _run()
             enriched = result.knowledge_graph_result

--- a/packages/cli/src/repowise/cli/commands/init_cmd/reporting.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/reporting.py
@@ -17,10 +17,6 @@ from repowise.cli.ui import (
     build_contextual_next_steps,
     format_elapsed,
 )
-from repowise.cli.ui.mascot import EYES_HAPPY, mini
-
-# Happy owl prefix for completion panel titles, e.g. "{^ ^}  repowise init complete".
-_HAPPY = mini(EYES_HAPPY)
 
 
 def show_analysis_summary(result: Any) -> None:
@@ -164,9 +160,7 @@ def show_completion(
         )
         console.print()
         console.print(
-            build_completion_panel(
-                f"{_HAPPY}  repowise index complete", metrics, next_steps=next_steps
-            )
+            build_completion_panel("repowise index complete", metrics, next_steps=next_steps)
         )
         console.print()
     else:
@@ -201,9 +195,7 @@ def show_completion(
 
         console.print()
         console.print(
-            build_completion_panel(
-                f"{_HAPPY}  repowise init complete", metrics, next_steps=next_steps
-            )
+            build_completion_panel("repowise init complete", metrics, next_steps=next_steps)
         )
         console.print()
         console.print(format_setup_instructions(repo_path))
@@ -252,9 +244,7 @@ def show_workspace_completion(
 
     console.print()
     console.print(
-        build_completion_panel(
-            f"{_HAPPY}  repowise workspace init complete", metrics, next_steps=next_steps
-        )
+        build_completion_panel("repowise workspace init complete", metrics, next_steps=next_steps)
     )
     console.print()
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/reporting.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/reporting.py
@@ -17,6 +17,10 @@ from repowise.cli.ui import (
     build_contextual_next_steps,
     format_elapsed,
 )
+from repowise.cli.ui.mascot import EYES_HAPPY, mini
+
+# Happy owl prefix for completion panel titles, e.g. "{^ ^}  repowise init complete".
+_HAPPY = mini(EYES_HAPPY)
 
 
 def show_analysis_summary(result: Any) -> None:
@@ -160,7 +164,9 @@ def show_completion(
         )
         console.print()
         console.print(
-            build_completion_panel("repowise index complete", metrics, next_steps=next_steps)
+            build_completion_panel(
+                f"{_HAPPY}  repowise index complete", metrics, next_steps=next_steps
+            )
         )
         console.print()
     else:
@@ -195,7 +201,9 @@ def show_completion(
 
         console.print()
         console.print(
-            build_completion_panel("repowise init complete", metrics, next_steps=next_steps)
+            build_completion_panel(
+                f"{_HAPPY}  repowise init complete", metrics, next_steps=next_steps
+            )
         )
         console.print()
         console.print(format_setup_instructions(repo_path))
@@ -244,7 +252,9 @@ def show_workspace_completion(
 
     console.print()
     console.print(
-        build_completion_panel("repowise workspace init complete", metrics, next_steps=next_steps)
+        build_completion_panel(
+            f"{_HAPPY}  repowise workspace init complete", metrics, next_steps=next_steps
+        )
     )
     console.print()
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
@@ -45,6 +45,8 @@ from repowise.cli.providers import resolve_embedder
 from repowise.cli.state_persistence import build_kg_state, save_knowledge_graph_json
 from repowise.cli.ui import (
     BRAND,
+    BRAND_STYLE,
+    OWL_SPINNER,
     MaybeCountColumn,
     RichProgressCallback,
     interactive_advanced_config,
@@ -211,7 +213,7 @@ def _ingest_and_generate_repo(repo: Any, idx: int, total: int, ctx: _WorkspaceCt
 
     try:
         with Progress(
-            SpinnerColumn(),
+            SpinnerColumn(spinner_name=OWL_SPINNER, style=BRAND_STYLE),
             TextColumn("[progress.description]{task.description}"),
             BarColumn(),
             MaybeCountColumn(),

--- a/packages/cli/src/repowise/cli/commands/reindex_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/reindex_cmd.py
@@ -12,6 +12,7 @@ from repowise.cli.helpers import (
     resolve_repo_path,
     run_async,
 )
+from repowise.cli.ui import BRAND_STYLE, OWL_SPINNER
 
 
 @click.command("reindex")
@@ -115,7 +116,7 @@ async def _reindex(repo_path, embedder_name: str, batch_size: int) -> None:
     failed = 0
 
     with Progress(
-        SpinnerColumn(),
+        SpinnerColumn(spinner_name=OWL_SPINNER, style=BRAND_STYLE),
         TextColumn("[progress.description]{task.description}"),
         BarColumn(),
         TextColumn("{task.completed}/{task.total}"),

--- a/packages/cli/src/repowise/cli/editor_integrations/claude.py
+++ b/packages/cli/src/repowise/cli/editor_integrations/claude.py
@@ -123,8 +123,11 @@ def maybe_generate_claude_md(
         return
     if not _claude_md_enabled(repo_path):
         return
+
+    from repowise.cli.ui import OWL_SPINNER
+
     try:
-        with console_obj.status("  Generating .claude/CLAUDE.md…", spinner="dots"):
+        with console_obj.status("  Generating .claude/CLAUDE.md…", spinner=OWL_SPINNER):
             run_async(_write_claude_md_async(repo_path))
         console_obj.print("  [green]✓[/green] .claude/CLAUDE.md updated")
     except Exception as exc:

--- a/packages/cli/src/repowise/cli/editor_integrations/claude.py
+++ b/packages/cli/src/repowise/cli/editor_integrations/claude.py
@@ -124,12 +124,10 @@ def maybe_generate_claude_md(
     if not _claude_md_enabled(repo_path):
         return
 
-    from repowise.cli.ui import BRAND_STYLE, OWL_SPINNER
+    from repowise.cli.ui import OWL_SPINNER
 
     try:
-        with console_obj.status(
-            "  Generating .claude/CLAUDE.md…", spinner=OWL_SPINNER, spinner_style=BRAND_STYLE
-        ):
+        with console_obj.status("  Generating .claude/CLAUDE.md…", spinner=OWL_SPINNER):
             run_async(_write_claude_md_async(repo_path))
         console_obj.print("  [green]✓[/green] .claude/CLAUDE.md updated")
     except Exception as exc:

--- a/packages/cli/src/repowise/cli/editor_integrations/claude.py
+++ b/packages/cli/src/repowise/cli/editor_integrations/claude.py
@@ -124,10 +124,12 @@ def maybe_generate_claude_md(
     if not _claude_md_enabled(repo_path):
         return
 
-    from repowise.cli.ui import OWL_SPINNER
+    from repowise.cli.ui import BRAND_STYLE, OWL_SPINNER
 
     try:
-        with console_obj.status("  Generating .claude/CLAUDE.md…", spinner=OWL_SPINNER):
+        with console_obj.status(
+            "  Generating .claude/CLAUDE.md…", spinner=OWL_SPINNER, spinner_style=BRAND_STYLE
+        ):
             run_async(_write_claude_md_async(repo_path))
         console_obj.print("  [green]✓[/green] .claude/CLAUDE.md updated")
     except Exception as exc:

--- a/packages/cli/src/repowise/cli/editor_integrations/codex.py
+++ b/packages/cli/src/repowise/cli/editor_integrations/codex.py
@@ -123,7 +123,7 @@ def maybe_generate_agents_md(
 
     from repowise.cli.editor_files import should_generate_editor_file
     from repowise.cli.helpers import run_async
-    from repowise.cli.ui import OWL_SPINNER
+    from repowise.cli.ui import BRAND_STYLE, OWL_SPINNER
 
     if not should_generate_editor_file(
         repo_path,
@@ -133,7 +133,9 @@ def maybe_generate_agents_md(
     ):
         return
     try:
-        with console_obj.status("  Generating AGENTS.md...", spinner=OWL_SPINNER):
+        with console_obj.status(
+            "  Generating AGENTS.md...", spinner=OWL_SPINNER, spinner_style=BRAND_STYLE
+        ):
             run_async(_write_agents_md_async(repo_path))
         console_obj.print("  [green]✓[/green] AGENTS.md updated")
     except Exception as exc:

--- a/packages/cli/src/repowise/cli/editor_integrations/codex.py
+++ b/packages/cli/src/repowise/cli/editor_integrations/codex.py
@@ -123,6 +123,7 @@ def maybe_generate_agents_md(
 
     from repowise.cli.editor_files import should_generate_editor_file
     from repowise.cli.helpers import run_async
+    from repowise.cli.ui import OWL_SPINNER
 
     if not should_generate_editor_file(
         repo_path,
@@ -132,7 +133,7 @@ def maybe_generate_agents_md(
     ):
         return
     try:
-        with console_obj.status("  Generating AGENTS.md...", spinner="dots"):
+        with console_obj.status("  Generating AGENTS.md...", spinner=OWL_SPINNER):
             run_async(_write_agents_md_async(repo_path))
         console_obj.print("  [green]✓[/green] AGENTS.md updated")
     except Exception as exc:

--- a/packages/cli/src/repowise/cli/editor_integrations/codex.py
+++ b/packages/cli/src/repowise/cli/editor_integrations/codex.py
@@ -123,7 +123,7 @@ def maybe_generate_agents_md(
 
     from repowise.cli.editor_files import should_generate_editor_file
     from repowise.cli.helpers import run_async
-    from repowise.cli.ui import BRAND_STYLE, OWL_SPINNER
+    from repowise.cli.ui import OWL_SPINNER
 
     if not should_generate_editor_file(
         repo_path,
@@ -133,9 +133,7 @@ def maybe_generate_agents_md(
     ):
         return
     try:
-        with console_obj.status(
-            "  Generating AGENTS.md...", spinner=OWL_SPINNER, spinner_style=BRAND_STYLE
-        ):
+        with console_obj.status("  Generating AGENTS.md...", spinner=OWL_SPINNER):
             run_async(_write_agents_md_async(repo_path))
         console_obj.print("  [green]✓[/green] AGENTS.md updated")
     except Exception as exc:

--- a/packages/cli/src/repowise/cli/ui/__init__.py
+++ b/packages/cli/src/repowise/cli/ui/__init__.py
@@ -19,6 +19,12 @@ from repowise.cli.ui.brand import (
     print_phase_header,
 )
 from repowise.cli.ui.env_persistence import load_dotenv
+from repowise.cli.ui.mascot import (
+    OWL_SPINNER,
+    THINKING_FRAMES,
+    banner_text,
+    mini,
+)
 from repowise.cli.ui.mode_selection import (
     LARGE_REPO_FILE_THRESHOLD,
     interactive_advanced_config,
@@ -55,11 +61,14 @@ __all__ = [
     "ERR",
     "LARGE_REPO_FILE_THRESHOLD",
     "OK",
+    "OWL_SPINNER",
+    "THINKING_FRAMES",
     "WARN",
     "MaybeCountColumn",
     "ProviderSelection",
     "RepoScanInfo",
     "RichProgressCallback",
+    "banner_text",
     "build_analysis_summary_panel",
     "build_completion_panel",
     "build_contextual_next_steps",
@@ -72,6 +81,7 @@ __all__ = [
     "interactive_provider_select",
     "interactive_repo_select",
     "load_dotenv",
+    "mini",
     "print_banner",
     "print_index_only_intro",
     "print_phase_header",

--- a/packages/cli/src/repowise/cli/ui/brand.py
+++ b/packages/cli/src/repowise/cli/ui/brand.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from rich.console import Console
 from rich.rule import Rule
-from rich.text import Text
 
 # ---------------------------------------------------------------------------
 # Brand / theme
@@ -18,24 +17,44 @@ WARN = "yellow"
 ERR = "bold red"
 
 # ---------------------------------------------------------------------------
-# ASCII art  —  bold half-block, compact lowercase, 2 lines
+# ASCII art  —  owl mascot + heatmap wordmark (see ui/mascot.py)
 # ---------------------------------------------------------------------------
 
-_LOGO = " █▀█ █▀▀ █▀█ █▀█ █ █ █ ▀ █▀▀ █▀▀\n █▀▄ ██▄ █▀▀ █▄█ ▀▄▀▄▀ █ ▄▄█ ██▄"
+# Plain-text compact render, kept as cheap insurance for anything that ever
+# reached for the private ``_LOGO`` name. The real banner is composed (and
+# coloured) by ``mascot.banner_text``.
+_LOGO = (
+    " ,___,  ███▄  ███ ███▄ ▄██▄ █   █ ███ ▄██▄ ███\n"
+    " (◉,◉)  █  █  █   █  █ █  █ █   █  █  █    █\n"
+    " ( ▼ )  ███▀  ██  ███▀ █  █ █ █ █  █  ▀██▄ ██\n"
+    " /)_(\\  █ ▀▄  █   █    █  █ █ █ █  █     █ █\n"
+    '  " "   █  ▀▄ ███ █    ▀██▀ ▀█▀█▀ ███ ▀██▀ ███'
+)
+
+# Full banner is 78 cols; below this width fall back to the compact variant
+# (same design at 1-char strokes, 47 cols).
+_FULL_BANNER_MIN_WIDTH = 82
 
 
 def print_banner(console: Console, repo_name: str | None = None) -> None:
-    """Print the repowise logo, tagline, and optional repo name."""
+    """Print the repowise owl banner, tagline, and optional repo name."""
     from repowise.cli import __version__
+    from repowise.cli.ui import mascot
 
+    compact = console.width < _FULL_BANNER_MIN_WIDTH
     console.print()
-    console.print(Text(_LOGO, style=BRAND_STYLE))
-    console.print(
-        f"  [dim]codebase intelligence for developers and AI[/dim]  [dim]v{__version__}[/dim]"
-    )
+    console.print(mascot.banner_text(repo_name, compact=compact))
+    console.print()
+    if compact:
+        console.print(f" [dim]codebase intelligence · v{__version__}[/dim]", highlight=False)
+    else:
+        console.print(
+            f" [dim]codebase intelligence for developers and AI  ·  v{__version__}[/dim]",
+            highlight=False,
+        )
     if repo_name:
         console.print()
-        console.print(f"  Repository: [bold]{repo_name}[/bold]")
+        console.print(f" Repository: [bold]{repo_name}[/bold]", highlight=False)
     console.print()
 
 

--- a/packages/cli/src/repowise/cli/ui/brand.py
+++ b/packages/cli/src/repowise/cli/ui/brand.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from rich.console import Console
+from rich.markup import escape
 from rich.rule import Rule
 
 # ---------------------------------------------------------------------------
@@ -31,9 +32,9 @@ _LOGO = (
     '  " "   █  ▀▄ ███ █    ▀██▀ ▀█▀█▀ ███ ▀██▀ ███'
 )
 
-# Full banner is 78 cols; below this width fall back to the compact variant
-# (same design at 1-char strokes, 47 cols).
-_FULL_BANNER_MIN_WIDTH = 82
+# Breathing room required beyond the rendered banner width before we pick the
+# full variant; below that we fall back to compact (same design, 1-char strokes).
+_BANNER_WIDTH_MARGIN = 4
 
 
 def print_banner(console: Console, repo_name: str | None = None) -> None:
@@ -41,7 +42,7 @@ def print_banner(console: Console, repo_name: str | None = None) -> None:
     from repowise.cli import __version__
     from repowise.cli.ui import mascot
 
-    compact = console.width < _FULL_BANNER_MIN_WIDTH
+    compact = console.width < mascot.banner_width() + _BANNER_WIDTH_MARGIN
     console.print()
     console.print(mascot.banner_text(repo_name, compact=compact))
     console.print()
@@ -54,7 +55,7 @@ def print_banner(console: Console, repo_name: str | None = None) -> None:
         )
     if repo_name:
         console.print()
-        console.print(f" Repository: [bold]{repo_name}[/bold]", highlight=False)
+        console.print(f" Repository: [bold]{escape(repo_name)}[/bold]", highlight=False)
     console.print()
 
 

--- a/packages/cli/src/repowise/cli/ui/brand.py
+++ b/packages/cli/src/repowise/cli/ui/brand.py
@@ -18,19 +18,8 @@ WARN = "yellow"
 ERR = "bold red"
 
 # ---------------------------------------------------------------------------
-# ASCII art  —  owl mascot + heatmap wordmark (see ui/mascot.py)
+# Banner  —  owl mascot + heatmap wordmark (art lives in ui/mascot.py)
 # ---------------------------------------------------------------------------
-
-# Plain-text compact render, kept as cheap insurance for anything that ever
-# reached for the private ``_LOGO`` name. The real banner is composed (and
-# coloured) by ``mascot.banner_text``.
-_LOGO = (
-    " ,___,  ███▄  ███ ███▄ ▄██▄ █   █ ███ ▄██▄ ███\n"
-    " (◉,◉)  █  █  █   █  █ █  █ █   █  █  █    █\n"
-    " ( ▼ )  ███▀  ██  ███▀ █  █ █ █ █  █  ▀██▄ ██\n"
-    " /)_(\\  █ ▀▄  █   █    █  █ █ █ █  █     █ █\n"
-    '  " "   █  ▀▄ ███ █    ▀██▀ ▀█▀█▀ ███ ▀██▀ ███'
-)
 
 # Breathing room required beyond the rendered banner width before we pick the
 # full variant; below that we fall back to compact (same design, 1-char strokes).

--- a/packages/cli/src/repowise/cli/ui/mascot.py
+++ b/packages/cli/src/repowise/cli/ui/mascot.py
@@ -1,0 +1,200 @@
+"""Owl mascot: banner art, state frames, and the heatmap wordmark.
+
+Single home for every piece of the init-banner identity: the owl, the
+REPOWISE block wordmark (full + compact variants), the GitHub-heatmap
+colouring, and the spinner frames used while repowise thinks.
+
+All render functions are pure and deterministic — the heatmap pattern is
+seeded from the repo name, so the same repo always gets the same banner.
+"""
+
+from __future__ import annotations
+
+import zlib
+from functools import cache
+from random import Random
+
+from rich.text import Text
+
+from repowise.cli.ui.brand import BRAND
+
+# ---------------------------------------------------------------------------
+# Palette
+# ---------------------------------------------------------------------------
+
+WHITE = "#E8E8E8"  # owl body strokes (logo white)
+
+# Floored 5-shade heatmap ramp: deep ember → blazing. No near-black shade so
+# the wordmark always reads, even at the cold end of the gradient.
+HEAT = ["#5C3208", "#9C5710", "#D97A16", "#F59520", "#FFC06A"]
+
+# ---------------------------------------------------------------------------
+# Owl
+# ---------------------------------------------------------------------------
+
+OWL_FULL = [
+    " ,_____,",
+    " (◉ , ◉)",
+    " (  ▼  )",
+    " /)___(\\",
+    '   " "  ',
+]
+
+OWL_COMPACT = [
+    " ,___,",
+    " (◉,◉)",
+    " ( ▼ )",
+    " /)_(\\",
+    '  " " ',
+]
+
+EYES_THINKING = ["◐", "◓", "◑", "◒"]  # eye-roll cycle
+EYES_IDLE = "◉"
+EYES_SLEEPY = "─"
+EYES_HAPPY = "^"
+EYES_ERROR = "x"
+
+
+def mini(eyes: str = EYES_IDLE) -> str:
+    """Single-line mini owl face, e.g. ``{◉ ◉}`` — always 5 chars wide."""
+    return "{" + eyes + " " + eyes + "}"
+
+
+THINKING_FRAMES = [mini(e) for e in EYES_THINKING]
+
+# ---------------------------------------------------------------------------
+# Spinner registration — ``rich._spinners.SPINNERS`` is private API (a plain
+# dict consumed by ``rich.spinner.Spinner``), so registration is wrapped: if a
+# future rich version moves it, everything silently stays on "dots". Always
+# reference ``OWL_SPINNER`` at call sites, never the literal ``"owl"``.
+# ---------------------------------------------------------------------------
+
+try:
+    from rich._spinners import SPINNERS
+
+    SPINNERS["owl"] = {"interval": 200, "frames": THINKING_FRAMES}
+    OWL_SPINNER = "owl"
+except Exception:  # pragma: no cover — depends on rich internals
+    OWL_SPINNER = "dots"
+
+# ---------------------------------------------------------------------------
+# Wordmark fonts — half-block finished letterforms (R tail = stepped taper).
+# FONT_FULL uses 2-char stroke cells; FONT_COMPACT is the same design at
+# 1-char strokes for narrow terminals.
+# ---------------------------------------------------------------------------
+
+FONT_FULL = {
+    "R": ["██████▄", "██   ██", "██████▀", "██ ▀█▄ ", "██  ▀█▄"],
+    "E": ["██████", "██    ", "█████ ", "██    ", "██████"],
+    "P": ["██████▄", "██   ██", "██████▀", "██     ", "██     "],
+    "O": ["▄█████▄", "██   ██", "██   ██", "██   ██", "▀█████▀"],
+    "W": ["██     ██", "██     ██", "██  █  ██", "██ ███ ██", "▀██▀ ▀██▀"],
+    "I": ["████", " ██ ", " ██ ", " ██ ", "████"],
+    "S": ["▄█████▄", "██     ", "▀█████▄", "     ██", "▀█████▀"],
+}
+
+FONT_COMPACT = {
+    "R": ["███▄ ", "█  █ ", "███▀ ", "█ ▀▄ ", "█  ▀▄"],
+    "E": ["███", "█  ", "██ ", "█  ", "███"],
+    "P": ["███▄", "█  █", "███▀", "█   ", "█   "],
+    "O": ["▄██▄", "█  █", "█  █", "█  █", "▀██▀"],
+    "W": ["█   █", "█   █", "█ █ █", "█ █ █", "▀█▀█▀"],
+    "I": ["███", " █ ", " █ ", " █ ", "███"],
+    "S": ["▄██▄", "█   ", "▀██▄", "   █", "▀██▀"],
+}
+
+_WORD = "REPOWISE"
+
+
+@cache
+def render_wordmark(compact: bool = False) -> tuple[tuple[str, ...], tuple[int, ...]]:
+    """Wordmark rows + per-column heat-cell ids.
+
+    Cell ids are aligned to each letter's own grid (one cell = ``cell_w``
+    columns starting at the letter's left edge) so every coloured unit is a
+    true square — a cell never slices a stroke or bleeds across the
+    inter-letter gap. Gap columns map to ``-1`` (unpainted).
+    """
+    font = FONT_COMPACT if compact else FONT_FULL
+    cell_w = 1 if compact else 2
+    gap = 1 if compact else 2
+
+    rows = ["", "", "", "", ""]
+    cellmap: list[int] = []
+    cell_base = 0
+    for li, ch in enumerate(_WORD):
+        glyph = font[ch]
+        width = len(glyph[0])
+        n_cells = (width + cell_w - 1) // cell_w
+        for lx in range(width):
+            cellmap.append(cell_base + min(lx // cell_w, n_cells - 1))
+        cell_base += n_cells
+        for r in range(5):
+            rows[r] += glyph[r]
+        if li < len(_WORD) - 1:
+            for r in range(5):
+                rows[r] += " " * gap
+            cellmap.extend([-1] * gap)
+    return tuple(rows), tuple(cellmap)
+
+
+def seed_for(repo_name: str | None) -> int:
+    """Stable cross-process seed for a repo's heatmap pattern.
+
+    Uses ``zlib.crc32`` deliberately — the built-in ``hash()`` is salted per
+    process, which would give every run a different banner.
+    """
+    return zlib.crc32((repo_name or "repowise").encode())
+
+
+def heat_grid(seed: int, n_cells: int) -> list[list[int]]:
+    """Gradient + jitter shade grid (5 rows by *n_cells*), deterministic.
+
+    Base shade sweeps linearly left→right across cells; each cell jitters
+    ±1 shade around the sweep, clamped to the palette bounds.
+    """
+    rng = Random(seed)
+    span = max(n_cells - 1, 1)
+    grid = [[0] * n_cells for _ in range(5)]
+    for r in range(5):
+        for c in range(n_cells):
+            base = (c / span) * (len(HEAT) - 1)
+            idx = round(base + rng.uniform(-1.1, 1.1))
+            grid[r][c] = min(max(idx, 0), len(HEAT) - 1)
+    return grid
+
+
+def _paint_owl(line: str) -> Text:
+    """Owl strokes in logo white, eyes in brand orange."""
+    out = Text()
+    for ch in line:
+        if ch == EYES_IDLE:
+            out.append(ch, style=f"bold {BRAND}")
+        elif ch == " ":
+            out.append(" ")
+        else:
+            out.append(ch, style=f"bold {WHITE}")
+    return out
+
+
+def banner_text(repo_name: str | None, compact: bool = False) -> Text:
+    """Compose owl + heatmap wordmark into a single renderable ``Text``."""
+    owl = OWL_COMPACT if compact else OWL_FULL
+    rows, cellmap = render_wordmark(compact)
+    n_cells = max(c for c in cellmap if c >= 0) + 1
+    grid = heat_grid(seed_for(repo_name), n_cells)
+
+    owl_w = max(len(line) for line in owl)
+    out = Text()
+    for r in range(5):
+        if r:
+            out.append("\n")
+        out.append(" ")
+        out.append_text(_paint_owl(owl[r].ljust(owl_w)))
+        out.append("  ")
+        for x, ch in enumerate(rows[r]):
+            if ch == " " or cellmap[x] < 0:
+                out.append(" ")
+            else:
+                out.append(ch, style=f"bold {HEAT[grid[r][cellmap[x]]]}")
+    return out

--- a/packages/cli/src/repowise/cli/ui/mascot.py
+++ b/packages/cli/src/repowise/cli/ui/mascot.py
@@ -138,6 +138,18 @@ def render_wordmark(compact: bool = False) -> tuple[tuple[str, ...], tuple[int, 
     return tuple(rows), tuple(cellmap)
 
 
+def banner_width(compact: bool = False) -> int:
+    """Total rendered banner width in columns (indent + owl + gap + wordmark).
+
+    Single source of truth for layout maths — ``print_banner`` derives its
+    full/compact switch threshold from this, so font or owl changes can't
+    silently desync the two.
+    """
+    owl = OWL_COMPACT if compact else OWL_FULL
+    rows, _ = render_wordmark(compact)
+    return 1 + max(len(line) for line in owl) + 2 + len(rows[0])
+
+
 def seed_for(repo_name: str | None) -> int:
     """Stable cross-process seed for a repo's heatmap pattern.
 

--- a/packages/cli/src/repowise/cli/ui/mascot.py
+++ b/packages/cli/src/repowise/cli/ui/mascot.py
@@ -48,11 +48,11 @@ OWL_COMPACT = [
     '  " " ',
 ]
 
-EYES_THINKING = ["◐", "◓", "◑", "◒"]  # eye-roll cycle
+EYES_THINKING = ["◐", "◓", "◑", "◒"]  # eye-roll cycle (spinner frames)
 EYES_IDLE = "◉"
-EYES_SLEEPY = "─"
-EYES_HAPPY = "^"
-EYES_ERROR = "x"
+EYES_SLEEPY = "─"  # interrupt message
+EYES_HAPPY = "^"  # completion panels
+EYES_ERROR = "x"  # reserved: error output deliberately stays sober (no owl) for now
 
 
 def mini(eyes: str = EYES_IDLE) -> str:

--- a/packages/cli/src/repowise/cli/ui/result_panels.py
+++ b/packages/cli/src/repowise/cli/ui/result_panels.py
@@ -10,6 +10,7 @@ from rich.table import Table
 from rich.text import Text
 
 from repowise.cli.ui.brand import BRAND
+from repowise.cli.ui.mascot import EYES_HAPPY, mini
 
 
 def build_analysis_summary_panel(
@@ -79,10 +80,12 @@ def build_completion_panel(
     *,
     next_steps: list[tuple[str, str]] | None = None,
 ) -> Panel:
-    """Build a bordered summary panel.
+    """Build a bordered summary panel, titled with the happy owl.
 
     *metrics* is a list of ``(label, value)`` pairs.
     *next_steps* is an optional list of ``(command, description)`` pairs.
+    The mascot prefix lives here (not at call sites) so every completion
+    panel gets it consistently.
     """
     table = Table(box=None, padding=(0, 2), show_header=False)
     table.add_column("Metric", style="dim", min_width=20)
@@ -101,7 +104,7 @@ def build_completion_panel(
 
     return Panel(
         Group(*parts),
-        title=f"[bold]{title}[/bold]",
+        title=f"[bold]{mini(EYES_HAPPY)}  {title}[/bold]",
         border_style=BRAND,
         padding=(1, 1),
     )

--- a/tests/unit/cli/test_mascot.py
+++ b/tests/unit/cli/test_mascot.py
@@ -1,0 +1,140 @@
+"""Tests for the owl mascot banner (``ui/mascot.py``).
+
+Pins the locked banner design: layout width, heatmap determinism (seeded from
+the repo name), letter-aligned colour cells, spinner frame geometry, and the
+Windows-safe character set.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+import zlib
+
+import pytest
+from rich.console import Console
+
+from repowise.cli.ui import mascot
+from repowise.cli.ui.brand import print_banner
+
+FULL_BANNER_MAX_COLS = 79
+COMPACT_BANNER_MAX_COLS = 47
+
+
+def _banner_lines(repo_name: str | None, *, compact: bool = False) -> list[str]:
+    return mascot.banner_text(repo_name, compact=compact).plain.split("\n")
+
+
+def test_banner_width() -> None:
+    for line in _banner_lines("my-cool-repo"):
+        assert len(line.rstrip()) <= FULL_BANNER_MAX_COLS
+
+
+def test_banner_deterministic() -> None:
+    a1 = mascot.banner_text("repo-a")
+    a2 = mascot.banner_text("repo-a")
+    b = mascot.banner_text("repo-b")
+    assert a1.markup == a2.markup  # same repo -> identical styled render
+    assert a1.markup != b.markup  # different repo -> different heat pattern
+    assert a1.plain == b.plain  # ... but identical letterforms
+
+
+def test_seed_is_stable_across_processes() -> None:
+    # seed must come from zlib.crc32 (stable), never the salted built-in
+    # hash() — pin a known value so a "simplification" to hash() fails loudly.
+    assert mascot.seed_for("repowise") == zlib.crc32(b"repowise") == 3401388275
+    assert mascot.seed_for(None) == mascot.seed_for("repowise")
+
+
+def test_heat_grid_bounds() -> None:
+    grid = mascot.heat_grid(seed=5, n_cells=30)
+    assert len(grid) == 5
+    for row in grid:
+        assert len(row) == 30
+        assert all(0 <= cell <= len(mascot.HEAT) - 1 for cell in row)
+
+
+@pytest.mark.parametrize("compact", [False, True])
+def test_cells_align_to_letters(compact: bool) -> None:
+    _rows, cellmap = mascot.render_wordmark(compact)
+    cell_w = 1 if compact else 2
+
+    # Gap columns are unpainted; letter columns carry nonnegative cell ids.
+    assert min(cellmap) == -1
+    painted = [c for c in cellmap if c >= 0]
+    assert painted[0] == 0
+    assert sorted(set(painted)) == list(range(max(painted) + 1))
+
+    # Cell ids never decrease left->right, each cell spans at most cell_w
+    # contiguous columns, and an id never recurs after a gap (no bleed
+    # across the inter-letter gap).
+    last = -1
+    run = 0
+    after_gap: set[int] = set()
+    for c in cellmap:
+        if c < 0:
+            after_gap.update(range(last + 1))
+            continue
+        assert c >= last
+        run = run + 1 if c == last else 1
+        assert run <= cell_w
+        assert c not in after_gap
+        last = c
+
+
+def test_frames_are_uniform_width() -> None:
+    assert all(len(frame) == 5 for frame in mascot.THINKING_FRAMES)
+    assert mascot.OWL_SPINNER in ("owl", "dots")
+    if mascot.OWL_SPINNER == "owl":
+        from rich.spinner import Spinner
+
+        spinner = Spinner("owl")
+        assert spinner.frames == mascot.THINKING_FRAMES
+
+
+def test_art_is_utf8_clean() -> None:
+    art: list[str] = [
+        *mascot.OWL_FULL,
+        *mascot.OWL_COMPACT,
+        *mascot.THINKING_FRAMES,
+        mascot.mini(mascot.EYES_IDLE),
+        mascot.mini(mascot.EYES_SLEEPY),
+        mascot.mini(mascot.EYES_HAPPY),
+        mascot.mini(mascot.EYES_ERROR),
+    ]
+    for font in (mascot.FONT_FULL, mascot.FONT_COMPACT):
+        for glyph in font.values():
+            art.extend(glyph)
+    for s in art:
+        s.encode("utf-8")  # must not raise
+        for ch in s:
+            assert unicodedata.east_asian_width(ch) not in ("W", "F")
+
+
+def test_compact_banner_under_80() -> None:
+    console = Console(width=70, record=True, force_terminal=True)
+    print_banner(console, repo_name="my-cool-repo")
+    out = console.export_text()
+    assert ",___," in out  # compact owl used
+    assert ",_____," not in out  # full owl absent
+    for line in out.split("\n"):
+        assert len(line.rstrip()) <= COMPACT_BANNER_MAX_COLS
+
+
+def test_full_banner_at_wide_width() -> None:
+    console = Console(width=100, record=True, force_terminal=True)
+    print_banner(console, repo_name="my-cool-repo")
+    out = console.export_text()
+    assert ",_____," in out
+    assert "codebase intelligence for developers and AI" in out
+    assert "Repository: my-cool-repo" in out
+
+
+def test_compact_full_same_seed_same_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Full and compact banners must derive their heat pattern from the same
+    # seed function -> pattern parity across sizes for a given repo.
+    seen: list[int] = []
+    real = mascot.seed_for
+    monkeypatch.setattr(mascot, "seed_for", lambda name: seen.append(real(name)) or real(name))
+    mascot.banner_text("repo-x", compact=False)
+    mascot.banner_text("repo-x", compact=True)
+    assert seen == [real("repo-x")] * 2

--- a/tests/unit/cli/test_mascot.py
+++ b/tests/unit/cli/test_mascot.py
@@ -147,12 +147,24 @@ def test_full_banner_at_wide_width() -> None:
     assert "Repository: my-cool-repo" in out
 
 
-def test_compact_full_same_seed_same_shape(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Full and compact banners must derive their heat pattern from the same
-    # seed function -> pattern parity across sizes for a given repo.
-    seen: list[int] = []
-    real = mascot.seed_for
-    monkeypatch.setattr(mascot, "seed_for", lambda name: seen.append(real(name)) or real(name))
-    mascot.banner_text("repo-x", compact=False)
-    mascot.banner_text("repo-x", compact=True)
-    assert seen == [real("repo-x")] * 2
+@pytest.mark.parametrize("compact", [False, True])
+def test_banner_colors_derive_from_repo_seed(compact: bool) -> None:
+    # Behavioral pin: every painted wordmark cell in the rendered banner must
+    # carry exactly the shade predicted by heat_grid(seed_for(repo), n) — for
+    # BOTH sizes, so full and compact share one seed (pattern parity).
+    rows, cellmap = mascot.render_wordmark(compact)
+    n_cells = max(c for c in cellmap if c >= 0) + 1
+    grid = mascot.heat_grid(mascot.seed_for("repo-x"), n_cells)
+
+    text = mascot.banner_text("repo-x", compact=compact)
+    owl = mascot.OWL_COMPACT if compact else mascot.OWL_FULL
+    offset = 1 + max(len(line) for line in owl) + 2  # indent + owl + gap
+    style_at = {span.start: str(span.style) for span in text.spans}
+
+    checked = 0
+    for x, ch in enumerate(rows[0]):
+        if ch == " " or cellmap[x] < 0:
+            continue
+        assert style_at[offset + x] == f"bold {mascot.HEAT[grid[0][cellmap[x]]]}"
+        checked += 1
+    assert checked > 20  # the whole top row of the wordmark was verified

--- a/tests/unit/cli/test_mascot.py
+++ b/tests/unit/cli/test_mascot.py
@@ -120,6 +120,24 @@ def test_compact_banner_under_80() -> None:
         assert len(line.rstrip()) <= COMPACT_BANNER_MAX_COLS
 
 
+def test_banner_width_single_source_of_truth() -> None:
+    # print_banner derives its full/compact threshold from these — pin the
+    # current layout so an accidental font/owl width change fails loudly.
+    assert mascot.banner_width() == 78
+    assert mascot.banner_width(compact=True) == 47
+    for compact, width in ((False, mascot.banner_width()), (True, 47)):
+        for line in _banner_lines("my-cool-repo", compact=compact):
+            assert len(line.rstrip()) <= width
+
+
+def test_repo_name_with_markup_is_escaped() -> None:
+    # A directory name containing rich markup must render literally, not
+    # crash with MarkupError or inject styling.
+    console = Console(width=100, record=True, force_terminal=True)
+    print_banner(console, repo_name="evil[/bold]name")
+    assert "evil[/bold]name" in console.export_text()
+
+
 def test_full_banner_at_wide_width() -> None:
     console = Console(width=100, record=True, force_terminal=True)
     print_banner(console, repo_name="my-cool-repo")

--- a/tests/unit/cli/test_ui_package.py
+++ b/tests/unit/cli/test_ui_package.py
@@ -39,6 +39,11 @@ def test_facade_reexports_public_surface() -> None:
         "build_contextual_next_steps",
         "format_elapsed",
         "LARGE_REPO_FILE_THRESHOLD",
+        # owl mascot additions (additive — everything above is the original surface)
+        "banner_text",
+        "mini",
+        "OWL_SPINNER",
+        "THINKING_FRAMES",
     }
     missing = {name for name in expected if not hasattr(ui, name)}
     assert not missing


### PR DESCRIPTION
## What

\`repowise init\` gets a brand identity: the owl mascot beside a REPOWISE block wordmark colored like a GitHub contribution heatmap, plus owl spinner frames everywhere the CLI thinks.

\`\`\`
  ,_____,  ██████▄  ██████  ██████▄  ▄█████▄  ██     ██  ████  ▄█████▄  ██████
  (◉ , ◉)  ██   ██  ██      ██   ██  ██   ██  ██     ██   ██   ██       ██
  (  ▼  )  ██████▀  █████   ██████▀  ██   ██  ██  █  ██   ██   ▀█████▄  █████
  /)___(\  ██ ▀█▄   ██      ██       ██   ██  ██ ███ ██   ██        ██  ██
    " "    ██  ▀█▄  ██████  ██       ▀█████▀  ▀██▀ ▀██▀  ████  ▀█████▀  ██████

 codebase intelligence for developers and AI  ·  v0.16.0
 Repository: repowise
\`\`\`

- **Heatmap wordmark**: 5-shade orange ramp, gradient + jitter, color cells aligned to each letter's grid so every colored unit is a true square. **Seeded by repo name** (\`zlib.crc32\`, stable across processes) — every repo gets its own permanent pattern; same repo always renders the same banner.
- **Width-adaptive**: full design ≥82 cols, identical design at 1-char strokes (47 cols) below; threshold derives from \`mascot.banner_width()\` so font changes can't desync it.
- **Owl spinner**: eye-roll frames \`{◐ ◐} {◓ ◓} {◑ ◑} {◒ ◒}\` registered as a custom rich spinner, swapped in at all 10 spinner sites (4 \`SpinnerColumn\` in brand orange, 6 \`console.status\` in default green). Registration touches rich's private \`SPINNERS\` dict behind try/except — worst case everything silently stays on \`dots\`.
- **Mascot moments**: completion panels titled \`{^ ^}  repowise init complete\` (owned by \`build_completion_panel\`), Ctrl-C interrupt gets a sleepy \`{─ ─}\`. Error paths deliberately stay sober.
- **Fix folded in**: \`print_banner\` now escapes \`repo_name\` before markup interpolation — a directory named like \`evil[/bold]name\` used to crash with \`MarkupError\` (pre-existing).

## Compatibility

- \`print_banner\` signature unchanged; \`ui\` facade additions (\`banner_text\`, \`mini\`, \`OWL_SPINNER\`, \`THINKING_FRAMES\`) are additive only.
- Degradation verified: NO_COLOR → legible monochrome; non-TTY → plain text, no ANSI leakage; <82 cols → compact variant; Windows cp1252 covered by the existing \`_stdio.py\` UTF-8 reconfiguration (all art chars are BMP, none east-asian-wide — pinned by test).
- Note: piped stdout defaults rich to width 80 → compact banner even on wide terminals (cosmetic; record demos in a real TTY ≥82 cols).

## Tests

13 new tests in \`tests/unit/cli/test_mascot.py\`: layout width, render determinism, crc32 seed pinned by literal value, letter-aligned cell invariants, behavioral check that rendered span colors match the seed-derived grid for both sizes, spinner frame geometry, UTF-8/width safety, markup-escape regression, compact/full switching.

Full unit suite: 3193 passed.

## Post-merge checklist

- [ ] Regenerate \`.github/assets/demo.gif\` — it still shows the old banner (record at ≥82 cols, truecolor)