### PR TITLE
fix(ingestion): resolve explicit relative JS imports

### DIFF
--- a/packages/core/src/repowise/core/ingestion/resolvers/typescript.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/typescript.py
@@ -22,6 +22,8 @@ def resolve_ts_js_import(module_path: str, importer_path: str, ctx: ResolverCont
         base_posix = posixpath.normpath(
             posixpath.join(importer_dir.as_posix(), module_path)
         )
+        if base_posix in ctx.path_set:
+            return base_posix
         exts: tuple[str, ...] = (
             ".ts",
             ".tsx",

--- a/tests/integration/test_commonjs_dead_code.py
+++ b/tests/integration/test_commonjs_dead_code.py
@@ -15,7 +15,7 @@ import pytest
 from repowise.core.analysis.dead_code import DeadCodeAnalyzer
 from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
 
-ENTRY_JS = """const svc = require('./svc');
+ENTRY_JS = """const svc = require('./svc.js');
 
 function main() {
   return svc.used();

--- a/tests/unit/ingestion/test_typescript_resolver.py
+++ b/tests/unit/ingestion/test_typescript_resolver.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 
 import networkx as nx
+import pytest
 
 from repowise.core.ingestion.resolvers.context import ResolverContext
 from repowise.core.ingestion.resolvers.ts_workspace import (
@@ -46,6 +47,34 @@ class TestSfcExtensions:
         assert ctx.has_sfc_files is False
         result = resolve_ts_js_import("./missing", "src/foo.ts", ctx)
         assert result is None
+
+
+class TestExplicitRelativeExtensions:
+    @pytest.mark.parametrize(
+        "extension",
+        [".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"],
+    )
+    def test_existing_explicit_relative_file_wins(
+        self, tmp_path: Path, extension: str
+    ) -> None:
+        ctx = _ctx(tmp_path, [f"data/example{extension}", "services/reader.js"])
+        result = resolve_ts_js_import(
+            f"../data/example{extension}",
+            "services/reader.js",
+            ctx,
+        )
+        assert result == f"data/example{extension}"
+
+    def test_ts_rewrite_fallback_still_resolves_when_js_file_absent(
+        self, tmp_path: Path
+    ) -> None:
+        ctx = _ctx(tmp_path, ["data/example.ts", "services/reader.js"])
+        result = resolve_ts_js_import(
+            "../data/example.js",
+            "services/reader.js",
+            ctx,
+        )
+        assert result == "data/example.ts"
 
 
 class TestWorkspaceMap:


### PR DESCRIPTION
## Summary
- resolve relative TS/JS imports directly when the normalized explicit path already exists
- keep existing extension probing and JS-to-TS rewrite fallback behavior intact
- add resolver and CommonJS dead-code regression coverage for explicit file-extension imports

Fixes #372

## Validation
- `uv run pytest tests/unit/ingestion/test_typescript_resolver.py -q` -> 33 passed
- `uv run pytest tests/integration/test_commonjs_dead_code.py -q` -> 3 passed