### PR TITLE
fix(generation): close never-started page coroutines on Ctrl+C abort

### DIFF
--- a/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
+++ b/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
@@ -365,6 +365,16 @@ class _GenerationRun:
                     error=str(exc),
                 )
                 return exc  # return as value so gather works
+            except BaseException:
+                # Cancellation (Ctrl+C teardown): CancelledError is a
+                # BaseException, so it skips the handler above. If the cancel
+                # landed while this page was still queued on the semaphore,
+                # ``coro`` was never started — close it so interpreter
+                # shutdown doesn't spray one "coroutine ... was never
+                # awaited" RuntimeWarning per pending page (issue #358).
+                # close() is a no-op on a coroutine that already ran.
+                coro.close()
+                raise
 
         tasks = [guarded_named(pid, c) for pid, c in named_coros]
         results = await asyncio.gather(*tasks)

--- a/tests/unit/generation/test_run_level_cancellation.py
+++ b/tests/unit/generation/test_run_level_cancellation.py
@@ -1,0 +1,147 @@
+"""Cancellation behaviour of ``_GenerationRun.run_level`` (issue #358).
+
+A Ctrl+C during generation cancels the gather inside ``run_level``. Pages
+still queued on the concurrency semaphore have never started their inner
+coroutine; unless that coroutine object is explicitly closed, interpreter
+shutdown emits one ``RuntimeWarning: coroutine ... was never awaited`` per
+pending page. These tests pin the fix: after cancellation every inner
+coroutine — running or queued — must be finalized.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import inspect
+import warnings
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from repowise.core.generation.models import GeneratedPage
+from repowise.core.generation.page_generator.orchestrate import _GenerationRun
+
+
+def _page(page_id: str) -> GeneratedPage:
+    now = datetime.now(UTC).isoformat()
+    return GeneratedPage(
+        page_id=page_id,
+        page_type="file_page",
+        title=page_id,
+        content=f"# {page_id}",
+        source_hash="deadbeef",
+        model_name="mock-model",
+        provider_name="mock",
+        input_tokens=1,
+        output_tokens=1,
+        cached_tokens=0,
+        generation_level=2,
+        target_path=page_id,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _fake_run(max_concurrency: int = 1) -> SimpleNamespace:
+    """Duck-typed ``_GenerationRun`` exposing only what ``run_level`` reads."""
+    return SimpleNamespace(
+        semaphore=asyncio.Semaphore(max_concurrency),
+        job_system=None,
+        job_id=None,
+        on_page_done=None,
+        on_page_ready=None,
+        vector_store=None,
+        completed_page_summaries={},
+    )
+
+
+async def _drain_cancelled_children() -> None:
+    """Give the loop a few ticks so cancelled child tasks finalize."""
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+
+async def test_cancel_closes_queued_coroutines():
+    """Coroutines still queued on the semaphore are closed, not leaked."""
+    run = _fake_run(max_concurrency=1)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocker() -> GeneratedPage:
+        started.set()
+        await release.wait()
+        return _page("blocker")
+
+    async def queued(i: int) -> GeneratedPage:
+        return _page(f"queued-{i}")
+
+    inner = [blocker()] + [queued(i) for i in range(5)]
+    named_coros = [(f"pid-{i}", c) for i, c in enumerate(inner)]
+
+    task = asyncio.ensure_future(_GenerationRun.run_level(run, named_coros, 2))
+    await started.wait()  # blocker holds the only semaphore slot
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await _drain_cancelled_children()
+
+    # Every inner coroutine — the one mid-await and the five never-started
+    # ones — must be finalized so no "never awaited" warning can fire.
+    states = [inspect.getcoroutinestate(c) for c in inner]
+    assert states == ["CORO_CLOSED"] * len(inner)
+
+
+async def test_cancel_emits_no_never_awaited_warning():
+    """End-to-end on the symptom: GC after cancel produces no RuntimeWarning."""
+    run = _fake_run(max_concurrency=1)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocker() -> GeneratedPage:
+        started.set()
+        await release.wait()
+        return _page("blocker")
+
+    async def queued(i: int) -> GeneratedPage:
+        return _page(f"queued-{i}")
+
+    named_coros = [("pid-b", blocker())] + [(f"pid-{i}", queued(i)) for i in range(5)]
+
+    task = asyncio.ensure_future(_GenerationRun.run_level(run, named_coros, 2))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await _drain_cancelled_children()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        del named_coros, task
+        gc.collect()
+
+    leaked = [
+        w
+        for w in caught
+        if issubclass(w.category, RuntimeWarning) and "was never awaited" in str(w.message)
+    ]
+    assert leaked == []
+
+
+async def test_run_level_completes_normally_after_fix():
+    """Happy path untouched: pages come back, failures stay return-values."""
+    run = _fake_run(max_concurrency=2)
+
+    async def ok(i: int) -> GeneratedPage:
+        await asyncio.sleep(0)
+        return _page(f"ok-{i}")
+
+    async def boom() -> GeneratedPage:
+        raise ValueError("synthetic failure")
+
+    named_coros = [(f"pid-{i}", ok(i)) for i in range(3)] + [("pid-boom", boom())]
+    pages = await _GenerationRun.run_level(run, named_coros, 2)
+
+    assert sorted(p.page_id for p in pages) == ["ok-0", "ok-1", "ok-2"]
+    # The failing page's summary was never captured, the others' were.
+    assert set(run.completed_page_summaries) == {"ok-0", "ok-1", "ok-2"}


### PR DESCRIPTION
﻿## Summary

Fixes the `RuntimeWarning: coroutine 'PerTypeGenerationMixin.generate_symbol_spotlight' was never awaited` spray reported in #358 when aborting generation with Ctrl+C.

**Root cause:** level builders create page coroutine objects eagerly; `run_level` awaits each one behind the shared concurrency semaphore inside `guarded_named`. When Ctrl+C tears down the event loop, tasks still **queued on the semaphore** are cancelled before their inner coroutine ever starts. `CancelledError` is a `BaseException`, so it bypassed the `except Exception` handler and the never-started coroutine objects leaked — one "never awaited" `RuntimeWarning` per pending page at interpreter shutdown (~980 of them on a 985-page run with default concurrency 5).

**Fix:** add a `BaseException` handler in `guarded_named` that closes the inner coroutine before re-raising. `coro.close()` is a no-op on a coroutine that already ran, so in-flight pages are unaffected. Purely cosmetic — completed pages were already persisted incrementally and `--resume` already picked up cleanly.

## Verification

- New regression tests in `tests/unit/generation/test_run_level_cancellation.py`:
  - `test_cancel_closes_queued_coroutines` — after cancelling `run_level` mid-flight, every inner coroutine (running and queued) is `CORO_CLOSED`.
  - `test_cancel_emits_no_never_awaited_warning` — end-to-end on the symptom: GC after cancellation emits zero "never awaited" `RuntimeWarning`s.
  - `test_run_level_completes_normally_after_fix` — happy path unchanged: pages returned, per-page failures still returned as values for `gather`.
- Confirmed the tests **fail without the fix** (queued coros stay `CORO_CREATED`; 10 leaked-coroutine warnings) and pass with it.
- Full generation suite: `423 passed` (`tests/unit/generation`).
- `ruff check` / `ruff format --check` clean on changed lines (pre-existing E741/RUF100 in untouched lines left as-is to keep the diff minimal).

Fixes the warning reported in #358.

