### PR TITLE
feat(init): clearer mode panel + searchable model selection

### DIFF
--- a/packages/cli/src/repowise/cli/ui/mode_selection.py
+++ b/packages/cli/src/repowise/cli/ui/mode_selection.py
@@ -70,26 +70,26 @@ def interactive_mode_select(console: Console) -> str:
     """
     body = Text()
     body.append("  [1]", style=BRAND_STYLE)
-    body.append("  Full documentation  ", style="bold")
+    body.append("  Everything  ", style="bold")
     body.append("(recommended)\n", style="dim")
-    body.append("       Generate wiki pages, architecture diagrams, and API\n")
-    body.append("       docs using an AI provider.\n\n")
+    body.append("       All five layers: dependency graph, git history, code\n")
+    body.append("       health, decisions + AI-generated wiki, diagrams & API docs.\n\n")
 
     body.append("  [2]", style=BRAND_STYLE)
     body.append("  Index only  ", style="bold")
     body.append("(no LLM, no cost)\n", style="dim")
-    body.append("       Dependency graph, git history, dead code analysis.\n")
-    body.append("       Perfect for MCP-powered AI coding assistants.\n\n")
+    body.append("       Same minus the AI docs: graph, git history, code health,\n")
+    body.append("       dead code. Great for MCP agents; add docs anytime later.\n\n")
 
     body.append("  [3]", style=BRAND_STYLE)
     body.append("  Advanced\n", style="bold")
-    body.append("       Full documentation with extra configuration\n")
+    body.append("       Everything, with extra configuration\n")
     body.append("       (commit limit, exclude patterns, concurrency …)")
 
     console.print(
         Panel(
             body,
-            title="[bold]How would you like to document this repo?[/bold]",
+            title="[bold]How would you like to index this repo?[/bold]",
             border_style=BRAND,
             padding=(1, 2),
         )

--- a/packages/cli/src/repowise/cli/ui/provider_selection.py
+++ b/packages/cli/src/repowise/cli/ui/provider_selection.py
@@ -240,34 +240,30 @@ def _format_reasoning_modes(modes: tuple[ReasoningMode, ...]) -> str:
     return ", ".join(modes)
 
 
-def _filtered_model_options(
-    console: Console,
+_MAX_MODEL_ROWS = 40
+
+
+def _initial_model_options(
     options: tuple[ProviderModelOption, ...],
 ) -> list[ProviderModelOption]:
-    if len(options) <= 40:
+    if len(options) <= _MAX_MODEL_ROWS:
         return list(options)
-
-    console.print(f"  [dim]{len(options):,} models available.[/dim]")
-    query = click.prompt(
-        "  Filter models (Enter for recommended)",
-        default="",
-        show_default=False,
-    ).strip()
-    if query:
-        q = query.lower()
-        filtered = [
-            option
-            for option in options
-            if q in option.model.lower()
-            or (option.label and q in option.label.lower())
-            or (option.notes and q in option.notes.lower())
-        ][:40]
-        if filtered:
-            return filtered
-        console.print(f"  [{WARN}]No models matched {query!r}; showing recommended.[/]")
-
     recommended = [option for option in options if option.recommended]
-    return (recommended or list(options))[:40]
+    return (recommended or list(options))[:_MAX_MODEL_ROWS]
+
+
+def _search_model_options(
+    options: tuple[ProviderModelOption, ...],
+    query: str,
+) -> list[ProviderModelOption]:
+    q = query.lower()
+    return [
+        option
+        for option in options
+        if q in option.model.lower()
+        or (option.label and q in option.label.lower())
+        or (option.notes and q in option.notes.lower())
+    ]
 
 
 def _select_model_option(
@@ -284,74 +280,115 @@ def _select_model_option(
         "don't improve doc quality.[/]"
     )
 
-    display_options = _filtered_model_options(console, options)
+    display_options = _initial_model_options(options)
     if not display_options:
         display_options = [_fallback_model_option(provider_name)]
+    searchable = len(options) > len(display_options)
+    if searchable:
+        console.print(
+            f"  [dim]Showing {len(display_options)} recommended of "
+            f"{len(options):,} available models.[/dim]"
+        )
 
-    table = Table(
-        show_header=True,
-        box=None,
-        padding=(0, 2),
-        title="[bold]Model Options[/bold]",
-        title_style="",
-    )
-    table.add_column("#", style=BRAND_STYLE, width=4)
-    table.add_column("Model", style="bold", min_width=22)
-    table.add_column("Reasoning", style="dim")
-    table.add_column("Source", style="dim")
-    table.add_column("Notes", style="dim")
+    while True:
+        table = Table(
+            show_header=True,
+            box=None,
+            padding=(0, 2),
+            title="[bold]Model Options[/bold]",
+            title_style="",
+        )
+        table.add_column("#", style=BRAND_STYLE, width=4)
+        table.add_column("Model", style="bold", min_width=22)
+        table.add_column("Reasoning", style="dim")
+        table.add_column("Source", style="dim")
+        table.add_column("Notes", style="dim")
 
-    default_idx = "1"
-    for idx, option in enumerate(display_options, 1):
-        if option.model == default_model or option.recommended:
-            default_idx = str(idx)
-            break
+        default_idx = "1"
+        for idx, option in enumerate(display_options, 1):
+            if option.model == default_model or option.recommended:
+                default_idx = str(idx)
+                break
 
-    for idx, option in enumerate(display_options, 1):
-        label = option.label or option.model
-        if option.recommended:
-            label = f"{label} [dim](recommended)[/dim]"
+        for idx, option in enumerate(display_options, 1):
+            label = option.label or option.model
+            if option.recommended:
+                label = f"{label} [dim](recommended)[/dim]"
+            table.add_row(
+                f"[{idx}]",
+                label,
+                _format_reasoning_modes(option.reasoning_modes),
+                option.source,
+                option.notes,
+            )
+
+        custom_idx = str(len(display_options) + 1)
         table.add_row(
-            f"[{idx}]",
-            label,
-            _format_reasoning_modes(option.reasoning_modes),
-            option.source,
-            option.notes,
+            f"[{custom_idx}]",
+            "Custom model",
+            "auto",
+            "manual",
+            "type an exact model id",
         )
 
-    custom_idx = str(len(display_options) + 1)
-    table.add_row(
-        f"[{custom_idx}]",
-        "Custom model",
-        "auto",
-        "manual",
-        "type an exact model id",
-    )
+        search_idx = None
+        if searchable:
+            search_idx = str(len(display_options) + 2)
+            table.add_row(
+                f"[{search_idx}]",
+                f"Search all {len(options):,} models",
+                "",
+                "",
+                "filter the full list by name",
+            )
 
-    console.print()
-    console.print(table)
-    console.print()
+        console.print()
+        console.print(table)
+        console.print()
 
-    choice = Prompt.ask(
-        "  Select model",
-        choices=[str(i) for i in range(1, len(display_options) + 2)],
-        default=default_idx,
-        console=console,
-    )
-    if choice == custom_idx:
-        model = click.prompt("  Model", default=default_model)
-        return ProviderModelOption(
-            model=model,
-            label=model,
-            reasoning_modes=_provider_supported_reasoning_modes(
-                provider_name,
-                model,
-                repo_path,
-            ),
-            source="fallback",
+        max_choice = len(display_options) + (2 if searchable else 1)
+        choice = Prompt.ask(
+            "  Select model",
+            choices=[str(i) for i in range(1, max_choice + 1)],
+            default=default_idx,
+            console=console,
         )
+        if search_idx and choice == search_idx:
+            query = click.prompt(
+                "  Search (e.g. 'mini' or 'nano')",
+                default="",
+                show_default=False,
+            ).strip()
+            if not query:
+                continue
+            matches = _search_model_options(options, query)
+            if not matches:
+                console.print(f"  [{WARN}]No models matched {query!r}.[/]")
+                continue
+            if len(matches) > _MAX_MODEL_ROWS:
+                console.print(
+                    f"  [dim]{len(matches)} matches; showing first "
+                    f"{_MAX_MODEL_ROWS}. Refine the search to see others.[/dim]"
+                )
+                matches = matches[:_MAX_MODEL_ROWS]
+            else:
+                console.print(f"  [dim]{len(matches)} match(es) for {query!r}.[/dim]")
+            display_options = matches
+            continue
+        if choice == custom_idx:
+            model = click.prompt("  Model", default=default_model)
+            return ProviderModelOption(
+                model=model,
+                label=model,
+                reasoning_modes=_provider_supported_reasoning_modes(
+                    provider_name,
+                    model,
+                    repo_path,
+                ),
+                source="fallback",
+            )
 
-    return display_options[int(choice) - 1]
+        return display_options[int(choice) - 1]
 
 
 def _select_reasoning_mode(


### PR DESCRIPTION
## What

Two interactive-init UX fixes, both from live user-testing confusion:

### 1. Mode panel: "Full documentation" undersold what it does
Option 1 read as "only generates docs", when it actually runs everything in
option 2 (graph, git history, code health, decisions) PLUS the LLM docs.

- "Full documentation" → "Everything", with all five layers spelled out
- "Index only" described as a strict subset: "Same minus the AI docs", plus
  "add docs anytime later" so picking it doesn't feel irreversible
- Panel title "How would you like to document this repo?" → "…index this
  repo?" (the old title primed the docs-only misreading)

### 2. Model selection: blind "Filter models" prompt removed
When a provider returns >40 models (OpenAI returns ~88), the wizard asked
"Filter models (Enter for recommended)" BEFORE showing any list — no hint it
wanted a search substring, nothing visible to filter.

Now: the recommended models table shows immediately; large catalogs get a
"Search all N models" row at the bottom (next to "Custom model"). Picking it
prompts "Search (e.g. 'mini' or 'nano')", prints match counts, re-renders the
table, and loops back on empty/no-match input instead of dead-ending.

## Testing

- `repowise init` against an OpenAI key (88 models): recommended table renders
  directly, search row filters and re-renders, no-match loops back
- Providers with ≤40 models: unchanged single-table flow
