### PR TITLE
feat(analysis): curated knowledge-graph engine — module derivation, layer spine, guided tour

### DIFF
--- a/packages/cli/src/repowise/cli/commands/doctor_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/doctor_cmd.py
@@ -23,6 +23,26 @@ def _check(name: str, ok: bool, detail: str = "") -> tuple[str, str, str]:
     return (name, status, detail)
 
 
+async def _decision_vector_ids(session, repository_id: str) -> set[str]:
+    """Vector-store ids for this repo's decision records.
+
+    Decisions are co-located in the *page* vector store under the
+    ``decision:<record_id>`` namespace (no separate table). The store therefore
+    legitimately holds page vectors *and* decision vectors, so any SQL↔vector
+    reconciliation must count decisions on the SQL side — otherwise every
+    decision embedding reads as an orphan.
+    """
+    from sqlalchemy import text as _sql_text
+
+    from repowise.core.analysis.decisions.semantic_match import DECISION_VECTOR_PREFIX
+
+    rows = await session.execute(
+        _sql_text("SELECT id FROM decision_records WHERE repository_id = :rid"),
+        {"rid": repository_id},
+    )
+    return {f"{DECISION_VECTOR_PREFIX}{r[0]}" for r in rows}
+
+
 def _print_cli_version_status() -> None:
     """Print a best-effort CLI update-check line.
 
@@ -228,6 +248,14 @@ def _run_repo_checks(repo_path: _DoctorPath, repair: bool) -> bool:
                         return set(), set(), set(), set()
                     pages = await list_pages(session, repo.id, limit=10000)
                     sql_ids = {p.page_id for p in pages}
+                    # The page vector store also holds decision embeddings under
+                    # the "decision:<id>" namespace, so they belong on the SQL
+                    # side of the ORPHAN check (but NOT FTS, which only indexes
+                    # pages). They are deliberately excluded from the MISSING
+                    # check: a decision can legitimately have no vector (empty
+                    # match text, swallowed embed failure) and repair cannot
+                    # re-embed it, so flagging it would be permanent noise.
+                    vector_sql_ids = sql_ids | await _decision_vector_ids(session, repo.id)
 
                 # Check vector store
                 vs_ids: set[str] = set()
@@ -242,7 +270,7 @@ def _run_repo_checks(repo_path: _DoctorPath, repair: bool) -> bool:
                         pass  # LanceDB not available
 
                 m_vec = sql_ids - vs_ids if vs_ids else set()
-                o_vec = vs_ids - sql_ids if vs_ids else set()
+                o_vec = vs_ids - vector_sql_ids if vs_ids else set()
 
                 # Check FTS
                 fts = FullTextSearch(engine)
@@ -289,6 +317,7 @@ def _run_repo_checks(repo_path: _DoctorPath, repair: bool) -> bool:
                 from repowise.core.persistence import (
                     create_engine,
                     create_session_factory,
+                    get_repository_by_path,
                     get_session,
                 )
                 from repowise.core.persistence.coordinator import AtomicStorageCoordinator
@@ -313,6 +342,33 @@ def _run_repo_checks(repo_path: _DoctorPath, repair: bool) -> bool:
                         session, graph_builder=None, vector_store=vector_store
                     )
                     result = await coord.health_check()
+
+                    # The coordinator's drift compares wiki_pages count against
+                    # the vector count, but the vector store also holds decision
+                    # embeddings ("decision:<id>" namespace). Without counting
+                    # decisions on the SQL side, every decision reads as drift.
+                    # Recompute drift with a decision-aware SQL count so a
+                    # consistent store reports ~0% rather than a false FAIL.
+                    # Count only decisions that actually have a vector: a
+                    # decision can legitimately be unembedded (empty match
+                    # text, swallowed embed failure), and counting it would
+                    # bias drift positive (SQL > Vector) forever.
+                    repo = await get_repository_by_path(session, str(repo_path))
+                    if repo is not None:
+                        dec_ids = await _decision_vector_ids(session, repo.id)
+                        decision_count = len(dec_ids)
+                        if vector_store is not None:
+                            with contextlib.suppress(Exception):
+                                store_ids = await vector_store.list_page_ids()
+                                decision_count = len(dec_ids & store_ids)
+                        sql_pages = result.get("sql_pages")
+                        vector_count = result.get("vector_count")
+                        if sql_pages is not None:
+                            adjusted_sql = sql_pages + decision_count
+                            result["sql_pages"] = adjusted_sql
+                            if vector_count is not None and vector_count != -1:
+                                denom = max(adjusted_sql, 1)
+                                result["drift"] = abs(adjusted_sql - vector_count) / denom
 
                 if vector_store is not None:
                     with contextlib.suppress(Exception):

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -109,6 +109,13 @@ def select_coverage(
     )
     from repowise.cli.coverage_select import interactive_coverage_select
 
+    # Curated modules from the in-memory index result, so the plan/cost
+    # estimate selects the same module set generation will (the artifact
+    # file is not on disk yet during a fresh init).
+    kg_modules = (
+        getattr(getattr(result, "knowledge_graph_result", None), "modules", None) or None
+    )
+
     if sys.stdin.isatty() and coverage_pct is None and not yes:
         options = compute_coverage_options(
             parsed_files=result.parsed_files,
@@ -119,6 +126,7 @@ def select_coverage(
             repo_path=repo_path,
             skip_tests=skip_tests,
             skip_infra=skip_infra,
+            kg_modules=kg_modules,
         )
         chosen = interactive_coverage_select(console, options)
         chosen_pct = chosen.pct
@@ -135,6 +143,7 @@ def select_coverage(
             gen_config_for_plan,
             skip_tests,
             skip_infra,
+            kg_modules=kg_modules,
         )
         est = estimate_cost(
             plans,
@@ -263,6 +272,22 @@ def run_repo_generation(
                 resume=resume,
                 cost_tracker=cost_tracker,
                 generation_config=gen_config,
+                # In-memory curated modules: on a fresh init the
+                # knowledge-graph.json artifact is only written during
+                # persistence, AFTER this generation pass — without this the
+                # kg_ctx file fallback is empty and module selection silently
+                # degrades to community grouping.
+                kg_modules=(
+                    getattr(
+                        getattr(result, "knowledge_graph_result", None), "modules", None
+                    )
+                    or None
+                ),
+                kg_data=(
+                    result.knowledge_graph_result.to_dict()
+                    if getattr(result, "knowledge_graph_result", None) is not None
+                    else None
+                ),
             )
         )
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/persistence.py
@@ -51,6 +51,7 @@ async def persist_result(result: Any, repo_path: Path) -> None:
         persist_analysis,
         persist_generation,
         persist_pipeline_result,
+        sweep_stale_generated_pages,
     )
 
     engine, sf, _repo_id = await open_repo_db(repo_path, repo_name=result.repo_name)
@@ -88,11 +89,26 @@ async def persist_result(result: Any, repo_path: Path) -> None:
                 existing = {}
             existing["tech_stack"] = result.tech_stack
             repo.settings_json = _json.dumps(existing)
+        swept_page_ids: list[str] = []
         if index_done:
             await persist_analysis(result, session, repo.id)
             await persist_generation(result, session, repo.id)
+            # persist_generation has already upserted the current pages, so the
+            # sweep only retires structurally-keyed pages this run did not
+            # reproduce. Without it the incremental-index path (every normal
+            # single-repo init) strands stale community-N / scc / layer pages
+            # forever. A type is swept when the run produced pages of it OR
+            # declared authority over it (curated runs are authoritative for
+            # module/layer pages even when every module page was skipped as
+            # 1:1 with a layer); types that are neither stay protected.
+            swept_page_ids = await sweep_stale_generated_pages(
+                session,
+                repo.id,
+                result.generated_pages,
+                getattr(result, "authoritative_page_types", None),
+            )
         else:
-            await persist_pipeline_result(result, session, repo.id)
+            swept_page_ids = await persist_pipeline_result(result, session, repo.id)
 
         # Record a completed GenerationJob so the web UI can show
         # "last synced" / "last re-indexed" timestamps.
@@ -109,7 +125,24 @@ async def persist_result(result: Any, repo_path: Path) -> None:
         job.started_at = now
         job.finished_at = now
 
-    # FTS indexing is done outside the session to avoid SQLite write conflicts
+        # Drop swept pages from the vector store *before* the SQL session
+        # commits. The vector store is a separate engine/file (pgvector DB,
+        # LanceDB dir, or in-memory) so there is no SQLite write-lock conflict,
+        # and the delete is idempotent. Keeping the SQL commit last as the
+        # durable source of truth means an interrupted run self-heals: the
+        # vector embedding is already gone, the SQL rows follow on commit.
+        if swept_page_ids:
+            store = getattr(result, "vector_store", None)
+            if store is not None:
+                await store.delete_many(swept_page_ids)
+
+    # FTS deletes/indexing run outside the session: the FTS index lives in the
+    # *same* SQLite file as the session, so touching it while the session still
+    # holds a write lock raises "database is locked". The swept-id delete must
+    # therefore stay here (it cannot move ahead of the SQL commit like the
+    # vector delete can); it is idempotent and narrow (orphan FTS rows only).
+    if fts is not None and swept_page_ids:
+        await fts.delete_many(swept_page_ids)
     if fts is not None and result.generated_pages:
         for page in result.generated_pages:
             await fts.index(page.page_id, page.title, page.content)

--- a/packages/cli/src/repowise/cli/commands/update_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd.py
@@ -1180,6 +1180,7 @@ def update_command(
             repo_structure,
             repo_name,
             git_meta_map=git_meta_map,
+            repo_path=repo_path,
         )
     )
 

--- a/packages/cli/src/repowise/cli/commands/workspace_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/workspace_cmd.py
@@ -545,6 +545,17 @@ def _run_index_for_repo(
             await persist_pipeline_result(result, session, repo.id)
 
         await engine.dispose()
+
+        # Save the curated KG artifact so doc generation can load curated
+        # module grouping (matches the `repowise init` idiom in
+        # init_cmd/command.py). Without it, generation falls back to raw
+        # community grouping and emits wrong module pages.
+        from repowise.cli.state_persistence import save_knowledge_graph_json
+
+        kg = getattr(result, "knowledge_graph_result", None)
+        if kg is not None:
+            save_knowledge_graph_json(repo_path, kg)
+
         return result.file_count, result.symbol_count, page_count
 
     try:
@@ -697,6 +708,7 @@ def _generate_docs_for_added_repo(
             graph_builder,
             repo_structure,
             repo_path.name,
+            repo_path=repo_path,
         )
 
         url = get_db_url_for_repo(repo_path)

--- a/packages/cli/src/repowise/cli/cost_estimator/coverage.py
+++ b/packages/cli/src/repowise/cli/cost_estimator/coverage.py
@@ -52,6 +52,7 @@ def compute_coverage_options(
     repo_path: Path | str | None = None,
     skip_tests: bool = False,
     skip_infra: bool = False,
+    kg_modules: list[dict] | None = None,
     percentages: tuple[float, ...] = DEFAULT_COVERAGE_OPTIONS,
     recommended: float = RECOMMENDED_COVERAGE,
 ) -> list[CoverageOption]:
@@ -66,7 +67,8 @@ def compute_coverage_options(
     for pct in percentages:
         cfg = replace(base_config, coverage_pct=pct, max_pages_pct=pct)
         plans = build_generation_plan(
-            parsed_files, graph_builder, cfg, skip_tests, skip_infra
+            parsed_files, graph_builder, cfg, skip_tests, skip_infra,
+            kg_modules=kg_modules,
         )
         est = estimate_cost(
             plans,

--- a/packages/cli/src/repowise/cli/cost_estimator/plans.py
+++ b/packages/cli/src/repowise/cli/cost_estimator/plans.py
@@ -22,6 +22,7 @@ def build_generation_plan(
     config: Any,
     skip_tests: bool = False,
     skip_infra: bool = False,
+    kg_modules: list[dict] | None = None,
 ) -> list[PageTypePlan]:
     """Return the per-page-type plan that ``generate_all`` will execute.
 
@@ -35,6 +36,11 @@ def build_generation_plan(
         Finalized GraphBuilder (build() already called).
     config:
         GenerationConfig — its ``coverage_pct`` drives the budget.
+    kg_modules:
+        Curated wiki modules from the KG artifact, when available. Must be
+        passed for ``module_grouping="curated"`` estimates to match the
+        actual run — without it the selector falls back to community
+        grouping, exactly as generation itself would without an artifact.
     """
     files = parsed_files
     if skip_tests:
@@ -63,6 +69,7 @@ def build_generation_plan(
             sccs=sccs,
             git_meta_map=None,
             config=config,
+            kg_modules=kg_modules,
         )
     )
 

--- a/packages/cli/src/repowise/cli/state_persistence.py
+++ b/packages/cli/src/repowise/cli/state_persistence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -22,16 +23,33 @@ def build_kg_state(kg: Any) -> dict[str, Any]:
     }
 
 
-def save_knowledge_graph_json(repo_path: Path, kg: Any) -> None:
+def save_knowledge_graph_json(repo_path: Path, kg: Any, *, portable: bool = False) -> None:
     """Write ``.repowise/knowledge-graph.json`` for a KG result.
 
     No-op when the result can't serialize itself (``to_dict`` missing), so
     callers only need to guard against a ``None`` knowledge graph.
+
+    When ``portable`` is set, write the self-contained, self-validated artifact
+    (curated layers + tour + entry points + summaries + a ``meta``/``validation``
+    block) instead of the bare ``to_dict`` output. Hard invariant violations are
+    logged but the artifact is still emitted, with the failures recorded under
+    ``meta.validation`` so a consumer can see them ("repaired, not rejected").
     """
     if not hasattr(kg, "to_dict"):
         return
     import json
 
+    if portable:
+        from repowise.core.analysis.kg_curation import build_portable_kg
+
+        data, validation = build_portable_kg(kg)
+        if not validation.ok:
+            logging.getLogger(__name__).warning(
+                "portable KG failed invariants: %s", "; ".join(validation.errors)
+            )
+    else:
+        data = kg.to_dict()
+
     kg_json_path = repo_path / ".repowise" / "knowledge-graph.json"
     kg_json_path.parent.mkdir(parents=True, exist_ok=True)
-    kg_json_path.write_text(json.dumps(kg.to_dict(), indent=2), encoding="utf-8")
+    kg_json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/packages/core/src/repowise/core/analysis/communities.py
+++ b/packages/core/src/repowise/core/analysis/communities.py
@@ -21,6 +21,8 @@ from pathlib import PurePosixPath
 import networkx as nx
 import structlog
 
+from repowise.core.analysis.kg_curation import GENERIC_ORG_SEGMENTS, dominant_segments
+
 log = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -40,15 +42,10 @@ _SYMBOL_COMMUNITY_EDGE_TYPES = frozenset({
     "calls", "extends", "implements", "has_method",
 })
 
-# Generic directory segments excluded from heuristic labeling.
-# These are organisational containers, not meaningful domain labels.
-_GENERIC_SEGMENTS = frozenset({
-    "src", "lib", "core", "common", "shared", "internal", "pkg",
-    "main", "app", "utils", "helpers", "index", "mod",
-    # Monorepo organisational directories
-    "packages", "modules", "workspace", "workspaces", "libs",
-    "projects", "services", "apps",
-})
+# Generic directory segments excluded from heuristic labeling — the shared
+# organisational-container vocabulary lives in kg_curation next to its
+# data-driven complement (dominant_segments).
+_GENERIC_SEGMENTS = GENERIC_ORG_SEGMENTS
 
 # Keywords checked in filename stems for fallback labeling
 _LABEL_KEYWORDS = (
@@ -125,8 +122,11 @@ def _partition(G: nx.Graph) -> tuple[dict, str]:
     try:
         from graspologic.partition import leiden
 
+        leiden_kwargs: dict = {}
+        if "random_seed" in inspect.signature(leiden).parameters:
+            leiden_kwargs["random_seed"] = 42  # determinism (matches louvain's seed)
         with _suppress_graspologic_output():
-            result = leiden(G)
+            result = leiden(G, **leiden_kwargs)
         return result, "leiden"
     except ImportError:
         pass
@@ -211,7 +211,9 @@ def _cohesion_score(G: nx.Graph, community_nodes: list[str]) -> float:
 # ---------------------------------------------------------------------------
 
 
-def _collect_path_segments(member_paths: list[str]) -> Counter[str]:
+def _collect_path_segments(
+    member_paths: list[str], extra_generic: frozenset[str] = frozenset()
+) -> Counter[str]:
     """Count non-generic directory segments across all member paths.
 
     Each path contributes at most once per segment to avoid
@@ -223,14 +225,21 @@ def _collect_path_segments(member_paths: list[str]) -> Counter[str]:
         seen: set[str] = set()
         for part in parts[:-1]:  # exclude filename
             lower = part.lower()
-            if lower not in _GENERIC_SEGMENTS and len(lower) > 1 and not lower.startswith("."):
+            if (
+                lower not in _GENERIC_SEGMENTS
+                and lower not in extra_generic
+                and len(lower) > 1
+                and not lower.startswith(".")
+            ):
                 if lower not in seen:
                     counter[lower] += 1
                     seen.add(lower)
     return counter
 
 
-def _best_sub_label(member_paths: list[str], primary: str) -> str:
+def _best_sub_label(
+    member_paths: list[str], primary: str, extra_generic: frozenset[str] = frozenset()
+) -> str:
     """Find the best distinguishing sub-segment within paths that contain *primary*.
 
     Given a community labeled "web", looks at paths containing "web" and
@@ -252,6 +261,7 @@ def _best_sub_label(member_paths: list[str], primary: str) -> str:
             if (
                 lower != primary_lower
                 and lower not in _GENERIC_SEGMENTS
+                and lower not in extra_generic
                 and len(lower) > 1
                 and not lower.startswith(".")
                 and lower not in seen
@@ -267,24 +277,30 @@ def _best_sub_label(member_paths: list[str], primary: str) -> str:
     return ""
 
 
-def _heuristic_label(member_paths: list[str], community_id: int) -> str:
+def _heuristic_label(
+    member_paths: list[str],
+    community_id: int,
+    extra_generic: frozenset[str] = frozenset(),
+) -> str:
     """Derive a human-readable label from member file paths.
 
-    Produces labels like ``"web/components"`` or ``"repowise/ingestion"``.
+    Produces labels like ``"web/components"`` or ``"core/ingestion"``.
     When multiple communities share the same top-level segment, the
-    sub-label differentiates them.
+    sub-label differentiates them. *extra_generic* carries repo-dominant
+    namespace segments (the repo's own name, ``src``…) that must never
+    become labels.
     """
     if not member_paths:
         return f"cluster_{community_id}"
 
     # Strategy 1: most common non-generic directory segment
-    seg_counter = _collect_path_segments(member_paths)
+    seg_counter = _collect_path_segments(member_paths, extra_generic)
 
     if seg_counter:
         best_seg, best_count = seg_counter.most_common(1)[0]
         if best_count / len(member_paths) >= 0.4:
             # Try to find a distinguishing sub-segment
-            sub = _best_sub_label(member_paths, best_seg)
+            sub = _best_sub_label(member_paths, best_seg, extra_generic)
             return f"{best_seg}/{sub}" if sub else best_seg
 
     # Strategy 2: keyword frequency in filenames
@@ -304,7 +320,7 @@ def _heuristic_label(member_paths: list[str], community_id: int) -> str:
     stem_counter2: Counter[str] = Counter()
     for path in member_paths:
         stem = PurePosixPath(path).stem.lower()
-        if stem not in _GENERIC_SEGMENTS and len(stem) > 1:
+        if stem not in _GENERIC_SEGMENTS and stem not in extra_generic and len(stem) > 1:
             stem_counter2[stem] += 1
     if stem_counter2:
         return stem_counter2.most_common(1)[0][0]
@@ -312,7 +328,10 @@ def _heuristic_label(member_paths: list[str], community_id: int) -> str:
     return f"cluster_{community_id}"
 
 
-def _deduplicate_labels(communities_info: dict[int, "CommunityInfo"]) -> None:
+def _deduplicate_labels(
+    communities_info: dict[int, "CommunityInfo"],
+    extra_generic: frozenset[str] = frozenset(),
+) -> None:
     """Add sub-labels to disambiguate communities that share the same label.
 
     Mutates *communities_info* in place.  Only touches communities whose
@@ -334,7 +353,7 @@ def _deduplicate_labels(communities_info: dict[int, "CommunityInfo"]) -> None:
             if "/" in ci.label:
                 continue  # already has a sub-label
 
-            sub = _best_sub_label(ci.members, base)
+            sub = _best_sub_label(ci.members, base, extra_generic)
             if sub:
                 ci.label = f"{base}/{sub}"
 
@@ -430,10 +449,12 @@ def detect_file_communities(
         - algorithm_used: "leiden" or "louvain"
     """
     # Extract file nodes (exclude external nodes — they're structural noise)
-    file_nodes = [
+    # Sorted: node order seeds the undirected graph's insertion order, and
+    # Louvain/Leiden partitions depend on iteration order even when seeded.
+    file_nodes = sorted(
         n for n, d in graph.nodes(data=True)
         if d.get("node_type", "file") == "file"
-    ]
+    )
 
     if not file_nodes:
         return {}, {}, "none"
@@ -449,11 +470,16 @@ def detect_file_communities(
     undirected = nx.Graph()
     undirected.add_nodes_from(prod_nodes)
 
-    for u, v, d in graph.edges(data=True):
-        edge_type = d.get("edge_type", "imports")
-        if edge_type in _FILE_COMMUNITY_EDGE_TYPES and u in undirected and v in undirected:
-            if not undirected.has_edge(u, v):
-                undirected.add_edge(u, v)
+    # Sorted for the same reason: edge insertion order shifts the partition
+    # (co-change edges arrive in git-indexer thread-completion order).
+    community_edges = sorted(
+        (u, v)
+        for u, v, d in graph.edges(data=True)
+        if d.get("edge_type", "imports") in _FILE_COMMUNITY_EDGE_TYPES
+        and u in undirected
+        and v in undirected
+    )
+    undirected.add_edges_from(community_edges)
 
     # Separate isolates
     isolates = [n for n in undirected.nodes() if undirected.degree(n) == 0]
@@ -506,11 +532,15 @@ def detect_file_communities(
             if not full_undirected.has_edge(u, v):
                 full_undirected.add_edge(u, v)
 
+    # Repo-dominant namespace segments (the repo's own package name, ``src``…)
+    # are noise, not labels — same data-driven stripping as module naming.
+    extra_generic = frozenset(s.lower() for s in dominant_segments(sorted(file_nodes)))
+
     for cid, members in community_members.items():
         sorted_members = sorted(members)
         communities_info[cid] = CommunityInfo(
             community_id=cid,
-            label=_heuristic_label(sorted_members, cid),
+            label=_heuristic_label(sorted_members, cid, extra_generic),
             members=sorted_members,
             size=len(sorted_members),
             cohesion=_cohesion_score(full_undirected, sorted_members),
@@ -519,7 +549,7 @@ def detect_file_communities(
 
     # Deduplicate labels — add sub-labels when multiple communities
     # share the same base (e.g. "web" → "web/components", "web/api")
-    _deduplicate_labels(communities_info)
+    _deduplicate_labels(communities_info, extra_generic)
 
     log.info(
         "file_communities_detected",

--- a/packages/core/src/repowise/core/analysis/kg_curation.py
+++ b/packages/core/src/repowise/core/analysis/kg_curation.py
@@ -1,0 +1,1770 @@
+"""Curation/presentation pass over the deterministic KG skeleton.
+
+The exported knowledge graph is a *presentation* artifact, distinct from the
+AST/dependency graph that powers queries. This module is the single seam where
+the skeleton produced by :func:`build_knowledge_graph_skeleton` is reshaped into
+something a human (or an AI reading the graph cold) can navigate: bounded,
+dependency-ordered layers; a capped, ranked set of real entry points; one
+canonical execution-flow tour; typed infra/CI/data nodes; and never-empty
+summaries.
+
+**Hard invariant.** Curation reads the NetworkX graph, communities, and
+centrality, but it *only ever writes the returned* :class:`KnowledgeGraphResult`.
+It never mutates ``graph_builder``'s graph, ``graph_edges``, centrality caches,
+community detection, or any DB table. There is a regression test that asserts the
+graph's node/edge counts are identical before and after this pass.
+
+Curation is feature-flagged (``REPOWISE_KG_CURATION``) and defaults **on**;
+the 38-repo cross-language validation matrix is the acceptance gate that
+flipped it. Setting the flag to ``0``/``false``/``no``/``off`` makes
+:func:`curate_knowledge_graph` a no-op that returns its input unchanged
+(the raw uncurated export).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any
+
+from repowise.core.analysis.knowledge_graph import KnowledgeGraphResult, _slugify
+from repowise.core.generation.layers import (
+    ADJACENT_LAYERS,
+    compute_layer_order,
+    infer_layer,
+    is_support_path,
+    layer_order_basis,
+)
+from repowise.core.generation.tour import (
+    DEFAULT_MAX_STOPS,
+    build_tour,
+    score_entry_points,
+)
+from repowise.core.ingestion.languages.registry import REGISTRY as _LANG_REGISTRY
+
+# Closing-stop anchors (conftest, spec_helper, test_helper, …) and
+# declaration descriptors (module-info.java) — both registry-declared.
+_SUITE_ANCHOR_STEMS: frozenset[str] = _LANG_REGISTRY.suite_anchor_stems()
+_DESCRIPTOR_FILENAMES: frozenset[str] = _LANG_REGISTRY.descriptor_filenames()
+# Test-fixture filename shapes (FooFixtures.java) — case-sensitive,
+# per-extension; fixture files hold test data, they never face the suite.
+_FIXTURE_CAMEL_RES = _LANG_REGISTRY.camel_fixture_res_by_extension()
+# Test-project dir suffixes (.Tests/.Specs) — when present, the suite's
+# face must come from inside one.
+_TEST_PROJECT_DIR_SUFFIXES: tuple[str, ...] = _LANG_REGISTRY.test_dir_suffixes()
+
+# Honest-degradation thresholds. Density = (imports + tested_by)
+# edges per dominant-language file — the same definition the validation
+# harness uses, calibrated on the 13-repo matrix: express (1.89, broken CJS
+# resolution) and sinatra (1.48, broken require resolution) land in
+# "sparse"; every healthy repo sits at ≥ 2.2. Repos below the file floor
+# skip the density check — density on a 7-file repo is noise, not evidence.
+# Low density alone stops indicting the resolver once the resolution rate
+# (internal targets / all targets) is strong: stdlib filtering makes an
+# honestly-resolved Ruby gem land at ~1.3 edges/file with 0.77 resolution —
+# that graph isn't lying, it's just require-light.
+_FLOW_DENSITY_FLOOR = 2.0
+_FLOW_RESOLUTION_FLOOR = 0.7
+_STRUCTURAL_DENSITY_FLOOR = 0.3
+_MODE_MIN_FILES = 25
+
+
+def _is_fixture_shaped(path: str) -> bool:
+    """True when the filename matches its language's fixture convention."""
+    pp = PurePosixPath(path)
+    fixture_re = _FIXTURE_CAMEL_RES.get(pp.suffix.lower())
+    return fixture_re is not None and fixture_re.search(pp.stem) is not None
+
+
+def _graph_mode(dominant_lang: str, lang_by_path: dict[str, str], graph_builder: Any) -> str:
+    """Classify how much the import graph can honestly claim.
+
+    ``flow``       — full resolver support and healthy density: the tour may
+                     narrate execution flow.
+    ``sparse``     — partial support, or full support with suspiciously low
+                     density: BFS still walks, but reasons must not blame
+                     files for the resolver's gaps.
+    ``structural`` — no resolver (or a near-edgeless graph): no execution
+                     claims at all; the tour walks the repo's structure.
+    """
+    support = _LANG_REGISTRY.import_support_for(dominant_lang)
+    if support == "none":
+        return "structural"
+    dom_files = {p for p, lang in lang_by_path.items() if lang == dominant_lang}
+    if not dom_files:
+        return "structural"
+    edge_count = 0
+    internal_targets = 0
+    external_targets = 0
+    try:
+        for src, dst, data in graph_builder.graph().edges(data=True):
+            if (data or {}).get("edge_type") in ("imports", "tested_by") and src in dom_files:
+                edge_count += 1
+                if isinstance(dst, str) and dst.startswith("external:"):
+                    external_targets += 1
+                else:
+                    internal_targets += 1
+    except Exception:  # pragma: no cover - defensive
+        return "flow" if support == "full" else "sparse"
+    total = internal_targets + external_targets
+    resolution = (internal_targets / total) if total else 0.0
+    if len(dom_files) < _MODE_MIN_FILES:
+        # Density is unmeasurable on tiny repos, but resolution is not: a
+        # partial-tier repo whose imports resolve cleanly must not have its
+        # tour blame "incomplete import resolution" just for being small.
+        if support == "full" or (total and resolution >= _FLOW_RESOLUTION_FLOOR):
+            return "flow"
+        return "sparse"
+    density = edge_count / len(dom_files)
+    if density < _STRUCTURAL_DENSITY_FLOOR:
+        return "structural"
+    # Partial-tier languages run in flow or sparse per their REAL density
+    # and resolution, exactly like full-tier ones: a regex-tier resolver
+    # that resolves 0.95+ of an Elixir repo's aliases must not have its
+    # tour blame "incomplete import resolution" — that would be the lie
+    # this mode exists to prevent, inverted.
+    # Low density indicts the resolver only when resolution is ALSO
+    # weak — a require-light but well-resolved graph narrates honestly.
+    if density < _FLOW_DENSITY_FLOOR and resolution < _FLOW_RESOLUTION_FLOOR:
+        return "sparse"
+    return "flow"
+
+__all__ = [
+    "KGValidation",
+    "apply_summary_floor",
+    "build_portable_kg",
+    "curate_knowledge_graph",
+    "curation_enabled",
+    "derive_modules",
+    "validate_kg",
+]
+
+logger = logging.getLogger(__name__)
+
+
+_FLAG_ENV = "REPOWISE_KG_CURATION"
+
+# A primary layer larger than this many files, or spanning more than this many
+# distinct sub-directories, is given a two-level structure (primary → named
+# sub-groups) so a mega-layer like core/* or ui/* stays drill-down legible
+# instead of becoming one opaque bucket (plan §Phase 1, edge case B).
+_SUBSPLIT_FILE_THRESHOLD = 60
+_SUBSPLIT_DIR_THRESHOLD = 8
+
+# Hard bound on the curated primary-layer count. The spine is bounded ≤~11 by
+# construction; if a future change ever blows past this we degrade to the
+# uncurated layers rather than ship an unreadable list.
+_MAX_LAYERS = 15
+
+# Entry-point precision (plan §Phase 2). A re-export *barrel* (typically an
+# ``index.ts``) carries the ``index`` stem heuristic's ``entry_point`` flag but
+# teaches a reader nothing, so it is demoted in the presentation view. Runtime
+# entries that survive are ranked by ``pagerank + betweenness`` and the surfaced
+# set is capped — the full ranked list is kept as ``entry_candidates``.
+_BARREL_STEMS = frozenset({"index"})
+_SUBSTANTIVE_KINDS = frozenset(
+    {"function", "method", "class", "struct", "interface", "enum", "trait", "impl", "macro"}
+)
+_MAX_ENTRY_POINTS = 8
+
+
+def curation_enabled() -> bool:
+    """Whether KG curation is enabled via the ``REPOWISE_KG_CURATION`` env flag.
+
+    Defaults to **on** — the cross-language validation matrix (38 pinned
+    repos, enforced density/orphan/catch-all thresholds, honest degradation
+    modes) is the acceptance gate that flipped it. Set ``0``/``false``/``no``/
+    ``off`` (case-insensitive) to fall back to the raw uncurated export.
+    Resolved at the call site so :func:`curate_knowledge_graph` itself stays
+    pure and trivially testable with an explicit ``enabled=``.
+    """
+    return os.environ.get(_FLAG_ENV, "").strip().lower() not in {"0", "false", "no", "off"}
+
+
+def curate_knowledge_graph(
+    kg: KnowledgeGraphResult,
+    *,
+    parsed_files: list[Any],
+    graph_builder: Any,
+    repo_structure: Any,
+    community_info: Any,
+    enabled: bool = False,
+    defer_summary_floor: bool = False,
+) -> KnowledgeGraphResult:
+    """Reshape the KG skeleton into an intuitive presentation artifact.
+
+    Pure with respect to the AST graph: reads ``graph_builder`` /
+    ``community_info`` but writes only the returned result. When ``enabled`` is
+    ``False`` this is a strict no-op returning ``kg`` unchanged (the default, so
+    the exported KG is unaffected until the flag flips).
+
+    ``defer_summary_floor`` skips the never-empty summary floor here so it can
+    run *after* the wiki-page backfill in generate mode (where richer summaries
+    exist); FAST mode leaves it ``False`` so the floor still lands at this seam.
+
+    Each curation step is guarded so that a failure degrades to the prior
+    (uncurated) field rather than aborting the export.
+    """
+    if not enabled:
+        return kg
+
+    # Each step mutates only ``kg`` (the presentation result) and is guarded so
+    # a failure degrades to the prior, uncurated field rather than aborting the
+    # export. Steps are layered in by subsequent phases:
+    #   _curate_layers -> _curate_entry_points -> _curate_tour
+    #   -> _curate_node_types -> _curate_summaries
+    layers_curated = False
+    try:
+        curated = _curate_layers(kg, graph_builder)
+        if curated is not None:
+            kg.layers = curated
+            layers_curated = True
+    except Exception:  # pragma: no cover - defensive; keep uncurated layers
+        logger.exception("kg_curation._curate_layers failed; keeping community layers")
+
+    # Wiki modules are a *sibling* artifact of the curated layers (same
+    # splitting machinery, module-sized granularity). Only derived when the
+    # spine landed — community layers would make the dir-split meaningless,
+    # and downstream consumers fall back to community grouping when this
+    # stays empty (the fallback matrix's "degraded" row).
+    if layers_curated:
+        try:
+            modules = _curate_modules(kg)
+            if modules is not None:
+                kg.modules = modules
+        except Exception:  # pragma: no cover - defensive; ship no modules
+            logger.exception("kg_curation._curate_modules failed; exporting no modules")
+
+    try:
+        _curate_entry_points(kg, parsed_files, graph_builder)
+    except Exception:  # pragma: no cover - defensive; keep skeleton entry points
+        logger.exception("kg_curation._curate_entry_points failed; keeping raw entry points")
+
+    try:
+        tour = _curate_tour(kg, parsed_files, graph_builder)
+        if tour is not None:
+            kg.tour = tour
+    except Exception:  # pragma: no cover - defensive; keep skeleton/LLM tour
+        logger.exception("kg_curation._curate_tour failed; keeping existing tour")
+
+    try:
+        _curate_node_types(kg)
+    except Exception:  # pragma: no cover - defensive; keep skeleton types
+        logger.exception("kg_curation._curate_node_types failed; keeping coarse types")
+
+    if not defer_summary_floor:
+        try:
+            apply_summary_floor(kg, parsed_files)
+        except Exception:  # pragma: no cover - defensive; leave summaries as-is
+            logger.exception("kg_curation summary floor failed; leaving summaries empty")
+
+    return kg
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — curated layers (replace raw-community layers with the spine)
+# ---------------------------------------------------------------------------
+
+
+def _file_nodes(kg: KnowledgeGraphResult) -> list[dict]:
+    """Return the file-typed nodes of *kg* (ids prefixed ``file:``)."""
+    return [
+        n
+        for n in kg.nodes
+        if isinstance(n.get("id"), str)
+        and n["id"].startswith("file:")
+        and isinstance(n.get("filePath"), str)
+    ]
+
+
+def _file_import_edges(graph_builder: Any) -> list[tuple[str, str]]:
+    """``(src, dst)`` string edges from the AST graph (src imports dst).
+
+    ``imports`` edges only (hint-sourced ones included — they are import
+    semantics). The raw graph also carries ``contains`` (file → symbol),
+    ``co_change``, ``calls``, and heritage edges; letting those through made
+    "execution flow" claims ride on symbol counts and change-history
+    coupling — a giant declarations header would out-rank every real entry
+    as the walk's widest-fan-out anchor. Externals are naturally ignored
+    downstream by :func:`compute_layer_order`, which only counts edges whose
+    endpoints are both in ``file_layers``.
+    """
+    edges: list[tuple[str, str]] = []
+    try:
+        g = graph_builder.graph()
+        for src, dst, data in g.edges(data=True):
+            if not (isinstance(src, str) and isinstance(dst, str)):
+                continue
+            if data.get("edge_type", "imports") != "imports":
+                continue
+            edges.append((src, dst))
+    except Exception:  # pragma: no cover - defensive
+        pass
+    return edges
+
+
+def _common_dir_prefix(seg_lists: list[tuple[str, ...]]) -> tuple[str, ...]:
+    """Longest common leading directory-segment prefix across *seg_lists*."""
+    if not seg_lists:
+        return ()
+    common = list(seg_lists[0])
+    for segs in seg_lists[1:]:
+        i = 0
+        while i < len(common) and i < len(segs) and common[i] == segs[i]:
+            i += 1
+        del common[i:]
+        if not common:
+            break
+    return tuple(common)
+
+
+def _sub_split(layer_id: str, node_ids: list[str], id_to_path: dict[str, str]) -> list[dict] | None:
+    """Two-level sub-groups for an oversized/wide primary layer, else ``None``.
+
+    Groups files by the first path segment that distinguishes them (the segment
+    after the layer's common directory prefix), so e.g. ``core/ingestion`` /
+    ``core/analysis`` / ``core/generation`` become named sub-groups. Only kicks
+    in past the size/width thresholds and only when it yields ≥2 groups.
+    """
+    if len(node_ids) < 2:
+        return None
+
+    dir_segs = {nid: PurePosixPath(id_to_path[nid]).parts[:-1] for nid in node_ids}
+    common = _common_dir_prefix(list(dir_segs.values()))
+
+    groups: dict[str, list[str]] = defaultdict(list)
+    for nid in node_ids:
+        segs = dir_segs[nid]
+        key = segs[len(common)] if len(segs) > len(common) else "(root)"
+        groups[key].append(nid)
+
+    oversized = len(node_ids) > _SUBSPLIT_FILE_THRESHOLD
+    wide = len(groups) > _SUBSPLIT_DIR_THRESHOLD
+    if not (oversized or wide) or len(groups) < 2:
+        return None
+
+    return [
+        {"id": f"{layer_id}:{_slugify(name)}", "name": name, "nodeIds": groups[name]}
+        for name in sorted(groups)
+    ]
+
+
+def _curate_layers(kg: KnowledgeGraphResult, graph_builder: Any) -> list[dict] | None:
+    """Build bounded, dependency-ordered layers from the ``infer_layer`` spine.
+
+    Returns the curated layer list, or ``None`` to keep the existing
+    (community) layers when the result would be degenerate or violate the
+    partition / bound invariants. Every file lands in exactly one layer, so the
+    partition (Σ nodeIds == file-node count) and singleton-elimination hold by
+    construction.
+    """
+    file_nodes = _file_nodes(kg)
+    if not file_nodes:
+        return None
+
+    id_to_path = {n["id"]: n["filePath"] for n in file_nodes}
+    file_layers = {
+        n["filePath"]: infer_layer(n["filePath"], (n.get("language") or "").lower())
+        for n in file_nodes
+    }
+    import_edges = _file_import_edges(graph_builder)
+    order = compute_layer_order(file_layers, import_edges)
+    # Honesty label (additive export field): "imports" when inter-layer edges
+    # informed the order, "canonical" when it is pure convention — consumers
+    # must not claim "X sits above Y" for a canonical order.
+    order_basis = layer_order_basis(file_layers, import_edges)
+
+    by_layer: dict[str, list[str]] = defaultdict(list)
+    for n in file_nodes:
+        by_layer[file_layers[n["filePath"]]].append(n["id"])
+
+    layers: list[dict] = []
+    for display_order, layer_name in enumerate(order):
+        node_ids = by_layer[layer_name]
+        layer_id = f"layer:{_slugify(layer_name)}"
+        layer: dict[str, Any] = {
+            "id": layer_id,
+            "name": layer_name,
+            "description": "",
+            "nodeIds": node_ids,
+            "display_order": display_order,
+            "order_basis": order_basis,
+        }
+        sub_groups = _sub_split(layer_id, node_ids, id_to_path)
+        if sub_groups:
+            layer["subGroups"] = sub_groups
+        layers.append(layer)
+
+    # Degrade rather than ship a broken artifact: enforce bound + partition.
+    total = sum(len(layer["nodeIds"]) for layer in layers)
+    if not layers or len(layers) > _MAX_LAYERS or total != len(file_nodes):
+        logger.warning(
+            "kg_curation: curated layers failed invariant "
+            "(count=%d, partition=%d/%d); keeping community layers",
+            len(layers),
+            total,
+            len(file_nodes),
+        )
+        return None
+    return layers
+
+
+# ---------------------------------------------------------------------------
+# Wiki modules — right-sized directory groups derived from the curated layers
+# ---------------------------------------------------------------------------
+
+# Granularity window for derived wiki modules. Sub-groups verbatim are NOT
+# module-sized (a 452-file ``core`` sub-group would make one vague mush of a
+# doc; a 1-file ``examples`` group would mint a confetti page), so the layer
+# node sets are split *recursively* by directory until every group fits the
+# window — bottoming out honestly on flat directories. ``target_max`` keeps
+# the 10 key-file template slots representative; ``target_min`` is the
+# merge-up floor below which a group folds into its nearest sibling.
+_MODULE_TARGET_MIN = 8
+_MODULE_TARGET_MAX = 120
+# A layer smaller than this yields no module at all (matches the selection
+# layer's ``min_module_size`` floor that kills singleton pages).
+_MODULE_MIN_FILES = 3
+# A directory segment present in more than this fraction of all repo paths is
+# *generic* (namespace dirs: ``src``, ``packages``, the repo's own name) and
+# never appears in a module name. Data-driven — no hardcoded segment list.
+_GENERIC_SEGMENT_FRACTION = 0.60
+# The legacy community labels' size-suffix dedupe ("ingestion (32)") is the
+# exact failure mode module names must never reproduce.
+_SIZE_SUFFIX_RE = re.compile(r"\(\d+\)\s*$")
+
+
+# Universal organizational directory names — containers, not domain labels.
+# Shared with community labeling; the data-driven ``dominant_segments`` set
+# complements this with per-repo namespace noise (the repo's own name).
+GENERIC_ORG_SEGMENTS = frozenset({
+    "src", "lib", "core", "common", "shared", "internal", "pkg",
+    "main", "app", "utils", "helpers", "index", "mod",
+    # Monorepo organisational directories
+    "packages", "modules", "workspace", "workspaces", "libs",
+    "projects", "services", "apps",
+})
+
+
+def dominant_segments(paths: list[str]) -> set[str]:
+    """Directory segments appearing in > 60% of *paths* (namespace noise).
+
+    Shared with community labeling (``analysis/communities.py``) so both
+    vocabularies strip the same namespace dirs (``src``, ``packages``, the
+    repo's own name) without depending on a hardcoded list.
+    """
+    n = len(paths)
+    if not n:
+        return set()
+    counts: Counter[str] = Counter()
+    for p in paths:
+        for seg in set(PurePosixPath(p).parts[:-1]):
+            counts[seg] += 1
+    return {s for s, c in counts.items() if c / n > _GENERIC_SEGMENT_FRACTION}
+
+
+def _split_to_granularity(
+    node_ids: list[str], id_to_path: dict[str, str], target_max: int
+) -> list[tuple[tuple[str, ...], list[str]]]:
+    """Recursively split *node_ids* by directory until groups fit *target_max*.
+
+    Returns ``[(dir_segments, sorted_node_ids), ...]``. Reuses ``_sub_split``'s
+    prefix logic (group by the first segment that distinguishes members after
+    the common directory prefix) but, unlike sub-groups, recurses into any
+    group still above ``target_max``. Recursion bottoms out when a directory
+    has no distinguishing subdirs — a 200-file flat dir stays one module
+    (honest), never an artificial split.
+    """
+    dir_segs = {nid: PurePosixPath(id_to_path[nid]).parts[:-1] for nid in node_ids}
+
+    def rec(ids: list[str]) -> list[tuple[tuple[str, ...], list[str]]]:
+        common = _common_dir_prefix([dir_segs[i] for i in ids])
+        if len(ids) <= target_max:
+            return [(common, ids)]
+        groups: dict[str, list[str]] = defaultdict(list)
+        for nid in ids:
+            segs = dir_segs[nid]
+            key = segs[len(common)] if len(segs) > len(common) else ""
+            groups[key].append(nid)
+        if len(groups) < 2:
+            return [(common, ids)]  # flat directory — no honest split exists
+        out: list[tuple[tuple[str, ...], list[str]]] = []
+        for key in sorted(groups):
+            if key == "":
+                # Files sitting directly in the common dir (the "(root)"
+                # group). Usually below target_min → folded by merge-up.
+                out.append((common, groups[key]))
+            else:
+                out.extend(rec(groups[key]))
+        return out
+
+    return [(d, sorted(ids)) for d, ids in rec(sorted(node_ids))]
+
+
+def _merge_small_groups(
+    groups: list[tuple[tuple[str, ...], list[str]]], target_min: int
+) -> list[tuple[tuple[str, ...], list[str]]]:
+    """Fold groups below *target_min* into their nearest sibling.
+
+    "Nearest" = the group sharing the longest directory prefix (the parent
+    subtree), largest first as the tie-break — so a 2-file "(root)" remnant
+    folds into its own subtree's biggest module, and an isolated small dir
+    folds into the layer's dominant module rather than minting a confetti
+    page. Never merges across layers (callers pass one layer at a time). A
+    layer that is itself below ``target_min`` stays one whole group.
+
+    A pre-pass fuses *small sibling* groups into one group at their common
+    parent when that collection is itself module-sized — ninety tiny locale
+    dirs become one ``conf/locale`` module instead of folding into whichever
+    sibling sorts first and misnaming it. The fold-in loop then never renames
+    a survivor: a healthy ``core/providers`` absorbing a 2-file sibling keeps
+    its identity.
+    """
+    merged = [(d, list(ids)) for d, ids in groups]
+
+    by_parent: dict[tuple[str, ...], list[tuple[tuple[str, ...], list[str]]]] = {}
+    for g in merged:
+        if len(g[1]) < target_min and len(g[0]) > 0:
+            by_parent.setdefault(g[0][:-1], []).append(g)
+    for parent, sibs in sorted(by_parent.items()):
+        if len(sibs) < 2 or sum(len(g[1]) for g in sibs) < target_min:
+            continue
+        fused = sorted(nid for g in sibs for nid in g[1])
+        for g in sibs:
+            merged.remove(g)
+        existing = next((g for g in merged if g[0] == parent), None)
+        if existing is not None:
+            existing[1].extend(fused)
+            existing[1].sort()
+        else:
+            merged.append((parent, fused))
+    merged.sort(key=lambda g: g[0])
+
+    def shared(a: tuple[str, ...], b: tuple[str, ...]) -> int:
+        return len(_common_dir_prefix([a, b]))
+
+    while len(merged) > 1:
+        small = min(
+            (g for g in merged if len(g[1]) < target_min),
+            key=lambda g: (len(g[1]), g[0]),
+            default=None,
+        )
+        if small is None:
+            break
+        merged.remove(small)
+        target = min(
+            merged,
+            key=lambda g: (-shared(g[0], small[0]), -len(g[1]), g[0]),
+        )
+        target[1].extend(small[1])
+        target[1].sort()
+    return [(d, ids) for d, ids in merged]
+
+
+def _name_modules(mods: list[dict], generic: set[str]) -> None:
+    """Assign unique, human module names in place.
+
+    Initial name = the last one or two *informative* directory segments
+    (generic namespace segments stripped; when stripping consumes every
+    segment, the raw tail is used instead). Collisions extend leftward by
+    one more parent segment — NEVER a size suffix. Single-module layers
+    take the layer's name; the root group (empty dir) becomes
+    "<Layer> (top-level)". The absolute fallback (identical informative
+    paths across layers) appends the layer name, which is unique by
+    construction.
+    """
+    per_layer: Counter[str] = Counter(m["layerId"] for m in mods)
+    info_by: dict[int, list[str]] = {}
+    used: dict[int, int | None] = {}  # informative segments consumed; None = fixed
+    for m in mods:
+        # Data-driven stripping can consume EVERY segment on fixture-dominated
+        # repos (aeson: tests/JSONTestSuite/test_parsing is >60% of all
+        # paths). The raw dir tail is still the honest name there —
+        # "(top-level)" would mislabel a real directory and collide across
+        # sibling groups (which trips the export degradation guard and ships
+        # no modules). Universal organizational dirs (pkg, src, packages…)
+        # stay excluded even in the fallback: "(top-level)" reads better than
+        # a container name, so it remains the name for true root groups.
+        info = [s for s in m["_dir"] if s not in generic] or [
+            s for s in m["_dir"] if s.lower() not in GENERIC_ORG_SEGMENTS
+        ]
+        info_by[id(m)] = info
+        if per_layer[m["layerId"]] == 1:
+            m["name"] = m["_layerName"]
+            used[id(m)] = None
+        elif not info:
+            m["name"] = f"{m['_layerName']} (top-level)"
+            used[id(m)] = None
+        else:
+            k = min(2, len(info))
+            m["name"] = "/".join(info[-k:])
+            used[id(m)] = k
+
+    for _ in range(16):  # bounded: each round consumes ≥1 segment somewhere
+        names = Counter(m["name"] for m in mods)
+        colliding = [m for m in mods if names[m["name"]] > 1]
+        if not colliding:
+            return
+        progressed = False
+        for m in colliding:
+            k = used.get(id(m))
+            info = info_by[id(m)]
+            if k is not None and k < len(info):
+                used[id(m)] = k + 1
+                m["name"] = "/".join(info[-(k + 1) :])
+                progressed = True
+        if not progressed:
+            break
+
+    # Two all-organizational groups in one layer (a root remnant plus a
+    # "packages"-style container) would both read "<Layer> (top-level)" —
+    # the container's raw tail is the honest tiebreak.
+    names = Counter(m["name"] for m in mods)
+    for m in mods:
+        if names[m["name"]] > 1 and not info_by[id(m)] and m["_dir"]:
+            m["name"] = "/".join(m["_dir"][-min(2, len(m["_dir"])) :])
+
+    # Same informative dir in two layers (or no segments left): the layer
+    # name disambiguates — (dir, layer) is unique by construction.
+    names = Counter(m["name"] for m in mods)
+    for m in mods:
+        if names[m["name"]] > 1:
+            m["name"] = f"{m['name']} ({m['_layerName']})"
+
+    # Absolute backstop (two all-org dirs in one layer sharing a tail): the
+    # full dir path is unique per layer.
+    names = Counter(m["name"] for m in mods)
+    for m in mods:
+        if names[m["name"]] > 1 and m["_dir"]:
+            m["name"] = "/".join(m["_dir"])
+
+
+def derive_modules(
+    layers: list[dict],
+    id_to_path: dict[str, str],
+    *,
+    target_min: int = _MODULE_TARGET_MIN,
+    target_max: int = _MODULE_TARGET_MAX,
+    min_module_size: int = _MODULE_MIN_FILES,
+    lang_by_id: dict[str, str] | None = None,
+) -> list[dict]:
+    """Derive right-sized, stably-identified wiki modules from curated layers.
+
+    ``Module = {"id": "module:<dir-slug>", "name": <human>, "path": <dir or "">,
+    "layerId": ..., "nodeIds": [...], "language": ...}``
+
+    Properties (each one an edge case from the research pass):
+
+    - **Partition per layer**: every node of every layer ≥ ``min_module_size``
+      lands in exactly one module; layers below the floor yield none. Never
+      merges across layers.
+    - **Granularity**: recursive directory splitting to the
+      [``target_min``, ``target_max``] window; flat dirs stay one honest
+      module; sub-``target_min`` remnants merge up into their subtree.
+    - **Names**: informative path segments only (data-driven generic-segment
+      stripping kills ``src``/``packages``/repo-name automatically); collision
+      resolution extends the path leftward — never a size suffix.
+    - **Ids**: ``module:`` + slug of the real directory path — stable across
+      runs and under file adds/renames inside the dir; changes only when the
+      directory itself moves. ``path`` is the actual dir (not the slug) so
+      path-prefix child lookups (``target_path LIKE 'dir/%'``) work.
+    - **Files only**: operates on ids present in ``id_to_path`` — external
+      nodes never pollute a module.
+    - **Determinism**: sorted iteration throughout; same inputs → same bytes.
+    """
+    generic = dominant_segments(sorted(set(id_to_path.values())))
+
+    mods: list[dict] = []
+    for layer in layers:
+        node_ids = [nid for nid in layer.get("nodeIds", []) if nid in id_to_path]
+        if len(node_ids) < min_module_size:
+            continue
+        groups = _merge_small_groups(
+            _split_to_granularity(node_ids, id_to_path, target_max), target_min
+        )
+        for dir_parts, ids in sorted(groups):
+            mods.append(
+                {
+                    "_dir": dir_parts,
+                    "_layerName": layer.get("name", ""),
+                    "path": "/".join(dir_parts),
+                    "layerId": layer.get("id", ""),
+                    "nodeIds": sorted(ids),
+                }
+            )
+
+    _name_modules(mods, generic)
+
+    # Ids: path-derived slugs; the bigger module keeps the plain id on the
+    # rare cross-layer dir collision (a dir whose files split across layers).
+    used_ids: set[str] = set()
+    for m in sorted(mods, key=lambda m: (-len(m["nodeIds"]), m["path"], m["layerId"])):
+        base = "module:" + _slugify(m["path"] or m["_layerName"])
+        mid = base
+        n = 1
+        while mid in used_ids:
+            mid = f"{base}--{_slugify(m['_layerName'])}" + ("" if n == 1 else f"-{n}")
+            n += 1
+        used_ids.add(mid)
+        m["id"] = mid
+
+    # A single-module layer is 1:1 with its layer page — mark it so page
+    # generation can skip the duplicate doc (the module stays in the
+    # artifact: canvas containers and the coverage invariant need it).
+    per_layer_count: Counter[str] = Counter(m["layerId"] for m in mods)
+
+    out: list[dict] = []
+    for m in mods:
+        module = {
+            "id": m["id"],
+            "name": m["name"],
+            "path": m["path"],
+            "layerId": m["layerId"],
+            "nodeIds": m["nodeIds"],
+        }
+        if per_layer_count[m["layerId"]] == 1:
+            module["wholeLayer"] = True
+        if lang_by_id is not None:
+            langs = Counter(
+                lang for nid in m["nodeIds"] if (lang := lang_by_id.get(nid, ""))
+            )
+            module["language"] = (
+                min(langs, key=lambda tag: (-langs[tag], tag)) if langs else ""
+            )
+        out.append(module)
+    return out
+
+
+def _curate_modules(kg: KnowledgeGraphResult) -> list[dict] | None:
+    """Derive wiki modules from the curated layers, or ``None`` on degradation.
+
+    Mirrors ``_curate_layers``' honest-degradation guard: a partition or
+    uniqueness violation ships *no* modules (consumers fall back to community
+    grouping) rather than a broken artifact.
+    """
+    file_nodes = _file_nodes(kg)
+    if not file_nodes:
+        return None
+    id_to_path = {n["id"]: n["filePath"] for n in file_nodes}
+    lang_by_id = {n["id"]: (n.get("language") or "").lower() for n in file_nodes}
+
+    modules = derive_modules(kg.layers, id_to_path, lang_by_id=lang_by_id)
+    if not modules:
+        return None
+
+    seen: set[str] = set()
+    for m in modules:
+        for nid in m["nodeIds"]:
+            if nid in seen or nid not in id_to_path:
+                logger.warning(
+                    "kg_curation: derived modules failed partition invariant; "
+                    "exporting no modules"
+                )
+                return None
+            seen.add(nid)
+    names = [m["name"] for m in modules]
+    ids = [m["id"] for m in modules]
+    if len(set(names)) != len(names) or len(set(ids)) != len(ids):
+        logger.warning(
+            "kg_curation: derived module names/ids not unique; exporting no modules"
+        )
+        return None
+    return modules
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — entry-point precision (demote barrels, rank + cap survivors)
+# ---------------------------------------------------------------------------
+
+
+def _is_barrel(parsed_file: Any) -> bool:
+    """True if *parsed_file* is a re-export barrel (``index`` shell, no runtime).
+
+    Conservative by design: a file is a barrel only when its stem is ``index``
+    and it defines no runtime-bearing symbol (function/class/method/…) — purely
+    re-exporting or empty. Anything that defines executable behaviour, even if
+    named ``index``, is kept as a genuine entry candidate.
+    """
+    fi = getattr(parsed_file, "file_info", None)
+    path = getattr(fi, "path", "")
+    if PurePosixPath(path).stem.lower() not in _BARREL_STEMS:
+        return False
+
+    symbols = getattr(parsed_file, "symbols", []) or []
+    if any(getattr(s, "kind", "") in _SUBSTANTIVE_KINDS for s in symbols):
+        return False
+
+    has_reexports = any(
+        getattr(imp, "is_reexport", False) for imp in getattr(parsed_file, "imports", []) or []
+    )
+    exports_only = bool(getattr(parsed_file, "exports", []))
+    return has_reexports or exports_only or not symbols
+
+
+def _dominant_language(code_langs: list[str]) -> str:
+    """Most common language, ties broken deterministically.
+
+    ``Counter.most_common`` breaks count ties by insertion order, which is
+    thread-completion-order nondeterministic here — and the result reaches
+    persisted output (``project.graph_mode`` plus tour prose). Tie-break by
+    count descending, then language name ascending, so the same KG always
+    yields the same dominant language regardless of ingestion ordering.
+    """
+    if not code_langs:
+        return ""
+    return min(Counter(code_langs).items(), key=lambda kv: (-kv[1], kv[0]))[0]
+
+
+def _curate_entry_points(
+    kg: KnowledgeGraphResult, parsed_files: list[Any], graph_builder: Any
+) -> None:
+    """Demote re-export barrels and surface a capped, ranked entry-point set.
+
+    Mutates only the presentation view: drops the ``entry_point`` *tag* from
+    barrel nodes (and adds a ``barrel`` tag) without touching the AST graph's
+    ``is_entry_point`` flag (the dead-code pass relies on it). Survivors are
+    ranked by ``pagerank + betweenness``; ``project.entry_points`` holds the top
+    few, ``project.entry_candidates`` the full ranked list. When ingestion
+    flagged no entries at all, the strong :func:`score_entry_points` scorers
+    (entry-style filenames) fill in, so the orientation panel never opens empty
+    on repos without a detectable main.
+    """
+    pf_by_path = {pf.file_info.path: pf for pf in parsed_files if getattr(pf, "file_info", None)}
+    lang_by_path = {n["filePath"]: (n.get("language") or "").lower() for n in _file_nodes(kg)}
+    pagerank = graph_builder.pagerank() or {}
+    try:
+        betweenness = graph_builder.betweenness_centrality() or {}
+    except Exception:  # pragma: no cover - defensive
+        betweenness = {}
+
+    survivors: list[tuple[float, str]] = []
+    for node in kg.nodes:
+        nid = node.get("id", "")
+        if not (isinstance(nid, str) and nid.startswith("file:")):
+            continue
+        tags = node.get("tags") or []
+        if "entry_point" not in tags:
+            continue
+        path = node.get("filePath", "")
+        if infer_layer(path, node.get("language")) in ADJACENT_LAYERS or is_support_path(path):
+            # Test fixtures (a wsgi.py inside tests/) and sample programs
+            # (examples/*/main.go) may carry the ingestion flag, but they are
+            # not where a reader enters the system.
+            continue
+        pf = pf_by_path.get(path)
+        if pf is not None and _is_barrel(pf):
+            new_tags = [t for t in tags if t != "entry_point"]
+            if "barrel" not in new_tags:
+                new_tags.append("barrel")
+            node["tags"] = new_tags
+            continue
+        score = pagerank.get(path, 0.0) + betweenness.get(path, 0.0)
+        survivors.append((score, path))
+
+    if not survivors:
+        # No ingestion-flagged entries (or all were barrels): fall back to the
+        # strong filename scorers the tour seeds from (score >= 3 means an
+        # entry-style name or flag, never just shallow/high-PageRank).
+        for s, path in score_entry_points(parsed_files, pagerank):
+            if s < 3.0:
+                continue
+            if infer_layer(path, lang_by_path.get(path)) in ADJACENT_LAYERS or is_support_path(path):
+                continue
+            pf = pf_by_path.get(path)
+            if pf is not None and _is_barrel(pf):
+                continue
+            score = pagerank.get(path, 0.0) + betweenness.get(path, 0.0)
+            survivors.append((score, path))
+
+    # Highest score first; path as a stable, deterministic tie-break.
+    survivors.sort(key=lambda sp: (-sp[0], sp[1]))
+    ranked = [path for _, path in survivors]
+    kg.project["entry_points"] = ranked[:_MAX_ENTRY_POINTS]
+    kg.project["entry_candidates"] = ranked
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — canonical execution-flow tour
+# ---------------------------------------------------------------------------
+
+
+def _readme_overview_node(kg: KnowledgeGraphResult) -> dict | None:
+    """The best root-level README/overview file node, if one exists."""
+    best: dict | None = None
+    for n in _file_nodes(kg):
+        path = n["filePath"]
+        name = PurePosixPath(path).name.lower()
+        depth = len(PurePosixPath(path).parts) - 1
+        if not (name.startswith("readme") and depth <= 1):
+            continue
+        # Prefer the shallowest README (the repo-root one).
+        if best is None or depth < (len(PurePosixPath(best["filePath"]).parts) - 1):
+            best = n
+    return best
+
+
+def _best_in_layer(paths: list[str], rank: dict[str, float], pagerank: dict[str, float]) -> str:
+    """Highest-ranked path in a layer (entry score, then PageRank, then name)."""
+    return sorted(paths, key=lambda p: (-rank.get(p, 0.0), -pagerank.get(p, 0.0), p))[0]
+
+
+def _structural_walk(
+    universe: list[str],
+    type_by_path: dict[str, str],
+    dominant_lang: str,
+    pagerank: dict[str, float],
+    graph_builder: Any,
+    project_name: str = "",
+) -> tuple[list[str], dict[str, str]]:
+    """Anchor + directory faces for repos with no usable import graph.
+
+    No execution-flow claims: the anchor is ranked by whatever evidence
+    exists (PageRank over the full graph — co-change/dynamic edges included
+    — then fan-in, shallowness, path), never alphabetically-first-by-luck;
+    the walk visits the largest top-level code areas, one face each. Every
+    reason says what the evidence is and what is missing.
+    """
+    # Manifests (mix.exs, setup.py) are code-shaped but describe the
+    # project rather than implement it — never the place to start reading.
+    manifests = _LANG_REGISTRY.manifest_filenames()
+    code = [
+        p
+        for p in universe
+        if type_by_path.get(p) not in {"config", "document"}
+        and PurePosixPath(p).name not in manifests
+    ]
+    if not code:
+        return [], {}
+
+    fan_in: Counter[str] = Counter()
+    for _src, dst in _file_import_edges(graph_builder):
+        fan_in[dst] += 1
+
+    spec = _LANG_REGISTRY.get(dominant_lang)
+    display = spec.display_name if spec else (dominant_lang or "this language")
+
+    # Conventional names trump raw connectivity: an entry-named file
+    # (application.ex, Main.hs) or the project-named module (lib/jason.ex in
+    # jason — the library-main convention) is where a reader starts.
+    entry_names = _LANG_REGISTRY.entry_point_names()
+    project_stem = (project_name or "").lower()
+
+    def conventional(p: str) -> bool:
+        pp = PurePosixPath(p)
+        return pp.name in entry_names or (
+            bool(project_stem) and pp.stem.lower() == project_stem
+        )
+
+    anchor = min(
+        code,
+        key=lambda p: (
+            not conventional(p),
+            -pagerank.get(p, 0.0),
+            -fan_in.get(p, 0),
+            len(PurePosixPath(p).parts),
+            p,
+        ),
+    )
+    if PurePosixPath(anchor).name in entry_names:
+        anchor_reason = (
+            f"Named like an entry file — the conventional place {display} "
+            "execution starts. Import analysis isn't supported for "
+            f"{display} yet, so the walk follows the repo's structure."
+        )
+    elif conventional(anchor):
+        anchor_reason = (
+            "Named after the project — by convention the library's main "
+            f"module. Import analysis isn't supported for {display} yet, "
+            "so the walk follows the repo's structure."
+        )
+    else:
+        anchor_reason = (
+            "The best-connected file by the evidence available (change "
+            f"history and references). Import analysis isn't supported for "
+            f"{display} yet, so the walk follows the repo's structure."
+        )
+
+    groups: dict[str, list[str]] = defaultdict(list)
+    for p in code:
+        if p == anchor:
+            continue
+        parts = PurePosixPath(p).parts
+        groups[parts[0] if len(parts) > 1 else "."].append(p)
+
+    walk = [anchor]
+    reasons = {anchor: anchor_reason}
+    for d in sorted(groups, key=lambda d: (-len(groups[d]), d)):
+        face = min(
+            groups[d],
+            key=lambda p: (-pagerank.get(p, 0.0), len(PurePosixPath(p).parts), p),
+        )
+        n = len(groups[d])
+        label = "the repository root" if d == "." else f"{d}/"
+        count = f"{n} code files live here" if n != 1 else "1 code file lives here"
+        reasons[face] = f"The face of {label} — {count}."
+        walk.append(face)
+    return walk, reasons
+
+
+_FANOUT_GROUP_MIN = 3
+
+
+def _import_groups(
+    graph_builder: Any, edge_types: frozenset[str] = frozenset({"imports"})
+) -> dict[str, list[list[str]]]:
+    """Imports edges grouped per source by originating import statement.
+
+    A resolver fan-out (Go/JVM package import → every file in the package)
+    emits many edges that share one source and identical ``imported_names``
+    — semantically ONE import relationship. Groups of
+    ``>= _FANOUT_GROUP_MIN`` targets are treated as fan-outs; smaller
+    groups stay one-edge-one-relationship (multi-ext probes, pairs).
+    """
+    keyed: dict[tuple[str, tuple[str, ...]], list[str]] = defaultdict(list)
+    try:
+        for src, dst, data in graph_builder.graph().edges(data=True):
+            if not (isinstance(src, str) and isinstance(dst, str)):
+                continue
+            if data.get("edge_type", "imports") not in edge_types:
+                continue
+            # Stdlib/external imports say nothing about where a walk can
+            # go — only repo-internal relationships count.
+            if src.startswith("external:") or dst.startswith("external:"):
+                continue
+            names = tuple(sorted(data.get("imported_names") or ())) or (dst,)
+            keyed[(src, names)].append(dst)
+    except Exception:  # pragma: no cover - defensive
+        return {}
+    groups: dict[str, list[list[str]]] = defaultdict(list)
+    for (src, _names), targets in keyed.items():
+        groups[src].append(targets)
+    return groups
+
+
+# The harness signal is "this test file *depends on* that one" — type
+# references and inheritance (a base test class) are exactly that evidence;
+# raw-graph type_use/heritage edges surface as plain imports in the export.
+_DEPENDENCY_EDGE_TYPES = frozenset({"imports", "type_use", "heritage"})
+
+
+def _import_pairs_excluding_fanout(graph_builder: Any) -> list[tuple[str, str]]:
+    """``(src, dst)`` dependency pairs with fan-out groups dropped."""
+    pairs: list[tuple[str, str]] = []
+    for src, target_groups in _import_groups(
+        graph_builder, edge_types=_DEPENDENCY_EDGE_TYPES
+    ).items():
+        for targets in target_groups:
+            if len(targets) >= _FANOUT_GROUP_MIN:
+                continue
+            pairs.extend((src, dst) for dst in targets)
+    return pairs
+
+
+def _anchor_fanout_rank(graph_builder: Any) -> dict[str, int]:
+    """Per-file count of distinct import *relationships* (fan-outs = 1).
+
+    The walk's anchor claims "its imports fan out the widest" — that must
+    mean import statements, not resolver edge multiplicity, or one Go
+    package import (15 sibling edges) out-ranks a file with a dozen real
+    dependencies and the anchor lands alphabetically-by-luck.
+    """
+    return {
+        src: len(target_groups)
+        for src, target_groups in _import_groups(graph_builder).items()
+    }
+
+
+def _curate_tour(
+    kg: KnowledgeGraphResult, parsed_files: list[Any], graph_builder: Any
+) -> list[dict] | None:
+    """Build one canonical, execution-flow tour over the curated layers.
+
+    Keeps the deterministic :func:`build_tour` ordering — README/overview
+    first, then the entry points and their import neighbourhood walking inward
+    (BFS depth) — so the tour follows how the program actually runs, not an
+    abstract stack walk. Layer coverage is preserved by *swapping* redundant
+    same-layer stops for representatives of uncovered runtime layers, never by
+    re-sorting the walk. Adjacent layers (tests) take no walk slots: the suite
+    gets a single closing stop before infrastructure. Step reasons state
+    evidence (entry point, import depth, layer anchor), not stack position.
+    Every step carries a ``layer_id`` mapping it to a curated layer; the LLM
+    may later rewrite step *prose* only.
+    """
+    file_nodes = _file_nodes(kg)
+    if not file_nodes:
+        return None
+
+    paths = [n["filePath"] for n in file_nodes]
+    type_by_path = {n["filePath"]: n.get("type", "file") for n in file_nodes}
+    lang_by_path = {n["filePath"]: (n.get("language") or "").lower() for n in file_nodes}
+    code_langs = [
+        lang
+        for p, lang in lang_by_path.items()
+        if lang and type_by_path.get(p) not in {"config", "document"}
+    ]
+    dominant_lang = _dominant_language(code_langs)
+    # How much may the tour honestly claim? Exported additively so
+    # consumers (UI, harness) can see the degradation level.
+    graph_mode = _graph_mode(dominant_lang, lang_by_path, graph_builder)
+    kg.project["graph_mode"] = graph_mode
+    file_layers = {p: infer_layer(p, lang_by_path.get(p)) for p in paths}
+    order = compute_layer_order(file_layers, _file_import_edges(graph_builder))
+
+    pagerank = graph_builder.pagerank() or {}
+    rank = {path: s for s, path in score_entry_points(parsed_files, pagerank)}
+    barrels = {
+        pf.file_info.path
+        for pf in parsed_files
+        if getattr(pf, "file_info", None) and _is_barrel(pf)
+    }
+
+    # Infra files (Docker/CI/etc.) close the tour; everything else is code.
+    infra_paths = [p for p in paths if type_by_path.get(p) in {"service", "pipeline"}]
+
+    # The overview step retargets to the root README — keep that file out of
+    # the walk so the tour never visits it twice. Tests and example programs
+    # are excluded from the walk universe *before* build_tour spends its step
+    # budget; otherwise a samples-heavy repo (express) fills the budget with
+    # stops that get filtered away afterwards.
+    readme = _readme_overview_node(kg)
+    overview_target = readme["filePath"] if readme is not None else None
+    walk_universe = [
+        p
+        for p in paths
+        if p != overview_target
+        and file_layers.get(p) not in ADJACENT_LAYERS
+        and not is_support_path(p)
+        and not PurePosixPath(p).parts[0].startswith(".")  # dot-dir tooling
+    ]
+
+    project_name = kg.project.get("name") or "repository"
+    # In structural mode the BFS walk is withheld entirely (a fake flow over
+    # a near-edgeless graph is a lie); build_tour still selects the overview
+    # and infra stops.
+    base = build_tour(
+        parsed_files,
+        pagerank,
+        _file_import_edges(graph_builder),
+        file_page_paths=[] if graph_mode == "structural" else walk_universe,
+        infra_paths=infra_paths,
+        repo_name=project_name,
+        max_stops=DEFAULT_MAX_STOPS,
+        graph_mode=graph_mode,
+        anchor_rank=_anchor_fanout_rank(graph_builder),
+    )
+
+    overview = [s for s in base if s.kind == "overview"]
+    infra = [s for s in base if s.kind == "infra"]
+    base_code = {s.target_path: s for s in base if s.kind == "code"}
+    if not overview:
+        overview_target = None
+
+    by_layer: dict[str, list[str]] = defaultdict(list)
+    for p in paths:
+        by_layer[file_layers[p]].append(p)
+
+    # One closing stop per adjacent layer present (the test suite) — tests
+    # verify the system, they don't start it, so they never lead the walk.
+    # Face = the shallowest suite anchor when present (conftest /
+    # spec_helper / test_helper — registry-declared suite roots), else the
+    # best code file, else anything (never a stray Cargo.toml if avoidable).
+    #
+    # Shared test harness files — base classes and helpers imported by two
+    # or more other test files (AbstractFileSystemTest, BaseTestCase,
+    # SpecUtil) — are what the suite runs ON, not where tests start. Their
+    # heavy in-degree otherwise wins the pagerank tie-break on every repo
+    # with shared fixtures.
+    adjacent_paths = {
+        p for layer in ADJACENT_LAYERS for p in by_layer.get(layer, [])
+    }
+    # Fan-out groups (one import statement expanded to many sibling targets
+    # — Go/JVM package imports) are *not* evidence that a specific file is
+    # referenced: a chi root test "imports" every sibling test through the
+    # package fan-out. Only single-target import evidence counts here.
+    harness_in: Counter[str] = Counter()
+    for src, dst in _import_pairs_excluding_fanout(graph_builder):
+        if src != dst and src in adjacent_paths and dst in adjacent_paths:
+            harness_in[dst] += 1
+    closing_paths: list[str] = []
+    for layer in order:
+        cands = by_layer.get(layer)
+        if layer not in ADJACENT_LAYERS or not cands:
+            continue
+        anchors = sorted(
+            (p for p in cands if PurePosixPath(p).stem.lower() in _SUITE_ANCHOR_STEMS),
+            key=lambda p: (len(PurePosixPath(p).parts), p),
+        )
+        if anchors:
+            closing_paths.append(anchors[0])
+            continue
+        code_cands = [
+            p
+            for p in cands
+            if type_by_path.get(p) not in {"config", "document"}
+            # Declaration descriptors (module-info.java) are source files
+            # that describe a module, not tests — gson's shallow JPMS
+            # descriptor must never face the suite.
+            and PurePosixPath(p).name not in _DESCRIPTOR_FILENAMES
+            # Fixture-shaped files (FooFixtures.java) hold test data; the
+            # suite's face must be something that verifies behavior.
+            and not _is_fixture_shaped(p)
+        ]
+        # Drop harness files unless that would leave nothing. One
+        # single-target import from another test file is already harness
+        # evidence — leaf tests have zero (okio's CipherFactory.kt had
+        # exactly one cipher-test importer and still faced the suite).
+        non_harness = [p for p in code_cands if harness_in.get(p, 0) < 1]
+        if non_harness:
+            code_cands = non_harness
+        # When the repo declares test *projects* (.NET's Foo.Tests/ or
+        # Foo.Specs/ sibling-project convention), the suite lives there —
+        # a test/Shared/ helper dir next to them is auxiliary compile-time
+        # plumbing, not where a maintainer says tests start.
+        in_test_project = [
+            p
+            for p in code_cands
+            if any(
+                seg.endswith(_TEST_PROJECT_DIR_SUFFIXES) and len(seg) > 1
+                for seg in PurePosixPath(p).parts[:-1]
+            )
+        ]
+        if in_test_project:
+            code_cands = in_test_project
+        if code_cands:
+            # No suite anchor (non-pytest/rspec suites): prefer the repo's
+            # dominant language (gson's suite face is a .java, not a stray
+            # .proto), then the shallowest test-root file (django's
+            # tests/runtests.py), most-imported as the tie-break.
+            code_cands.sort(
+                key=lambda p: (
+                    lang_by_path.get(p, "") != dominant_lang,
+                    len(PurePosixPath(p).parts),
+                    -pagerank.get(p, 0.0),
+                    p,
+                )
+            )
+            closing_paths.append(code_cands[0])
+        else:
+            closing_paths.append(_best_in_layer(cands, rank, pagerank))
+
+    budget = max(0, DEFAULT_MAX_STOPS - len(overview) - len(closing_paths) - len(infra))
+    swapped_depth: dict[str, int] = {}  # rep path -> depth of the slot it fills
+    structural_reasons: dict[str, str] = {}
+
+    if graph_mode == "structural":
+        # Structure, not flow: evidence-ranked anchor + one face per
+        # top-level code area. No layer-coverage swaps — the directory walk
+        # IS the diversity, and "most depended-on" claims need edges.
+        walk, structural_reasons = _structural_walk(
+            walk_universe,
+            type_by_path,
+            dominant_lang,
+            pagerank,
+            graph_builder,
+            project_name=project_name,
+        )
+        walk = walk[:budget]
+    else:
+        # The walk = build_tour's execution order minus adjacent-layer stops
+        # and example programs (documentation-by-code, not the system),
+        # truncated up front so later swaps land inside the kept window.
+        walk = [
+            s.target_path
+            for s in base
+            if s.kind == "code"
+            and s.target_path != overview_target
+            and file_layers.get(s.target_path) not in ADJACENT_LAYERS
+            and not is_support_path(s.target_path)
+        ]
+        walk = walk[:budget]
+
+        # --- Diversify for layer coverage (swap slots, never re-sort) -----
+        seen_layers: set[str] = set()
+        redundant_positions: list[int] = []
+        for i, p in enumerate(walk):
+            layer = file_layers.get(p)
+            if layer in seen_layers:
+                redundant_positions.append(i)
+            else:
+                seen_layers.add(layer)
+
+        uncovered = [
+            name for name in order if name not in seen_layers and name not in ADJACENT_LAYERS
+        ]
+        for layer in uncovered:
+            if not redundant_positions:
+                break
+            # Manifests (mix.exs, project.clj, Setup.lhs) are code-shaped
+            # but describe the project rather than implement it — never a
+            # layer's face, same rule as the structural anchor.
+            manifest_names = _LANG_REGISTRY.manifest_filenames()
+            candidates = [
+                p
+                for p in by_layer.get(layer, [])
+                if p not in walk
+                and p != overview_target
+                and not is_support_path(p)
+                and not PurePosixPath(p).parts[0].startswith(".")  # never a layer face
+                and PurePosixPath(p).name not in manifest_names
+            ]
+            if not candidates:
+                continue
+            # A layer's face must be code. A layer holding only configs/docs
+            # (a plugins/ dir of JSON manifests) gets no manufactured stop —
+            # except Config itself, where "this is where configuration
+            # lives" is the point.
+            # Infra-language scripts (run-hlint.sh, deploy.sh) wire the
+            # project, they don't implement a layer — never its face.
+            infra_langs = _LANG_REGISTRY.infra_languages()
+            code_candidates = [
+                p
+                for p in candidates
+                if type_by_path.get(p) not in {"config", "document"}
+                and lang_by_path.get(p) not in infra_langs
+            ]
+            if not code_candidates and layer != "Config":
+                continue
+            rep = _best_in_layer(code_candidates or candidates, rank, pagerank)
+            pos = redundant_positions.pop()
+            replaced = base_code.get(walk[pos])
+            swapped_depth[rep] = replaced.depth if replaced is not None else 0
+            walk[pos] = rep
+            seen_layers.add(layer)
+
+    # --- Assemble the exported tour --------------------------------------
+    tour: list[dict] = []
+    order_n = 0
+
+    if overview:
+        order_n += 1
+        ov = overview[0].as_dict()
+        ov["order"] = order_n
+        if readme is not None:
+            ov["target_path"] = readme["filePath"]
+            ov["title"] = PurePosixPath(readme["filePath"]).name
+            ov["layer_id"] = f"layer:{_slugify(file_layers[readme['filePath']])}"
+        else:
+            ov["layer_id"] = None
+        tour.append(ov)
+
+    max_depth = 0
+    for p in walk:
+        order_n += 1
+        layer = file_layers.get(p, "")
+        step = base_code.get(p)
+        if p in structural_reasons:
+            depth = 0  # import depth is meaningless without an import graph
+            reason = structural_reasons[p]
+        elif p in swapped_depth:
+            depth = swapped_depth[p]
+            reason = f"The {layer} layer's anchor — its most depended-on file."
+        elif step is not None:
+            depth = step.depth
+            reason = step.reason
+        else:  # pragma: no cover - walk paths come from base or swaps
+            depth = 0
+            reason = f"A key {layer} file on the walk from the entry points."
+        if p in barrels:
+            # A re-export shell may seed the walk (imports genuinely fan out
+            # from it), but it must not claim to be an execution entry point.
+            reason = "A re-export hub — the package's public surface fans out from here."
+        max_depth = max(max_depth, depth)
+        tour.append(
+            {
+                "order": order_n,
+                "target_path": p,
+                "page_type": "file_page",
+                "title": PurePosixPath(p).name,
+                "depth": depth,
+                "kind": "code",
+                "reason": reason,
+                "layer_id": f"layer:{_slugify(layer)}",
+            }
+        )
+
+    # Polyglot fairness: languages holding ≥20% of the code with
+    # their own test files get named in the closing-stop reason — the stop
+    # faces the dominant suite, but the others must not vanish.
+    lang_counts = Counter(code_langs)
+    total_code = sum(lang_counts.values()) or 1
+    test_langs = {
+        lang_by_path.get(p, "")
+        for layer in ADJACENT_LAYERS
+        for p in by_layer.get(layer, [])
+    }
+    other_suites = sorted(
+        spec.display_name
+        for tag, n in lang_counts.items()
+        if tag != dominant_lang
+        and n / total_code >= 0.20
+        and tag in test_langs
+        and (spec := _LANG_REGISTRY.get(tag)) is not None
+    )
+    closing_reason = "The test suite — how the system's behavior is verified."
+    if other_suites:
+        closing_reason = (
+            "The test suite — how the system's behavior is verified "
+            f"(the {' and '.join(other_suites)} test suite"
+            f"{'s' if len(other_suites) > 1 else ''} live"
+            f"{'' if len(other_suites) > 1 else 's'} alongside it)."
+        )
+
+    for p in closing_paths:
+        order_n += 1
+        layer = file_layers.get(p, "Test")
+        max_depth += 1
+        tour.append(
+            {
+                "order": order_n,
+                "target_path": p,
+                "page_type": "file_page",
+                "title": PurePosixPath(p).name,
+                "depth": max_depth,
+                "kind": "code",
+                "reason": closing_reason,
+                "layer_id": f"layer:{_slugify(layer)}",
+            }
+        )
+
+    for s in infra:
+        order_n += 1
+        step = s.as_dict()
+        step["order"] = order_n
+        step["layer_id"] = f"layer:{_slugify(file_layers.get(s.target_path, 'Config'))}"
+        tour.append(step)
+
+    return tour
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — node typing & never-empty summaries
+# ---------------------------------------------------------------------------
+
+# Path signals for richer node typing than the skeleton's coarse
+# file/config/service/document. These run only in the presentation view; the
+# AST graph node_type used elsewhere is untouched.
+_CI_PATH_MARKERS = (
+    ".github/workflows/",
+    ".gitlab-ci",
+    ".circleci/",
+    "azure-pipelines",
+    "jenkinsfile",
+    "bitbucket-pipelines",
+)
+_INFRA_NAME_MARKERS = ("dockerfile", "docker-compose", "compose.yaml", "compose.yml")
+_INFRA_PATH_MARKERS = ("/k8s/", "/kubernetes/", "/helm/", "/terraform/")
+_INFRA_SUFFIXES = (".tf", ".hcl")
+_DATA_PATH_MARKERS = ("/migrations/", "/migration/")
+_DATA_SUFFIXES = (".sql", ".prisma")
+
+# Source-code extensions. A code file is never CI/infra config however its
+# name or directory reads — ``languages/specs/dockerfile.py`` *parses*
+# Dockerfiles, it isn't one. Registry-derived: every is_code,
+# non-infra language's extensions are protected — .dart/.hs/.clj included;
+# shell/terraform stay promotable (they ARE infra); the historical orphan
+# ``.pl`` (no perl spec) is gone.
+_CODE_SUFFIXES = _LANG_REGISTRY.non_infra_code_extensions()
+
+
+def _enrich_type(path: str, current_type: str) -> tuple[str, str | None]:
+    """Return a richer ``(type, extra_tag)`` for a file node, or keep current.
+
+    The tag (``ci``/``infra``/``data``) is additive; ``None`` means no new tag.
+    Name/path markers never fire for source-code files (``_CODE_SUFFIXES``);
+    only genuine config artifacts get promoted.
+    """
+    p = path.lower()
+    name = PurePosixPath(p).name
+    suffix = PurePosixPath(p).suffix
+    is_code = suffix in _CODE_SUFFIXES
+
+    if not is_code and (any(m in p for m in _CI_PATH_MARKERS) or name == "jenkinsfile"):
+        return "pipeline", "ci"
+    if (
+        not is_code
+        and (
+            name.startswith("dockerfile")
+            or any(m in name for m in _INFRA_NAME_MARKERS)
+            or any(m in p for m in _INFRA_PATH_MARKERS)
+        )
+    ) or suffix in _INFRA_SUFFIXES:
+        return "service", "infra"
+    if any(m in p for m in _DATA_PATH_MARKERS) or suffix in _DATA_SUFFIXES:
+        return "schema", "data"
+    return current_type, None
+
+
+def _curate_node_types(kg: KnowledgeGraphResult) -> None:
+    """Promote infra/CI/data file nodes to first-class presentation types."""
+    for node in _file_nodes(kg):
+        new_type, tag = _enrich_type(node["filePath"], node.get("type", "file"))
+        if new_type != node.get("type"):
+            node["type"] = new_type
+        if tag:
+            tags = node.setdefault("tags", [])
+            if tag not in tags:
+                tags.append(tag)
+
+
+def _infer_test_target(path: str) -> str:
+    """Best-effort name of what a test file covers (strip test markers)."""
+    stem = PurePosixPath(path).stem
+    for marker in (".test", ".spec", "_test", "test_", "_spec", "spec_"):
+        if marker in stem.lower():
+            cleaned = stem.lower().replace(marker, "")
+            return cleaned.strip("_.- ") or stem
+    return stem
+
+
+def _cheap_summary(node: dict, parsed_file: Any | None) -> str:
+    """A deterministic, honest fallback summary (zero LLM cost)."""
+    path = node["filePath"]
+    stem = PurePosixPath(path).stem
+    parent = PurePosixPath(path).parent.name or "root"
+    node_type = node.get("type", "file")
+    tags = node.get("tags") or []
+    layer = infer_layer(path, (node.get("language") or "").lower())
+
+    if "barrel" in tags:
+        return f"Re-export barrel for {parent}/."
+    if node_type == "pipeline" or "ci" in tags:
+        return f"CI / pipeline definition: {PurePosixPath(path).name}."
+    if node_type == "service" or "infra" in tags:
+        return f"Infrastructure definition: {PurePosixPath(path).name}."
+    if node_type == "schema" or "data" in tags:
+        return f"Data / schema definition: {PurePosixPath(path).name}."
+    if node_type == "config" or "config" in tags:
+        return f"Configuration file: {PurePosixPath(path).name}."
+    if node_type == "document":
+        return f"Documentation: {PurePosixPath(path).name}."
+    if "test" in tags:
+        return f"Tests for {_infer_test_target(path)}."
+
+    # Code file: name the layer and its most prominent symbols.
+    symbol_names: list[str] = []
+    if parsed_file is not None:
+        symbol_names = [
+            getattr(s, "name", "")
+            for s in (getattr(parsed_file, "symbols", []) or [])
+            if getattr(s, "kind", "") in _SUBSTANTIVE_KINDS and getattr(s, "name", "")
+        ][:3]
+    if symbol_names:
+        return f"{layer} module {stem} defining {', '.join(symbol_names)}."
+    count = node.get("symbolCount", 0)
+    if count:
+        return f"{layer} module {stem} ({count} symbols)."
+    return f"{layer} module {stem}."
+
+
+def apply_summary_floor(kg: KnowledgeGraphResult, parsed_files: list[Any] | None = None) -> None:
+    """Ensure every file node carries a summary (cheap deterministic floor).
+
+    Idempotent and never clobbering: only fills nodes whose summary is still
+    empty, so a richer wiki-page summary (backfilled before this runs in
+    generate mode) always wins. ``parsed_files`` is optional — when absent the
+    fallback uses the node's symbol count instead of naming top symbols.
+    """
+    pf_by_path = {
+        pf.file_info.path: pf for pf in (parsed_files or []) if getattr(pf, "file_info", None)
+    }
+    for node in _file_nodes(kg):
+        if node.get("summary"):
+            continue
+        node["summary"] = _cheap_summary(node, pf_by_path.get(node["filePath"]))
+
+
+# ---------------------------------------------------------------------------
+# Phase 7 — invariant validation (shared by tests and the portable writer)
+# ---------------------------------------------------------------------------
+
+# Quality thresholds. The lower layer bound and coverage targets are *soft*
+# (warnings) because they depend on repo size/shape; the partition, hard count
+# bound, capped entry set, never-empty summaries, and tour budget are *hard*.
+_MIN_LAYERS = 6
+_MAX_LAYER_FRACTION = 0.35
+_MAX_CATCHALL_FRACTION = 0.20
+_MAX_SINGLETON_FRACTION = 0.10
+_MIN_TOUR_COVERAGE = 0.90
+
+
+@dataclass
+class KGValidation:
+    """Outcome of :func:`validate_kg` — hard errors, soft warnings, metrics."""
+
+    ok: bool
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "errors": self.errors,
+            "warnings": self.warnings,
+            "metrics": self.metrics,
+        }
+
+
+def validate_kg(kg: KnowledgeGraphResult) -> KGValidation:
+    """Validate a curated KG against the intuitiveness invariants (plan §5/§7).
+
+    Pure and side-effect free. Hard violations set ``ok=False`` and populate
+    ``errors``; size/shape-dependent shortfalls go to ``warnings``. The
+    ``metrics`` block is the per-repo intuitiveness scorecard.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    file_nodes = _file_nodes(kg)
+    file_count = len(file_nodes)
+    file_ids = {n["id"] for n in file_nodes}
+    tags_by_path = {n["filePath"]: (n.get("tags") or []) for n in file_nodes}
+    summary_by_id = {n["id"]: n.get("summary") for n in file_nodes}
+
+    layers = kg.layers or []
+    n_layers = len(layers)
+
+    # -- Layer count -------------------------------------------------------
+    if n_layers == 0:
+        errors.append("no layers")
+    elif n_layers > _MAX_LAYERS:
+        errors.append(f"too many layers: {n_layers} > {_MAX_LAYERS}")
+    elif n_layers < _MIN_LAYERS:
+        warnings.append(f"few layers: {n_layers} < {_MIN_LAYERS} (small/flat repo?)")
+
+    # -- Partition ---------------------------------------------------------
+    layered: list[str] = [nid for layer in layers for nid in layer.get("nodeIds", [])]
+    layered_set = set(layered)
+    if len(layered) != len(layered_set):
+        errors.append("partition: a file appears in more than one layer")
+    if file_count and layered_set != file_ids:
+        missing = len(file_ids - layered_set)
+        extra = len(layered_set - file_ids)
+        errors.append(f"partition: {missing} unlayered, {extra} unknown ids")
+
+    # -- Singleton spam & mega-layer balance -------------------------------
+    sizes = [len(layer.get("nodeIds", [])) for layer in layers]
+    singleton_frac = (sum(1 for s in sizes if s == 1) / n_layers) if n_layers else 0.0
+    if singleton_frac >= _MAX_SINGLETON_FRACTION:
+        warnings.append(f"singleton layers {singleton_frac:.0%} ≥ {_MAX_SINGLETON_FRACTION:.0%}")
+
+    largest_frac = (max(sizes) / file_count) if (sizes and file_count) else 0.0
+    if largest_frac > _MAX_LAYER_FRACTION:
+        warnings.append(f"largest layer {largest_frac:.0%} > {_MAX_LAYER_FRACTION:.0%}")
+
+    catchall = next((layer for layer in layers if layer.get("name") == "Application"), None)
+    catchall_frac = (
+        (len(catchall.get("nodeIds", [])) / file_count) if (catchall and file_count) else 0.0
+    )
+    if catchall_frac > _MAX_CATCHALL_FRACTION:
+        warnings.append(f"Application catch-all {catchall_frac:.0%} > {_MAX_CATCHALL_FRACTION:.0%}")
+
+    # -- Entry points ------------------------------------------------------
+    entry_points = kg.project.get("entry_points", []) if isinstance(kg.project, dict) else []
+    if len(entry_points) > _MAX_ENTRY_POINTS:
+        errors.append(f"too many entry points: {len(entry_points)} > {_MAX_ENTRY_POINTS}")
+    barrels_surfaced = [p for p in entry_points if "barrel" in tags_by_path.get(p, [])]
+    if barrels_surfaced:
+        errors.append(f"barrels surfaced as entry points: {barrels_surfaced}")
+
+    # -- Tour --------------------------------------------------------------
+    tour = kg.tour or []
+    tour_coverage = 0.0
+    if tour:
+        if len(tour) > DEFAULT_MAX_STOPS:
+            errors.append(f"tour too long: {len(tour)} > {DEFAULT_MAX_STOPS}")
+        if tour[0].get("kind") != "overview":
+            errors.append("tour does not open with an overview/README step")
+        layer_ids = {layer.get("id") for layer in layers}
+        covered = {
+            s.get("layer_id")
+            for s in tour
+            if s.get("kind") != "overview" and s.get("layer_id") in layer_ids
+        }
+        tour_coverage = (len(covered) / len(layer_ids)) if layer_ids else 0.0
+        if tour_coverage < _MIN_TOUR_COVERAGE:
+            warnings.append(f"tour covers {tour_coverage:.0%} of layers < {_MIN_TOUR_COVERAGE:.0%}")
+
+    # -- Modules (only when the curated artifact carries them) -------------
+    modules = getattr(kg, "modules", None) or []
+    module_covered: set[str] = set()
+    if modules:
+        module_member_lists = [m.get("nodeIds", []) for m in modules]
+        flat = [nid for ids in module_member_lists for nid in ids]
+        module_covered = set(flat)
+        if len(flat) != len(module_covered):
+            errors.append("modules: a file appears in more than one module")
+        if not module_covered <= file_ids:
+            errors.append(
+                f"modules: {len(module_covered - file_ids)} unknown ids in modules"
+            )
+        module_names = [m.get("name", "") for m in modules]
+        if len(set(module_names)) != len(module_names):
+            errors.append("modules: names not unique")
+        size_suffixed = [n for n in module_names if _SIZE_SUFFIX_RE.search(n)]
+        if size_suffixed:
+            errors.append(f"modules: size-suffixed names: {size_suffixed}")
+        oversized = sum(
+            1 for ids in module_member_lists if len(ids) > _MODULE_TARGET_MAX
+        )
+        if oversized:
+            # Flat dirs may honestly exceed the window — soft signal only.
+            warnings.append(f"{oversized} modules above target_max (flat dirs?)")
+
+    # -- Summaries ---------------------------------------------------------
+    empty_summaries = [nid for nid, s in summary_by_id.items() if not s]
+    if empty_summaries:
+        errors.append(f"{len(empty_summaries)} file nodes have an empty summary")
+    summary_completeness = 1.0 - len(empty_summaries) / file_count if file_count else 1.0
+
+    metrics = {
+        "file_count": file_count,
+        "layer_count": n_layers,
+        "module_count": len(modules),
+        "module_coverage_pct": round(
+            (len(module_covered) / file_count * 100) if (modules and file_count) else 0.0, 1
+        ),
+        "singleton_layer_pct": round(singleton_frac * 100, 1),
+        "largest_layer_pct": round(largest_frac * 100, 1),
+        "application_pct": round(catchall_frac * 100, 1),
+        "entry_point_count": len(entry_points),
+        "tour_steps": len(tour),
+        "tour_coverage_pct": round(tour_coverage * 100, 1),
+        "summary_completeness_pct": round(summary_completeness * 100, 1),
+    }
+
+    return KGValidation(ok=not errors, errors=errors, warnings=warnings, metrics=metrics)
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 — portable, self-validated export artifact
+# ---------------------------------------------------------------------------
+
+
+def build_portable_kg(kg: KnowledgeGraphResult) -> tuple[dict, KGValidation]:
+    """Assemble a self-contained, self-validated ``knowledge-graph.json`` dict.
+
+    Kept separate from :meth:`KnowledgeGraphResult.to_dict` so the *default*
+    export stays byte-identical (curation flag-off contract); the portable
+    artifact adds a ``meta`` block (counts, fingerprint) and an embedded
+    ``validation`` report so an external consumer can trust it without a server.
+    Returns ``(data, validation)`` so the writer can decide on hard violations.
+    """
+    data = kg.to_dict()
+    validation = validate_kg(kg)
+    data["meta"] = {
+        "schema_version": data.get("version", "1.0.0"),
+        "generator": "repowise-kg-curation",
+        "fingerprint": getattr(kg, "fingerprint", ""),
+        "file_count": validation.metrics.get("file_count", 0),
+        "layer_count": validation.metrics.get("layer_count", 0),
+        "module_count": validation.metrics.get("module_count", 0),
+        "entry_point_count": validation.metrics.get("entry_point_count", 0),
+        "tour_steps": validation.metrics.get("tour_steps", 0),
+        "validation": validation.as_dict(),
+    }
+    return data, validation

--- a/packages/core/src/repowise/core/analysis/knowledge_graph.py
+++ b/packages/core/src/repowise/core/analysis/knowledge_graph.py
@@ -25,17 +25,54 @@ class KnowledgeGraphResult:
     edges: list[dict] = field(default_factory=list)
     layers: list[dict] = field(default_factory=list)
     tour: list[dict] = field(default_factory=list)
+    # Curated wiki modules (``derive_modules`` in kg_curation): right-sized
+    # directory groups with stable path-derived ids. Only the curated export
+    # populates this; empty means the key is omitted from ``to_dict`` so the
+    # flag-off artifact stays byte-identical.
+    modules: list[dict] = field(default_factory=list)
     fingerprint: str = ""
 
     def to_dict(self) -> dict:
-        return {
+        # Canonical ordering: node/edge/layer-member lists carry no semantic
+        # order, but file-traversal and graph-insertion order vary run to
+        # run. Sorting here makes the exported artifact byte-stable across
+        # identical runs (baseline diffs, fingerprint reuse, clean diffs).
+        nodes = sorted(self.nodes, key=lambda n: str(n.get("id", "")))
+        edges = sorted(
+            self.edges,
+            key=lambda e: (
+                str(e.get("source", "")),
+                str(e.get("target", "")),
+                str(e.get("type", "")),
+            ),
+        )
+        def _canonical_layer(layer: dict) -> dict:
+            out = {**layer, "nodeIds": sorted(layer.get("nodeIds", []))}
+            if isinstance(layer.get("subGroups"), list):
+                out["subGroups"] = [
+                    {**sg, "nodeIds": sorted(sg.get("nodeIds", []))}
+                    if isinstance(sg, dict)
+                    else sg
+                    for sg in layer["subGroups"]
+                ]
+            return out
+
+        layers = [_canonical_layer(layer) for layer in self.layers]
+        out = {
             "version": "1.0.0",
             "project": self.project,
-            "nodes": self.nodes,
-            "edges": self.edges,
-            "layers": self.layers,
+            "nodes": nodes,
+            "edges": edges,
+            "layers": layers,
             "tour": self.tour,
         }
+        if self.modules:
+            # Additive key: present only when curation derived modules, so
+            # the uncurated export's byte shape is unchanged.
+            out["modules"] = [
+                {**m, "nodeIds": sorted(m.get("nodeIds", []))} for m in self.modules
+            ]
+        return out
 
     @classmethod
     def from_file(cls, path: Path) -> KnowledgeGraphResult | None:
@@ -50,6 +87,7 @@ class KnowledgeGraphResult:
             edges=data.get("edges", []),
             layers=data.get("layers", []),
             tour=data.get("tour", []),
+            modules=data.get("modules", []),
         )
 
 
@@ -71,6 +109,8 @@ _INFRA_NAMES = frozenset({
     "vagrantfile", "procfile",
 })
 
+_INFRA_LANGUAGES = frozenset({"dockerfile", "makefile"})
+
 _DOC_EXTENSIONS = frozenset({
     ".md", ".rst", ".txt", ".adoc",
 })
@@ -82,7 +122,14 @@ def _classify_file_type(path: str, language: str, is_config: bool) -> str:
 
     if is_config or ext in _CONFIG_EXTENSIONS:
         return "config"
-    if ext in _INFRA_EXTENSIONS or stem in _INFRA_NAMES:
+    # Infra names only count for extension-less files (Dockerfile, Makefile)
+    # or when ingestion parsed the file as an infra language — a Python module
+    # *named* dockerfile.py is code, not infrastructure.
+    if (
+        ext in _INFRA_EXTENSIONS
+        or language in _INFRA_LANGUAGES
+        or (not ext and stem in _INFRA_NAMES)
+    ):
         return "service"
     if ext in _DOC_EXTENSIONS:
         return "document"
@@ -250,13 +297,22 @@ def build_knowledge_graph_skeleton(
             continue
         seen_edges.add(edge_key)
 
-        edges.append({
+        edge_dict = {
             "source": source_id,
             "target": target_id,
             "type": kg_type,
             "direction": "forward",
             "weight": data.get("confidence", 1.0),
-        })
+        }
+        # Additive provenance marker: edges synthesised from convention
+        # passes (e.g. JVM same-package references) carry their origin so
+        # density metrics can separate them from declared imports and any
+        # false positive is diagnosable at the source. Key absent for
+        # regular declared-import edges.
+        hint = data.get("hint_source")
+        if hint:
+            edge_dict["hint"] = hint
+        edges.append(edge_dict)
 
     # ---- Layers (from communities) ---------------------------------------
     layers_by_id: dict[str, dict] = {}

--- a/packages/core/src/repowise/core/generation/context/assembler.py
+++ b/packages/core/src/repowise/core/generation/context/assembler.py
@@ -201,6 +201,7 @@ class ContextAssembler:
             community_cohesion=community_cohesion,
             decision_records=decision_records or [],
             kg_layer_name=kg_context.layer_name if kg_context else "",
+            kg_layer_id=kg_context.layer_id if kg_context else "",
             kg_layer_description=kg_context.layer_description if kg_context else "",
             kg_layer_role=kg_context.role if kg_context else "",
             kg_neighbors=kg_context.neighbors if kg_context else [],

--- a/packages/core/src/repowise/core/generation/context/contexts.py
+++ b/packages/core/src/repowise/core/generation/context/contexts.py
@@ -53,6 +53,9 @@ class FilePageContext:
     decision_records: list[dict] = field(default_factory=list)
     # KG layer context (populated when knowledge graph available)
     kg_layer_name: str = ""
+    # Stable slug id of the layer (``layer:<slug>``) — used to join a file
+    # page to its layer page; ``kg_layer_name`` is the mutable display label.
+    kg_layer_id: str = ""
     kg_layer_description: str = ""
     kg_layer_role: str = ""
     kg_neighbors: list[dict] = field(default_factory=list)
@@ -106,6 +109,9 @@ class LayerPageContext:
     layer_name: str
     layer_description: str
     file_count: int
+    # Stable slug id (``layer:<slug>``) — the layer page's target_path and
+    # page_id derive from this, never from the mutable ``layer_name``.
+    layer_id: str = ""
     key_files: list[dict] = field(default_factory=list)
     deps_out: list[dict] = field(default_factory=list)
     deps_in: list[dict] = field(default_factory=list)

--- a/packages/core/src/repowise/core/generation/kg_context.py
+++ b/packages/core/src/repowise/core/generation/kg_context.py
@@ -23,6 +23,10 @@ class KGFileContext:
     layer_name: str
     layer_description: str
     role: str  # "entry_point" | "internal" | "edge_connector"
+    # Stable slug identity of the layer (``layer:<slug>``), distinct from the
+    # mutable ``layer_name`` the LLM enrichment may rewrite. Page keys and
+    # joins use this so they survive layer renames.
+    layer_id: str = ""
     neighbors: list[dict] = field(default_factory=list)
     tour_step: dict | None = None
     tags: list[str] = field(default_factory=list)
@@ -32,16 +36,32 @@ class KGFileContext:
 class KnowledgeGraphContext:
     """Index a knowledge-graph.json for fast per-file lookups during generation."""
 
-    def __init__(self, kg_path: Path | None, repo_root: Path | None = None):
+    def __init__(
+        self,
+        kg_path: Path | None,
+        repo_root: Path | None = None,
+        *,
+        data: dict | None = None,
+    ):
         self._file_to_layer: dict[str, dict] = {}
         self._file_to_tour: dict[str, dict] = {}
         self._file_to_node: dict[str, dict] = {}
         self._layers: list[dict] = []
+        self._modules: list[dict] = []
         self._tour: list[dict] = []
+        self._project: dict = {}
         self._edges_by_source: dict[str, list[dict]] = {}
         self._edges_by_target: dict[str, list[dict]] = {}
         self._loaded = False
-        if kg_path and kg_path.exists():
+        if data is not None:
+            # In-memory KG (the pipeline result's export dict). The artifact
+            # file is only written during persistence — AFTER generation — so
+            # a fresh init has no file to read and silently lost every
+            # kg_ctx-derived page (layer pages, tour context, file layers).
+            if repo_root is None and kg_path is not None:
+                repo_root = kg_path.parent.parent
+            self._index(data, repo_root or Path())
+        elif kg_path and kg_path.exists():
             self._load(kg_path, repo_root)
 
     @property
@@ -58,7 +78,9 @@ class KnowledgeGraphContext:
 
         if repo_root is None:
             repo_root = path.parent.parent
+        self._index(kg, repo_root)
 
+    def _index(self, kg: dict, repo_root: Path) -> None:
         for node in kg.get("nodes", []):
             fp = node.get("filePath", "")
             if fp:
@@ -72,13 +94,23 @@ class KnowledgeGraphContext:
                     if fp not in self._file_to_layer:
                         self._file_to_layer[fp] = layer
 
+        self._project = kg.get("project") or {}
+        # Curated wiki modules (additive key; absent on uncurated artifacts).
+        self._modules = kg.get("modules", [])
         self._tour: list[dict] = kg.get("tour", [])
         for step in self._tour:
-            for node_id in step.get("nodeIds", []):
-                if node_id.startswith("file:"):
-                    fp = node_id[5:]
-                    if (repo_root / fp).exists():
-                        self._file_to_tour[fp] = step
+            # Curated tour steps carry a single target_path; the older shape
+            # listed nodeIds. Accept both.
+            paths = [
+                node_id[5:]
+                for node_id in step.get("nodeIds", [])
+                if node_id.startswith("file:")
+            ]
+            if step.get("target_path"):
+                paths.append(step["target_path"])
+            for fp in paths:
+                if (repo_root / fp).exists():
+                    self._file_to_tour[fp] = step
 
         for edge in kg.get("edges", []):
             src = edge.get("source", "")
@@ -132,11 +164,14 @@ class KnowledgeGraphContext:
 
         return KGFileContext(
             layer_name=layer.get("name", ""),
+            layer_id=layer.get("id", ""),
             layer_description=layer.get("description", ""),
             role=role,
             neighbors=neighbors[:10],
             tour_step={"order": tour["order"], "title": tour["title"],
-                       "description": tour["description"][:300]} if tour else None,
+                       # Curated steps state their evidence in "reason".
+                       "description": (tour.get("description") or tour.get("reason") or "")[:300]}
+            if tour else None,
             tags=node.get("tags", []),
             node_summary=node.get("summary", ""),
         )
@@ -144,8 +179,20 @@ class KnowledgeGraphContext:
     def get_layers(self) -> list[dict]:
         return self._layers if self._loaded else []
 
+    def get_modules(self) -> list[dict]:
+        """Curated wiki modules from the KG artifact (empty when uncurated)."""
+        return self._modules if self._loaded else []
+
     def get_tour(self) -> list[dict]:
         return self._tour if self._loaded else []
+
+    def get_graph_mode(self) -> str | None:
+        """The curation pass's honesty mode (flow/sparse/structural).
+
+        Only the curated export writes ``project.graph_mode`` — its presence
+        is the marker that the KG (and its tour) went through curation.
+        """
+        return self._project.get("graph_mode") if self._loaded else None
 
     def get_inter_layer_edges(self, layer: dict) -> tuple[list[dict], list[dict]]:
         """Return (deps_out, deps_in) aggregated by target/source layer."""

--- a/packages/core/src/repowise/core/generation/knowledge_graph.py
+++ b/packages/core/src/repowise/core/generation/knowledge_graph.py
@@ -58,13 +58,34 @@ async def enrich_knowledge_graph(
         reasoning=reasoning,
     )
 
-    tour = await _generate_tour(
-        enriched_layers, llm_client, graph_builder, repo_structure, kg_skeleton,
-        reasoning=reasoning,
-    )
+    # When curation is enabled it has already written the canonical,
+    # layer-aware tour (deterministic, one per layer top→bottom). The LLM must
+    # not reselect or reorder it — keep the curated tour as-is (prose narration
+    # can be layered on separately). Otherwise fall back to LLM tour generation.
+    from repowise.core.analysis.kg_curation import curation_enabled
+
+    if curation_enabled() and kg_skeleton.tour:
+        tour = kg_skeleton.tour
+    else:
+        tour = await _generate_tour(
+            enriched_layers, llm_client, graph_builder, repo_structure, kg_skeleton,
+            reasoning=reasoning,
+        )
 
     if generated_pages:
         _backfill_summaries(kg_skeleton, generated_pages)
+
+    # Deterministic summary floor, applied *after* the page backfill so rich
+    # page summaries always win and only never-paged files fall back. Gated by
+    # the curation flag (the seam already floored FAST-mode output; this covers
+    # the generate-mode path where the seam deferred to let backfill run first).
+    if curation_enabled():
+        from repowise.core.analysis.kg_curation import apply_summary_floor
+
+        try:
+            apply_summary_floor(kg_skeleton)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("kg_summary_floor_failed", error=str(exc))
 
     kg_skeleton.layers = enriched_layers
     kg_skeleton.tour = tour
@@ -92,23 +113,28 @@ async def _enrich_layers(
 
     pagerank = graph_builder.pagerank()
     enriched = list(layers)
+    # Join LLM responses back onto layers by their stable id, never by list
+    # position: positional joins silently corrupt every name when a model
+    # returns batch-relative indices.
+    by_id = {layer["id"]: layer for layer in enriched if layer.get("id")}
 
     for batch_start in range(0, len(layers), _LAYER_BATCH_SIZE):
         batch = layers[batch_start : batch_start + _LAYER_BATCH_SIZE]
         batch_context = []
-        for i, layer in enumerate(batch):
+        for layer in batch:
             node_ids = layer.get("nodeIds", [])
             file_paths = [nid.removeprefix("file:") for nid in node_ids if nid.startswith("file:")]
             top_files = sorted(file_paths, key=lambda p: pagerank.get(p, 0.0), reverse=True)[:20]
 
             batch_context.append({
-                "index": batch_start + i,
+                "id": layer.get("id", ""),
                 "heuristic_label": layer["name"],
                 "file_count": len(file_paths),
                 "top_files": top_files,
             })
 
         user_prompt = _build_layer_naming_prompt(batch_context, tech_stack, repo_structure)
+        batch_ids = {layer.get("id") for layer in batch}
 
         try:
             response = await llm_client.generate(
@@ -121,12 +147,19 @@ async def _enrich_layers(
             parsed = _parse_json_response(response.content)
             if parsed and "layers" in parsed:
                 for item in parsed["layers"]:
-                    idx = item.get("index")
-                    if idx is not None and 0 <= idx < len(enriched):
-                        if item.get("name"):
-                            enriched[idx]["name"] = item["name"]
-                        if item.get("description"):
-                            enriched[idx]["description"] = item["description"]
+                    layer_id = item.get("id")
+                    target = by_id.get(layer_id) if layer_id in batch_ids else None
+                    if target is None:
+                        logger.warning(
+                            "kg_layer_naming_unknown_id",
+                            layer_id=layer_id,
+                            batch_ids=sorted(filter(None, batch_ids)),
+                        )
+                        continue
+                    if item.get("name"):
+                        target["name"] = item["name"]
+                    if item.get("description"):
+                        target["description"] = item["description"]
         except Exception as exc:
             logger.warning("kg_layer_naming_batch_failed", error=str(exc))
 
@@ -152,14 +185,15 @@ def _build_layer_naming_prompt(
     ]
 
     for ctx in batch_context:
-        lines.append(f"\n--- Community {ctx['index']} ---")
+        lines.append(f"\n--- Community \"{ctx['id']}\" ---")
         lines.append(f"Heuristic label: {ctx['heuristic_label']}")
         lines.append(f"File count: {ctx['file_count']}")
         lines.append(f"Top files: {', '.join(ctx['top_files'][:10])}")
 
     lines.append("")
     lines.append(
-        'Respond with: {"layers": [{"index": 0, "name": "...", "description": "..."}]}'
+        "Respond with each community's id echoed verbatim: "
+        '{"layers": [{"id": "...", "name": "...", "description": "..."}]}'
     )
     return "\n".join(lines)
 
@@ -328,10 +362,15 @@ def _backfill_summaries(kg_result: Any, generated_pages: list[Any]) -> None:
             page_summaries[target] = summary
 
     for node in kg_result.nodes:
-        if node["type"] in ("file", "config", "service", "document"):
-            path = node.get("filePath", node["id"].removeprefix("file:"))
-            if path in page_summaries and not node.get("summary"):
-                node["summary"] = page_summaries[path]
+        # Any file-level node (any presentation type — file/config/service/
+        # pipeline/schema/document). Only fill empties: a page summary is the
+        # richest source, and the deterministic curation floor is applied
+        # *after* this backfill so it never blocks a real page summary.
+        if not str(node.get("id", "")).startswith("file:"):
+            continue
+        path = node.get("filePath", node["id"].removeprefix("file:"))
+        if path in page_summaries and not node.get("summary"):
+            node["summary"] = page_summaries[path]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/core/src/repowise/core/generation/layers.py
+++ b/packages/core/src/repowise/core/generation/layers.py
@@ -24,6 +24,8 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from pathlib import PurePosixPath
 
+from repowise.core.ingestion.languages.registry import REGISTRY as _LANG_REGISTRY
+
 # ---------------------------------------------------------------------------
 # Directory → layer hint table. Each canonical layer maps to the
 # directory-name tokens that imply it. A
@@ -31,7 +33,10 @@ from pathlib import PurePosixPath
 # from the deepest segment outward (the closest directory wins).
 # ---------------------------------------------------------------------------
 
+_TEST_DIR_TOKENS = frozenset({"__tests__", "test", "tests", "spec", "specs", "e2e"})
+
 _LAYER_HINTS: tuple[tuple[str, frozenset[str]], ...] = (
+    ("CLI", frozenset({"cli", "commands", "cmd", "cli_commands"})),
     ("API", frozenset({"routes", "api", "controllers", "endpoints", "handlers", "routers"})),
     ("Service", frozenset({"services", "core", "lib", "domain", "logic", "usecases"})),
     ("Data", frozenset({"models", "db", "data", "persistence", "repository", "repositories", "store", "stores", "entities"})),
@@ -39,9 +44,169 @@ _LAYER_HINTS: tuple[tuple[str, frozenset[str]], ...] = (
     ("Middleware", frozenset({"middleware", "plugins", "interceptors", "guards"})),
     ("Utility", frozenset({"utils", "helpers", "common", "shared", "tools", "util"})),
     ("Config", frozenset({"config", "constants", "env", "settings", "conf"})),
-    ("Test", frozenset({"__tests__", "test", "tests", "spec", "specs", "e2e"})),
+    ("Test", _TEST_DIR_TOKENS),
     ("Types", frozenset({"types", "interfaces", "schemas", "contracts", "dtos", "typings"})),
 )
+
+# Layers that observe or support the runtime stack rather than participate in
+# it. Tests import production code and are never imported back, so letting
+# them compete on import direction would crown them the top "consumer" in
+# every codebase that has tests. They are excluded from the dependency race
+# and pinned after the runtime layers instead.
+ADJACENT_LAYERS: frozenset[str] = frozenset({"Test"})
+
+# Test-dir tokens that also name non-test directories in the wild ("spec(s)" =
+# specifications, OpenAPI specs, language specs, …). These assign the Test
+# layer only when the *file* corroborates; otherwise the scan continues
+# outward to the next matching segment.
+_AMBIGUOUS_TEST_DIR_TOKENS: frozenset[str] = frozenset({"spec", "specs"})
+
+# Filename shapes that mark a test on their own (pytest, Go, Jest/Vitest,
+# RSpec/minitest fixtures, …). Derived from the language registry — each
+# language declares its own conventions on its spec; the union applies
+# globally here (parity with the historical hard-coded tuples is pinned by
+# tests/unit/ingestion/test_language_capabilities.py).
+_TEST_FILE_STEM_PREFIXES = _LANG_REGISTRY.test_stem_prefixes()
+_TEST_FILE_STEM_SUFFIXES = _LANG_REGISTRY.test_stem_suffixes()
+_TEST_FILE_INFIXES = _LANG_REGISTRY.test_infixes()
+_TEST_FIXTURE_STEMS = _LANG_REGISTRY.test_fixture_stems()
+
+# Case-sensitive camel-boundary suffix patterns (FooTest.java, BarSpec.scala),
+# keyed by extension so each language's convention applies only to its own
+# files (polyglot fairness). The lowercase-boundary lookbehind keeps
+# `latest.java`, `contest.cs`, and bare `Test.java` out — conventions match
+# with their own case sensitivity.
+_TEST_CAMEL_RES = _LANG_REGISTRY.camel_test_res_by_extension()
+
+# Multi-segment test roots (src/it/java) and case-sensitive test-project dir
+# suffixes (.NET sibling Foo.Tests/ projects). Both are unambiguous — like
+# tests/ and __tests__/, they mark any file beneath them.
+# A ``*``-segment form ("src/*Test") matches a Gradle source-set directory:
+# the literal segment(s) match lowercased, the ``*<Suffix>`` segment matches
+# the original-case dir name by proper suffix (src/jvmTest, src/commonTest,
+# src/integrationTest, …).
+_TEST_DIR_PATHS: tuple[tuple[str, ...], ...] = tuple(
+    tuple(p.split("/")) for p in _LANG_REGISTRY.test_dir_paths() if "*" not in p
+)
+_TEST_DIR_WILDCARDS: tuple[tuple[str, str], ...] = tuple(
+    (p.split("/")[0], p.split("/")[1].lstrip("*"))
+    for p in _LANG_REGISTRY.test_dir_paths()
+    if "*" in p
+)
+_TEST_DIR_SUFFIXES = _LANG_REGISTRY.test_dir_suffixes()
+# Per-language unambiguous test-dir tokens: ruby's spec/ needs no filename
+# corroboration — a Ruby file under spec/ is RSpec material whatever its
+# name (support helpers, vendored fixtures).
+_LANG_TEST_DIR_TOKENS = _LANG_REGISTRY.test_dir_tokens_by_language()
+
+
+def _is_test_file_name(filename: str) -> bool:
+    """Whether *filename* alone marks a test (test_x.py, x_test.go, x.spec.ts, …)."""
+    name = filename.lower()
+    stem = PurePosixPath(name).stem
+    if (
+        stem in _TEST_FIXTURE_STEMS
+        or stem.startswith(_TEST_FILE_STEM_PREFIXES)
+        or stem.endswith(_TEST_FILE_STEM_SUFFIXES)
+        or any(m in name for m in _TEST_FILE_INFIXES)
+    ):
+        return True
+    camel_re = _TEST_CAMEL_RES.get(PurePosixPath(filename).suffix.lower())
+    return camel_re is not None and camel_re.search(PurePosixPath(filename).stem) is not None
+
+
+def _is_test_dir_path(segments: list[str], original_segments: list[str]) -> bool:
+    """Whether the directory path itself is an unambiguous test root.
+
+    *segments* are lowercased dir names, *original_segments* preserve case
+    for the case-sensitive project-dir suffix rule (``Foo.Tests/``).
+    """
+    for needle in _TEST_DIR_PATHS:
+        span = len(needle)
+        if span <= len(segments) and any(
+            tuple(segments[i : i + span]) == needle
+            for i in range(len(segments) - span + 1)
+        ):
+            return True
+    for prefix_seg, camel_sfx in _TEST_DIR_WILDCARDS:
+        for i in range(len(segments) - 1):
+            nxt = original_segments[i + 1]
+            if (
+                segments[i] == prefix_seg
+                and nxt.endswith(camel_sfx)
+                and len(nxt) > len(camel_sfx)
+            ):
+                return True
+    return any(seg.endswith(_TEST_DIR_SUFFIXES) for seg in original_segments)
+
+
+# Per-language layer hints (they fire only for files of the
+# declaring language, never others'). Partitioned by hint shape at import time — exact
+# lowercase tokens, multi-segment paths ("src/bin"), and case-sensitive
+# dir-name suffixes (".Api", "-cli"). The generic table above wins at any
+# given depth; a deeper segment beats a shallower one across both tables.
+_LANG_TOKEN_HINTS: dict[str, dict[str, str]] = {}
+_LANG_PATH_HINTS: dict[str, tuple[tuple[tuple[str, ...], str], ...]] = {}
+_LANG_SUFFIX_HINTS: dict[str, tuple[tuple[str, str], ...]] = {}
+_LANG_ROOT_HINTS: dict[str, dict[str, str]] = {}
+for _tag, _hints in _LANG_REGISTRY.layer_dir_hints_by_language().items():
+    _tokens: dict[str, str] = {}
+    _paths: list[tuple[tuple[str, ...], str]] = []
+    _suffixes: list[tuple[str, str]] = []
+    _roots: dict[str, str] = {}
+    for _key, _layer in _hints:
+        if _key.startswith("/"):
+            # Root-anchored token ("/include"): the convention is a
+            # top-level dir — a vendored include/ buried deep in another
+            # language's tree must not mint the layer.
+            _roots[_key[1:]] = _layer
+        elif "/" in _key:
+            _paths.append((tuple(_key.split("/")), _layer))
+        elif _key.startswith((".", "-")):
+            _suffixes.append((_key, _layer))
+        else:
+            _tokens[_key] = _layer
+    if _tokens:
+        _LANG_TOKEN_HINTS[_tag] = _tokens
+    if _paths:
+        _LANG_PATH_HINTS[_tag] = tuple(_paths)
+    if _suffixes:
+        _LANG_SUFFIX_HINTS[_tag] = tuple(_suffixes)
+    if _roots:
+        _LANG_ROOT_HINTS[_tag] = _roots
+
+
+# Example/demo/benchmark directories: documentation-by-code and support
+# harnesses, not the system itself. Their files carry entry-style names
+# (main.go, index.js, decode.exs) by convention, so without demotion they
+# flood entry points and the tour on any repo that ships samples (express,
+# chi, …) or benchmarks (cargo's benches/, jason's bench/).
+_EXAMPLE_DIR_TOKENS = frozenset(
+    {
+        "examples", "_examples", "example", "samples", "sample", "demo", "demos",
+        "bench", "benches", "benchmarks",
+    }
+)
+
+
+# Documentation directories: sphinx/docusaurus/vitepress sites and runnable
+# doc snippets (libuv's docs/code/*/main.c, docfx template assets). Like the
+# example dirs above, their files carry entry-style names by convention but
+# document the system rather than being it.
+_DOC_DIR_TOKENS = frozenset({"docs", "doc", "website"})
+
+
+def is_support_path(path: str) -> bool:
+    """Whether *path* is support material (examples/benchmarks/docs sites).
+
+    Support files never seed or anchor a tour and never surface as entry
+    points — a reader orienting in the repo must land in the system itself,
+    not in its documentation or sample harnesses.
+    """
+    return any(
+        s.lower() in _EXAMPLE_DIR_TOKENS or s.lower() in _DOC_DIR_TOKENS
+        for s in PurePosixPath(path).parts[:-1]
+    )
 
 # Fallback layer for files whose path matches no hint (root scripts, etc.).
 DEFAULT_LAYER = "Application"
@@ -52,32 +217,126 @@ DEFAULT_LAYER = "Application"
 # (foundational): top imports middle imports bottom.
 _CANONICAL_RANK: dict[str, int] = {
     "UI": 0,
-    "API": 1,
-    "Middleware": 2,
-    "Service": 3,
-    DEFAULT_LAYER: 4,
-    "Data": 5,
-    "Types": 6,
-    "Config": 7,
-    "Utility": 8,
-    "Test": 9,
+    "CLI": 1,
+    "API": 2,
+    "Middleware": 3,
+    "Service": 4,
+    DEFAULT_LAYER: 5,
+    "Data": 6,
+    "Types": 7,
+    "Config": 8,
+    "Utility": 9,
+    "Test": 10,
 }
 
 
-def infer_layer(path: str) -> str:
+def infer_layer(path: str, language: str | None = None) -> str:
     """Return the architectural layer name for *path*.
 
-    Scans path segments from the deepest directory outward and returns the
-    first layer whose hint set contains a segment. Falls back to
-    :data:`DEFAULT_LAYER` when nothing matches.
+    A test-shaped filename wins outright — Go and Jest colocate tests beside
+    sources (``mux_test.go``, ``Button.test.tsx``), so without this check
+    repos with no ``tests/`` dir get no Test layer at all. A test root
+    anywhere on the path wins next: ``tests/models/x.py`` is a test fixture,
+    not Data, so unambiguous test dirs (``tests``/``__tests__``/…) mark the
+    file from any depth. Ambiguous test-dir tokens (``spec``/``specs``) count
+    only when the filename itself looks like a test — a ``specs/`` directory
+    full of ordinary modules is a specification folder, not a test suite.
+    Otherwise scans path segments from the deepest directory outward and
+    returns the first layer whose hint set contains a segment. When
+    *language* is given, that language's registry-declared hints (Go
+    ``internal/``, Rust ``src/bin/``, .NET ``Foo.Api/``…) are consulted at
+    each depth after the generic table — they never fire for other
+    languages' files. Falls back to :data:`DEFAULT_LAYER` when nothing
+    matches.
     """
-    segments = [s.lower() for s in PurePosixPath(path).parts[:-1]]  # drop filename
+    original_parts = list(PurePosixPath(path).parts)
+    parts = [s.lower() for s in original_parts]
+    # Original case is preserved for the case-sensitive rules (camel-suffix
+    # filenames, .NET ``Foo.Tests/`` project dirs).
+    filename = original_parts[-1] if original_parts else ""
+    segments = parts[:-1]  # drop filename
+
+    if _is_test_file_name(filename):
+        return "Test"
+
+    lang_test_tokens = _LANG_TEST_DIR_TOKENS.get((language or "").lower(), frozenset())
+    for seg in segments:
+        if seg not in _TEST_DIR_TOKENS:
+            continue
+        if (
+            seg in _AMBIGUOUS_TEST_DIR_TOKENS
+            and seg not in lang_test_tokens
+            and not _is_test_file_name(filename)
+        ):
+            continue  # "spec(s)/" without a test-shaped file: not a test root
+        return "Test"
+
+    if _is_test_dir_path(segments, original_parts[:-1]):
+        return "Test"
+
+    # Repo-root dot-directories (.github, .agents, .claude, .vscode, …) hold
+    # tooling, not architecture — their inner dir names (e.g. "plugins") must
+    # not mint phantom runtime layers.
+    if segments and segments[0].startswith("."):
+        return "Config"
+
+    lang = (language or "").lower()
+    token_hints = _LANG_TOKEN_HINTS.get(lang)
+    path_hints = _LANG_PATH_HINTS.get(lang)
+    suffix_hints = _LANG_SUFFIX_HINTS.get(lang)
+    root_hints = _LANG_ROOT_HINTS.get(lang)
+    original_segments = original_parts[:-1]
+
     # Deepest directory first — the closest folder describes the file best.
-    for seg in reversed(segments):
+    for i in range(len(segments) - 1, -1, -1):
+        seg = segments[i]
         for layer_name, tokens in _LAYER_HINTS:
+            if layer_name == "Test":
+                continue  # handled above
             if seg in tokens:
                 return layer_name
+        if token_hints and seg in token_hints:
+            return token_hints[seg]
+        if path_hints:
+            for needle, layer_name in path_hints:
+                span = len(needle)
+                if span <= i + 1 and tuple(segments[i - span + 1 : i + 1]) == needle:
+                    return layer_name
+        if suffix_hints:
+            orig = original_segments[i]
+            for sfx, layer_name in suffix_hints:
+                # Proper suffix only — a dir literally named ".Api" is not
+                # the convention.
+                if orig.endswith(sfx) and len(orig) > len(sfx):
+                    return layer_name
+        if i == 0 and root_hints and seg in root_hints:
+            return root_hints[seg]
     return DEFAULT_LAYER
+
+
+def layer_order_basis(
+    file_layers: Mapping[str, str],
+    import_edges: Iterable[tuple[str, str]],
+) -> str:
+    """Whether :func:`compute_layer_order`'s result is evidence or convention.
+
+    Returns ``"imports"`` when at least one inter-layer runtime edge
+    participated in the ordering race, ``"canonical"`` when the order is
+    purely the conventional rank (edgeless/sparse graphs, single-layer
+    repos). Consumers must not claim "X sits above Y" for a canonical
+    order — no edge supports it.
+    """
+    for src, dst in import_edges:
+        if src.startswith("external:") or dst.startswith("external:"):
+            continue
+        ls = file_layers.get(src)
+        ld = file_layers.get(dst)
+        if not ls or not ld or ls == ld:
+            continue
+        if ls in ADJACENT_LAYERS or ld in ADJACENT_LAYERS:
+            continue
+        return "imports"
+    return "canonical"
 
 
 def compute_layer_order(
@@ -100,10 +359,18 @@ def compute_layer_order(
     imports many but is imported by few is a consumer (top). Ties fall back to
     the canonical rank so the result is stable on graphs with no clear
     direction.
+
+    :data:`ADJACENT_LAYERS` (tests) sit outside the runtime stack: their edges
+    are excluded from the race (a test importing a service says nothing about
+    where the service sits) and they are appended after the runtime layers in
+    canonical-rank order.
     """
     layers = sorted(set(file_layers.values()))
     if len(layers) <= 1:
         return layers
+
+    runtime = [layer for layer in layers if layer not in ADJACENT_LAYERS]
+    adjacent = [layer for layer in layers if layer in ADJACENT_LAYERS]
 
     out_deg: dict[str, int] = defaultdict(int)  # edges leaving the layer
     in_deg: dict[str, int] = defaultdict(int)  # edges entering the layer
@@ -114,6 +381,8 @@ def compute_layer_order(
         ld = file_layers.get(dst)
         if not ls or not ld or ls == ld:
             continue
+        if ls in ADJACENT_LAYERS or ld in ADJACENT_LAYERS:
+            continue
         out_deg[ls] += 1
         in_deg[ld] += 1
 
@@ -123,4 +392,6 @@ def compute_layer_order(
         net = in_deg[layer] - out_deg[layer]
         return (net, _CANONICAL_RANK.get(layer, len(_CANONICAL_RANK)))
 
-    return sorted(layers, key=sort_key)
+    ordered = sorted(runtime, key=sort_key)
+    ordered += sorted(adjacent, key=lambda la: _CANONICAL_RANK.get(la, len(_CANONICAL_RANK)))
+    return ordered

--- a/packages/core/src/repowise/core/generation/models.py
+++ b/packages/core/src/repowise/core/generation/models.py
@@ -112,10 +112,16 @@ class GenerationConfig:
     file_page_min_symbols: int = 1
     skip_trivial_files: bool = True
     dedupe_near_clones: bool = True
-    # Phase 2: switch module_page grouping from top-directory to graph
-    # communities. min_module_size is the floor below which a community
-    # doesn't get its own page (its files still appear under file_page).
-    module_grouping: Literal["community", "top_dir"] = "community"
+    # Module-page grouping source. "curated" (default) groups by the wiki
+    # modules the KG curation pass derives (stable path ids, human names,
+    # right-sized groups) and silently falls back to "community" when no
+    # curated modules are available (curation off, degraded, or no KG
+    # artifact), so it is always safe. "community" groups by raw graph
+    # communities (the pre-curation behavior, kept as the escape hatch),
+    # "top_dir" by top-level directory.
+    # min_module_size is the floor below which a group doesn't get its own
+    # page (its files still appear under file_page).
+    module_grouping: Literal["community", "top_dir", "curated"] = "curated"
     min_module_size: int = 3
     # Phase 3: emit the curated Onboarding collection at level 8. Each
     # subkind defines its own gate; slots whose gates fail are silently

--- a/packages/core/src/repowise/core/generation/onboarding/subkinds/how_it_works.py
+++ b/packages/core/src/repowise/core/generation/onboarding/subkinds/how_it_works.py
@@ -139,11 +139,29 @@ def _collect_flows(signals: OnboardingSignals) -> list[FlowTrace]:
     return flows
 
 
+def _normalize_tour_step(step: dict) -> dict:
+    """One template-facing shape for both tour-step generations.
+
+    Legacy steps carry ``nodeIds`` + ``description``; curated steps carry a
+    single ``target_path`` + evidence in ``reason``. The strict template
+    (``step.nodeIds`` / ``step.description``) must never see a missing key.
+    """
+    node_ids = list(step.get("nodeIds") or [])
+    if step.get("target_path"):
+        node_ids.append(f"file:{step['target_path']}")
+    return {
+        "order": step.get("order", 0),
+        "title": step.get("title", ""),
+        "description": step.get("description") or step.get("reason") or "",
+        "nodeIds": node_ids,
+    }
+
+
 def _build(signals: OnboardingSignals) -> HowItWorksContext | None:
     archetype, evidence = _classify_archetype(signals)
     flows = _collect_flows(signals)
 
-    kg_tour = list(signals.kg_tour_steps) if signals.kg_tour_steps else []
+    kg_tour = [_normalize_tour_step(s) for s in signals.kg_tour_steps or ()]
 
     # Gate: need either a real trace, tour steps, or a non-trivial archetype.
     if not flows and not kg_tour and archetype == "module":

--- a/packages/core/src/repowise/core/generation/page_generator/core.py
+++ b/packages/core/src/repowise/core/generation/page_generator/core.py
@@ -60,15 +60,23 @@ def _attach_file_provenance(page: GeneratedPage, ctx: FilePageContext) -> None:
     """
     if ctx.kg_layer_name:
         page.metadata["layer_name"] = ctx.kg_layer_name
+        # Stable slug id of the layer page this file links to. The layer page
+        # is keyed by slug (``layer:<slug>``) so the join survives the LLM
+        # layer-name enrichment that mutates ``layer_name`` after generation.
+        if ctx.kg_layer_id:
+            page.metadata["layer_id"] = ctx.kg_layer_id
         if ctx.kg_layer_role:
             page.metadata["layer_role"] = ctx.kg_layer_role
     else:
         # Guarantee every file page carries a layer so the Architecture tree
         # can group it. When the knowledge graph has no layer, fall back to
         # path-based inference.
+        from ...analysis.knowledge_graph import _slugify
         from ..layers import infer_layer
 
-        page.metadata["layer_name"] = infer_layer(ctx.file_path)
+        inferred = infer_layer(ctx.file_path, getattr(ctx, "language", None))
+        page.metadata["layer_name"] = inferred
+        page.metadata["layer_id"] = f"layer:{_slugify(inferred)}"
 
     sources: list[dict[str, str]] = []
     seen: set[str] = set()
@@ -171,6 +179,8 @@ class PageGenerator(PerTypeGenerationMixin):
         decision_report: Any | None = None,
         external_systems: list[dict] | None = None,
         on_page_ready: Callable[[GeneratedPage], None] | None = None,
+        kg_modules: list[dict] | None = None,
+        kg_data: dict | None = None,
     ) -> list[GeneratedPage]:
         """Generate all wiki pages for a repository.
 
@@ -198,6 +208,8 @@ class PageGenerator(PerTypeGenerationMixin):
             decision_report=decision_report,
             external_systems=external_systems,
             on_page_ready=on_page_ready,
+            kg_modules=kg_modules,
+            kg_data=kg_data,
         )
 
     # ------------------------------------------------------------------

--- a/packages/core/src/repowise/core/generation/page_generator/levels.py
+++ b/packages/core/src/repowise/core/generation/page_generator/levels.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
+from ...analysis.knowledge_graph import _slugify
 from .. import onboarding as _onboarding
 from ..context_assembler import FilePageContext
 from ..models import compute_page_id
@@ -317,7 +318,13 @@ def build_level5_coros(run: _GenerationRun) -> list[tuple[str, Any]]:
             continue
 
         layer_name = layer.get("name", "")
-        page_id = compute_page_id("layer_page", f"layer:{layer_name}")
+        # Key the page by the layer's STABLE slug id (``layer:<slug>``), not its
+        # display name: the LLM layer-name enrichment rewrites ``name`` after
+        # generation, so a name-keyed page would no longer join to its KG layer.
+        # ``id`` is derived from the deterministic heuristic name at curation
+        # time and never changes under enrichment.
+        layer_id = layer.get("id", "") or f"layer:{_slugify(layer_name)}"
+        page_id = compute_page_id("layer_page", layer_id)
         if page_id in run.completed_ids:
             continue
 
@@ -354,6 +361,7 @@ def build_level5_coros(run: _GenerationRun) -> list[tuple[str, Any]]:
 
         ctx = LayerPageContext(
             layer_name=layer_name,
+            layer_id=layer_id,
             layer_description=layer.get("description", ""),
             file_count=len(file_paths),
             key_files=key_files,

--- a/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
+++ b/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
@@ -60,6 +60,8 @@ class _GenerationRun:
         decision_report: Any | None,
         external_systems: list[dict] | None,
         on_page_ready: Callable[[GeneratedPage], None] | None = None,
+        kg_modules: list[dict] | None = None,
+        kg_data: dict | None = None,
     ) -> None:
         self.gen = gen
         self.config = gen._config
@@ -83,6 +85,11 @@ class _GenerationRun:
         self.resume = resume
         self.repo_path = repo_path
         self.external_systems = external_systems or []
+        # Curated wiki modules from the IN-MEMORY pipeline result. The kg_ctx
+        # file fallback below is one run stale on update and absent on a
+        # fresh init (the artifact is written AFTER generation) — the live
+        # repowise run shipped community-grouped module pages because of it.
+        self.kg_modules = kg_modules or []
 
         # ---- Graph metrics ----
         self.graph = graph_builder.graph()
@@ -98,17 +105,27 @@ class _GenerationRun:
         # ---- KG context (per-file knowledge graph lookups) ----
         from repowise.core.generation.kg_context import KnowledgeGraphContext
 
-        kg_path = None
+        # Prefer the in-memory KG (the pipeline result's export dict): the
+        # artifact file is only written during persistence — AFTER this
+        # generation pass — so on a fresh init the file path below finds
+        # nothing and every kg_ctx-derived page (layer pages, tour context,
+        # file layers) silently vanished from first-run wikis.
+        rp = None
         if repo_path:
             rp = Path(repo_path) if not isinstance(repo_path, Path) else repo_path
-            for candidate in [
-                rp / ".repowise" / "knowledge-graph.json",
-                rp / ".understand-anything" / "knowledge-graph.json",
-            ]:
-                if candidate.exists():
-                    kg_path = candidate
-                    break
-        self.kg_ctx = KnowledgeGraphContext(kg_path)
+        if kg_data is not None:
+            self.kg_ctx = KnowledgeGraphContext(None, rp, data=kg_data)
+        else:
+            kg_path = None
+            if rp:
+                for candidate in [
+                    rp / ".repowise" / "knowledge-graph.json",
+                    rp / ".understand-anything" / "knowledge-graph.json",
+                ]:
+                    if candidate.exists():
+                        kg_path = candidate
+                        break
+            self.kg_ctx = KnowledgeGraphContext(kg_path)
 
         # ---- Run bookkeeping ----
         self.semaphore = asyncio.Semaphore(self.config.max_concurrency)
@@ -214,6 +231,11 @@ class _GenerationRun:
                 git_meta_map=self.git_meta_map,
                 config=self.config,
                 kg_file_scores=kg_scores or None,
+                # Curated wiki modules: prefer the in-memory pipeline
+                # result (fresh); the artifact file is absent on first init
+                # and one run stale on update. Inert unless
+                # module_grouping == "curated".
+                kg_modules=self.kg_modules or self.kg_ctx.get_modules() or None,
             )
         )
 
@@ -293,24 +315,40 @@ class _GenerationRun:
 
         import_edges = self._file_import_edges()
 
-        # Tour: ordered stops over the selected file/infra pages + overview.
-        stops = build_tour(
-            self.parsed_files,
-            self.pagerank,
-            import_edges,
-            file_page_paths=self.sel_file_paths,
-            infra_paths=self.sel_infra_paths,
-            repo_name=self.repo_name,
-        )
-        self.tour_stops = [s.as_dict() for s in stops]
+        # When the indexed KG carries the curated tour (project.graph_mode is
+        # written only by the curation pass), adopt it wholesale instead of
+        # re-deriving a second, divergent tour from the raw graph: the curated
+        # tour knows the repo's honesty mode (flow/sparse/structural), walks
+        # imports-type edges only, and excludes support paths — and the wiki's
+        # file cards already cite its steps. One tour, every surface.
+        if self.kg_ctx.available and self.kg_ctx.get_graph_mode():
+            self.tour_stops = [dict(s) for s in self.kg_ctx.get_tour()]
+        if not self.tour_stops:
+            # Tour: ordered stops over the selected file/infra pages + overview.
+            stops = build_tour(
+                self.parsed_files,
+                self.pagerank,
+                import_edges,
+                file_page_paths=self.sel_file_paths,
+                infra_paths=self.sel_infra_paths,
+                repo_name=self.repo_name,
+            )
+            self.tour_stops = [s.as_dict() for s in stops]
 
         # Layer spine: every documented file gets a layer (KG when present,
         # path-based inference otherwise), then layers are ordered top→bottom
         # by inter-layer dependency direction.
+        lang_by_path = {
+            p.file_info.path: (getattr(p.file_info, "language", "") or "").lower()
+            for p in self.parsed_files
+            if getattr(p, "file_info", None)
+        }
         file_layers: dict[str, str] = {}
         for path in self.sel_file_paths:
             kg_fc = self.kg_ctx.get_file_context(path) if self.kg_ctx.available else None
-            file_layers[path] = (kg_fc.layer_name if kg_fc and kg_fc.layer_name else "") or infer_layer(path)
+            file_layers[path] = (kg_fc.layer_name if kg_fc and kg_fc.layer_name else "") or infer_layer(
+                path, lang_by_path.get(path)
+            )
         self.layer_order = compute_layer_order(file_layers, import_edges)
 
     # ------------------------------------------------------------------

--- a/packages/core/src/repowise/core/generation/page_generator/pertype.py
+++ b/packages/core/src/repowise/core/generation/page_generator/pertype.py
@@ -310,7 +310,10 @@ class PerTypeGenerationMixin:
         ctx: LayerPageContext,
     ) -> GeneratedPage:
         user_prompt = self._render("layer_page.j2", ctx=ctx)
-        target = f"layer:{ctx.layer_name}"
+        # target_path = the layer's STABLE slug id, so the page key survives
+        # the post-generation LLM rename of ``layer_name``. The title still
+        # uses the (heuristic) display name.
+        target = ctx.layer_id
         response = await self._call_provider(
             "layer_page", user_prompt, str(uuid.uuid4()), target_path=target
         )

--- a/packages/core/src/repowise/core/generation/selection/selector.py
+++ b/packages/core/src/repowise/core/generation/selection/selector.py
@@ -45,8 +45,9 @@ class ModuleGroup:
     """One ``module_page`` worth of files.
 
     ``key`` is the stable identifier persisted as ``target_path``:
-    ``community-<id>`` when grouping by community, the top-level
-    directory when falling back to ``top_dir``.
+    the module's real directory path when grouping by curated KG modules
+    (so path-prefix child lookups work), ``community-<id>`` when grouping
+    by community, the top-level directory when falling back to ``top_dir``.
     """
 
     key: str
@@ -108,6 +109,11 @@ class SelectionInputs:
     git_meta_map: dict[str, dict] | None
     config: Any  # GenerationConfig — duck-typed to avoid the import cycle
     kg_file_scores: dict[str, float] | None = None
+    # Curated wiki modules from the KG artifact (``modules`` top-level key),
+    # passed through — never re-derived here. Only read when
+    # ``config.module_grouping == "curated"``; ``None``/empty falls back to
+    # community grouping (the fallback-matrix "degraded" row).
+    kg_modules: list[dict] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -184,11 +190,84 @@ def _build_symbol_candidates(
     return scored
 
 
+def _build_curated_module_groups(
+    inputs: SelectionInputs, min_size: int
+) -> list[tuple[float, ModuleGroup]] | None:
+    """Scored groups from curated KG modules, or ``None`` when unavailable.
+
+    ``key`` = the module's real directory path (its ``target_path``, so the
+    MCP child lookup ``target_path LIKE 'dir/%'`` works), ``display``/``label``
+    = the curated human name, ``cohesion`` = None (the community block in the
+    template is conditional and has no meaning for directory groups). Ranked
+    by Σ PageRank of members — better than ``score_module``'s cohesion term,
+    which is meaningless here. Returns ``None`` only when no curated modules
+    were passed in (→ community fallback); an artifact whose modules all fall
+    below the floor yields an empty list, not a vocabulary mix.
+    """
+    if not inputs.kg_modules:
+        return None
+
+    code_by_path = {
+        p.file_info.path: p for p in inputs.parsed_files if _is_code_file(p)
+    }
+    scored: list[tuple[float, ModuleGroup]] = []
+    seen_keys: set[str] = set()
+    for module in inputs.kg_modules:
+        if module.get("wholeLayer"):
+            # 1:1 with a layer page (single-module layers, flat libs) — a
+            # module doc would re-document the layer. Skip the page; the
+            # module stays in the KG artifact for canvas/coverage.
+            continue
+        member_paths = sorted(
+            path
+            for nid in module.get("nodeIds", [])
+            if isinstance(nid, str)
+            and (path := nid.removeprefix("file:")) in code_by_path
+        )
+        if len(member_paths) < min_size:
+            continue
+        key = module.get("path") or (module.get("id") or "").removeprefix("module:")
+        if not key or key in seen_keys:
+            # Rare cross-layer dir collision: the slug id is still unique.
+            key = (module.get("id") or "").removeprefix("module:")
+        if not key or key in seen_keys:
+            continue
+        seen_keys.add(key)
+        name = module.get("name") or key
+        language = module.get("language") or code_by_path[
+            member_paths[0]
+        ].file_info.language
+        score = sum(inputs.pagerank.get(p, 0.0) for p in member_paths)
+        scored.append(
+            (
+                score,
+                ModuleGroup(
+                    key=key,
+                    display=name,
+                    language=language,
+                    file_paths=tuple(member_paths),
+                    label=name,
+                    cohesion=None,
+                ),
+            )
+        )
+    scored.sort(key=lambda x: (-x[0], x[1].key))
+    return scored
+
+
 def _build_module_groups(inputs: SelectionInputs) -> list[tuple[float, ModuleGroup]]:
-    """Return scored module groups — either community-based or top-dir."""
+    """Return scored module groups — curated, community-based, or top-dir."""
     cfg = inputs.config
     min_size = max(1, getattr(cfg, "min_module_size", 3))
-    use_communities = getattr(cfg, "module_grouping", "community") == "community"
+    grouping = getattr(cfg, "module_grouping", "community")
+
+    if grouping == "curated":
+        curated = _build_curated_module_groups(inputs, min_size)
+        if curated is not None:
+            return curated
+        grouping = "community"  # no curated artifact → today's path, unchanged
+
+    use_communities = grouping == "community"
 
     # Bucket files into groups.
     groups: dict[str, list[Any]] = {}

--- a/packages/core/src/repowise/core/generation/tour.py
+++ b/packages/core/src/repowise/core/generation/tour.py
@@ -35,22 +35,34 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Any
 
+from repowise.core.generation.layers import ADJACENT_LAYERS, infer_layer, is_support_path
+from repowise.core.ingestion.languages.registry import REGISTRY as _LANG_REGISTRY
+
 # Filenames that conventionally mark an executable / wiring entry point.
-_ENTRY_FILENAME_STEMS: frozenset[str] = frozenset(
-    {
-        "index",
-        "main",
-        "app",
-        "server",
-        "mod",
-        "manage",
-        "wsgi",
-        "asgi",
-        "cli",
-        "__main__",
-        "bootstrap",
-        "entry",
-    }
+# Derived from the language registry (generic stems + per-language stems);
+# parity with the historical hard-coded set is pinned by
+# tests/unit/ingestion/test_language_capabilities.py.
+_ENTRY_FILENAME_STEMS: frozenset[str] = _LANG_REGISTRY.entry_filename_stems()
+
+# A genuine entry whose forward BFS reaches no more than this many files is a
+# wiring stub (supervision/bootstrap); the widest-fanout file then co-anchors.
+_STUB_ENTRY_REACH = 3
+
+# Languages whose files can never be execution entry points, however
+# entry-like their stem is: docs/data/config (``is_code=False`` —
+# docs/index.md is not a program's front door, and neither is
+# schema.graphql or an openapi index) plus build/deploy wiring
+# (``is_infra`` — a Dockerfile or deploy.sh wires the system rather than
+# starting its control flow; infra pages close the tour instead). Both
+# sets derive from the registry; the lowercase aliases guard against
+# unnormalized language strings from older indexes (none is a spec tag).
+_NON_CODE_ALIASES: frozenset[str] = frozenset(
+    {"md", "yml", "txt", "html", "css", "csv", "xml", "svg", "rst", "text", "ini", "cmake"}
+)
+_NON_CODE_LANGUAGES: frozenset[str] = (
+    _LANG_REGISTRY.config_languages()
+    | _LANG_REGISTRY.infra_languages()
+    | _NON_CODE_ALIASES
 )
 
 # Upper bound on tour stops — long enough to teach the spine, short enough to
@@ -98,10 +110,16 @@ def score_entry_points(
     """Score code files as candidate tour entry points, descending.
 
     Scoring (additive):
-      * ``is_entry_point`` ingestion flag .............. +3
-      * filename stem in the entry-name set ............ +3
+      * ``is_entry_point`` ingestion flag .............. +3 (code files only)
+      * filename stem in the entry-name set ............ +3 (code files only)
       * file at repo root or one level deep ............ +1
       * PageRank in the top 10% of all files ........... +1
+
+    Both entry bonuses are withheld from doc/data languages — ``docs/index.md``
+    must never outrank a real ``main.py``, even when ingestion's stem rule
+    flagged it — from test files (``tests/testserver/server.py`` is a fixture,
+    not where a reader enters the system), and from example/demo dirs (every
+    ``examples/*/main.go`` is an entry by *name*; none is the system).
 
     Returns ``[(score, path), ...]`` sorted by score then path for stability.
     Only files with a positive score are returned.
@@ -117,9 +135,15 @@ def score_entry_points(
         fi = p.file_info
         path = fi.path
         score = 0.0
-        if getattr(fi, "is_entry_point", False):
+        language = (getattr(fi, "language", "") or "").lower()
+        entry_eligible = (
+            language not in _NON_CODE_LANGUAGES
+            and infer_layer(path, language) not in ADJACENT_LAYERS
+            and not is_support_path(path)
+        )
+        if entry_eligible and getattr(fi, "is_entry_point", False):
             score += 3.0
-        if PurePosixPath(path).stem.lower() in _ENTRY_FILENAME_STEMS:
+        if entry_eligible and PurePosixPath(path).stem.lower() in _ENTRY_FILENAME_STEMS:
             score += 3.0
         if _path_depth(path) <= 1:
             score += 1.0
@@ -178,6 +202,8 @@ def build_tour(
     infra_paths: Iterable[str] = (),
     repo_name: str = "",
     max_stops: int = DEFAULT_MAX_STOPS,
+    graph_mode: str = "flow",
+    anchor_rank: Mapping[str, int] | None = None,
 ) -> list[TourStop]:
     """Build the ordered tour over pages that already exist.
 
@@ -185,14 +211,24 @@ def build_tour(
     tour never references undocumented files, so it is budget-safe by
     construction. ``repo_overview`` (when *repo_name* is given) always opens
     the tour; infrastructure pages close it.
+
+    ``graph_mode="sparse"`` keeps the BFS walk but softens the reasons that
+    interpret *absence* of edges: on a sparse graph (broken/partial import
+    resolution), "off the import path" would blame the file for the
+    resolver's gaps. Reasons grounded in edges that DO exist are unchanged.
+    Truly edgeless repos should not walk at all — the caller is expected to
+    build a structural tour instead (``graph_mode="structural"`` is handled
+    by the curation layer, not here).
     """
     documented = set(file_page_paths)
     infra = set(infra_paths)
     adjacency: dict[str, list[str]] = defaultdict(list)
+    fan_in: dict[str, int] = defaultdict(int)
     for src, dst in import_edges:
         if src.startswith("external:") or dst.startswith("external:"):
             continue
         adjacency[src].append(dst)
+        fan_in[dst] += 1
 
     # Seeds = the genuine entry points (the ``is_entry_point`` flag or an
     # entry-style filename, both worth +3), restricted to documented files. A
@@ -200,18 +236,84 @@ def build_tour(
     # otherwise every root file would seed the walk and flatten all depths.
     scored = score_entry_points(parsed_files, pagerank)
     seeds = [path for s, path in scored if s >= 3.0 and path in documented]
+    # Whether the seeds are genuine entry points (flag/filename evidence) or
+    # just the best-available anchor — the step reasons must not overclaim.
+    genuine_entries = bool(seeds)
+
+    # Docs, config, and test files can't anchor a walk.
+    ineligible = {
+        p.file_info.path
+        for p in parsed_files
+        if getattr(p, "file_info", None)
+        and (
+            (getattr(p.file_info, "language", "") or "").lower() in _NON_CODE_LANGUAGES
+            or infer_layer(p.file_info.path, p.file_info.language) in ADJACENT_LAYERS
+            or is_support_path(p.file_info.path)
+        )
+    }
+
+    # Rank by import *relationships* when the caller supplies the
+    # fan-out-collapsed counts (one package import = one relationship),
+    # else raw out-degree.
+    def _fanout(p: str) -> int:
+        if anchor_rank is not None:
+            return anchor_rank.get(p, 0)
+        return len(adjacency.get(p, []))
+
+    def _best_anchor(exclude: set[str]) -> str | None:
+        eligible = sorted(
+            (p for p in documented if p not in ineligible and p not in exclude),
+            key=lambda p: (-_fanout(p), -pagerank.get(p, 0.0), p),
+        )
+        return eligible[0] if eligible else None
+
+    anchor_seeds: set[str] = set()
     if not seeds:
-        # Fall back to the single highest-scored documented file so the walk
-        # still has an anchor on repos with no obvious entry point.
-        seeds = [path for _, path in scored if path in documented][:1]
+        # No genuine entry point anywhere (flat libraries like requests).
+        # Anchor the walk on the eligible code file whose imports fan out the
+        # widest — the closest thing to "execution starts here" the import
+        # graph offers.
+        best = _best_anchor(set())
+        seeds = [best] if best else [path for _, path in scored if path in documented][:1]
     depths = _bfs_depths(seeds, adjacency, documented)
 
+    # Wiring-stub entries: an OTP application.ex or DI bootstrap starts
+    # supervisors, not the domain logic — its forward BFS dies at depth 1
+    # and every walk slot fills with unreached parking. When the genuine
+    # entries reach almost nothing and a non-seed file's imports fan out
+    # substantially, that file co-anchors the walk (its own steps use
+    # anchor wording, never "entry point").
+    if genuine_entries and len(depths) <= _STUB_ENTRY_REACH and len(documented) > _STUB_ENTRY_REACH * 2:
+        co_anchor = _best_anchor(set(seeds))
+        if co_anchor is not None and _fanout(co_anchor) >= 3:
+            anchor_seeds.add(co_anchor)
+            seeds = [*seeds, co_anchor]
+            depths = _bfs_depths(seeds, adjacency, documented)
+
     # Documented files never reached from a seed still belong in the tour;
-    # park them after the deepest reached file, ranked by PageRank.
+    # park them after the deepest reached file, ranked by PageRank. Remember
+    # which files were genuinely reached so their reasons stay truthful.
+    # Documents and config/data files are exempt from parking: they can
+    # never be on an import path, so an unreached CHANGELOG.md or
+    # wally.toml is expected — not worth a tour slot that displaces code.
+    non_code_paths = {
+        p.file_info.path
+        for p in parsed_files
+        if getattr(p, "file_info", None)
+        and (getattr(p.file_info, "language", "") or "").lower() in _NON_CODE_LANGUAGES
+    }
+    reached = set(depths)
     max_reached = max(depths.values(), default=-1)
+    # Manifests (mix.exs, project.clj, Setup.lhs) are code-shaped but cannot
+    # be on an import path by design — like documents, an unreached manifest
+    # is expected and never worth a parked tour slot.
+    manifest_names = _LANG_REGISTRY.manifest_filenames()
     for path in documented:
         if path not in depths:
+            if path in non_code_paths or PurePosixPath(path).name in manifest_names:
+                continue
             depths[path] = max_reached + 1
+    documented = {p for p in documented if p in depths}
 
     pr_score = score_entry_points(parsed_files, pagerank)
     ep_score = {path: s for s, path in pr_score}
@@ -252,9 +354,48 @@ def build_tour(
         order += 1
         d = depths[path]
         if d <= 0:
-            reason = "An entry point — execution and imports fan out from here."
+            if path in anchor_seeds:
+                reason = (
+                    "The walk's anchor — the entry point above only wires the "
+                    "app together, so the tour follows the file whose imports "
+                    "fan out the widest."
+                )
+            elif genuine_entries:
+                reason = "An entry point — execution and imports fan out from here."
+            else:
+                # State the anchor's actual selection evidence (widest import
+                # fan-out), not a vague "best-connected" that implies fan-in.
+                reason = "The walk's anchor — its imports fan out the widest in a repo with no single entry point."
+        elif path not in reached:
+            if graph_mode == "sparse":
+                # The graph, not the file, is the likely cause here.
+                reason = (
+                    "Not on the resolved import paths — import resolution is "
+                    "incomplete for this repo, so links may be missing."
+                )
+            elif genuine_entries:
+                reason = (
+                    "Off the import path from the entry points — a standalone "
+                    "or supporting file."
+                )
+            elif fan_in.get(path, 0) >= 3:
+                reason = "A widely-imported module — much of the repo depends on it."
+            else:
+                # No fan-in evidence: a generated lookup table parked by
+                # PageRank must not claim the repo depends on it.
+                reason = (
+                    "Off the import paths walked above — a standalone or "
+                    "supporting file."
+                )
         elif d == 1:
-            reason = "Directly used by the entry points above; a core collaborator."
+            # Anchor-seeded walks have no entry points — the reason must not
+            # invent them. When a co-anchor rescued a wiring-stub entry, the
+            # depth-1 files were reached through the anchor, not the entry.
+            reason = (
+                "Directly used by the entry points above; a core collaborator."
+                if genuine_entries and not anchor_seeds
+                else "Directly imported by the anchor above; a core collaborator."
+            )
         else:
             reason = f"Reached {d} imports deep — a supporting building block."
         stops.append(

--- a/packages/core/src/repowise/core/pipeline/__init__.py
+++ b/packages/core/src/repowise/core/pipeline/__init__.py
@@ -12,6 +12,9 @@ Usage::
 
 from .orchestrator import PipelineResult, run_generation, run_pipeline
 from .persist import (
+    _sweep_stale_generated_pages as sweep_stale_generated_pages,
+)
+from .persist import (
     persist_analysis,
     persist_generation,
     persist_git,
@@ -35,4 +38,5 @@ __all__ = [
     "rehydrate_graph_builder",
     "run_generation",
     "run_pipeline",
+    "sweep_stale_generated_pages",
 ]

--- a/packages/core/src/repowise/core/pipeline/orchestrator.py
+++ b/packages/core/src/repowise/core/pipeline/orchestrator.py
@@ -136,6 +136,16 @@ class PipelineResult:
     it is already on disk — and writes only analysis + generation. False for
     every non-resume caller, which persist the full result as before."""
 
+    authoritative_page_types: set[str] = field(default_factory=set)
+    """Structural page types this run fully decided — i.e. its emitted set is
+    "exactly these, possibly none". The stale-page sweep retires prior rows of
+    a type when it was produced OR is named here, so a legitimately-empty
+    authoritative type (e.g. every curated module collapsed into its layer via
+    wholeLayer) still wipes the previous run's stragglers. Populated only on a
+    curated run with a real KG; left empty on degraded/community fallback and
+    on incremental no-KG paths, which preserves degradation honesty (a fallback
+    run never wipes curated pages it could not reproduce)."""
+
 
 # ---------------------------------------------------------------------------
 # Pipeline
@@ -525,6 +535,34 @@ async def run_pipeline(
                     f"{len(knowledge_graph_result.layers)} layers",
                 )
         _phase_done(progress, "knowledge_graph.skeleton")
+
+        # ---- KG curation/presentation pass (flagged, default on) ---------
+        # Reshapes only the exported KG (layers/tour/entry-points/summaries);
+        # never touches the AST graph, communities, or centrality. No-op when
+        # REPOWISE_KG_CURATION is set to a falsy value (the raw uncurated
+        # export). Runs in BOTH FAST and STANDARD (before the generate branch).
+        if knowledge_graph_result is not None:
+            from repowise.core.analysis.kg_curation import (
+                curate_knowledge_graph,
+                curation_enabled,
+            )
+
+            try:
+                # In generate mode the summary floor is deferred to run after
+                # the wiki-page backfill (in ``enrich_knowledge_graph``), so
+                # rich page summaries win; FAST mode floors here.
+                will_generate = generate_docs and llm_client is not None
+                knowledge_graph_result = curate_knowledge_graph(
+                    knowledge_graph_result,
+                    parsed_files=parsed_files,
+                    graph_builder=graph_builder,
+                    repo_structure=repo_structure,
+                    community_info=graph_builder.community_info(),
+                    enabled=curation_enabled(),
+                    defer_summary_floor=will_generate,
+                )
+            except (ValueError, KeyError, RuntimeError) as cur_err:
+                logger.error("kg_curation_failed", error=str(cur_err), exc_info=True)
     except (ValueError, KeyError, OSError, RuntimeError) as kg_err:
         logger.error("kg_skeleton_building_failed", error=str(kg_err), exc_info=True)
 
@@ -543,6 +581,10 @@ async def run_pipeline(
 
     # ---- Phase 3: Generation (optional) ------------------------------------
     generated_pages: list[Any] | None = None
+    # Structural page types this run was authoritative for (see
+    # PipelineResult.authoritative_page_types). Stays empty unless curated
+    # generation engaged below.
+    authoritative_page_types: set[str] = set()
     if generate_docs and llm_client is not None:
         if progress:
             progress.on_message("info", "Phase 3: Generation")
@@ -590,7 +632,38 @@ async def run_pipeline(
             decision_report=gen_decision_report,
             external_systems=external_systems,
             on_page_ready=on_page_ready,
+            # In-memory KG — the artifact file is written after generation,
+            # so it cannot carry layers/tour/modules on a fresh init.
+            kg_modules=(
+                knowledge_graph_result.modules or None
+                if knowledge_graph_result is not None
+                else None
+            ),
+            kg_data=(
+                knowledge_graph_result.to_dict()
+                if knowledge_graph_result is not None
+                else None
+            ),
         )
+
+        # Record which structural page types this run authoritatively decided,
+        # so the sweep can retire prior rows of a type even when this run
+        # legitimately emitted zero pages of it. Mirrors the selector's curated
+        # engagement test (_build_curated_module_groups returns None — i.e.
+        # falls back to community — only when kg_modules is empty) so the signal
+        # is set iff the curated grouping actually engaged. On the degraded
+        # community fallback both stay unset, preserving degradation honesty.
+        kg_modules_present = bool(
+            knowledge_graph_result is not None and knowledge_graph_result.modules
+        )
+        kg_layers_present = bool(
+            knowledge_graph_result is not None and knowledge_graph_result.layers
+        )
+        module_grouping = getattr(resolved_generation_config, "module_grouping", "community")
+        if module_grouping == "curated" and kg_modules_present:
+            authoritative_page_types.add("module_page")
+        if kg_layers_present:
+            authoritative_page_types.add("layer_page")
 
     # ---- Knowledge Graph LLM enrichment (layer naming + tour) -----------------
     if knowledge_graph_result is not None and generate_docs and llm_client is not None:
@@ -674,6 +747,7 @@ async def run_pipeline(
         index_persisted_incrementally=(
             resume_controller.index_persisted if resume_controller is not None else False
         ),
+        authoritative_page_types=authoritative_page_types,
     )
 
 

--- a/packages/core/src/repowise/core/pipeline/persist.py
+++ b/packages/core/src/repowise/core/pipeline/persist.py
@@ -216,6 +216,74 @@ async def _prune_stale_file_rows(
     await _delete_stale_by_paths(GitMetadata, GitMetadata.file_path, current_git_file_paths)
 
 
+# Generated page types keyed on run-scoped structure: module/scc pages on
+# clustering ordinals, layer pages on display names. Those keys shift between
+# runs, so re-runs mint fresh page ids and the previous rows linger as
+# duplicates unless swept against the current run's output.
+_SWEPT_GENERATED_PAGE_TYPES = ("module_page", "layer_page", "scc_page")
+
+
+async def _sweep_stale_generated_pages(
+    session: Any,
+    repo_id: str,
+    generated_pages: list[Any] | None,
+    authoritative_page_types: set[str] | None = None,
+) -> list[str]:
+    """Delete structurally-keyed generated pages this run did not produce.
+
+    Sweeps a page type when the run either produced at least one page of it OR
+    declared itself authoritative for it (``authoritative_page_types`` — set by
+    the generation layer when it fully decided the type, even if that decision
+    was "emit none"; e.g. a curated run whose modules all collapsed into their
+    layers via ``wholeLayer``). A type that is neither produced nor authoritative
+    is left untouched, so a skipped/failed/degraded level never wipes the last
+    good set. When authoritative-but-empty, the current set is empty and every
+    prior row of that type is retired. Page versions go with their page (FK
+    enforcement requires it, and a retired structural id never comes back to
+    claim its history). Returns the swept page ids so the caller can drop them
+    from FTS after the session closes (the FTS store must not be touched
+    in-session).
+    """
+    from sqlalchemy import delete, select
+
+    from repowise.core.persistence.models import Page, PageVersion
+
+    produced: dict[str, set[str]] = {}
+    for page in generated_pages or []:
+        produced.setdefault(page.page_type, set()).add(page.page_id)
+    authoritative = authoritative_page_types or set()
+
+    swept: list[str] = []
+    for page_type in _SWEPT_GENERATED_PAGE_TYPES:
+        current = produced.get(page_type)
+        if not current and page_type not in authoritative:
+            continue
+        current = current or set()
+        existing = (
+            (
+                await session.execute(
+                    select(Page.id).where(
+                        Page.repository_id == repo_id, Page.page_type == page_type
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        stale = [pid for pid in existing if pid not in current]
+        for i in range(0, len(stale), _PRUNE_CHUNK):
+            batch = stale[i : i + _PRUNE_CHUNK]
+            await session.execute(delete(PageVersion).where(PageVersion.page_id.in_(batch)))
+            await session.execute(
+                delete(Page).where(Page.repository_id == repo_id, Page.id.in_(batch))
+            )
+        swept.extend(stale)
+
+    if swept:
+        logger.info("stale_generated_pages_swept", repo_id=repo_id, count=len(swept))
+    return swept
+
+
 async def persist_ingestion(result: Any, session: Any, repo_id: str) -> int:
     """Persist ingestion-phase outputs: graph nodes/edges, external systems,
     symbols, and the per-file security scan.
@@ -479,22 +547,45 @@ async def persist_generation(result: Any, session: Any, repo_id: str) -> None:
         for page in result.generated_pages:
             await upsert_page_from_generated(session, page, repo_id)
 
-    # ---- Knowledge graph layers & tour steps --------------------------------
+    # ---- Knowledge graph layers, tour steps & curated meta ------------------
     kg = getattr(result, "knowledge_graph_result", None)
     if kg is not None:
-        from repowise.core.persistence.crud import upsert_kg_layers, upsert_kg_tour_steps
+        from repowise.core.persistence.crud import (
+            file_node_meta_from_kg_nodes,
+            upsert_kg_layers,
+            upsert_kg_node_meta,
+            upsert_kg_project_meta,
+            upsert_kg_tour_steps,
+        )
 
         if hasattr(kg, "layers") and kg.layers:
             await upsert_kg_layers(session, repo_id, kg.layers)
         if hasattr(kg, "tour") and kg.tour:
             await upsert_kg_tour_steps(session, repo_id, kg.tour)
 
+        # Project-level curated meta (ranked entry points from the curation pass).
+        project = getattr(kg, "project", None)
+        if isinstance(project, dict) and project.get("entry_points"):
+            await upsert_kg_project_meta(
+                session,
+                repo_id,
+                entry_points=project["entry_points"],
+                entry_candidates=project.get("entry_candidates", []),
+            )
+
+        # Per-node curated meta (type/summary/tags) for file nodes, stored with
+        # the "file:" prefix stripped so the architecture view can match its
+        # node ids (plain repo-relative paths) directly.
+        file_node_meta = file_node_meta_from_kg_nodes(getattr(kg, "nodes", None) or [])
+        if file_node_meta:
+            await upsert_kg_node_meta(session, repo_id, file_node_meta)
+
 
 async def persist_pipeline_result(
     result: Any,
     session: Any,
     repo_id: str,
-) -> None:
+) -> list[str]:
     """Persist all outputs from a :class:`PipelineResult` into the database.
 
     Thin composition of the four phase-scoped persisters
@@ -511,6 +602,11 @@ async def persist_pipeline_result(
         An active SQLAlchemy ``AsyncSession`` (caller manages commit/rollback).
     repo_id:
         The repository ID to associate all records with.
+
+    Returns
+    -------
+    The page ids of stale generated pages swept by this run. Callers should
+    remove them from the FTS index after the session closes.
 
     Note
     ----
@@ -537,6 +633,17 @@ async def persist_pipeline_result(
     await persist_analysis(result, session, repo_id)
     await persist_generation(result, session, repo_id)
 
+    # Sweep structurally-keyed generated pages (module/layer/scc) that this
+    # run did not reproduce — their ids drift between runs, so without the
+    # sweep every re-index strands the previous set as duplicates. Full runs
+    # only, same rule as _prune_stale_file_rows.
+    swept_page_ids = await _sweep_stale_generated_pages(
+        session,
+        repo_id,
+        result.generated_pages,
+        getattr(result, "authoritative_page_types", None),
+    )
+
     logger.info(
         "pipeline_result_persisted",
         repo_id=repo_id,
@@ -545,3 +652,4 @@ async def persist_pipeline_result(
         symbols=symbol_count,
         git_files=len(result.git_metadata_list),
     )
+    return swept_page_ids

--- a/packages/core/src/repowise/core/pipeline/phases/generation.py
+++ b/packages/core/src/repowise/core/pipeline/phases/generation.py
@@ -40,6 +40,8 @@ async def run_generation(
     external_systems: list[dict] | None = None,
     on_page_ready: Any | None = None,
     prior_pages: dict[str, Any] | None = None,
+    kg_modules: list[dict] | None = None,
+    kg_data: dict | None = None,
 ) -> list[Any]:
     """Run LLM-powered page generation.
 
@@ -137,6 +139,8 @@ async def run_generation(
         decision_report=decision_report,
         external_systems=external_systems,
         on_page_ready=on_page_ready,
+        kg_modules=kg_modules,
+        kg_data=kg_data,
     )
 
     # Onboarding summary — count generated slots and surface which ones

--- a/packages/server/src/repowise/server/job_executor.py
+++ b/packages/server/src/repowise/server/job_executor.py
@@ -311,7 +311,7 @@ async def execute_job(
 
         # ---- Persist results -----------------------------------------------
         async with get_session(session_factory) as session:
-            await persist_pipeline_result(result, session, repo_id)
+            swept_page_ids = await persist_pipeline_result(result, session, repo_id)
 
             # Persist incrementally regenerated pages
             if incremental_pages:
@@ -320,8 +320,22 @@ async def execute_job(
                 for page in incremental_pages:
                     await upsert_page_from_generated(session, page, repo_id)
 
-        # FTS indexing runs after session closes to avoid SQLite write conflicts
+            # Drop swept pages from the vector store *before* the SQL session
+            # commits. The vector store is a separate engine/file (pgvector DB,
+            # LanceDB dir, or in-memory), so there is no SQLite write-lock
+            # conflict and the idempotent delete leaves the durable SQL commit
+            # last: an interrupted run self-heals (embedding already gone, SQL
+            # rows follow on commit).
+            if swept_page_ids and vector_store is not None:
+                await vector_store.delete_many(swept_page_ids)
+
+        # FTS deletes/indexing run after the session closes: the FTS index can
+        # share the SQLite file with the session, so writing it while the
+        # session holds a write lock raises "database is locked". The swept-id
+        # delete is idempotent (orphan FTS rows only) and must stay here.
         all_pages = (result.generated_pages or []) + incremental_pages
+        if fts is not None and swept_page_ids:
+            await fts.delete_many(swept_page_ids)
         if fts is not None and all_pages:
             for page in all_pages:
                 await fts.index(page.page_id, page.title, page.content)
@@ -528,6 +542,7 @@ async def _incremental_page_regen(
             result.repo_structure,
             result.repo_name,
             git_meta_map=result.git_meta_map,
+            repo_path=repo_path,
         )
 
         logger.info("incremental_page_regen_done", pages=len(pages))

--- a/tests/unit/analysis/kg_fixtures.py
+++ b/tests/unit/analysis/kg_fixtures.py
@@ -1,0 +1,137 @@
+"""Shared synthetic-repo builders for KG curation/invariant tests.
+
+Not a test module (no ``test_`` prefix → not collected). Builds parsed files +
+a mock ``GraphBuilder`` and runs the real skeleton + curation, so invariant
+tests exercise the production code paths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from repowise.core.analysis.kg_curation import curate_knowledge_graph
+from repowise.core.analysis.knowledge_graph import (
+    KnowledgeGraphResult,
+    build_knowledge_graph_skeleton,
+)
+
+
+@dataclass
+class FakeFileInfo:
+    path: str
+    language: str = "python"
+    size_bytes: int = 1000
+    is_test: bool = False
+    is_config: bool = False
+    is_api_contract: bool = False
+    is_entry_point: bool = False
+    line_count: int = 100
+
+
+@dataclass
+class FakeSymbol:
+    name: str = "thing"
+    kind: str = "function"
+    start_line: int = 1
+    end_line: int = 10
+
+
+@dataclass
+class FakeParsedFile:
+    file_info: FakeFileInfo
+    symbols: list = field(default_factory=list)
+    imports: list = field(default_factory=list)
+    exports: list = field(default_factory=list)
+
+
+def _community_info(cid: int, label: str, members: list[str]):
+    return SimpleNamespace(
+        community_id=cid,
+        label=label,
+        members=members,
+        size=len(members),
+        cohesion=0.8,
+        dominant_language="python",
+    )
+
+
+def build_repo(
+    paths: list[str],
+    *,
+    tests: set[str] | None = None,
+    entries: set[str] | None = None,
+    edges: list[tuple[str, str]] | None = None,
+    barrels: set[str] | None = None,
+):
+    """Build a synthetic repo: parsed files + a mock GraphBuilder."""
+    import networkx as nx
+
+    tests = tests or set()
+    entries = entries or set()
+    barrels = barrels or set()
+
+    parsed = []
+    g = nx.DiGraph()
+    for p in paths:
+        is_test, is_entry = p in tests, p in entries
+        if p in barrels:
+            pf = FakeParsedFile(
+                FakeFileInfo(p, is_test=is_test, is_entry_point=is_entry),
+                symbols=[],
+                imports=[SimpleNamespace(is_reexport=True)],
+                exports=["A"],
+            )
+        else:
+            pf = FakeParsedFile(
+                FakeFileInfo(p, is_test=is_test, is_entry_point=is_entry),
+                symbols=[FakeSymbol()],
+            )
+        parsed.append(pf)
+        attrs = {"node_type": "file", "language": "python"}
+        if is_test:
+            attrs["is_test"] = True
+        if is_entry:
+            attrs["is_entry_point"] = True
+        g.add_node(p, **attrs)
+    for u, v in edges or []:
+        g.add_edge(u, v, edge_type="imports", confidence=1.0)
+
+    # One community per file → the "103 layers" pathology curation must absorb.
+    communities = {p: i for i, p in enumerate(paths)}
+    infos = {i: _community_info(i, f"cluster_{i}", [p]) for i, p in enumerate(paths)}
+    pagerank = {p: 1.0 / max(len(paths), 1) for p in paths}
+
+    builder = MagicMock()
+    builder.graph.return_value = g
+    builder.pagerank.return_value = pagerank
+    builder.betweenness_centrality.return_value = {}
+    builder.community_detection.return_value = communities
+    builder.community_info.return_value = infos
+    repo_structure = SimpleNamespace(
+        is_monorepo=True, total_files=len(paths), entry_points=sorted(entries)
+    )
+    return SimpleNamespace(parsed=parsed, builder=builder, repo_structure=repo_structure)
+
+
+def build_skeleton(repo) -> KnowledgeGraphResult:
+    return build_knowledge_graph_skeleton(
+        parsed_files=repo.parsed,
+        graph_builder=repo.builder,
+        repo_structure=repo.repo_structure,
+        tech_stack=[],
+        external_systems=[],
+    )
+
+
+def curate(repo, **kw) -> KnowledgeGraphResult:
+    return curate_knowledge_graph(
+        build_skeleton(repo),
+        parsed_files=repo.parsed,
+        graph_builder=repo.builder,
+        repo_structure=repo.repo_structure,
+        community_info=repo.builder.community_info(),
+        enabled=kw.pop("enabled", True),
+        **kw,
+    )

--- a/tests/unit/analysis/test_community_labels.py
+++ b/tests/unit/analysis/test_community_labels.py
@@ -1,0 +1,115 @@
+"""Community label hygiene: repo-dominant namespace segments never become labels.
+
+The legacy failure mode: a namespace dir present in ~every path (the repo's
+own name, ``src``, ``packages``) is not in the hardcoded ``_GENERIC_SEGMENTS``
+list, so labels degrade to ``repowise (161)`` and flipped twins like
+``ingestion/repowise`` / ``repowise/ingestion``. Labeling now strips
+data-driven dominant segments (shared with module naming in kg_curation).
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import networkx as nx
+
+from repowise.core.analysis.communities import (
+    CommunityInfo,
+    _deduplicate_labels,
+    _heuristic_label,
+    detect_file_communities,
+)
+from repowise.core.analysis.kg_curation import dominant_segments
+
+
+def _graph(paths: list[str], edges: list[tuple[str, str]]) -> nx.DiGraph:
+    g = nx.DiGraph()
+    for p in paths:
+        g.add_node(p, node_type="file", language="python")
+    for u, v in edges:
+        g.add_edge(u, v, edge_type="imports")
+    return g
+
+
+class TestHeuristicLabelStripping:
+    def test_dominant_segment_never_becomes_label(self):
+        # Dominance is repo-wide: "acme"/"src" appear in every path,
+        # "ingestion" only in this community's slice.
+        members = [f"acme/src/ingestion/file{i}.py" for i in range(5)]
+        repo_paths = members + [f"acme/src/web/w{i}.py" for i in range(5)]
+        generic = frozenset(s.lower() for s in dominant_segments(repo_paths))
+        assert generic == {"acme", "src"}
+        label = _heuristic_label(members, 0, generic)
+        assert label == "ingestion"
+
+    def test_flipped_twins_collapse(self):
+        # Without stripping these two communities label as "acme/ingestion"
+        # and "ingestion/acme" — flipped twins. With stripping both reduce
+        # to their informative segment.
+        ingest = [f"acme/src/ingestion/p{i}.py" for i in range(4)]
+        persist = [f"acme/src/persistence/p{i}.py" for i in range(4)]
+        generic = frozenset(
+            s.lower() for s in dominant_segments(ingest + persist)
+        )
+        assert "acme" in generic and "src" in generic
+        assert _heuristic_label(ingest, 0, generic) == "ingestion"
+        assert _heuristic_label(persist, 1, generic) == "persistence"
+
+    def test_no_extra_generic_preserves_legacy_behavior(self):
+        # Default empty set: byte-identical to the pre-change heuristic.
+        paths = [f"web/components/c{i}.tsx" for i in range(4)]
+        assert _heuristic_label(paths, 0) == _heuristic_label(
+            paths, 0, frozenset()
+        )
+
+    def test_stem_fallback_skips_dominant_segment(self):
+        # Strategy 3 (filename stems) must not resurrect a stripped segment.
+        paths = ["acme/acme.py", "acme/acme.pyi"]
+        label = _heuristic_label(paths, 7, frozenset({"acme"}))
+        assert label == "cluster_7"
+
+
+class TestDeduplicateLabels:
+    def test_sub_label_disambiguation_skips_generic(self):
+        a = CommunityInfo(
+            community_id=0,
+            label="ingestion",
+            members=[f"acme/src/ingestion/resolvers/r{i}.py" for i in range(4)],
+            size=4,
+            cohesion=0.5,
+            dominant_language="python",
+        )
+        b = CommunityInfo(
+            community_id=1,
+            label="ingestion",
+            members=[f"acme/src/ingestion/parsing/p{i}.py" for i in range(4)],
+            size=4,
+            cohesion=0.5,
+            dominant_language="python",
+        )
+        info = {0: a, 1: b}
+        _deduplicate_labels(info, frozenset({"acme", "src"}))
+        labels = {info[0].label, info[1].label}
+        # Disambiguated by informative sub-segments, never by "acme"/"src".
+        assert labels == {"ingestion/resolvers", "ingestion/parsing"}
+        for label in labels:
+            assert "acme" not in label and "src" not in label
+
+
+class TestDetectFileCommunitiesLabels:
+    def test_end_to_end_labels_strip_repo_namespace(self):
+        # Two clusters under a shared monorepo namespace.
+        ingest = [f"acme/src/acmepkg/ingestion/m{i}.py" for i in range(6)]
+        web = [f"acme/src/acmepkg/web/w{i}.py" for i in range(6)]
+        edges = list(itertools.pairwise(ingest)) + list(itertools.pairwise(web))
+        g = _graph(ingest + web, edges)
+        _, info, _ = detect_file_communities(g)
+        labels = [ci.label for ci in info.values()]
+        for label in labels:
+            for noise in ("acme", "src", "acmepkg"):
+                assert noise not in label.split("/"), (
+                    f"dominant segment {noise!r} leaked into label {label!r}"
+                )
+        # The informative segments survive somewhere in the labels.
+        joined = " ".join(labels)
+        assert "ingestion" in joined and "web" in joined

--- a/tests/unit/analysis/test_kg_curation.py
+++ b/tests/unit/analysis/test_kg_curation.py
@@ -1,0 +1,1241 @@
+"""Tests for the KG curation/presentation pass (``kg_curation``).
+
+Grows phase-by-phase. Phase 0 locks the seam: a no-op when the flag is off, a
+flag reader, and the AST-graph-untouched guard.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from repowise.core.analysis.kg_curation import (
+    _dominant_language,
+    curate_knowledge_graph,
+    curation_enabled,
+)
+from repowise.core.analysis.knowledge_graph import (
+    KnowledgeGraphResult,
+    build_knowledge_graph_skeleton,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeFileInfo:
+    path: str
+    language: str = "python"
+    size_bytes: int = 1000
+    is_test: bool = False
+    is_config: bool = False
+    is_api_contract: bool = False
+    is_entry_point: bool = False
+    line_count: int = 100
+
+
+@dataclass
+class FakeSymbol:
+    name: str = "my_func"
+    kind: str = "function"
+    start_line: int = 1
+    end_line: int = 10
+    is_reexport: bool = False
+
+
+@dataclass
+class FakeParsedFile:
+    file_info: FakeFileInfo
+    symbols: list = field(default_factory=list)
+    imports: list = field(default_factory=list)
+    exports: list = field(default_factory=list)
+
+
+def _make_graph_builder(
+    nodes: dict[str, dict],
+    edges: list[tuple[str, str, dict]],
+    communities: dict[str, int],
+    community_infos: dict[int, Any],
+    pagerank: dict[str, float],
+    betweenness: dict[str, float] | None = None,
+):
+    import networkx as nx
+
+    g = nx.DiGraph()
+    for nid, data in nodes.items():
+        g.add_node(nid, **data)
+    for u, v, data in edges:
+        g.add_edge(u, v, **data)
+
+    builder = MagicMock()
+    builder.graph.return_value = g
+    builder.pagerank.return_value = pagerank
+    builder.betweenness_centrality.return_value = betweenness or {}
+    builder.community_detection.return_value = communities
+    builder.community_info.return_value = community_infos
+    return builder
+
+
+def _community_info(cid: int, label: str, members: list[str]):
+    return SimpleNamespace(
+        community_id=cid,
+        label=label,
+        members=members,
+        size=len(members),
+        cohesion=0.8,
+        dominant_language="python",
+    )
+
+
+@pytest.fixture
+def simple_repo():
+    """A tiny three-file repo: entry, core, test."""
+    parsed = [
+        FakeParsedFile(
+            FakeFileInfo("src/main.py", is_entry_point=True), symbols=[FakeSymbol("main")]
+        ),
+        FakeParsedFile(FakeFileInfo("src/core.py"), symbols=[FakeSymbol("Core", "class")]),
+        FakeParsedFile(
+            FakeFileInfo("tests/test_main.py", is_test=True), symbols=[FakeSymbol("test_main")]
+        ),
+    ]
+    nodes = {
+        "src/main.py": {"node_type": "file", "language": "python", "is_entry_point": True},
+        "src/core.py": {"node_type": "file", "language": "python"},
+        "tests/test_main.py": {"node_type": "file", "language": "python", "is_test": True},
+    }
+    edges = [
+        ("src/main.py", "src/core.py", {"edge_type": "imports", "confidence": 1.0}),
+        ("tests/test_main.py", "src/main.py", {"edge_type": "imports", "confidence": 1.0}),
+    ]
+    communities = {"src/main.py": 0, "src/core.py": 0, "tests/test_main.py": 1}
+    infos = {
+        0: _community_info(0, "src/core", ["src/main.py", "src/core.py"]),
+        1: _community_info(1, "tests", ["tests/test_main.py"]),
+    }
+    pagerank = {"src/main.py": 0.5, "src/core.py": 0.3, "tests/test_main.py": 0.2}
+    builder = _make_graph_builder(nodes, edges, communities, infos, pagerank)
+    repo_structure = SimpleNamespace(
+        is_monorepo=False,
+        total_files=3,
+        entry_points=["src/main.py"],
+    )
+    return SimpleNamespace(parsed=parsed, builder=builder, repo_structure=repo_structure)
+
+
+def _build_skeleton(repo) -> KnowledgeGraphResult:
+    return build_knowledge_graph_skeleton(
+        parsed_files=repo.parsed,
+        graph_builder=repo.builder,
+        repo_structure=repo.repo_structure,
+        tech_stack=[],
+        external_systems=[],
+    )
+
+
+def _curate(repo, **kw) -> KnowledgeGraphResult:
+    return curate_knowledge_graph(
+        _build_skeleton(repo),
+        parsed_files=repo.parsed,
+        graph_builder=repo.builder,
+        repo_structure=repo.repo_structure,
+        community_info=repo.builder.community_info(),
+        **kw,
+    )
+
+
+def build_repo(
+    paths: list[str],
+    *,
+    tests: set[str] | None = None,
+    entries: set[str] | None = None,
+    edges: list[tuple[str, str]] | None = None,
+    barrels: set[str] | None = None,
+    pagerank: dict[str, float] | None = None,
+    betweenness: dict[str, float] | None = None,
+):
+    """Build a synthetic repo (parsed files + mock graph builder) from paths."""
+    tests = tests or set()
+    entries = entries or set()
+    barrels = barrels or set()
+
+    parsed = []
+    nodes: dict[str, dict] = {}
+    for p in paths:
+        is_test = p in tests
+        is_entry = p in entries
+        # Language follows the extension (registry truth) so polyglot
+        # fixtures behave like real repos; bare paths default to python.
+        from pathlib import PurePosixPath
+
+        from repowise.core.ingestion.languages.registry import REGISTRY
+
+        lang = REGISTRY.from_extension(PurePosixPath(p).suffix)
+        if lang == "unknown":
+            lang = "python"
+        if p in barrels:
+            # A re-export shell: no runtime symbols, exports names only.
+            pf = FakeParsedFile(
+                FakeFileInfo(p, language=lang, is_test=is_test, is_entry_point=is_entry),
+                symbols=[],
+                imports=[SimpleNamespace(is_reexport=True)],
+                exports=["A", "B"],
+            )
+        else:
+            pf = FakeParsedFile(
+                FakeFileInfo(p, language=lang, is_test=is_test, is_entry_point=is_entry),
+                symbols=[FakeSymbol(name="thing", kind="function")],
+            )
+        parsed.append(pf)
+        nodes[p] = {"node_type": "file", "language": lang}
+        if is_test:
+            nodes[p]["is_test"] = True
+        if is_entry:
+            nodes[p]["is_entry_point"] = True
+
+    graph_edges = [(u, v, {"edge_type": "imports", "confidence": 1.0}) for u, v in (edges or [])]
+    communities = {p: 0 for p in paths}
+    infos = {0: _community_info(0, "all", list(paths))}
+    pr = pagerank or {p: 1.0 / max(len(paths), 1) for p in paths}
+    builder = _make_graph_builder(nodes, graph_edges, communities, infos, pr, betweenness)
+    repo_structure = SimpleNamespace(
+        is_monorepo=True, total_files=len(paths), entry_points=sorted(entries)
+    )
+    return SimpleNamespace(parsed=parsed, builder=builder, repo_structure=repo_structure)
+
+
+@pytest.fixture
+def large_repo():
+    """A realistically-shaped monorepo: several layers, two mega-layers."""
+    paths: list[str] = []
+    # Service mega-layer (core/*) spanning sub-dirs → should sub-split.
+    for sub in ("ingestion", "analysis", "generation"):
+        paths += [f"packages/core/src/repowise/core/{sub}/mod{i}.py" for i in range(24)]
+    # UI mega-layer, spanning sub-dirs → should also sub-split.
+    for sub in ("buttons", "forms", "layout"):
+        paths += [f"packages/ui/src/components/{sub}/C{i}.tsx" for i in range(24)]
+    # CLI (edge case A — must not be Application).
+    paths += [f"packages/cli/src/repowise/cli/commands/cmd{i}.py" for i in range(20)]
+    # API, Data, Config, Test, Utility — smaller named layers.
+    paths += [f"src/api/route{i}.py" for i in range(12)]
+    paths += [f"src/models/model{i}.py" for i in range(10)]
+    paths += [f"src/utils/util{i}.py" for i in range(8)]
+    paths += [f"config/conf{i}.yaml" for i in range(6)]
+    tests = {f"tests/unit/test_{i}.py" for i in range(30)}
+    paths += sorted(tests)
+    # A realistic monorepo HAS imports: wire a dense chain so the honest-
+    # degradation detector classifies it as flow, not structural.
+    code = [p for p in paths if not p.endswith(".yaml") and p not in tests]
+    edges = [
+        (code[i], code[i + step])
+        for step in (1, 2, 3)
+        for i in range(len(code) - step)
+    ]
+    return build_repo(paths, tests=tests, edges=edges)
+
+
+# ---------------------------------------------------------------------------
+# Phase 0 — the seam
+# ---------------------------------------------------------------------------
+
+
+class TestCurationFlag:
+    def test_default_on(self, monkeypatch):
+        # Flipped at the cross-language acceptance gate: the 38-repo matrix
+        # is the evidence; the env var is an opt-out now.
+        monkeypatch.delenv("REPOWISE_KG_CURATION", raising=False)
+        assert curation_enabled() is True
+
+    @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on"])
+    def test_truthy_values_enable(self, monkeypatch, val):
+        monkeypatch.setenv("REPOWISE_KG_CURATION", val)
+        assert curation_enabled() is True
+
+    @pytest.mark.parametrize("val", ["0", "false", "FALSE", "no", "off"])
+    def test_falsy_values_disable(self, monkeypatch, val):
+        monkeypatch.setenv("REPOWISE_KG_CURATION", val)
+        assert curation_enabled() is False
+
+
+class TestIdentityPass:
+    def test_noop_returns_input_unchanged(self, simple_repo):
+        kg = _build_skeleton(simple_repo)
+        before = kg.to_dict()
+        out = curate_knowledge_graph(
+            kg,
+            parsed_files=simple_repo.parsed,
+            graph_builder=simple_repo.builder,
+            repo_structure=simple_repo.repo_structure,
+            community_info=simple_repo.builder.community_info(),
+            enabled=False,
+        )
+        assert out is kg
+        assert out.to_dict() == before
+
+    def test_ast_graph_untouched(self, simple_repo):
+        """The §4D guard: graph node/edge counts identical pre/post curation."""
+        g = simple_repo.builder.graph()
+        before = (g.number_of_nodes(), g.number_of_edges())
+        _curate(simple_repo, enabled=True)
+        g = simple_repo.builder.graph()
+        assert (g.number_of_nodes(), g.number_of_edges()) == before
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — curated layers
+# ---------------------------------------------------------------------------
+
+
+def _layer_names(kg) -> set[str]:
+    return {layer["name"] for layer in kg.layers}
+
+
+def _file_node_count(kg) -> int:
+    return sum(1 for n in kg.nodes if n["id"].startswith("file:"))
+
+
+class TestCuratedLayers:
+    def test_flag_off_keeps_community_layers(self, large_repo):
+        kg = _curate(large_repo, enabled=False)
+        # The skeleton's community layers: one community "all" → one layer.
+        assert _layer_names(kg) == {"all"}
+
+    def test_layer_count_bounded(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        assert 6 <= len(kg.layers) <= 15
+
+    def test_partition_invariant(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        seen: set[str] = set()
+        for layer in kg.layers:
+            for nid in layer["nodeIds"]:
+                assert nid not in seen, "a file appears in two layers"
+                seen.add(nid)
+        assert len(seen) == _file_node_count(kg), "every file in exactly one layer"
+
+    def test_no_singleton_spam(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        singletons = sum(1 for layer in kg.layers if len(layer["nodeIds"]) == 1)
+        assert singletons / len(kg.layers) < 0.10
+
+    def test_cli_is_its_own_layer(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        assert "CLI" in _layer_names(kg)
+        assert "Application" not in _layer_names(kg)  # nothing falls through here
+
+    def test_mega_layers_sub_split(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        by_name = {layer["name"]: layer for layer in kg.layers}
+        for mega in ("Service", "UI"):
+            sub = by_name[mega].get("subGroups")
+            assert sub and len(sub) >= 2, f"{mega} should sub-split"
+            # Sub-groups partition their parent layer.
+            sub_ids = [nid for grp in sub for nid in grp["nodeIds"]]
+            assert sorted(sub_ids) == sorted(by_name[mega]["nodeIds"])
+
+    def test_largest_primary_layer_within_bound(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        total = _file_node_count(kg)
+        largest = max(len(layer["nodeIds"]) for layer in kg.layers)
+        assert largest / total <= 0.35
+
+    def test_layers_are_dependency_ordered(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        orders = [layer["display_order"] for layer in kg.layers]
+        assert orders == list(range(len(kg.layers)))
+
+    def test_deterministic(self, large_repo):
+        a = _curate(large_repo, enabled=True)
+        b = _curate(large_repo, enabled=True)
+        assert a.layers == b.layers
+
+
+class TestDominantLanguageDeterminism:
+    def test_empty_input_returns_empty(self):
+        assert _dominant_language([]) == ""
+
+    def test_clear_majority_wins(self):
+        assert _dominant_language(["python", "python", "go"]) == "python"
+
+    def test_tie_is_order_independent(self):
+        # Counter.most_common breaks count ties by insertion order, which is
+        # ingestion-completion-order nondeterministic and reaches persisted
+        # output (graph_mode + tour prose). The same multiset must yield the
+        # same dominant language whatever order it was accumulated in.
+        forward = _dominant_language(["go", "go", "python", "python"])
+        reverse = _dominant_language(["python", "python", "go", "go"])
+        assert forward == reverse
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — entry-point precision
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def entry_repo():
+    """Real runtime entries plus re-export barrels, all flagged entry_point."""
+    reals = [f"src/app{i}/main.py" for i in range(12)]
+    barrels = {f"packages/p{i}/index.ts" for i in range(5)}
+    paths = reals + sorted(barrels)
+    entries = set(reals) | barrels
+    # Give barrels deliberately high PageRank — they must still be demoted.
+    pagerank = {p: (12 - i) / 100.0 for i, p in enumerate(reals)}
+    for b in barrels:
+        pagerank[b] = 0.9
+    return build_repo(paths, entries=entries, barrels=barrels, pagerank=pagerank)
+
+
+def _project(kg) -> dict:
+    return kg.project
+
+
+class TestEntryPointPrecision:
+    def test_barrels_demoted_in_presentation(self, entry_repo):
+        kg = _curate(entry_repo, enabled=True)
+        for node in kg.nodes:
+            if node.get("filePath", "").endswith("index.ts"):
+                assert "entry_point" not in node["tags"]
+                assert "barrel" in node["tags"]
+
+    def test_no_barrel_in_surfaced_set(self, entry_repo):
+        kg = _curate(entry_repo, enabled=True)
+        assert all(not p.endswith("index.ts") for p in _project(kg)["entry_points"])
+        assert all(not p.endswith("index.ts") for p in _project(kg)["entry_candidates"])
+
+    def test_surfaced_set_capped(self, entry_repo):
+        kg = _curate(entry_repo, enabled=True)
+        assert len(_project(kg)["entry_points"]) <= 8
+
+    def test_ranked_by_centrality(self, entry_repo):
+        kg = _curate(entry_repo, enabled=True)
+        # app0 has the highest PageRank among reals → ranks first.
+        assert _project(kg)["entry_points"][0] == "src/app0/main.py"
+
+    def test_full_candidate_list_kept(self, entry_repo):
+        kg = _curate(entry_repo, enabled=True)
+        # All 12 real entries survive as candidates; 5 barrels excluded.
+        assert len(_project(kg)["entry_candidates"]) == 12
+
+    def test_ast_is_entry_point_flag_untouched(self, entry_repo):
+        """Demotion is presentation-only — the graph flag stays for dead-code."""
+        _curate(entry_repo, enabled=True)
+        g = entry_repo.builder.graph()
+        for path, data in g.nodes(data=True):
+            if path.endswith("index.ts"):
+                assert data.get("is_entry_point") is True
+
+    def test_deterministic(self, entry_repo):
+        a = _curate(entry_repo, enabled=True)
+        b = _curate(entry_repo, enabled=True)
+        assert a.project["entry_points"] == b.project["entry_points"]
+        assert a.project["entry_candidates"] == b.project["entry_candidates"]
+
+    def test_flag_off_leaves_entry_points_untouched(self, entry_repo):
+        kg = _curate(entry_repo, enabled=False)
+        assert "entry_candidates" not in kg.project
+
+    def test_ruby_spec_dir_entry_excluded_via_language(self):
+        # A Ruby file under spec/ is RSpec material whatever its name; ruby
+        # declares spec/ as an unambiguous test-dir token, so the entry-point
+        # guards must pass language to infer_layer. Without it, config.rb
+        # classifies as a runtime layer and (flagged entry_point) leaks into
+        # the surfaced entry set.
+        repo = build_repo(
+            ["src/main.rb", "spec/dummy/config.rb"],
+            entries={"src/main.rb", "spec/dummy/config.rb"},
+        )
+        kg = _curate(repo, enabled=True)
+        assert "spec/dummy/config.rb" not in kg.project["entry_points"]
+        assert "spec/dummy/config.rb" not in kg.project["entry_candidates"]
+        assert "src/main.rb" in kg.project["entry_candidates"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — canonical, layer-aware tour
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def readme_repo():
+    """large_repo shape plus a real root README to anchor the tour."""
+    paths = ["README.md", "src/api/route0.py", "src/api/route1.py"]
+    paths += [f"src/models/model{i}.py" for i in range(4)]
+    paths += [f"src/utils/util{i}.py" for i in range(3)]
+    paths += [f"packages/cli/src/cli/commands/cmd{i}.py" for i in range(3)]
+    return build_repo(paths)
+
+
+@pytest.fixture
+def flow_repo():
+    """A repo with a real entry point, an import chain, and a test suite."""
+    paths = [
+        "README.md",
+        "src/cli/main.py",
+        "src/api/route.py",
+        "src/services/svc.py",
+        "src/models/model.py",
+        "src/utils/helpers.py",
+        "tests/conftest.py",
+        "tests/test_svc.py",
+    ]
+    edges = [
+        ("src/cli/main.py", "src/api/route.py"),
+        ("src/api/route.py", "src/services/svc.py"),
+        ("src/services/svc.py", "src/models/model.py"),
+        ("tests/test_svc.py", "src/services/svc.py"),
+        ("tests/conftest.py", "src/cli/main.py"),
+    ]
+    return build_repo(paths, entries={"src/cli/main.py"}, edges=edges)
+
+
+def _layer_ids(kg) -> set[str]:
+    return {layer["id"] for layer in kg.layers}
+
+
+class TestCuratedTour:
+    def test_within_step_budget(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        assert 0 < len(kg.tour) <= 12
+
+    def test_opens_with_overview(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        assert kg.tour[0]["kind"] == "overview"
+        assert kg.tour[0]["order"] == 1
+
+    def test_every_step_maps_to_a_curated_layer(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        ids = _layer_ids(kg)
+        for step in kg.tour:
+            if step["kind"] == "overview":
+                continue  # overview maps to a layer only when a README exists
+            assert step["layer_id"] in ids
+
+    def test_covers_most_layers(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        covered = {s["layer_id"] for s in kg.tour if s["kind"] != "overview"}
+        assert len(covered) / len(_layer_ids(kg)) >= 0.90
+
+    def test_orders_are_contiguous(self, large_repo):
+        kg = _curate(large_repo, enabled=True)
+        assert [s["order"] for s in kg.tour] == list(range(1, len(kg.tour) + 1))
+
+    def test_readme_is_first_stop(self, readme_repo):
+        kg = _curate(readme_repo, enabled=True)
+        assert kg.tour[0]["kind"] == "overview"
+        assert kg.tour[0]["target_path"] == "README.md"
+
+    def test_deterministic(self, large_repo):
+        a = _curate(large_repo, enabled=True)
+        b = _curate(large_repo, enabled=True)
+        assert a.tour == b.tour
+
+    def test_flag_off_leaves_tour_empty(self, large_repo):
+        kg = _curate(large_repo, enabled=False)
+        assert kg.tour == []
+
+    def test_entry_point_leads_the_walk(self, flow_repo):
+        # Execution-flow order: right after the overview comes a real entry
+        # point, never a test fixture or an arbitrary "top layer" file.
+        kg = _curate(flow_repo, enabled=True)
+        assert kg.tour[0]["kind"] == "overview"
+        assert kg.tour[1]["target_path"] == "src/cli/main.py"
+        assert "entry point" in kg.tour[1]["reason"]
+
+    def test_walk_follows_import_depth(self, flow_repo):
+        # main -> route -> svc -> model: the chain appears in BFS order.
+        kg = _curate(flow_repo, enabled=True)
+        pos = {s["target_path"]: i for i, s in enumerate(kg.tour)}
+        assert (
+            pos["src/cli/main.py"]
+            < pos["src/api/route.py"]
+            < pos["src/services/svc.py"]
+            < pos["src/models/model.py"]
+        )
+
+    def test_tests_take_one_closing_stop(self, flow_repo):
+        # The Test layer never competes for walk slots — exactly one closing
+        # stop, after every runtime code stop.
+        kg = _curate(flow_repo, enabled=True)
+        test_steps = [s for s in kg.tour if s["layer_id"] == "layer:test"]
+        assert len(test_steps) == 1
+        last_runtime = max(
+            i
+            for i, s in enumerate(kg.tour)
+            if s["kind"] == "code" and s["layer_id"] != "layer:test"
+        )
+        assert kg.tour.index(test_steps[0]) > last_runtime
+        assert "verified" in test_steps[0]["reason"]
+
+    def test_no_stack_position_claims(self, flow_repo, large_repo):
+        # Reasons state evidence, never sort position ("Top of the stack"
+        # branded conftest.py the start of the control flow).
+        for repo in (flow_repo, large_repo):
+            kg = _curate(repo, enabled=True)
+            for step in kg.tour:
+                assert "Top of the stack" not in step["reason"]
+                assert "mid-stack" not in step["reason"]
+
+    def test_readme_never_visited_twice(self, flow_repo):
+        # The overview retargets to the root README — it must not reappear
+        # as a code stop later in the walk.
+        kg = _curate(flow_repo, enabled=True)
+        readme_steps = [s for s in kg.tour if s["target_path"] == "README.md"]
+        assert len(readme_steps) == 1
+        assert readme_steps[0]["kind"] == "overview"
+
+    def test_codeless_layers_get_no_manufactured_stop(self):
+        # A "plugins" dir of JSON manifests mints a Middleware layer with no
+        # code — the tour must not manufacture an anchor stop for it. The
+        # code files exceed the walk budget so a manifest could only appear
+        # via diversification.
+        code = ["src/cli/main.py"] + [f"src/services/svc{i}.py" for i in range(14)]
+        paths = code + [f"plugins/p{i}/plugin.json" for i in range(3)]
+        repo = build_repo(
+            paths,
+            entries={"src/cli/main.py"},
+            edges=[("src/cli/main.py", p) for p in code[1:]],
+        )
+        kg = _curate(repo, enabled=True)
+        for step in kg.tour:
+            assert not step["target_path"].endswith("plugin.json")
+
+    def test_example_programs_never_take_tour_slots(self):
+        # examples/ are documentation-by-code: no walk slots, no layer faces.
+        code = ["src/cli/main.py"] + [f"src/services/svc{i}.py" for i in range(3)]
+        paths = code + [f"examples/demo{i}/main.py" for i in range(5)]
+        paths += ["examples/versions/data/errors.py"]  # would front Data otherwise
+        repo = build_repo(
+            paths,
+            entries={"src/cli/main.py"},
+            edges=[("src/cli/main.py", p) for p in code[1:]],
+        )
+        kg = _curate(repo, enabled=True)
+        for step in kg.tour:
+            assert not step["target_path"].startswith("examples/")
+
+    def test_barrel_steps_never_claim_entry_point(self):
+        # An index.ts barrel may legitimately seed the walk, but its reason
+        # must say re-export hub, not execution entry point.
+        barrel = "packages/types/src/index.ts"
+        repo = build_repo(
+            [barrel, "src/services/svc.py"],
+            entries={barrel},
+            barrels={barrel},
+            edges=[(barrel, "src/services/svc.py")],
+        )
+        kg = _curate(repo, enabled=True)
+        barrel_steps = [s for s in kg.tour if s["target_path"] == barrel]
+        assert barrel_steps, "barrel should still appear on the walk"
+        for s in barrel_steps:
+            assert "An entry point" not in s["reason"]
+            assert "re-export hub" in s["reason"]
+
+
+class TestEntryPointFallback:
+    def test_filename_scorers_fill_in_when_nothing_is_flagged(self):
+        # No ingestion entry flags at all: the entry-style filename (main.py)
+        # still surfaces, so the orientation panel never opens empty.
+        repo = build_repo(
+            ["src/cli/main.py", "src/services/svc.py", "tests/test_svc.py"],
+            edges=[("src/cli/main.py", "src/services/svc.py")],
+        )
+        kg = _curate(repo, enabled=True)
+        assert kg.project["entry_points"] == ["src/cli/main.py"]
+
+    def test_fallback_skips_test_files(self):
+        # A test named like an entry must not be surfaced by the fallback.
+        repo = build_repo(["tests/main.py", "src/services/svc.py"])
+        kg = _curate(repo, enabled=True)
+        assert kg.project["entry_points"] == []
+
+    def test_code_files_never_typed_infra_by_name(self):
+        # A Python module that *parses* Dockerfiles is code, not infra.
+        repo = build_repo(
+            ["core/ingestion/languages/specs/dockerfile.py", "Dockerfile"]
+        )
+        kg = _curate(repo, enabled=True)
+        by_path = {
+            n["filePath"]: n
+            for n in kg.nodes
+            if n.get("filePath") and str(n.get("id", "")).startswith("file:")
+        }
+        spec = by_path["core/ingestion/languages/specs/dockerfile.py"]
+        assert spec.get("type") != "service"
+        assert "infra" not in (spec.get("tags") or [])
+        assert by_path["Dockerfile"].get("type") == "service"  # real one still promoted
+
+    def test_flagged_test_fixtures_not_surfaced(self):
+        # Ingestion may flag a wsgi.py inside tests/ as an entry point; the
+        # presentation surface must keep it out (a reader enters via src/).
+        repo = build_repo(
+            ["src/app/wsgi.py", "tests/test_apps/helloworld/wsgi.py"],
+            entries={"src/app/wsgi.py", "tests/test_apps/helloworld/wsgi.py"},
+        )
+        kg = _curate(repo, enabled=True)
+        assert kg.project["entry_points"] == ["src/app/wsgi.py"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — node typing & never-empty summaries
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def typed_repo():
+    """A repo exercising infra/CI/data typing plus a barrel and a test."""
+    barrel = "packages/p/index.ts"
+    paths = [
+        ".github/workflows/ci.yml",
+        "Dockerfile",
+        "infra/main.tf",
+        "db/migrations/001_init.sql",
+        "config/app.yaml",
+        "README.md",
+        "src/api/route.py",
+        "tests/unit/test_route.py",
+        barrel,
+    ]
+    return build_repo(
+        paths,
+        tests={"tests/unit/test_route.py"},
+        entries={barrel},
+        barrels={barrel},
+    )
+
+
+def _node_by_path(kg, path):
+    return next(n for n in kg.nodes if n.get("filePath") == path)
+
+
+class TestNodeTyping:
+    def test_ci_workflow_is_pipeline(self, typed_repo):
+        kg = _curate(typed_repo, enabled=True)
+        n = _node_by_path(kg, ".github/workflows/ci.yml")
+        assert n["type"] == "pipeline"
+        assert "ci" in n["tags"]
+
+    def test_dockerfile_and_terraform_are_infra(self, typed_repo):
+        kg = _curate(typed_repo, enabled=True)
+        for p in ("Dockerfile", "infra/main.tf"):
+            n = _node_by_path(kg, p)
+            assert n["type"] == "service"
+            assert "infra" in n["tags"]
+
+    def test_migration_sql_is_schema(self, typed_repo):
+        kg = _curate(typed_repo, enabled=True)
+        n = _node_by_path(kg, "db/migrations/001_init.sql")
+        assert n["type"] == "schema"
+        assert "data" in n["tags"]
+
+
+class TestSummaryFloor:
+    def test_no_empty_file_summary(self, typed_repo, large_repo):
+        for repo in (typed_repo, large_repo):
+            kg = _curate(repo, enabled=True)
+            for n in kg.nodes:
+                if n["id"].startswith("file:"):
+                    assert n["summary"], f"empty summary for {n['filePath']}"
+
+    def test_barrel_summary_is_honest(self, typed_repo):
+        kg = _curate(typed_repo, enabled=True)
+        n = _node_by_path(kg, "packages/p/index.ts")
+        assert "barrel" in n["summary"].lower()
+
+    def test_test_summary_names_target(self, typed_repo):
+        kg = _curate(typed_repo, enabled=True)
+        n = _node_by_path(kg, "tests/unit/test_route.py")
+        assert n["summary"].lower().startswith("tests for")
+
+    def test_flag_off_leaves_summaries_empty(self, typed_repo):
+        kg = _curate(typed_repo, enabled=False)
+        assert all(n["summary"] == "" for n in kg.nodes if n["id"].startswith("file:"))
+
+    def test_deterministic(self, typed_repo):
+        a = _curate(typed_repo, enabled=True)
+        b = _curate(typed_repo, enabled=True)
+        assert [n.get("summary") for n in a.nodes] == [n.get("summary") for n in b.nodes]
+
+
+class TestSummaryFloorDeferral:
+    def test_defer_leaves_summaries_for_later(self, typed_repo):
+        # Generate mode defers the floor so page backfill can win first.
+        kg = curate_knowledge_graph(
+            _build_skeleton(typed_repo),
+            parsed_files=typed_repo.parsed,
+            graph_builder=typed_repo.builder,
+            repo_structure=typed_repo.repo_structure,
+            community_info=typed_repo.builder.community_info(),
+            enabled=True,
+            defer_summary_floor=True,
+        )
+        assert any(n["summary"] == "" for n in kg.nodes if n["id"].startswith("file:"))
+
+    def test_apply_floor_fills_only_empties(self, typed_repo):
+        from repowise.core.analysis.kg_curation import apply_summary_floor
+
+        kg = _build_skeleton(typed_repo)
+        # Simulate a rich page summary already backfilled onto one node.
+        _node_by_path(kg, "src/api/route.py")["summary"] = "Rich page summary."
+        apply_summary_floor(kg, typed_repo.parsed)
+        assert _node_by_path(kg, "src/api/route.py")["summary"] == "Rich page summary."
+        assert all(n["summary"] for n in kg.nodes if n["id"].startswith("file:"))
+
+
+# ---------------------------------------------------------------------------
+# Closing-stop selection (suite anchors, descriptors, polyglot)
+# ---------------------------------------------------------------------------
+
+
+def _closing_stops(kg) -> list[dict]:
+    return [s for s in kg.tour if "test suite" in s["reason"]]
+
+
+class TestClosingStopParity:
+    def test_descriptor_never_faces_the_suite(self):
+        # gson regression: a shallow JPMS module-info.java sits in the Test
+        # layer; the closing stop must face a real camel test instead.
+        repo = build_repo(
+            [
+                "src/main/java/com/x/App.java",
+                "src/main/java/com/x/Core.java",
+                "jpms/src/test/java/module-info.java",
+                "src/test/java/com/x/core/AppTest.java",
+            ],
+            entries={"src/main/java/com/x/App.java"},
+            edges=[("src/main/java/com/x/App.java", "src/main/java/com/x/Core.java")],
+        )
+        kg = _curate(repo, enabled=True)
+        closing = _closing_stops(kg)
+        assert len(closing) == 1
+        assert closing[0]["target_path"] == "src/test/java/com/x/core/AppTest.java"
+
+    def test_fixture_file_never_faces_the_suite(self):
+        # gson regression: same-package edges gave the test tree's
+        # ParameterizedTypeFixtures.java the highest pagerank — but a
+        # fixtures file holds test data, it doesn't verify behavior.
+        repo = build_repo(
+            [
+                "src/main/java/com/x/App.java",
+                "src/main/java/com/x/Core.java",
+                "src/test/java/com/x/TypeFixtures.java",
+                "src/test/java/com/x/CoreTest.java",
+            ],
+            entries={"src/main/java/com/x/App.java"},
+            edges=[
+                ("src/main/java/com/x/App.java", "src/main/java/com/x/Core.java"),
+                # Tests lean on the fixture file — its rank dwarfs the test's.
+                ("src/test/java/com/x/CoreTest.java", "src/test/java/com/x/TypeFixtures.java"),
+            ],
+            pagerank={"src/test/java/com/x/TypeFixtures.java": 0.9},
+        )
+        kg = _curate(repo, enabled=True)
+        closing = _closing_stops(kg)
+        assert len(closing) == 1
+        assert closing[0]["target_path"] == "src/test/java/com/x/CoreTest.java"
+
+    def test_fixture_convention_does_not_leak_to_other_languages(self):
+        # The Fixture/Fixtures camel rule is declared by java — a python
+        # file with the same shape stays an eligible suite face.
+        repo = build_repo(
+            [
+                "src/app.py",
+                "src/core.py",
+                "tests/DataFixtures.py",
+            ],
+            entries={"src/app.py"},
+            edges=[("src/app.py", "src/core.py")],
+        )
+        kg = _curate(repo, enabled=True)
+        closing = _closing_stops(kg)
+        assert len(closing) == 1
+        assert closing[0]["target_path"] == "tests/DataFixtures.py"
+
+    def test_ruby_suite_anchor_wins(self):
+        repo = build_repo(
+            [
+                "lib/app.rb",
+                "lib/core.rb",
+                "test/test_helper.rb",
+                "test/app_test.rb",
+            ],
+            entries={"lib/app.rb"},
+            edges=[("lib/app.rb", "lib/core.rb")],
+        )
+        kg = _curate(repo, enabled=True)
+        closing = _closing_stops(kg)
+        assert len(closing) == 1
+        assert closing[0]["target_path"] == "test/test_helper.rb"
+
+    def test_runner_face_preserved_without_anchor(self):
+        # django-style: no conftest, the suite runner is the shallowest
+        # dominant-language file — it must keep facing the suite.
+        repo = build_repo(
+            [
+                "src/app.py",
+                "src/core.py",
+                "tests/runtests.py",
+                "tests/test_deep/test_one.py",
+            ],
+            entries={"src/app.py"},
+            edges=[("src/app.py", "src/core.py")],
+        )
+        kg = _curate(repo, enabled=True)
+        closing = _closing_stops(kg)
+        assert len(closing) == 1
+        assert closing[0]["target_path"] == "tests/runtests.py"
+
+    def test_polyglot_closing_reason_mentions_other_suites(self):
+        # 6 python + 4 ts code files (40% ts) with a ts test tree: the stop
+        # faces the python suite but names the TypeScript one.
+        repo = build_repo(
+            [
+                "src/a.py", "src/b.py", "src/c.py", "src/d.py", "src/e.py", "src/f.py",
+                "web/x.ts", "web/y.ts", "web/z.ts", "web/w.ts",
+                "tests/conftest.py",
+                "web/__tests__/x.test.ts",
+            ],
+            entries={"src/a.py"},
+            edges=[("src/a.py", "src/b.py")],
+        )
+        kg = _curate(repo, enabled=True)
+        closing = _closing_stops(kg)
+        assert len(closing) == 1
+        assert closing[0]["target_path"] == "tests/conftest.py"
+        assert "TypeScript test suite lives alongside it" in closing[0]["reason"]
+
+    def test_monoglot_reason_unchanged(self):
+        repo = build_repo(
+            ["src/app.py", "src/core.py", "tests/conftest.py"],
+            entries={"src/app.py"},
+            edges=[("src/app.py", "src/core.py")],
+        )
+        kg = _curate(repo, enabled=True)
+        closing = _closing_stops(kg)
+        assert closing[0]["reason"] == "The test suite — how the system's behavior is verified."
+
+
+class TestNonInfraCodeTyping:
+    def test_tier3_code_never_typed_infra_by_name(self):
+        # Equivalents of the dockerfile.py guard for every code language:
+        # code that *handles* infra formats is code, not infra.
+        from repowise.core.analysis.kg_curation import _enrich_type
+
+        assert _enrich_type("k8s/dockerfile.nim", "file") == ("file", None)
+        assert _enrich_type("build/makefile.clj", "file") == ("file", None)
+        assert _enrich_type("ci/.github/workflows/helpers.hs", "file") == ("file", None)
+        assert _enrich_type("tools/docker-compose.dart", "file") == ("file", None)
+
+    def test_infra_languages_still_promote(self):
+        from repowise.core.analysis.kg_curation import _enrich_type
+
+        assert _enrich_type("deploy/k8s/deploy.sh", "file") == ("service", "infra")
+        assert _enrich_type("infra/main.tf", "file") == ("service", "infra")
+        assert _enrich_type(".github/workflows/ci.yml", "config") == ("pipeline", "ci")
+
+
+# ---------------------------------------------------------------------------
+# Honest degradation (flow / sparse / structural)
+# ---------------------------------------------------------------------------
+
+# Vocabulary that claims an execution flow. Structural tours must never use
+# it — "named like an entry file" is the one sanctioned entry phrasing.
+_FLOW_CLAIMS = (
+    "entry point",
+    "imports fan out",
+    "imports deep",
+    "import path",
+    "directly used by the entry",
+    "widely-imported",
+)
+
+
+def _edgeless_zig_repo():
+    """A Tier-3 repo: real code files, import_support='none', zero edges.
+
+    Zig stays on the structural (no-resolver) tier — elixir, the previous
+    fixture language, was promoted to the lightweight regex tier.
+    """
+    paths = [
+        "src/shop.zig",
+        "src/application.zig",
+        "src/checkout.zig",
+        "src/cart.zig",
+        "src/billing/invoice.zig",
+        "tools/seeds.zig",
+        "test/shop_test.zig",
+        "test/helper.zig",
+        "README.md",
+    ]
+    return build_repo(paths, tests={"test/shop_test.zig", "test/helper.zig"})
+
+
+class TestHonestDegradation:
+    def test_structural_mode_for_unsupported_language(self):
+        repo = _edgeless_zig_repo()
+        kg = _curate(repo, enabled=True)
+        assert kg.project["graph_mode"] == "structural"
+
+    def test_structural_tour_makes_no_flow_claims(self):
+        repo = _edgeless_zig_repo()
+        kg = _curate(repo, enabled=True)
+        assert kg.tour, "structural repos still get a tour"
+        for step in kg.tour:
+            low = step["reason"].lower()
+            for claim in _FLOW_CLAIMS:
+                assert claim not in low, (step["target_path"], step["reason"])
+
+    def test_structural_anchor_states_the_evidence_and_the_gap(self):
+        repo = _edgeless_zig_repo()
+        kg = _curate(repo, enabled=True)
+        code_steps = [s for s in kg.tour if s["kind"] == "code" and "test" not in s["reason"].lower()]
+        assert code_steps, kg.tour
+        anchor = code_steps[0]
+        assert "isn't supported for Zig yet" in anchor["reason"]
+        assert anchor["depth"] == 0
+
+    def test_structural_layers_labeled_canonical(self):
+        repo = _edgeless_zig_repo()
+        kg = _curate(repo, enabled=True)
+        assert kg.layers
+        assert all(layer.get("order_basis") == "canonical" for layer in kg.layers)
+
+    def test_flow_layers_labeled_imports(self, flow_repo):
+        kg = _curate(flow_repo, enabled=True)
+        assert any(layer.get("order_basis") == "imports" for layer in kg.layers)
+
+    def test_flow_repo_stays_flow(self, flow_repo):
+        kg = _curate(flow_repo, enabled=True)
+        assert kg.project["graph_mode"] == "flow"
+
+    def test_sparse_mode_for_low_density_weak_resolution(self):
+        # 30 python files (over the small-repo floor), thin internal chain
+        # and most import targets landing on external nodes: low density
+        # AND weak resolution is the broken-resolver signature -> sparse.
+        paths = [f"src/m{i}.py" for i in range(30)]
+        edges = [(paths[i], paths[i + 1]) for i in range(29)]
+        edges += [(paths[i], f"external:mystery{i}") for i in range(5, 30)]
+        repo = build_repo(paths, entries={"src/m0.py"}, edges=edges)
+        kg = _curate(repo, enabled=True)
+        assert kg.project["graph_mode"] == "sparse"
+
+    def test_flow_mode_for_low_density_strong_resolution(self):
+        # Same thin chain but almost every target resolves internally: a
+        # require-light, well-resolved graph (sinatra after stdlib
+        # filtering: 1.31 edges/file at 0.77 resolution) narrates honestly
+        # -> flow, not sparse. Low density alone no longer indicts the
+        # resolver.
+        paths = [f"src/m{i}.py" for i in range(30)]
+        edges = [(paths[i], paths[i + 1]) for i in range(29)]
+        edges += [(paths[0], "external:gem:rack")]
+        repo = build_repo(paths, entries={"src/m0.py"}, edges=edges)
+        kg = _curate(repo, enabled=True)
+        assert kg.project["graph_mode"] == "flow"
+
+    def test_sparse_unreached_reason_blames_the_graph(self):
+        # Files off the walk in sparse mode cite incomplete resolution, not
+        # the file ("standalone or supporting" would blame the file).
+        paths = [f"src/m{i}.py" for i in range(30)]
+        # Density in the sparse band with weak resolution, edges
+        # concentrated in m0..m5: the walk's later slots fill with
+        # unreached files, whose reasons are under test.
+        edges = [
+            (paths[i], paths[j]) for i in range(6) for j in range(i + 1, 6)
+        ][:12]
+        edges += [(paths[i], f"external:mystery{i}") for i in range(6, 30)]
+        repo = build_repo(paths, entries={"src/m0.py"}, edges=edges)
+        kg = _curate(repo, enabled=True)
+        unreached_reasons = [
+            s["reason"] for s in kg.tour if "import resolution is incomplete" in s["reason"]
+        ]
+        assert unreached_reasons, [s["reason"] for s in kg.tour]
+        assert not any("standalone or supporting" in s["reason"] for s in kg.tour)
+
+    def test_small_repo_density_is_not_evidence(self):
+        # 7 healthy python files (mini-taskq shape): low density on a tiny
+        # repo must not demote a full-support language out of flow mode.
+        paths = [f"src/m{i}.py" for i in range(6)] + ["tests/test_m.py"]
+        edges = [("src/m0.py", "src/m1.py")]
+        repo = build_repo(paths, entries={"src/m0.py"}, edges=edges, tests={"tests/test_m.py"})
+        kg = _curate(repo, enabled=True)
+        assert kg.project["graph_mode"] == "flow"
+
+
+class TestClosingStopHarnessExclusion:
+    def test_shared_harness_never_faces_the_suite(self):
+        # okio/Alamofire/scopt regression: the base class or helper every
+        # test imports (AbstractFileSystemTest, BaseTestCase, SpecUtil)
+        # carries the suite's highest pagerank — but it is what the suite
+        # runs ON, not where tests start.
+        repo = build_repo(
+            [
+                "src/app.py",
+                "src/core.py",
+                "tests/harness.py",
+                "tests/test_one.py",
+                "tests/test_two.py",
+            ],
+            entries={"src/app.py"},
+            edges=[
+                ("src/app.py", "src/core.py"),
+                ("tests/test_one.py", "tests/harness.py"),
+                ("tests/test_two.py", "tests/harness.py"),
+            ],
+            pagerank={"tests/harness.py": 0.9},
+        )
+        kg = _curate(repo, enabled=True)
+        closing = _closing_stops(kg)
+        assert len(closing) == 1
+        assert closing[0]["target_path"] in ("tests/test_one.py", "tests/test_two.py")
+
+    def test_single_importer_helper_excluded(self):
+        # okio's CipherFactory.kt: even ONE test-file importer marks a
+        # helper — leaf tests import helpers, nothing imports leaf tests.
+        repo = build_repo(
+            [
+                "src/app.py",
+                "tests/util.py",
+                "tests/test_one.py",
+            ],
+            entries={"src/app.py"},
+            edges=[("tests/test_one.py", "tests/util.py")],
+            pagerank={"tests/util.py": 0.9},
+        )
+        kg = _curate(repo, enabled=True)
+        closing = _closing_stops(kg)
+        assert len(closing) == 1
+        assert closing[0]["target_path"] == "tests/test_one.py"
+
+    def test_test_project_dir_wins_over_shared_helpers(self):
+        # Polly regression: test/Shared/TestCancellation.cs is shallower
+        # than the .Specs project files, but the declared test-project
+        # convention (.Tests/.Specs) is where the suite lives.
+        repo = build_repo(
+            [
+                "src/Core/App.cs",
+                "src/Core/Core.cs",
+                "test/Shared/TestCancellation.cs",
+                "test/Acme.Specs/RetrySpecs.cs",
+            ],
+            entries={"src/Core/App.cs"},
+            edges=[("src/Core/App.cs", "src/Core/Core.cs")],
+            pagerank={"test/Shared/TestCancellation.cs": 0.9},
+        )
+        kg = _curate(repo, enabled=True)
+        closing = _closing_stops(kg)
+        assert len(closing) == 1
+        assert closing[0]["target_path"] == "test/Acme.Specs/RetrySpecs.cs"
+
+
+class TestSupportDirExclusion:
+    def test_doc_site_entries_never_surface(self):
+        # libuv/Polly regression: docs/code/*/main.c snippets and docfx
+        # template main.js flooded the entry surface and the whole tour.
+        repo = build_repo(
+            [
+                "docs/code/spawn/main.c",
+                "docs/template/public/main.js",
+                "website/theme/index.ts",
+                "src/core.c",
+                "src/run.c",
+            ],
+            entries={
+                "docs/code/spawn/main.c",
+                "docs/template/public/main.js",
+                "website/theme/index.ts",
+            },
+            edges=[("src/run.c", "src/core.c")],
+        )
+        kg = _curate(repo, enabled=True)
+        entries = kg.project.get("entry_points", [])
+        assert all(not e.startswith(("docs/", "website/")) for e in entries)
+        tour_paths = {s["target_path"] for s in (kg.tour or [])}
+        assert not any(p.startswith(("docs/", "website/")) for p in tour_paths)
+
+
+class TestFanoutCollapse:
+    def _gb(self):
+        from types import SimpleNamespace
+
+        import networkx as nx
+
+        g = nx.DiGraph()
+        # One Go-style package import fanned out to 3 sibling targets…
+        for t in ("pkg/a.py", "pkg/b.py", "pkg/c.py"):
+            g.add_edge("tests/test_x.py", t, edge_type="imports", imported_names=["pkg"])
+        # …and one explicit single-target import.
+        g.add_edge(
+            "tests/test_x.py", "tests/harness.py",
+            edge_type="imports", imported_names=["Harness"],
+        )
+        g.add_edge(
+            "tests/test_y.py", "tests/harness.py",
+            edge_type="imports", imported_names=["Harness"],
+        )
+        return SimpleNamespace(graph=lambda: g)
+
+    def test_fanout_groups_excluded_from_pairs(self):
+        from repowise.core.analysis.kg_curation import _import_pairs_excluding_fanout
+
+        pairs = set(_import_pairs_excluding_fanout(self._gb()))
+        # chi regression: a package fan-out is not evidence that each
+        # sibling file is individually referenced.
+        assert ("tests/test_x.py", "pkg/a.py") not in pairs
+        assert ("tests/test_x.py", "tests/harness.py") in pairs
+        assert ("tests/test_y.py", "tests/harness.py") in pairs
+
+    def test_anchor_rank_counts_relationships_not_edges(self):
+        from repowise.core.analysis.kg_curation import _anchor_fanout_rank
+
+        rank = _anchor_fanout_rank(self._gb())
+        # 4 raw out-edges from test_x, but only 2 import relationships
+        # (the fan-out collapses to one).
+        assert rank["tests/test_x.py"] == 2
+        assert rank["tests/test_y.py"] == 1
+
+
+class TestPartialTierGraphMode:
+    """Regex-tier (partial) languages run flow/sparse per REAL density and
+    resolution — partial support alone no longer pins sparse."""
+
+    def test_well_resolved_partial_repo_flows(self):
+        # 30 elixir files, thin but cleanly-resolved alias chain → flow:
+        # blaming "incomplete import resolution" at 0.97 resolution is a lie.
+        paths = [f"lib/m{i}.ex" for i in range(30)]
+        edges = [(paths[i], paths[i + 1]) for i in range(29)]
+        edges += [(paths[0], "external:Phoenix")]
+        repo = build_repo(paths, edges=edges)
+        kg = _curate(repo, enabled=True)
+        assert kg.project["graph_mode"] == "flow"
+
+    def test_weakly_resolved_partial_repo_stays_sparse(self):
+        paths = [f"lib/m{i}.ex" for i in range(30)]
+        edges = [(paths[i], paths[i + 1]) for i in range(9)]
+        edges += [(paths[i], f"external:Dep{i}") for i in range(10, 30)]
+        repo = build_repo(paths, edges=edges)
+        kg = _curate(repo, enabled=True)
+        assert kg.project["graph_mode"] == "sparse"
+
+    def test_small_partial_repo_with_clean_resolution_flows(self):
+        # Density is unmeasurable on tiny repos but resolution is not: a
+        # 24-file Elixir repo resolving 0.9 of its aliases must not have
+        # its tour blame "incomplete import resolution" for being small.
+        paths = [f"lib/m{i}.ex" for i in range(8)]
+        edges = [(paths[i], paths[i + 1]) for i in range(7)]
+        repo = build_repo(paths, edges=edges)
+        kg = _curate(repo, enabled=True)
+        assert kg.project["graph_mode"] == "flow"
+
+    def test_small_partial_repo_with_weak_resolution_stays_sparse(self):
+        paths = [f"lib/m{i}.ex" for i in range(8)]
+        edges = [(paths[0], paths[1])]
+        edges += [(paths[i], f"external:Dep{i}") for i in range(2, 8)]
+        repo = build_repo(paths, edges=edges)
+        kg = _curate(repo, enabled=True)
+        assert kg.project["graph_mode"] == "sparse"

--- a/tests/unit/analysis/test_kg_export_determinism.py
+++ b/tests/unit/analysis/test_kg_export_determinism.py
@@ -1,0 +1,64 @@
+"""Canonical ordering of the exported knowledge-graph artifact.
+
+File-traversal and graph-insertion order vary run to run (parallel parsing,
+thread-completion order); ``KnowledgeGraphResult.to_dict`` must therefore
+emit byte-stable output regardless of the in-memory list order it was
+handed. Pinned after the 2026-06 discovery that identical re-runs produced
+different knowledge-graph.json bytes on every validation repo.
+"""
+
+from __future__ import annotations
+
+from repowise.core.analysis.knowledge_graph import KnowledgeGraphResult
+
+
+def _result(node_order: list[str], edge_order: list[tuple[str, str]]) -> KnowledgeGraphResult:
+    return KnowledgeGraphResult(
+        project={"name": "x"},
+        nodes=[{"id": n, "type": "file"} for n in node_order],
+        edges=[
+            {"source": s, "target": t, "type": "imports", "direction": "forward", "weight": 1.0}
+            for s, t in edge_order
+        ],
+        layers=[
+            {
+                "id": "layer:application",
+                "name": "Application",
+                "nodeIds": list(node_order),
+                "display_order": 0,
+                "subGroups": [
+                    {"id": "layer:application:root", "name": "(root)", "nodeIds": list(node_order)}
+                ],
+            }
+        ],
+        tour=[],
+    )
+
+
+class TestCanonicalExport:
+    def test_shuffled_inputs_export_identically(self) -> None:
+        a = _result(["file:b", "file:a", "file:c"], [("file:b", "file:a"), ("file:a", "file:c")])
+        b = _result(["file:c", "file:b", "file:a"], [("file:a", "file:c"), ("file:b", "file:a")])
+        assert a.to_dict() == b.to_dict()
+
+    def test_nodes_sorted_by_id(self) -> None:
+        d = _result(["file:b", "file:a"], []).to_dict()
+        assert [n["id"] for n in d["nodes"]] == ["file:a", "file:b"]
+
+    def test_edges_sorted_by_source_target_type(self) -> None:
+        d = _result(["file:a", "file:b"], [("file:b", "file:a"), ("file:a", "file:b")]).to_dict()
+        assert [(e["source"], e["target"]) for e in d["edges"]] == [
+            ("file:a", "file:b"),
+            ("file:b", "file:a"),
+        ]
+
+    def test_layer_node_ids_and_subgroups_sorted(self) -> None:
+        d = _result(["file:b", "file:a"], []).to_dict()
+        layer = d["layers"][0]
+        assert layer["nodeIds"] == ["file:a", "file:b"]
+        assert layer["subGroups"][0]["nodeIds"] == ["file:a", "file:b"]
+
+    def test_tour_order_untouched(self) -> None:
+        r = _result(["file:a"], [])
+        r.tour = [{"order": 1, "target_path": "z"}, {"order": 2, "target_path": "a"}]
+        assert [s["target_path"] for s in r.to_dict()["tour"]] == ["z", "a"]

--- a/tests/unit/analysis/test_kg_invariants.py
+++ b/tests/unit/analysis/test_kg_invariants.py
@@ -1,0 +1,147 @@
+"""Phase 7 — KG intuitiveness invariants locked across structurally different
+repos (many-isolates regression, flat single-package, deep monorepo) plus the
+portable artifact and the AST-untouched guard."""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.analysis.kg_curation import build_portable_kg, validate_kg
+
+from .kg_fixtures import build_repo, build_skeleton, curate
+
+# ---------------------------------------------------------------------------
+# Structurally different repos
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def many_isolates_repo():
+    """Many weakly-connected files — the historical 103-layers / 73-singletons
+    pathology. Curated layers must collapse to a bounded named set."""
+    paths: list[str] = []
+    for layer_dir in ("api", "services", "models", "ui", "utils", "config"):
+        paths += [f"pkg{layer_dir}/{layer_dir}/f{i}.py" for i in range(14)]
+    tests = {f"tests/test_{i}.py" for i in range(14)}
+    paths += sorted(tests)
+    return build_repo(paths, tests=tests)  # no edges → every file an isolate
+
+
+@pytest.fixture
+def flat_repo():
+    """A single flat package — few layers, but must stay partitioned/valid."""
+    return build_repo([f"src/mod{i}.py" for i in range(40)])
+
+
+@pytest.fixture
+def deep_monorepo():
+    """A realistically layered monorepo with two mega-layers."""
+    paths: list[str] = []
+    for sub in ("ingestion", "analysis", "generation"):
+        paths += [f"packages/core/src/repowise/core/{sub}/m{i}.py" for i in range(24)]
+    for sub in ("buttons", "forms", "layout"):
+        paths += [f"packages/ui/src/components/{sub}/c{i}.tsx" for i in range(24)]
+    paths += [f"packages/cli/src/cli/commands/cmd{i}.py" for i in range(20)]
+    paths += [f"src/api/r{i}.py" for i in range(12)]
+    paths += [f"src/models/m{i}.py" for i in range(10)]
+    paths += [f"src/utils/u{i}.py" for i in range(8)]
+    paths += [f"config/c{i}.yaml" for i in range(6)]
+    tests = {f"tests/unit/test_{i}.py" for i in range(30)}
+    paths += sorted(tests)
+    return build_repo(paths, tests=tests)
+
+
+ALL_REPOS = ["many_isolates_repo", "flat_repo", "deep_monorepo"]
+
+
+@pytest.mark.parametrize("repo_fixture", ALL_REPOS)
+class TestInvariantsAcrossRepos:
+    def test_layer_count_never_explodes(self, repo_fixture, request):
+        kg = curate(request.getfixturevalue(repo_fixture))
+        assert len(kg.layers) <= 15  # the 103→bounded guarantee
+
+    def test_partition_holds(self, repo_fixture, request):
+        kg = curate(request.getfixturevalue(repo_fixture))
+        v = validate_kg(kg)
+        assert "partition" not in " ".join(v.errors)
+        seen: set[str] = set()
+        for layer in kg.layers:
+            for nid in layer["nodeIds"]:
+                assert nid not in seen
+                seen.add(nid)
+        file_count = sum(1 for n in kg.nodes if n["id"].startswith("file:"))
+        assert len(seen) == file_count
+
+    def test_no_empty_summaries(self, repo_fixture, request):
+        kg = curate(request.getfixturevalue(repo_fixture))
+        assert all(n["summary"] for n in kg.nodes if n["id"].startswith("file:"))
+
+    def test_entry_points_capped(self, repo_fixture, request):
+        kg = curate(request.getfixturevalue(repo_fixture))
+        assert len(kg.project.get("entry_points", [])) <= 8
+
+    def test_tour_within_budget_and_opens_overview(self, repo_fixture, request):
+        kg = curate(request.getfixturevalue(repo_fixture))
+        assert len(kg.tour) <= 12
+        if kg.tour:
+            assert kg.tour[0]["kind"] == "overview"
+
+    def test_no_hard_validation_errors(self, repo_fixture, request):
+        kg = curate(request.getfixturevalue(repo_fixture))
+        v = validate_kg(kg)
+        assert v.ok, v.errors
+
+    def test_deterministic(self, repo_fixture, request):
+        a = curate(request.getfixturevalue(repo_fixture))
+        b = curate(request.getfixturevalue(repo_fixture))
+        assert a.layers == b.layers
+        assert a.tour == b.tour
+        assert a.project.get("entry_points") == b.project.get("entry_points")
+
+    def test_ast_graph_untouched(self, repo_fixture, request):
+        repo = request.getfixturevalue(repo_fixture)
+        g = repo.builder.graph()
+        before = (g.number_of_nodes(), g.number_of_edges())
+        curate(repo)
+        g = repo.builder.graph()
+        assert (g.number_of_nodes(), g.number_of_edges()) == before
+
+
+class TestManyIsolatesRegression:
+    def test_does_not_produce_one_layer_per_file(self, many_isolates_repo):
+        # Skeleton (community) layers = one per file (the pathology).
+        skel = build_skeleton(many_isolates_repo)
+        file_count = sum(1 for n in skel.nodes if n["id"].startswith("file:"))
+        assert len(skel.layers) == file_count
+        # Curated layers collapse to a bounded named set.
+        kg = curate(many_isolates_repo)
+        assert len(kg.layers) <= 15
+        assert len(kg.layers) < file_count
+
+
+# ---------------------------------------------------------------------------
+# Portable artifact (Phase 6)
+# ---------------------------------------------------------------------------
+
+
+class TestPortableArtifact:
+    def test_self_contained_and_validated(self, deep_monorepo):
+        kg = curate(deep_monorepo)
+        data, validation = build_portable_kg(kg)
+        for key in ("version", "project", "nodes", "edges", "layers", "tour", "meta"):
+            assert key in data
+        assert data["meta"]["validation"]["ok"] is validation.ok
+        assert data["meta"]["layer_count"] == len(kg.layers)
+        assert validation.ok, validation.errors
+
+    def test_default_to_dict_has_no_meta(self, deep_monorepo):
+        # The bare export stays byte-identical-shaped (no meta leakage).
+        kg = curate(deep_monorepo)
+        assert "meta" not in kg.to_dict()
+
+    def test_metrics_block_populated(self, deep_monorepo):
+        kg = curate(deep_monorepo)
+        m = validate_kg(kg).metrics
+        assert m["layer_count"] >= 6
+        assert m["summary_completeness_pct"] == 100.0
+        assert 0 <= m["largest_layer_pct"] <= 35

--- a/tests/unit/analysis/test_kg_modules.py
+++ b/tests/unit/analysis/test_kg_modules.py
@@ -1,0 +1,420 @@
+"""Tests for curated wiki modules (``derive_modules`` in ``kg_curation``).
+
+Acceptance gates: partition/coverage invariants, determinism, naming
+(generic-segment stripping, no size suffixes, collision handling), the
+granularity window, stable path-derived ids, and the artifact export seam
+(``modules`` key present only when curation derived modules).
+"""
+
+from __future__ import annotations
+
+import json
+
+from repowise.core.analysis.kg_curation import derive_modules, validate_kg
+from repowise.core.analysis.knowledge_graph import KnowledgeGraphResult
+
+from .kg_fixtures import build_repo, curate
+
+# ---------------------------------------------------------------------------
+# Pure derive_modules fixtures
+# ---------------------------------------------------------------------------
+
+
+def _layer(name: str, paths: list[str]) -> dict:
+    return {
+        "id": f"layer:{name.lower()}",
+        "name": name,
+        "nodeIds": [f"file:{p}" for p in paths],
+    }
+
+
+def _id_map(*path_lists: list[str]) -> dict[str, str]:
+    return {f"file:{p}": p for paths in path_lists for p in paths}
+
+
+def _monorepo():
+    """Synthetic monorepo where ``packages``/``acme``/``src`` are generic.
+
+    175 files total; the namespace dirs appear in 140 (80% > 60% → generic)
+    while ``core`` stays at 100/175 (57% → informative).
+    """
+    ns = "packages/acme/src/acme"
+    service = (
+        [f"{ns}/core/ingestion/resolvers/r{i}.py" for i in range(30)]
+        + [f"{ns}/core/ingestion/parsers/p{i}.py" for i in range(18)]
+        + [f"{ns}/core/ingestion/root{i}.py" for i in range(2)]
+        + [f"{ns}/core/analysis/a{i}.py" for i in range(30)]
+        + [f"{ns}/core/generation/g{i}.py" for i in range(20)]
+    )
+    ui = [f"{ns}/ui/components/c{i}.tsx" for i in range(40)]
+    tests = [f"tests/unit/test_{i}.py" for i in range(20)] + [
+        f"tests/integration/test_{i}.py" for i in range(10)
+    ]
+    config = [f"conf{i}.yaml" for i in range(5)]
+    layers = [
+        _layer("Service", service),
+        _layer("UI", ui),
+        _layer("Test", tests),
+        _layer("Config", config),
+    ]
+    return layers, _id_map(service, ui, tests, config)
+
+
+def _derive(layers, id_to_path, **kw):
+    kw.setdefault("target_min", 4)
+    kw.setdefault("target_max", 40)
+    return derive_modules(layers, id_to_path, **kw)
+
+
+# ---------------------------------------------------------------------------
+# Invariants — partition, coverage, determinism
+# ---------------------------------------------------------------------------
+
+
+class TestInvariants:
+    def test_partition_within_each_layer(self):
+        layers, id_to_path = _monorepo()
+        modules = _derive(layers, id_to_path)
+        covered = [nid for m in modules for nid in m["nodeIds"]]
+        assert len(covered) == len(set(covered)), "a file appears in two modules"
+        # Every layer is ≥ the module floor, so coverage is total.
+        all_ids = {nid for layer in layers for nid in layer["nodeIds"]}
+        assert set(covered) == all_ids
+
+    def test_never_merges_across_layers(self):
+        layers, id_to_path = _monorepo()
+        modules = _derive(layers, id_to_path)
+        layer_of = {
+            nid: layer["id"] for layer in layers for nid in layer["nodeIds"]
+        }
+        for m in modules:
+            assert {layer_of[nid] for nid in m["nodeIds"]} == {m["layerId"]}
+
+    def test_deterministic_byte_equal(self):
+        layers, id_to_path = _monorepo()
+        a = json.dumps(_derive(layers, id_to_path), sort_keys=True)
+        # Re-derive from shuffled inputs: dict/list order must not leak.
+        shuffled_layers = [
+            {**layer, "nodeIds": list(reversed(layer["nodeIds"]))}
+            for layer in layers
+        ]
+        shuffled_map = dict(reversed(list(id_to_path.items())))
+        b = json.dumps(_derive(shuffled_layers, shuffled_map), sort_keys=True)
+        assert a == b
+
+    def test_tiny_layer_yields_no_module(self):
+        layers, id_to_path = _monorepo()
+        tiny = _layer("Data", ["db/schema.sql", "db/seed.sql"])
+        id_to_path = {**id_to_path, **_id_map(["db/schema.sql", "db/seed.sql"])}
+        modules = _derive([*layers, tiny], id_to_path, min_module_size=3)
+        assert not [m for m in modules if m["layerId"] == "layer:data"]
+
+    def test_external_node_ids_ignored(self):
+        layers, id_to_path = _monorepo()
+        layers[0]["nodeIds"].append("external:@radix-ui/react-progress")
+        modules = _derive(layers, id_to_path)
+        all_member_ids = {nid for m in modules for nid in m["nodeIds"]}
+        assert "external:@radix-ui/react-progress" not in all_member_ids
+
+
+# ---------------------------------------------------------------------------
+# Granularity window
+# ---------------------------------------------------------------------------
+
+
+class TestGranularity:
+    def test_window_respected(self):
+        layers, id_to_path = _monorepo()
+        modules = _derive(layers, id_to_path)
+        sizes = {m["name"]: len(m["nodeIds"]) for m in modules}
+        # Single-module layers may sit below target_min (rule 3); split
+        # products must respect the window.
+        assert all(s <= 40 for s in sizes.values()), sizes
+        # Mega-layer split landed at the expected granularity.
+        assert sizes["ingestion/resolvers"] == 32  # 30 + 2 merged-up root files
+        assert sizes["ingestion/parsers"] == 18
+        assert sizes["core/analysis"] == 30
+        assert sizes["core/generation"] == 20
+
+    def test_flat_dir_stays_one_honest_module(self):
+        paths = [f"src/lib/f{i}.py" for i in range(60)]
+        modules = _derive([_layer("Service", paths)], _id_map(paths))
+        assert len(modules) == 1
+        assert len(modules[0]["nodeIds"]) == 60  # > target_max, but flat
+
+    def test_small_remnant_merges_up_not_confetti(self):
+        layers, id_to_path = _monorepo()
+        modules = _derive(layers, id_to_path)
+        # The 2 root files of core/ingestion folded into the biggest
+        # ingestion sibling instead of minting a 2-file module.
+        split_modules = [m for m in modules if m["layerId"] == "layer:service"]
+        assert all(len(m["nodeIds"]) >= 4 for m in split_modules)
+
+    def test_surviving_root_group_named_top_level(self):
+        paths = (
+            [f"pkg/sub1/f{i}.py" for i in range(10)]
+            + [f"pkg/sub2/f{i}.py" for i in range(10)]
+            + [f"pkg/r{i}.py" for i in range(6)]
+        )
+        modules = _derive(
+            [_layer("Application", paths)], _id_map(paths), target_max=12
+        )
+        names = {m["name"] for m in modules}
+        assert "Application (top-level)" in names
+        assert {"sub1", "sub2"} <= names
+
+
+# ---------------------------------------------------------------------------
+# Naming
+# ---------------------------------------------------------------------------
+
+
+class TestNaming:
+    def test_generic_segments_never_in_names(self):
+        layers, id_to_path = _monorepo()
+        modules = _derive(layers, id_to_path)
+        for m in modules:
+            for seg in m["name"].split("/"):
+                assert seg not in {"packages", "acme", "src"}, m["name"]
+
+    def test_expected_names(self):
+        layers, id_to_path = _monorepo()
+        names = {m["name"] for m in _derive(layers, id_to_path)}
+        assert names == {
+            "ingestion/resolvers",
+            "ingestion/parsers",
+            "core/analysis",
+            "core/generation",
+            "UI",
+            "Test",
+            "Config",
+        }
+
+    def test_names_unique_and_never_size_suffixed(self):
+        layers, id_to_path = _monorepo()
+        names = [m["name"] for m in _derive(layers, id_to_path)]
+        assert len(names) == len(set(names))
+        assert not any(n.rstrip().endswith(")") and "(" in n and n.split("(")[-1].rstrip(") ").isdigit() for n in names)
+
+    def test_collision_extends_path_leftward(self):
+        paths = (
+            [f"a/x/utils/f{i}.py" for i in range(8)]
+            + [f"b/x/utils/g{i}.py" for i in range(8)]
+            + [f"c/api/h{i}.py" for i in range(12)]
+        )
+        modules = _derive([_layer("Service", paths)], _id_map(paths), target_max=10)
+        names = {m["name"] for m in modules}
+        # Both dirs end x/utils — disambiguated by the parent segment,
+        # NOT by a size suffix.
+        assert {"a/x/utils", "b/x/utils"} <= names
+        assert not any("(" in n for n in names)
+
+    def test_single_module_layer_named_after_layer(self):
+        # Flat-library shape (requests-like): one dir → one module.
+        paths = [f"src/requests/m{i}.py" for i in range(12)]
+        modules = _derive([_layer("Service", paths)], _id_map(paths))
+        assert len(modules) == 1
+        assert modules[0]["name"] == "Service"
+        assert modules[0]["path"] == "src/requests"
+
+    def test_dominant_language_tag(self):
+        layers, id_to_path = _monorepo()
+        lang_by_id = {
+            nid: ("typescript" if p.endswith(".tsx") else "python")
+            for nid, p in id_to_path.items()
+        }
+        modules = _derive(layers, id_to_path, lang_by_id=lang_by_id)
+        by_name = {m["name"]: m for m in modules}
+        assert by_name["UI"]["language"] == "typescript"
+        assert by_name["core/analysis"]["language"] == "python"
+
+
+# ---------------------------------------------------------------------------
+# Ids — stable, path-derived
+# ---------------------------------------------------------------------------
+
+
+class TestIds:
+    def test_ids_are_dir_path_slugs(self):
+        layers, id_to_path = _monorepo()
+        by_name = {m["name"]: m for m in _derive(layers, id_to_path)}
+        m = by_name["ingestion/resolvers"]
+        assert m["id"] == "module:packages-acme-src-acme-core-ingestion-resolvers"
+        assert m["path"] == "packages/acme/src/acme/core/ingestion/resolvers"
+
+    def test_id_stable_under_file_adds(self):
+        layers, id_to_path = _monorepo()
+        before = {m["id"] for m in _derive(layers, id_to_path)}
+        extra = "packages/acme/src/acme/core/ingestion/resolvers/r_new.py"
+        layers2 = [dict(layer) for layer in layers]
+        layers2[0] = {
+            **layers[0],
+            "nodeIds": layers[0]["nodeIds"] + [f"file:{extra}"],
+        }
+        after = {m["id"] for m in _derive(layers2, {**id_to_path, f"file:{extra}": extra})}
+        assert "module:packages-acme-src-acme-core-ingestion-resolvers" in before & after
+        assert before == after
+
+    def test_ids_unique(self):
+        layers, id_to_path = _monorepo()
+        ids = [m["id"] for m in _derive(layers, id_to_path)]
+        assert len(ids) == len(set(ids))
+
+    def test_root_path_module_has_empty_path(self):
+        layers, id_to_path = _monorepo()
+        by_name = {m["name"]: m for m in _derive(layers, id_to_path)}
+        assert by_name["Config"]["path"] == ""
+        assert by_name["Config"]["id"] == "module:config"
+
+
+# ---------------------------------------------------------------------------
+# Artifact seam — curation populates kg.modules; export key is conditional
+# ---------------------------------------------------------------------------
+
+
+def _curated_repo():
+    paths: list[str] = []
+    for sub in ("ingestion", "analysis", "generation"):
+        paths += [f"packages/core/src/repowise/core/{sub}/mod{i}.py" for i in range(24)]
+    paths += [f"packages/cli/src/repowise/cli/commands/cmd{i}.py" for i in range(20)]
+    paths += [f"src/api/route{i}.py" for i in range(12)]
+    paths += [f"src/utils/util{i}.py" for i in range(8)]
+    tests = {f"tests/unit/test_{i}.py" for i in range(30)}
+    paths += sorted(tests)
+    code = [p for p in paths if p not in tests]
+    edges = [
+        (code[i], code[i + step]) for step in (1, 2, 3) for i in range(len(code) - step)
+    ]
+    return build_repo(paths, tests=tests, edges=edges)
+
+
+class TestArtifactSeam:
+    def test_curation_derives_modules(self):
+        kg = curate(_curated_repo())
+        assert kg.modules, "curated KG should carry derived modules"
+        covered = [nid for m in kg.modules for nid in m["nodeIds"]]
+        assert len(covered) == len(set(covered))
+
+    def test_flag_off_exports_no_modules_key(self):
+        kg = curate(_curated_repo(), enabled=False)
+        assert kg.modules == []
+        assert "modules" not in kg.to_dict()
+
+    def test_curated_export_carries_modules_key(self):
+        kg = curate(_curated_repo())
+        data = kg.to_dict()
+        assert data["modules"] == kg.to_dict()["modules"]  # deterministic
+        assert all(m["nodeIds"] == sorted(m["nodeIds"]) for m in data["modules"])
+
+    def test_from_file_roundtrip(self, tmp_path):
+        kg = curate(_curated_repo())
+        f = tmp_path / "knowledge-graph.json"
+        f.write_text(json.dumps(kg.to_dict()), encoding="utf-8")
+        loaded = KnowledgeGraphResult.from_file(f)
+        assert loaded is not None
+        assert loaded.modules == kg.to_dict()["modules"]
+
+    def test_validate_kg_flags_module_violations(self):
+        kg = curate(_curated_repo())
+        assert validate_kg(kg).ok
+        # Duplicate membership → hard error.
+        kg.modules[0]["nodeIds"].append(kg.modules[1]["nodeIds"][0])
+        report = validate_kg(kg)
+        assert not report.ok
+        assert any("more than one module" in e for e in report.errors)
+
+    def test_validate_kg_flags_size_suffix_names(self):
+        kg = curate(_curated_repo())
+        kg.modules[0]["name"] = "ingestion (32)"
+        kg.modules[1]["name"] = "ingestion (18)"
+        report = validate_kg(kg)
+        assert any("size-suffixed" in e for e in report.errors)
+
+    def test_validate_kg_reports_module_metrics(self):
+        kg = curate(_curated_repo())
+        metrics = validate_kg(kg).metrics
+        assert metrics["module_count"] == len(kg.modules)
+        assert metrics["module_coverage_pct"] > 0
+
+
+class TestMatrixSurfacedShapes:
+    """Regression shapes surfaced by the 38-repo validation matrix."""
+
+    def test_fixture_dominated_repo_keeps_real_dir_names(self):
+        # aeson shape: one fixture subtree IS >60% of the repo, so every one
+        # of its segments is "dominant". Naming must fall back to the raw
+        # dir tail — the old "<Layer> (top-level)" fallback collided across
+        # sibling groups and tripped the export degradation guard (0 modules).
+        parsing = [f"tests/JSONTestSuite/test_parsing/case{i}.json" for i in range(300)]
+        transform = [f"tests/JSONTestSuite/test_transform/case{i}.json" for i in range(22)]
+        unit = [f"tests/UnitTests/u{i}.hs" for i in range(13)]
+        src = [f"src/Data/Aeson/m{i}.hs" for i in range(40)]
+        layers = [
+            _layer("Application", src),
+            _layer("Test", parsing + transform + unit),
+        ]
+        modules = _derive(layers, _id_map(parsing, transform, unit, src))
+        names = [m["name"] for m in modules]
+        assert len(names) == len(set(names)), names  # no collision → no degradation
+        joined = " ".join(names)
+        assert "test_parsing" in joined and "test_transform" in joined
+        assert "(top-level)" not in joined
+
+    def test_small_siblings_fuse_into_parent_dir_module(self):
+        # django/conf/locale shape: ~30 tiny per-locale dirs. They must fuse
+        # into ONE module at the parent dir — not fold into the
+        # alphabetically-first locale and misname 170 files as "locale/ar".
+        locales = [
+            f"django/conf/locale/{loc}/f{i}.py"
+            for loc in ("ar", "be", "cs", "da", "de", "el", "es", "fi", "fr", "he")
+            for i in range(3)
+        ]
+        core = [f"django/core/c{i}.py" for i in range(20)]
+        layers = [_layer("Application", locales + core)]
+        modules = _derive(layers, _id_map(locales, core))
+        by_path = {m["path"]: m for m in modules}
+        assert "django/conf/locale" in by_path, sorted(by_path)
+        assert len(by_path["django/conf/locale"]["nodeIds"]) == 30
+        assert by_path["django/conf/locale"]["name"].endswith("locale")
+
+    def test_healthy_module_keeps_identity_absorbing_small_sibling(self):
+        # The sibling fuse must not generalise a big module's dir upward:
+        # core/providers absorbing a 2-file sibling stays core/providers.
+        providers = [f"acme/core/providers/p{i}.py" for i in range(20)]
+        stray = [f"acme/core/stray/s{i}.py" for i in range(2)]
+        other = [f"acme/web/w{i}.py" for i in range(20)]
+        layers = [_layer("Service", providers + stray + other)]
+        # target_max=20 forces core(22) to split into providers(20)+stray(2)
+        modules = _derive(layers, _id_map(providers, stray, other), target_max=20)
+        paths = {m["path"] for m in modules}
+        assert "acme/core/providers" in paths, sorted(paths)
+
+    def test_two_all_org_groups_in_one_layer_get_unique_names(self):
+        # repowise shape: a root remnant AND a "packages" container group in
+        # the same layer both strip to nothing. The container takes its raw
+        # tail; only the true root group reads "(top-level)".
+        root = ["Makefile.py", "conftest.py", "setup.py", "tasks.py", "noxfile.py"]
+        pkgs = [f"packages/p{i}.py" for i in range(6)]
+        deep = [f"packages/acme/src/acme/core/d{i}.py" for i in range(40)]
+        layers = [_layer("Application", root + pkgs + deep)]
+        modules = _derive(layers, _id_map(root, pkgs, deep), target_max=20)
+        names = [m["name"] for m in modules]
+        assert len(names) == len(set(names)), names
+
+    def test_whole_layer_modules_flagged_for_page_dedupe(self):
+        # Single-module layers are 1:1 with their layer page; the flag lets
+        # selection skip the duplicate doc while the artifact keeps coverage.
+        flat = [f"lib/f{i}.py" for i in range(10)]
+        deep_a = [f"acme/web/a{i}.py" for i in range(10)]
+        deep_b = [f"acme/api/b{i}.py" for i in range(10)]
+        layers = [
+            _layer("Service", flat),
+            _layer("Application", deep_a + deep_b),
+        ]
+        modules = _derive(layers, _id_map(flat, deep_a, deep_b), target_max=12)
+        by_layer = {}
+        for m in modules:
+            by_layer.setdefault(m["layerId"], []).append(m)
+        assert all(m.get("wholeLayer") for m in by_layer["layer:service"])
+        assert len(by_layer["layer:application"]) > 1
+        assert not any(m.get("wholeLayer") for m in by_layer["layer:application"])

--- a/tests/unit/cli/test_doctor_vector_decisions.py
+++ b/tests/unit/cli/test_doctor_vector_decisions.py
@@ -1,0 +1,185 @@
+"""Regression tests for the doctor SQL<->vector reconciliation.
+
+The page vector store also holds *decision* embeddings under the
+``decision:<record_id>`` namespace. The drift / orphan check used to compare
+vector ids against ``wiki_pages`` only, so every decision embedding was counted
+as an orphan vector — a false "Coordinator drift FAIL" on a consistent store,
+and (with ``--repair``) a *destructive* deletion of valid decision vectors.
+
+These tests pin the corrected behavior:
+  * the SQL-side id set used for vector reconciliation is
+    ``page_ids | {"decision:<id>"}``;
+  * a genuinely orphaned vector (id in neither table) is still detected;
+  * the repair deletion targets only the genuine orphan, never a decision.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from repowise.cli.commands.doctor_cmd import _decision_vector_ids
+from repowise.core.analysis.decisions.semantic_match import DECISION_VECTOR_PREFIX
+from repowise.core.persistence.database import init_db
+from repowise.core.persistence.models import DecisionRecord
+from repowise.core.persistence.vector_store import InMemoryVectorStore
+from repowise.core.providers.embedding.base import MockEmbedder
+
+
+async def _setup_session() -> tuple[object, AsyncSession]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    await init_db(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    session = factory()
+    return engine, session
+
+
+async def _insert_repo(session: AsyncSession):
+    from repowise.core.persistence.crud import upsert_repository
+
+    repo = await upsert_repository(
+        session,
+        name="taskq",
+        local_path="/tmp/taskq",
+        url="https://github.com/example/taskq",
+    )
+    await session.commit()
+    return repo
+
+
+async def _insert_page(session: AsyncSession, repo_id: str, page_id: str) -> None:
+    from repowise.core.persistence.crud import upsert_page
+
+    await upsert_page(
+        session,
+        page_id=page_id,
+        repository_id=repo_id,
+        page_type="file_page",
+        title=page_id,
+        content="body",
+        target_path=page_id,
+        source_hash="h",
+        model_name="mock",
+        provider_name="mock",
+        input_tokens=1,
+        output_tokens=1,
+    )
+    await session.commit()
+
+
+async def _insert_decision(session: AsyncSession, repo_id: str, title: str) -> str:
+    rec = DecisionRecord(repository_id=repo_id, title=title, decision="because")
+    session.add(rec)
+    await session.commit()
+    return rec.id
+
+
+@pytest.mark.asyncio
+async def test_decision_vector_ids_returns_namespaced_ids():
+    engine, session = await _setup_session()
+    try:
+        repo = await _insert_repo(session)
+        d1 = await _insert_decision(session, repo.id, "Adopt Redis")
+        d2 = await _insert_decision(session, repo.id, "Use Postgres")
+
+        ids = await _decision_vector_ids(session, repo.id)
+        assert ids == {f"{DECISION_VECTOR_PREFIX}{d1}", f"{DECISION_VECTOR_PREFIX}{d2}"}
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_decisions_not_counted_as_orphans():
+    """Consistent store: pages + decisions both embedded => zero orphan/drift."""
+    engine, session = await _setup_session()
+    try:
+        repo = await _insert_repo(session)
+        await _insert_page(session, repo.id, "file_page:a.py")
+        await _insert_page(session, repo.id, "file_page:b.py")
+        d1 = await _insert_decision(session, repo.id, "Adopt Redis")
+
+        vs = InMemoryVectorStore(MockEmbedder())
+        await vs.embed_and_upsert("file_page:a.py", "a", {})
+        await vs.embed_and_upsert("file_page:b.py", "b", {})
+        await vs.embed_and_upsert(f"{DECISION_VECTOR_PREFIX}{d1}", "redis", {})
+
+        page_ids = {"file_page:a.py", "file_page:b.py"}
+        vector_sql_ids = page_ids | await _decision_vector_ids(session, repo.id)
+        vs_ids = await vs.list_page_ids()
+
+        # This mirrors the doctor reconciliation arithmetic.
+        orphaned = vs_ids - vector_sql_ids
+        missing = vector_sql_ids - vs_ids
+        assert orphaned == set()
+        assert missing == set()
+
+        # Coordinator-style drift: SQL (pages + decisions) vs vector count.
+        adjusted_sql = len(page_ids) + len(await _decision_vector_ids(session, repo.id))
+        drift = abs(adjusted_sql - len(vs_ids)) / max(adjusted_sql, 1)
+        assert drift == 0.0
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_genuine_orphan_still_detected():
+    engine, session = await _setup_session()
+    try:
+        repo = await _insert_repo(session)
+        await _insert_page(session, repo.id, "file_page:a.py")
+        d1 = await _insert_decision(session, repo.id, "Adopt Redis")
+
+        vs = InMemoryVectorStore(MockEmbedder())
+        await vs.embed_and_upsert("file_page:a.py", "a", {})
+        await vs.embed_and_upsert(f"{DECISION_VECTOR_PREFIX}{d1}", "redis", {})
+        # A vector whose id is in neither wiki_pages nor decision_records.
+        await vs.embed_and_upsert("file_page:ghost.py", "ghost", {})
+
+        page_ids = {"file_page:a.py"}
+        vector_sql_ids = page_ids | await _decision_vector_ids(session, repo.id)
+        vs_ids = await vs.list_page_ids()
+
+        orphaned = vs_ids - vector_sql_ids
+        assert orphaned == {"file_page:ghost.py"}
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_repair_deletes_only_genuine_orphan_not_decisions():
+    engine, session = await _setup_session()
+    try:
+        repo = await _insert_repo(session)
+        await _insert_page(session, repo.id, "file_page:a.py")
+        d1 = await _insert_decision(session, repo.id, "Adopt Redis")
+        decision_vid = f"{DECISION_VECTOR_PREFIX}{d1}"
+
+        vs = InMemoryVectorStore(MockEmbedder())
+        await vs.embed_and_upsert("file_page:a.py", "a", {})
+        await vs.embed_and_upsert(decision_vid, "redis", {})
+        await vs.embed_and_upsert("file_page:ghost.py", "ghost", {})
+
+        page_ids = {"file_page:a.py"}
+        vector_sql_ids = page_ids | await _decision_vector_ids(session, repo.id)
+        vs_ids = await vs.list_page_ids()
+        orphaned = vs_ids - vector_sql_ids
+
+        # Repair deletes exactly the orphan set (doctor's --repair loop).
+        for pid in orphaned:
+            await vs.delete(pid)
+
+        surviving = await vs.list_page_ids()
+        assert decision_vid in surviving, "decision embedding must survive repair"
+        assert "file_page:a.py" in surviving
+        assert "file_page:ghost.py" not in surviving
+    finally:
+        await session.close()
+        await engine.dispose()

--- a/tests/unit/cli/test_persist_result_sweep.py
+++ b/tests/unit/cli/test_persist_result_sweep.py
@@ -1,0 +1,227 @@
+"""End-to-end sweep behaviour of the CLI ``persist_result`` path.
+
+The normal single-repo ``repowise init`` persists the INDEX phase
+incrementally during the run, so ``persist_result`` takes the
+``index_persisted_incrementally=True`` branch. Before the fix that branch
+called ``persist_analysis`` + ``persist_generation`` but never swept stale
+structurally-keyed pages (community-N / scc / layer), so they survived every
+re-index forever — and their FTS + vector embeddings leaked with them.
+
+These tests drive ``persist_result`` against a real repo-local SQLite DB with
+a pre-seeded stale ``module_page`` and assert it is swept from the DB, the FTS
+index, and an attached vector store, while the run's current page survives.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+from repowise.cli._repo_session import open_repo_db
+from repowise.cli.commands.init_cmd.persistence import persist_result
+from repowise.core.generation.models import GeneratedPage
+from repowise.core.persistence import FullTextSearch, get_session
+from repowise.core.persistence.models import Page
+from repowise.core.persistence.vector_store.in_memory import InMemoryVectorStore
+from repowise.core.providers.embedding.base import MockEmbedder
+
+
+def _generated_page(page_type: str, target: str) -> GeneratedPage:
+    now = datetime.now(UTC).isoformat()
+    pid = f"{page_type}:{target}"
+    return GeneratedPage(
+        page_id=pid,
+        page_type=page_type,
+        title=target,
+        content=f"content for {target}",
+        source_hash="x" * 64,
+        model_name="mock",
+        provider_name="mock",
+        input_tokens=1,
+        output_tokens=1,
+        cached_tokens=0,
+        generation_level=1,
+        target_path=target,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _result(
+    repo_name: str,
+    generated_pages: list[GeneratedPage],
+    *,
+    vector_store=None,
+    authoritative_page_types: set[str] | None = None,
+) -> SimpleNamespace:
+    """A minimal PipelineResult stand-in for the ``index_done`` branch.
+
+    persist_analysis / persist_generation read these attributes; everything is
+    falsy so they no-op except the page upsert + the sweep.
+    """
+    return SimpleNamespace(
+        repo_name=repo_name,
+        index_persisted_incrementally=True,
+        generated_pages=generated_pages,
+        tech_stack=None,
+        vector_store=vector_store,
+        dead_code_report=None,
+        health_report=None,
+        decision_report=None,
+        git_metadata_list=[],
+        knowledge_graph_result=None,
+        authoritative_page_types=authoritative_page_types or set(),
+    )
+
+
+async def _seed_stale_module_page(repo_path, page_id: str) -> str:
+    """Insert a stale module_page directly and return the repo id."""
+    engine, sf, repo_id = await open_repo_db(repo_path, repo_name="r")
+    try:
+        now = datetime.now(UTC)
+        async with get_session(sf) as session:
+            session.add(
+                Page(
+                    id=page_id,
+                    repository_id=repo_id,
+                    page_type="module_page",
+                    title="stale",
+                    content="stale body",
+                    target_path="community-155",
+                    source_hash="x" * 64,
+                    model_name="mock",
+                    provider_name="mock",
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+    finally:
+        await engine.dispose()
+    return repo_id
+
+
+async def test_persist_result_index_done_sweeps_stale_module_page(tmp_path):
+    """The incremental-index branch must sweep stale structural pages.
+
+    Pre-fix this fails: the ``index_done`` branch never called the sweep, so
+    the pre-seeded ``module_page:community-155`` survived alongside the new
+    ``module_page:community-75``.
+    """
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-155"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    current = _generated_page("module_page", "community-75")
+    await persist_result(_result("r", [current]), repo_path)
+
+    engine, sf, _ = await open_repo_db(repo_path, repo_name="r")
+    try:
+        async with get_session(sf) as session:
+            ids = (
+                (await session.execute(select(Page.id).where(Page.page_type == "module_page")))
+                .scalars()
+                .all()
+            )
+        assert set(ids) == {"module_page:community-75"}
+        assert stale_id not in ids
+    finally:
+        await engine.dispose()
+
+
+async def test_persist_result_index_done_sweeps_fts_and_vector(tmp_path):
+    """Swept ids are removed from FTS + vector store; current ids survive."""
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-155"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    # Seed the FTS index for the stale page through the same engine
+    # persist_result will reuse.
+    engine, _sf, _ = await open_repo_db(repo_path, repo_name="r")
+    fts = FullTextSearch(engine)
+    await fts.ensure_index()
+    await fts.index(stale_id, "stale", "stale body about widgets")
+    await engine.dispose()
+
+    # Seed the vector store with both the stale page and the page the run keeps.
+    store = InMemoryVectorStore(MockEmbedder())
+    current = _generated_page("module_page", "community-75")
+    await store.embed_batch(
+        [
+            (stale_id, "stale body about widgets", {}),
+            (current.page_id, "current body", {}),
+        ]
+    )
+
+    await persist_result(_result("r", [current], vector_store=store), repo_path)
+
+    # Vector store: stale gone, current survives.
+    assert await store.list_page_ids() == {"module_page:community-75"}
+
+    # FTS: the stale page is no longer searchable; the current page is indexed.
+    engine, _sf, _ = await open_repo_db(repo_path, repo_name="r")
+    fts = FullTextSearch(engine)
+    await fts.ensure_index()
+    hits = {r.page_id for r in await fts.search("widgets", limit=10)}
+    assert stale_id not in hits
+    # The run's current page is freshly FTS-indexed (its content mentions its
+    # target_path "community-75").
+    current_hits = {r.page_id for r in await fts.search("community-75", limit=10)}
+    assert current.page_id in current_hits
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_persist_result_index_done_keeps_pages_when_no_module_run(tmp_path):
+    """A run with no module pages must not wipe existing module pages."""
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-1"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    # Run produces only a file_page — module pages are an unproduced type.
+    current = _generated_page("file_page", "src/app.py")
+    await persist_result(_result("r", [current]), repo_path)
+
+    engine, sf, _ = await open_repo_db(repo_path, repo_name="r")
+    try:
+        async with get_session(sf) as session:
+            ids = (await session.execute(select(Page.id))).scalars().all()
+        assert stale_id in ids
+        assert "file_page:src/app.py" in ids
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_persist_result_curated_zero_modules_sweeps_stale(tmp_path):
+    """Live mini-taskq regression through the CLI path.
+
+    A curated run authoritative for ``module_page`` that emitted ZERO module
+    pages (every module collapsed into its layer via wholeLayer) must still
+    sweep the pre-curated ``module_page:community-0``.
+    """
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-0"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    # Run emits only a layer page but is authoritative for module_page too.
+    current = _generated_page("layer_page", "layer:Data")
+    await persist_result(
+        _result("r", [current], authoritative_page_types={"module_page", "layer_page"}),
+        repo_path,
+    )
+
+    engine, sf, _ = await open_repo_db(repo_path, repo_name="r")
+    try:
+        async with get_session(sf) as session:
+            ids = (await session.execute(select(Page.id))).scalars().all()
+        assert stale_id not in ids
+        assert "layer_page:layer:Data" in ids
+    finally:
+        await engine.dispose()

--- a/tests/unit/cli/test_workspace_curated_grouping.py
+++ b/tests/unit/cli/test_workspace_curated_grouping.py
@@ -1,0 +1,91 @@
+"""Tests for curated-grouping wiring in ``repowise workspace add``.
+
+``module_grouping="curated"`` is the default. Doc generation can only engage
+curated module grouping if (a) the KG artifact (``.repowise/knowledge-graph.json``)
+was saved during indexing and (b) the generator is told the ``repo_path`` so it
+can load that artifact. These tests pin both seams so a regression to community
+grouping is caught.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from repowise.cli.commands.workspace_cmd import _generate_docs_for_added_repo
+
+
+def test_do_index_save_idiom_writes_artifact(tmp_path):
+    """The ``_do_index`` save idiom must persist the curated KG artifact.
+
+    ``_do_index`` is a nested closure, so we exercise the exact save call it
+    performs: when the pipeline result carries a ``knowledge_graph_result``,
+    ``save_knowledge_graph_json`` writes ``.repowise/knowledge-graph.json``.
+    """
+    from repowise.cli.state_persistence import save_knowledge_graph_json
+
+    kg = SimpleNamespace(to_dict=lambda: {"nodes": [], "layers": []})
+    result = SimpleNamespace(knowledge_graph_result=kg)
+
+    saved = getattr(result, "knowledge_graph_result", None)
+    assert saved is not None
+    save_knowledge_graph_json(tmp_path, saved)
+
+    assert (tmp_path / ".repowise" / "knowledge-graph.json").is_file()
+
+
+def test_generate_docs_for_added_repo_passes_repo_path(tmp_path):
+    """``generate_all`` must receive ``repo_path`` so the curated KG loads."""
+    repo_path = tmp_path
+
+    generator = MagicMock()
+    generator.generate_all = AsyncMock(return_value=[])
+
+    traverser = MagicMock()
+    traverser.traverse.return_value = []
+    traverser.get_repo_structure.return_value = object()
+
+    fts = MagicMock()
+    fts.ensure_index = AsyncMock()
+    fts.index = AsyncMock()
+
+    engine = MagicMock()
+    engine.dispose = AsyncMock()
+
+    class _SessionCtx:
+        async def __aenter__(self):
+            return MagicMock()
+
+        async def __aexit__(self, *a):
+            return False
+
+    def _fake_get_session(_sf):
+        return _SessionCtx()
+
+    with (
+        patch("repowise.cli.helpers.get_db_url_for_repo", return_value="sqlite://"),
+        patch("repowise.core.generation.PageGenerator", return_value=generator),
+        patch("repowise.core.generation.ContextAssembler"),
+        patch("repowise.core.generation.GenerationConfig"),
+        patch("repowise.core.ingestion.FileTraverser", return_value=traverser),
+        patch("repowise.core.ingestion.ASTParser"),
+        patch("repowise.core.ingestion.GraphBuilder", return_value=MagicMock()),
+        patch("repowise.core.persistence.create_engine", return_value=engine),
+        patch("repowise.core.persistence.create_session_factory", return_value=MagicMock()),
+        patch("repowise.core.persistence.init_db", AsyncMock()),
+        patch("repowise.core.persistence.get_session", _fake_get_session),
+        patch("repowise.core.persistence.upsert_repository", AsyncMock()),
+        patch("repowise.core.persistence.upsert_page_from_generated", AsyncMock()),
+        patch("repowise.core.persistence.FullTextSearch", return_value=fts),
+    ):
+        _generate_docs_for_added_repo(
+            repo_path=repo_path,
+            provider=object(),
+            embedder_name="fake",
+            concurrency=1,
+            reasoning="low",
+            exclude_patterns=[],
+        )
+
+    generator.generate_all.assert_awaited_once()
+    assert generator.generate_all.await_args.kwargs["repo_path"] == repo_path

--- a/tests/unit/generation/test_kg_context.py
+++ b/tests/unit/generation/test_kg_context.py
@@ -212,3 +212,57 @@ class TestInterLayerEdges:
         deps_out, deps_in = ctx.get_inter_layer_edges(ctx.get_layers()[0])
         assert deps_out == []
         assert deps_in == []
+
+
+class TestCuratedTourShape:
+    """The curated export's tour steps carry target_path + reason (no nodeIds)."""
+
+    @pytest.fixture
+    def curated_kg_json(self, tmp_path):
+        kg = {
+            "version": "1.0.0",
+            "project": {"name": "test", "graph_mode": "flow"},
+            "nodes": [
+                {"id": "file:src/main.py", "type": "file", "filePath": "src/main.py"},
+            ],
+            "edges": [],
+            "layers": [
+                {"id": "layer:app", "name": "Application",
+                 "nodeIds": ["file:src/main.py"]},
+            ],
+            "tour": [
+                {"order": 1, "target_path": "src/main.py", "page_type": "file_page",
+                 "title": "main.py", "depth": 1, "kind": "code",
+                 "reason": "An entry point — execution and imports fan out from here.",
+                 "layer_id": "layer:app"},
+            ],
+        }
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").touch()
+        kg_path = tmp_path / ".repowise" / "knowledge-graph.json"
+        kg_path.parent.mkdir()
+        kg_path.write_text(json.dumps(kg))
+        return kg_path
+
+    def test_target_path_steps_map_to_files(self, curated_kg_json):
+        ctx = KnowledgeGraphContext(curated_kg_json)
+        fc = ctx.get_file_context("src/main.py")
+        assert fc is not None and fc.tour_step is not None
+        assert fc.tour_step["order"] == 1
+
+    def test_tour_step_description_falls_back_to_reason(self, curated_kg_json):
+        ctx = KnowledgeGraphContext(curated_kg_json)
+        fc = ctx.get_file_context("src/main.py")
+        assert fc.tour_step["description"].startswith("An entry point")
+
+    def test_get_graph_mode(self, curated_kg_json):
+        ctx = KnowledgeGraphContext(curated_kg_json)
+        assert ctx.get_graph_mode() == "flow"
+
+    def test_graph_mode_absent_on_uncurated(self, sample_kg_json):
+        ctx = KnowledgeGraphContext(sample_kg_json)
+        assert ctx.get_graph_mode() is None
+
+    def test_graph_mode_unavailable(self):
+        ctx = KnowledgeGraphContext(None)
+        assert ctx.get_graph_mode() is None

--- a/tests/unit/generation/test_knowledge_graph_enrichment.py
+++ b/tests/unit/generation/test_knowledge_graph_enrichment.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import SimpleNamespace
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -15,7 +14,6 @@ from repowise.core.generation.knowledge_graph import (
     build_deterministic_tour,
     enrich_knowledge_graph,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -85,8 +83,8 @@ class TestEnrichLayers:
     @pytest.mark.asyncio
     async def test_enriches_layer_names(self):
         llm = _make_llm_client(
-            '{"layers": [{"index": 0, "name": "Core Pipeline", "description": "Handles data flow"}, '
-            '{"index": 1, "name": "CLI Interface", "description": "Command line entry"}]}'
+            '{"layers": [{"id": "layer:core", "name": "Core Pipeline", "description": "Handles data flow"}, '
+            '{"id": "layer:cli", "name": "CLI Interface", "description": "Command line entry"}]}'
         )
         skeleton = _make_kg_skeleton()
         builder = _make_graph_builder({"src/core.py": 0.5, "src/main.py": 0.3})
@@ -96,6 +94,77 @@ class TestEnrichLayers:
         assert result.layers[0]["name"] == "Core Pipeline"
         assert result.layers[0]["description"] == "Handles data flow"
         assert result.layers[1]["name"] == "CLI Interface"
+
+    @pytest.mark.asyncio
+    async def test_positional_index_responses_are_ignored(self):
+        # Regression: a model answering with list positions instead of layer
+        # ids must not rename anything (positional joins once shuffled every
+        # layer name when later batches restarted their indices at 0).
+        llm = _make_llm_client(
+            '{"layers": [{"index": 0, "name": "Wrong Name", "description": "wrong"}, '
+            '{"index": 1, "name": "Also Wrong", "description": "wrong"}]}'
+        )
+        skeleton = _make_kg_skeleton()
+        builder = _make_graph_builder()
+        repo = _make_repo_structure()
+
+        result = await enrich_knowledge_graph(skeleton, llm, builder, repo, [])
+        assert result.layers[0]["name"] == "src/core"  # heuristic preserved
+        assert result.layers[1]["name"] == "cli"
+
+    @pytest.mark.asyncio
+    async def test_cross_batch_ids_do_not_clobber_other_layers(self):
+        # Eight layers → two batches of five and three. Batch 2's response
+        # echoes batch 1's ids; those answers must be dropped, not applied.
+        layers = [
+            {"id": f"layer:l{i}", "name": f"heuristic-{i}", "description": "",
+             "nodeIds": [f"file:src/f{i}.py"]}
+            for i in range(8)
+        ]
+        nodes = [
+            {"id": f"file:src/f{i}.py", "type": "file", "filePath": f"src/f{i}.py", "summary": ""}
+            for i in range(8)
+        ]
+        responses = [
+            # Batch 1 (l0..l4): correct ids.
+            '{"layers": [{"id": "layer:l0", "name": "Named Zero", "description": "d0"}]}',
+            # Batch 2 (l5..l7): answers with batch-1 ids — all must be skipped.
+            '{"layers": [{"id": "layer:l0", "name": "Clobbered", "description": "x"}, '
+            '{"id": "layer:l1", "name": "Clobbered", "description": "x"}]}',
+            # Tour call.
+            '{"tour": []}',
+        ]
+        call_count = 0
+
+        async def _side_effect(*args, **kwargs):
+            nonlocal call_count
+            content = responses[min(call_count, len(responses) - 1)]
+            call_count += 1
+            return SimpleNamespace(content=content, input_tokens=10, output_tokens=10)
+
+        llm = AsyncMock()
+        llm.generate.side_effect = _side_effect
+
+        skeleton = _make_kg_skeleton(layers=layers, nodes=nodes)
+        builder = _make_graph_builder()
+        repo = _make_repo_structure()
+
+        result = await enrich_knowledge_graph(skeleton, llm, builder, repo, [])
+        assert result.layers[0]["name"] == "Named Zero"
+        assert all(layer["name"] != "Clobbered" for layer in result.layers)
+        assert result.layers[5]["name"] == "heuristic-5"  # untouched by bad batch
+
+    @pytest.mark.asyncio
+    async def test_unknown_id_is_skipped(self):
+        llm = _make_llm_client(
+            '{"layers": [{"id": "layer:nonexistent", "name": "Ghost", "description": "x"}]}'
+        )
+        skeleton = _make_kg_skeleton()
+        builder = _make_graph_builder()
+        repo = _make_repo_structure()
+
+        result = await enrich_knowledge_graph(skeleton, llm, builder, repo, [])
+        assert all(layer["name"] != "Ghost" for layer in result.layers)
 
     @pytest.mark.asyncio
     async def test_falls_back_on_llm_failure(self):

--- a/tests/unit/generation/test_layer_pages.py
+++ b/tests/unit/generation/test_layer_pages.py
@@ -241,7 +241,8 @@ class TestBuildLevel5Coros:
         run = self._make_run(tmp_path, layers)
         coros = build_level5_coros(run)
         assert len(coros) == 1
-        assert coros[0][0] == "layer_page:layer:Core"
+        # Page keyed by the layer's stable slug id, not its display name.
+        assert coros[0][0] == "layer_page:layer:core"
 
     def test_skips_small_layers(self, tmp_path):
         from repowise.core.generation.page_generator.levels import build_level5_coros
@@ -279,7 +280,7 @@ class TestBuildLevel5Coros:
              "nodeIds": ["file:a.py", "file:b.py", "file:c.py"]},
         ]
         run = self._make_run(tmp_path, layers)
-        run.completed_ids = {"layer_page:layer:Core"}
+        run.completed_ids = {"layer_page:layer:core"}
         coros = build_level5_coros(run)
         assert len(coros) == 0
 
@@ -298,5 +299,50 @@ class TestBuildLevel5Coros:
         coros = build_level5_coros(run)
         assert len(coros) == 2
         page_ids = {c[0] for c in coros}
-        assert "layer_page:layer:Core" in page_ids
-        assert "layer_page:layer:API" in page_ids
+        assert "layer_page:layer:core" in page_ids
+        assert "layer_page:layer:api" in page_ids
+
+    def test_page_key_uses_slug_not_display_name(self, tmp_path):
+        """The page key derives from the stable slug id, never the mutable
+        display name — a layer named "Task Queue Core" with id ``layer:queue``
+        is keyed by ``layer:queue`` so an LLM rename can't churn the key."""
+        from repowise.core.generation.page_generator.levels import build_level5_coros
+
+        layers = [
+            {"id": "layer:queue", "name": "Task Queue Core",
+             "nodeIds": ["file:a.py", "file:b.py", "file:c.py"]},
+        ]
+        run = self._make_run(tmp_path, layers)
+        coros = build_level5_coros(run)
+        assert len(coros) == 1
+        assert coros[0][0] == "layer_page:layer:queue"
+
+
+# ---------------------------------------------------------------------------
+# Slug identity stability under enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestLayerIdStability:
+    def test_enrichment_renames_name_not_id_so_page_key_is_stable(self, tmp_path):
+        """The LLM layer-name enrichment mutates ``name`` only; the slug ``id``
+        — and therefore the layer page key — is unchanged across the rename."""
+        from repowise.core.generation.page_generator.levels import build_level5_coros
+
+        node_ids = ["file:a.py", "file:b.py", "file:c.py"]
+
+        def key_for(name: str) -> str:
+            layers = [{"id": "layer:queue", "name": name, "nodeIds": node_ids}]
+            run = self._make_run(tmp_path, layers)
+            coros = build_level5_coros(run)
+            assert len(coros) == 1
+            return coros[0][0]
+
+        # Heuristic name -> page key.
+        before = key_for("Application")
+        # Enrichment rewrites the display name; id (and key) must not move.
+        after = key_for("Task Queue Core")
+        assert before == after == "layer_page:layer:queue"
+
+    # Reuse the level-5 fixture harness verbatim.
+    _make_run = TestBuildLevel5Coros._make_run

--- a/tests/unit/generation/test_layers.py
+++ b/tests/unit/generation/test_layers.py
@@ -8,7 +8,6 @@ from repowise.core.generation.layers import (
     infer_layer,
 )
 
-
 # ---------------------------------------------------------------------------
 # infer_layer — every file maps to exactly one layer
 # ---------------------------------------------------------------------------
@@ -26,6 +25,13 @@ def test_infer_layer_matches_directory_hints():
     assert infer_layer("src/types/dtos.ts") == "Types"
 
 
+def test_infer_layer_recognizes_cli_command_surface():
+    # Edge case A: a CLI command surface must not fall through to Application.
+    assert infer_layer("packages/cli/src/repowise/cli/commands/init_cmd.py") == "CLI"
+    assert infer_layer("src/cli/main.py") == "CLI"
+    assert infer_layer("app/cmd/serve.py") == "CLI"
+
+
 def test_infer_layer_uses_deepest_matching_directory():
     # The closest directory wins over a shallower one.
     assert infer_layer("services/api/handler.py") == "API"
@@ -34,6 +40,162 @@ def test_infer_layer_uses_deepest_matching_directory():
 def test_infer_layer_falls_back_for_unmatched_paths():
     assert infer_layer("main.py") == DEFAULT_LAYER
     assert infer_layer("random/folder/thing.py") == DEFAULT_LAYER
+
+
+def test_infer_layer_spec_dirs_need_test_shaped_files():
+    # A "specs/" directory of ordinary modules is a specification folder —
+    # the scan continues outward instead of branding them tests.
+    assert infer_layer("core/ingestion/languages/specs/dockerfile.py") == "Service"
+    assert infer_layer("specs/openapi.py") == DEFAULT_LAYER
+    # With a test-shaped filename the same dirs DO mean tests.
+    assert infer_layer("specs/auth.spec.ts") == "Test"
+    assert infer_layer("spec/test_auth.py") == "Test"
+
+
+def test_infer_layer_unambiguous_test_dirs_take_any_file():
+    # tests/ and __tests__/ are test roots regardless of filename.
+    assert infer_layer("tests/helpers.py") == "Test"
+    assert infer_layer("tests/conftest.py") == "Test"
+    assert infer_layer("src/__tests__/render.tsx") == "Test"
+
+
+def test_infer_layer_colocated_test_files_are_test():
+    # Go and Jest colocate tests beside sources — the filename is the signal.
+    assert infer_layer("middleware/compress_test.go") == "Test"
+    assert infer_layer("src/components/Button.test.tsx") == "Test"
+    assert infer_layer("rack-protection/spec/spec_helper.rb") == "Test"
+
+
+def test_infer_layer_ambiguous_spec_dir_needs_language_corroboration():
+    # Ruby declares spec/ as an unambiguous test-dir token: a Ruby file under
+    # spec/ is RSpec material whatever its name, so config.ru is Test only when
+    # the language is supplied. Omitting language leaves the ambiguous "spec"
+    # token uncorroborated and the file falls through (not Test) — this
+    # divergence is exactly what the curation/tour guard sites must respect by
+    # passing language to infer_layer.
+    assert infer_layer("spec/dummy/config.ru", "ruby") == "Test"
+    assert infer_layer("spec/dummy/config.ru") != "Test"
+
+
+def test_infer_layer_root_dot_dirs_are_tooling_config():
+    # .agents/plugins/* must not mint a phantom Middleware layer.
+    assert infer_layer(".agents/plugins/marketplace.json") == "Config"
+    assert infer_layer(".github/workflows/ci.yml") == "Config"
+    assert infer_layer(".claude/CLAUDE.md") == "Config"
+
+
+def test_infer_layer_test_root_beats_deeper_hints():
+    # A fixture under tests/models/ is a test, not Data — the test root wins
+    # over any deeper directory hint.
+    assert infer_layer("tests/models/__init__.py") == "Test"
+    assert infer_layer("tests/test_apps/cliapp/app.py") == "Test"
+    assert infer_layer("test/api/fixtures.py") == "Test"
+
+
+# ---------------------------------------------------------------------------
+# Case-sensitive camel-suffix test conventions (per language)
+# ---------------------------------------------------------------------------
+
+
+def test_infer_layer_camel_suffix_tests_per_language():
+    # The convention's own case applies: FooTest.java is a test wherever it sits.
+    assert infer_layer("gson/src/main/java/com/google/gson/JsonParserTest.java") == "Test"
+    assert infer_layer("src/GsonTests.java") == "Test"
+    assert infer_layer("src/SplitFunctionalIT.java") == "Test"
+    assert infer_layer("app/PaymentServiceTest.kt") == "Test"
+    assert infer_layer("app/CheckoutSpec.kt") == "Test"
+    assert infer_layer("core/ParserSpec.scala") == "Test"
+    assert infer_layer("core/RouterSuite.scala") == "Test"
+    assert infer_layer("Billing/InvoiceTests.cs") == "Test"
+    assert infer_layer("Billing/InvoiceSpecs.cs") == "Test"
+    assert infer_layer("Sources/AppCore/RouterTests.swift") == "Test"
+    assert infer_layer("src/Service/MailerTest.php") == "Test"
+    assert infer_layer("src/ParserSpec.hs") == "Test"
+
+
+def test_infer_layer_camel_suffix_false_positive_guards():
+    # Lowercase boundaries and bare names never match (D-005): `latest`,
+    # `contest`, `Test.java` (no prefix), `MyTestimony` are not tests.
+    assert infer_layer("src/latest.java") != "Test"
+    assert infer_layer("src/contest.cs") != "Test"
+    assert infer_layer("src/Test.java") != "Test"
+    assert infer_layer("app/MyTestimony.kt") != "Test"
+    assert infer_layer("src/UNIT.java") != "Test"  # uppercase boundary before IT
+    # Conventions don't leak across languages: Java's IT rule means nothing
+    # for Python; Haskell's Spec rule means nothing for Go.
+    assert infer_layer("src/SplitIT.py") != "Test"
+    assert infer_layer("pkg/HandlerSpec.go") != "Test"
+
+
+def test_infer_layer_camel_suffix_works_without_lowercase_filename_callers():
+    # sinatra's vendored spec/okjson.rb regression: an ambiguous spec/ dir
+    # with a non-test-shaped file stays non-test even with camel rules live.
+    assert infer_layer("rack-protection/spec/okjson.rb") != "Test"
+
+
+def test_infer_layer_multi_segment_test_roots():
+    # Maven/Gradle/sbt sourceset roots mark any file beneath them.
+    assert infer_layer("module/src/it/java/com/x/FlowVerifier.java") == "Test"
+    assert infer_layer("module/src/integrationTest/java/com/x/Flow.java") == "Test"
+    assert infer_layer("core/src/it/scala/com/x/Pipeline.scala") == "Test"
+    # src/test/java was already covered by the generic "test" token.
+    assert infer_layer("gson/src/test/java/com/google/gson/Helper.java") == "Test"
+    # "it" alone is NOT a test token — only the full sourceset shape matches.
+    assert infer_layer("docs/it/translation.md") != "Test"
+    assert infer_layer("src/it/locale.py") != "Test"
+
+
+def test_infer_layer_dotnet_test_project_dirs():
+    # Sibling Foo.Tests/ projects are test roots for everything inside.
+    assert infer_layer("Billing.Tests/InvoiceFixture.cs") == "Test"
+    assert infer_layer("src/Billing.Tests/data/sample.json") == "Test"
+    # Case matters: a lowercase "billing.tests" dir is not the convention.
+    assert infer_layer("billing.tests/notes.md") != "Test"
+
+
+# ---------------------------------------------------------------------------
+# Per-language layer-dir hints
+# ---------------------------------------------------------------------------
+
+
+def test_infer_layer_go_internal_pkg_hints():
+    assert infer_layer("internal/auth.go", "go") == "Service"
+    assert infer_layer("pkg/render/render.go", "go") == "Service"
+    # Without the language (or for another language) the hint never fires.
+    assert infer_layer("internal/auth.go") == DEFAULT_LAYER
+    assert infer_layer("internal/auth.py", "python") == DEFAULT_LAYER
+    # A deeper generic hint still wins over the language hint.
+    assert infer_layer("internal/handlers/auth.go", "go") == "API"
+
+
+def test_infer_layer_rust_cli_hints():
+    assert infer_layer("src/bin/extra.rs", "rust") == "CLI"
+    assert infer_layer("crates/typst-cli/src/main.rs", "rust") == "CLI"
+    assert infer_layer("src/bin/extra.rs") == DEFAULT_LAYER
+    # Case-sensitive suffix; an unrelated "Bin" or non-rust file never matches.
+    assert infer_layer("crates/typst-cli/src/main.py", "python") == DEFAULT_LAYER
+    # A dir literally named "-cli" is not the convention (proper suffix only).
+    assert infer_layer("-cli/main.rs", "rust") == DEFAULT_LAYER
+
+
+def test_infer_layer_ruby_rails_jobs():
+    assert infer_layer("app/jobs/cleanup_job.rb", "ruby") == "Service"
+    assert infer_layer("app/jobs/cleanup.py", "python") == DEFAULT_LAYER
+
+
+def test_infer_layer_dotnet_project_suffixes():
+    assert infer_layer("src/Billing.Api/Program.cs", "csharp") == "API"
+    assert infer_layer("Billing.Domain/Invoice.cs", "csharp") == "Service"
+    assert infer_layer("Billing.Infrastructure/Repo.cs", "csharp") == "Data"
+    # Generic deeper dirs still win; lowercase variants are not the convention.
+    assert infer_layer("src/Billing.Api/models/Dto.cs", "csharp") == "Data"
+    assert infer_layer("billing.api/Program.cs", "csharp") == DEFAULT_LAYER
+
+
+def test_infer_layer_test_rules_beat_language_hints():
+    # A camel test inside a hinted dir is still a test.
+    assert infer_layer("internal/AuthTest.java", "java") == "Test"
+    assert infer_layer("pkg/render/render_test.go", "go") == "Test"
 
 
 # ---------------------------------------------------------------------------
@@ -77,3 +239,84 @@ def test_compute_layer_order_stable_without_edges():
 def test_compute_layer_order_single_layer():
     assert compute_layer_order({"a.py": "API"}, []) == ["API"]
     assert compute_layer_order({}, []) == []
+
+
+def test_compute_layer_order_tests_never_top_the_stack():
+    # Tests import everything and are imported by nothing — by raw import
+    # math they'd win "top consumer" in every codebase. They must be pinned
+    # after the runtime layers instead.
+    file_layers = {
+        "api/h.py": "API",
+        "services/s.py": "Service",
+        "tests/test_h.py": "Test",
+        "tests/test_s.py": "Test",
+    }
+    edges = [
+        ("api/h.py", "services/s.py"),
+        ("tests/test_h.py", "api/h.py"),
+        ("tests/test_h.py", "services/s.py"),
+        ("tests/test_s.py", "services/s.py"),
+        ("tests/test_s.py", "api/h.py"),
+    ]
+    order = compute_layer_order(file_layers, edges)
+    assert order[-1] == "Test"
+    # Test edges don't distort the runtime ordering either.
+    assert order.index("API") < order.index("Service")
+
+
+class TestRubySpecDirToken:
+    def test_ruby_file_under_spec_is_test_without_corroboration(self):
+        # RSpec convention: support helpers and vendored fixtures under
+        # spec/ are test material whatever their filename.
+        assert infer_layer("sinatra-contrib/spec/okjson.rb", language="ruby") == "Test"
+
+    def test_spec_dir_stays_ambiguous_for_other_languages(self):
+        # Polyglot fairness: ruby's rule never leaks to other languages.
+        assert infer_layer("specs/openapi.yaml", language="yaml") != "Test"
+        assert infer_layer("spec/helper.py", language="python") != "Test"
+
+
+def test_infer_layer_gradle_test_sourcesets():
+    # okio regression: multiplatform test sourcesets (src/jvmTest,
+    # src/commonTest) are test roots for any file beneath them.
+    assert infer_layer("okio/src/jvmTest/kotlin/okio/AsyncSocket.kt", "kotlin") == "Test"
+    assert infer_layer("okio/src/commonTest/kotlin/okio/util/Helpers.kt", "kotlin") == "Test"
+    assert infer_layer("m/src/integrationTest/kotlin/F.kt", "kotlin") == "Test"
+    # Main sourcesets and non-src camel dirs stay untouched.
+    assert infer_layer("okio/src/commonMain/kotlin/okio/Buffer.kt", "kotlin") != "Test"
+    assert infer_layer("okio/src/hashFunctions/kotlin/H.kt", "kotlin") != "Test"
+    # The wildcard requires the camel "Test" suffix — lowercase doesn't fire
+    # (src/test is its own exact rule via the generic token).
+    assert infer_layer("a/src/latest/kotlin/F.kt", "kotlin") != "Test"
+
+
+def test_infer_layer_dotnet_specs_project_dirs():
+    # Polly evidence: BDD-style sibling test projects named Foo.Specs/.
+    assert infer_layer("test/Polly.Specs/Retry/RetrySpecs.cs", "csharp") == "Test"
+
+
+def test_infer_layer_c_cpp_include_is_api():
+    # A C/C++ library's installed public headers are its API surface.
+    assert infer_layer("include/uv.h", "c") == "API"
+    assert infer_layer("include/uv/unix.h", "c") == "API"
+    assert infer_layer("include/fmt/format.h", "cpp") == "API"
+    # Polyglot fairness: the hint rides on the file's own language.
+    assert infer_layer("include/util.py", "python") != "API"
+    # Root-anchored: okio's vendored linux uapi headers must not mint an
+    # API layer from deep inside a Kotlin repo.
+    assert infer_layer("okio/src/linuxMain/headers/include/uapi/linux/stat.h", "cpp") != "API"
+
+
+def test_is_support_path_covers_doc_dirs():
+    from repowise.core.generation.layers import is_support_path
+
+    # Doc sites and runnable doc snippets are support material (libuv's
+    # docs/code/*/main.c, docfx templates, vitepress sites).
+    assert is_support_path("docs/code/spawn/main.c")
+    assert is_support_path("docs/template/public/main.js")
+    assert is_support_path("website/.vitepress/theme/index.ts")
+    assert is_support_path("doc/build.py")
+    assert is_support_path("examples/hello/main.go")
+    # Real code is not support — names containing "docs" don't fire.
+    assert not is_support_path("src/docs_generator.py")
+    assert not is_support_path("lib/init.lua")

--- a/tests/unit/generation/test_models.py
+++ b/tests/unit/generation/test_models.py
@@ -153,7 +153,7 @@ def test_generation_config_defaults():
     assert config.staleness_threshold_days == 7
     assert config.expiry_threshold_days == 30
     assert config.top_symbol_percentile == 0.20
-    assert config.module_grouping == "community"
+    assert config.module_grouping == "curated"
     assert config.min_module_size == 3
     assert config.large_file_source_pct == 0.4
     assert config.reasoning == "auto"

--- a/tests/unit/generation/test_onboarding.py
+++ b/tests/unit/generation/test_onboarding.py
@@ -610,3 +610,60 @@ def test_subkind_template_renders(subkind_slot: str, ctx_factory: Any) -> None:
     rendered = template.render(ctx=ctx, slot=subkind_slot)
     assert rendered.strip()  # non-empty
     assert "{{" not in rendered  # no unrendered Jinja
+
+
+def test_how_it_works_renders_curated_tour_steps() -> None:
+    """Curated tour steps (target_path + reason, no nodeIds/description) must
+    normalize into the strict template's expected shape — regression for the
+    first docs run against a curated KG ('dict object' has no attribute
+    'nodeIds')."""
+    import dataclasses
+
+    spec = onboarding.get_spec(SLOT_HOW_IT_WORKS)
+    assert spec is not None
+    sig = _signals(
+        files=[_file("src/main.py", is_entry_point=True)],
+        entry_points=["src/main.py"],
+    )
+    curated_steps = (
+        {"order": 1, "target_path": "README.md", "page_type": "repo_overview",
+         "title": "README.md", "depth": 0, "kind": "overview",
+         "reason": "Start here for the end-to-end picture."},
+        {"order": 2, "target_path": "src/main.py", "page_type": "file_page",
+         "title": "main.py", "depth": 1, "kind": "code",
+         "reason": "An entry point — execution and imports fan out from here."},
+    )
+    sig = dataclasses.replace(sig, kg_tour_steps=curated_steps)
+    ctx = spec.build_context(sig)
+    assert ctx is not None
+    # Normalized: description fed from reason, nodeIds synthesized from target_path.
+    assert ctx.kg_tour_steps[0]["description"].startswith("Start here")
+    assert ctx.kg_tour_steps[1]["nodeIds"] == ["file:src/main.py"]
+
+    rendered = _jinja_env().get_template("onboarding/how_it_works.j2").render(ctx=ctx)
+    assert "`src/main.py`" in rendered
+    assert "An entry point" in rendered
+
+
+def test_how_it_works_renders_legacy_tour_steps() -> None:
+    """The pre-curation step shape (nodeIds + description) keeps working."""
+    import dataclasses
+
+    spec = onboarding.get_spec(SLOT_HOW_IT_WORKS)
+    assert spec is not None
+    sig = _signals(
+        files=[_file("src/main.py", is_entry_point=True)],
+        entry_points=["src/main.py"],
+    )
+    legacy_steps = (
+        {"order": 1, "title": "Start Here",
+         "description": "Begin with the entry point.",
+         "nodeIds": ["file:src/main.py"]},
+    )
+    sig = dataclasses.replace(sig, kg_tour_steps=legacy_steps)
+    ctx = spec.build_context(sig)
+    assert ctx is not None
+    assert ctx.kg_tour_steps[0]["description"] == "Begin with the entry point."
+    assert ctx.kg_tour_steps[0]["nodeIds"] == ["file:src/main.py"]
+    rendered = _jinja_env().get_template("onboarding/how_it_works.j2").render(ctx=ctx)
+    assert "`src/main.py`" in rendered

--- a/tests/unit/generation/test_page_generator.py
+++ b/tests/unit/generation/test_page_generator.py
@@ -448,3 +448,154 @@ def test_compute_cache_key_varies_by_language():
     assert gen_en._compute_cache_key("file_page", "x") != gen_ru._compute_cache_key(
         "file_page", "x"
     )
+
+
+async def test_generate_all_uses_in_memory_kg_modules_without_artifact_file():
+    """Curated module pages must come from the IN-MEMORY pipeline modules.
+
+    The knowledge-graph.json artifact is written AFTER generation, so on a
+    fresh init it does not exist when selection runs — relying on the file
+    silently fell back to community grouping (caught live on repowise's own
+    wiki: 20 community-N module pages on a curated run).
+    """
+    config = GenerationConfig(
+        max_tokens=256,
+        token_budget=100_000,
+        max_concurrency=2,
+        module_grouping="curated",
+        min_module_size=2,
+        coverage_pct=1.0,
+        module_page_share=1.0,
+        dedupe_near_clones=False,  # synthetic files are identical by design
+    )
+    provider = MockProvider()
+    assembler = ContextAssembler(config)
+    gen = PageGenerator(provider, assembler, config)
+
+    paths = [f"pkg/core/m{i}.py" for i in range(3)] + [f"pkg/web/w{i}.py" for i in range(3)]
+    parsed = []
+    for p in paths:
+        fi = _make_file_info(p, language="python")
+        sym = _make_symbol(file_path=p)
+        parsed.append(
+            ParsedFile(
+                file_info=fi, symbols=[sym], imports=[], exports=[],
+                docstring=None, parse_errors=[],
+            )
+        )
+    repo = RepoStructure(
+        is_monorepo=False,
+        packages=[],
+        root_language_distribution={"python": 1.0},
+        total_files=len(paths),
+        total_loc=100,
+        entry_points=[],
+    )
+    kg_modules = [
+        {
+            "id": "module:pkg-core",
+            "name": "core",
+            "path": "pkg/core",
+            "layerId": "layer:service",
+            "nodeIds": [f"file:{p}" for p in paths if "/core/" in p],
+            "language": "python",
+        },
+        {
+            "id": "module:pkg-web",
+            "name": "web",
+            "path": "pkg/web",
+            "layerId": "layer:ui",
+            "nodeIds": [f"file:{p}" for p in paths if "/web/" in p],
+            "language": "python",
+        },
+    ]
+
+    builder = _make_builder_with(parsed)
+    # repo_path deliberately omitted → no knowledge-graph.json on disk.
+    pages = await gen.generate_all(
+        parsed,
+        {p: b"pass" for p in paths},
+        builder,
+        repo,
+        "test-repo",
+        kg_modules=kg_modules,
+    )
+
+    module_pages = [p for p in pages if p.page_type == "module_page"]
+    targets = {p.target_path for p in module_pages}
+    assert targets, "no module pages generated"
+    assert targets <= {"pkg/core", "pkg/web"}, targets
+    assert not any(t.startswith("community-") for t in targets)
+
+
+async def test_generate_all_builds_kg_ctx_from_in_memory_kg_data():
+    """Layer pages must generate on a FRESH init via the in-memory KG.
+
+    kg_ctx previously only read knowledge-graph.json, which is written during
+    persistence — after generation — so first-run wikis silently had zero
+    layer pages (caught live: fresh repowise wiki had 37 module pages and no
+    Architecture layers).
+    """
+    config = GenerationConfig(
+        max_tokens=256,
+        token_budget=100_000,
+        max_concurrency=2,
+        coverage_pct=1.0,
+        dedupe_near_clones=False,
+    )
+    provider = MockProvider()
+    assembler = ContextAssembler(config)
+    gen = PageGenerator(provider, assembler, config)
+
+    paths = [f"pkg/core/m{i}.py" for i in range(4)]
+    parsed = []
+    for p in paths:
+        fi = _make_file_info(p, language="python")
+        sym = _make_symbol(file_path=p)
+        parsed.append(
+            ParsedFile(
+                file_info=fi, symbols=[sym], imports=[], exports=[],
+                docstring=None, parse_errors=[],
+            )
+        )
+    repo = RepoStructure(
+        is_monorepo=False,
+        packages=[],
+        root_language_distribution={"python": 1.0},
+        total_files=len(paths),
+        total_loc=100,
+        entry_points=[],
+    )
+    kg_data = {
+        "version": "1.0.0",
+        "project": {"name": "test-repo", "total_files": len(paths), "entry_points": []},
+        "nodes": [
+            {"id": f"file:{p}", "type": "file", "filePath": p, "language": "python"}
+            for p in paths
+        ],
+        "edges": [],
+        "layers": [
+            {
+                "id": "layer:service",
+                "name": "Service",
+                "nodeIds": [f"file:{p}" for p in paths],
+                "display_order": 0,
+            }
+        ],
+        "tour": [],
+    }
+
+    builder = _make_builder_with(parsed)
+    # repo_path deliberately omitted → no knowledge-graph.json on disk.
+    pages = await gen.generate_all(
+        parsed,
+        {p: b"pass" for p in paths},
+        builder,
+        repo,
+        "test-repo",
+        kg_data=kg_data,
+    )
+
+    layer_pages = [p for p in pages if p.page_type == "layer_page"]
+    assert layer_pages, "no layer pages generated from in-memory KG"
+    assert any("Service" in p.title for p in layer_pages)

--- a/tests/unit/generation/test_provenance.py
+++ b/tests/unit/generation/test_provenance.py
@@ -31,6 +31,7 @@ def _ctx(**over):
     base = dict(
         file_path="pkg/foo.py",
         kg_layer_name="",
+        kg_layer_id="",
         kg_layer_role="",
         dependencies=[],
         decision_records=[],
@@ -41,17 +42,28 @@ def _ctx(**over):
 
 def test_layer_metadata_attached():
     page = _page()
-    _attach_file_provenance(page, _ctx(kg_layer_name="Domain", kg_layer_role="entry_point"))
+    _attach_file_provenance(
+        page,
+        _ctx(
+            kg_layer_name="Domain",
+            kg_layer_id="layer:domain",
+            kg_layer_role="entry_point",
+        ),
+    )
     assert page.metadata["layer_name"] == "Domain"
+    # Stable slug id is attached so the UI joins file -> layer page by id.
+    assert page.metadata["layer_id"] == "layer:domain"
     assert page.metadata["layer_role"] == "entry_point"
 
 
 def test_no_kg_layer_falls_back_to_inferred_layer():
     # Every file page must carry a layer_name so the Architecture tree can
-    # group it; with no KG layer it is inferred from the path.
+    # group it; with no KG layer it is inferred from the path, and the
+    # layer_id is the slug of that inferred name.
     page = _page()
     _attach_file_provenance(page, _ctx(file_path="src/api/users.py"))
     assert page.metadata["layer_name"] == "API"
+    assert page.metadata["layer_id"] == "layer:api"
     # No KG role is invented for the fallback path.
     assert "layer_role" not in page.metadata
 

--- a/tests/unit/generation/test_selection_curated_modules.py
+++ b/tests/unit/generation/test_selection_curated_modules.py
@@ -1,0 +1,278 @@
+"""Curated module grouping in the selection layer.
+
+Covers the ``module_grouping="curated"`` source (key = real dir path,
+display = curated name, cohesion = None, Σ-PageRank ranking), every row of
+the fallback matrix, and the golden inertness contract: with the default
+``"community"`` grouping, passing ``kg_modules`` changes NOTHING — the
+ship-dark guarantee that every existing path stays byte-identical.
+"""
+
+from __future__ import annotations
+
+from repowise.core.generation.models import GenerationConfig
+from repowise.core.generation.selection import SelectionInputs, select_pages
+from repowise.core.generation.selection.selector import _build_module_groups
+from tests.unit.generation.test_selection_budget import (
+    FakeFileInfo,
+    FakeParsedFile,
+    FakeSymbol,
+    _build_synthetic_repo,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _repo_with_modules():
+    """A synthetic repo plus a matching curated-modules artifact."""
+    paths = (
+        [f"packages/app/src/core/ingestion/f{i}.py" for i in range(8)]
+        + [f"packages/app/src/core/analysis/f{i}.py" for i in range(6)]
+        + [f"packages/app/src/ui/c4/f{i}.py" for i in range(5)]
+        + ["packages/app/src/ui/tiny/f0.py", "packages/app/src/ui/tiny/f1.py"]
+    )
+    parsed = [
+        FakeParsedFile(file_info=FakeFileInfo(path=p), symbols=[FakeSymbol(name="fn")])
+        for p in paths
+    ]
+    # ui/c4 members carry the highest PageRank so Σ-PageRank must rank that
+    # module first despite it being smaller than core/ingestion.
+    pagerank = {p: (1.0 if "/ui/c4/" in p else 0.1) for p in paths}
+    community = {p: (0 if "/core/" in p else 1) for p in paths}
+
+    modules = [
+        {
+            "id": "module:packages-app-src-core-ingestion",
+            "name": "core/ingestion",
+            "path": "packages/app/src/core/ingestion",
+            "layerId": "layer:service",
+            "nodeIds": [f"file:{p}" for p in paths if "/core/ingestion/" in p],
+            "language": "python",
+        },
+        {
+            "id": "module:packages-app-src-core-analysis",
+            "name": "core/analysis",
+            "path": "packages/app/src/core/analysis",
+            "layerId": "layer:service",
+            "nodeIds": [f"file:{p}" for p in paths if "/core/analysis/" in p],
+            "language": "python",
+        },
+        {
+            "id": "module:packages-app-src-ui-c4",
+            "name": "ui/c4",
+            "path": "packages/app/src/ui/c4",
+            "layerId": "layer:ui",
+            "nodeIds": [f"file:{p}" for p in paths if "/ui/c4/" in p],
+            "language": "python",
+        },
+        {
+            # Below min_module_size=3 → must be skipped, never a page.
+            "id": "module:packages-app-src-ui-tiny",
+            "name": "ui/tiny",
+            "path": "packages/app/src/ui/tiny",
+            "layerId": "layer:ui",
+            "nodeIds": [f"file:{p}" for p in paths if "/ui/tiny/" in p],
+            "language": "python",
+        },
+    ]
+    return parsed, pagerank, community, modules
+
+
+def _inputs(parsed, pagerank, community, *, cfg=None, kg_modules=None):
+    return SelectionInputs(
+        parsed_files=parsed,
+        pagerank=pagerank,
+        betweenness=dict.fromkeys(pagerank, 0.0),
+        community=community,
+        community_info=None,
+        sccs=[],
+        git_meta_map=None,
+        config=cfg or GenerationConfig(),
+        kg_modules=kg_modules,
+    )
+
+
+def _cfg(grouping: str) -> GenerationConfig:
+    return GenerationConfig(module_grouping=grouping)
+
+
+# ---------------------------------------------------------------------------
+# Curated grouping source
+# ---------------------------------------------------------------------------
+
+
+class TestCuratedGrouping:
+    def test_groups_keyed_by_dir_path_with_curated_names(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        by_key = {g.key: g for _, g in groups}
+        assert "packages/app/src/core/ingestion" in by_key
+        g = by_key["packages/app/src/core/ingestion"]
+        assert g.display == "core/ingestion"
+        assert g.label == "core/ingestion"
+        assert g.cohesion is None
+        assert g.language == "python"
+        assert len(g.file_paths) == 8
+
+    def test_ranked_by_sum_pagerank_of_members(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        # ui/c4: 5 x 1.0 = 5.0 beats core/ingestion: 8 x 0.1 = 0.8.
+        assert groups[0][1].display == "ui/c4"
+        scores = [s for s, _ in groups]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_min_module_size_floor_kills_tiny_modules(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        assert "packages/app/src/ui/tiny" not in {g.key for _, g in groups}
+
+    def test_members_restricted_to_parsed_code_files(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        modules[0]["nodeIds"].append("file:packages/app/src/core/ingestion/ghost.py")
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        by_key = {g.key: g for _, g in groups}
+        assert not any(
+            "ghost" in p
+            for p in by_key["packages/app/src/core/ingestion"].file_paths
+        )
+
+    def test_no_community_ids_in_curated_keys(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        assert not any(g.key.startswith("community-") for _, g in groups)
+
+
+# ---------------------------------------------------------------------------
+# Fallback matrix (one test per row)
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackMatrix:
+    def test_curated_without_artifact_falls_back_to_community(self):
+        """curation off / degraded / no KG json → today's community path."""
+        parsed, pr, _bet, comm = _build_synthetic_repo(100)
+        curated_no_artifact = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=None)
+        )
+        community = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("community"))
+        )
+        assert curated_no_artifact == community
+
+    def test_curated_with_all_modules_below_floor_emits_none_not_community(self):
+        """A present-but-filtered artifact must not mix vocabularies."""
+        parsed, pr, comm, modules = _repo_with_modules()
+        tiny_only = [m for m in modules if m["name"] == "ui/tiny"]
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=tiny_only)
+        )
+        assert groups == []
+
+    def test_explicit_community_honored_even_with_artifact(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        with_artifact = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("community"), kg_modules=modules)
+        )
+        without = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("community"))
+        )
+        assert with_artifact == without
+        assert not any(g.key.startswith("packages/") for _, g in with_artifact)
+
+    def test_explicit_top_dir_honored_even_with_artifact(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        with_artifact = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("top_dir"), kg_modules=modules)
+        )
+        without = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("top_dir"))
+        )
+        assert with_artifact == without
+        assert {g.key for _, g in with_artifact} == {"packages"}
+
+
+# ---------------------------------------------------------------------------
+# Golden inertness — the ship-dark contract
+# ---------------------------------------------------------------------------
+
+
+class TestGoldenByteIdentity:
+    def test_community_selection_identical_with_and_without_kg_modules(self):
+        """With the "community" escape hatch, kg_modules must change NOTHING.
+
+        This was the ship-dark rollout guarantee while "community" was the
+        default; post-flip it pins the revert story — setting
+        module_grouping="community" restores the pre-curation selection
+        byte-for-byte regardless of what the KG artifact carries.
+        """
+        parsed, pr, bet, comm = _build_synthetic_repo(300)
+        _, _, _, modules = _repo_with_modules()
+        cfg = GenerationConfig(module_grouping="community")
+
+        def run(kg_modules):
+            return select_pages(
+                SelectionInputs(
+                    parsed_files=parsed,
+                    pagerank=pr,
+                    betweenness=bet,
+                    community=comm,
+                    community_info=None,
+                    sccs=[],
+                    git_meta_map=None,
+                    config=cfg,
+                    kg_modules=kg_modules,
+                )
+            )
+
+        assert run(None) == run(modules)
+
+    def test_curated_selection_is_deterministic(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        cfg = _cfg("curated")
+
+        def run():
+            return select_pages(
+                _inputs(parsed, pr, comm, cfg=cfg, kg_modules=modules)
+            )
+
+        a, b = run(), run()
+        assert a.module_groups == b.module_groups
+        assert a == b
+
+
+class TestWholeLayerDedupe:
+    """Modules 1:1 with a layer never get a module page (layer_page covers them)."""
+
+    def test_whole_layer_module_skipped(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        modules = [dict(m) for m in modules]
+        modules[0]["wholeLayer"] = True  # core/ingestion now 1:1 with its layer
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        keys = {g.key for _, g in groups}
+        assert "packages/app/src/core/ingestion" not in keys
+        assert "packages/app/src/ui/c4" in keys
+
+    def test_all_whole_layer_yields_no_module_pages_not_community(self):
+        # Flat-lib shape: every module is 1:1 with a layer → zero module
+        # pages, and NO fallback to community grouping (vocabulary stays
+        # curated; the layer pages carry the documentation).
+        parsed, pr, comm, modules = _repo_with_modules()
+        modules = [dict(m, wholeLayer=True) for m in modules]
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        assert groups == []

--- a/tests/unit/generation/test_tour.py
+++ b/tests/unit/generation/test_tour.py
@@ -16,6 +16,7 @@ from repowise.core.generation.tour import (
 class _FI:
     path: str
     is_entry_point: bool = False
+    language: str = "python"
 
 
 @dataclass
@@ -44,6 +45,19 @@ def test_score_entry_points_excludes_zero_score():
     files = _repo({"deep/nested/pkg/thing.py": False})
     pr = {"deep/nested/pkg/thing.py": 0.0}
     assert score_entry_points(files, pr) == []
+
+
+def test_score_entry_points_withholds_stem_bonus_from_docs():
+    # docs/index.md has an entry-style stem but is markdown — it must never
+    # outrank a real main.py, even when ingestion's stem rule flagged it.
+    files = [
+        _PF(_FI(path="docs/index.md", language="markdown", is_entry_point=True)),
+        _PF(_FI(path="src/main.py")),
+    ]
+    pr = {"docs/index.md": 0.9, "src/main.py": 0.5}
+    scored = {p: s for s, p in score_entry_points(files, pr)}
+    assert scored["src/main.py"] >= 3.0
+    assert scored.get("docs/index.md", 0.0) < 3.0
 
 
 # ---------------------------------------------------------------------------
@@ -103,6 +117,78 @@ def test_build_tour_weaves_infra_last():
     assert stops[-1].target_path == "Dockerfile"
 
 
+def test_build_tour_unreached_files_get_honest_reasons():
+    # disconnected.py is never reached from the entry point — its reason must
+    # not claim it was "reached N imports deep".
+    files = _repo({"main.py": True, "a.py": False, "disconnected.py": False})
+    pr = {"main.py": 0.9, "a.py": 0.5, "disconnected.py": 0.1}
+    edges = [("main.py", "a.py")]
+    stops = build_tour(
+        files, pr, edges, file_page_paths={"main.py", "a.py", "disconnected.py"}
+    )
+    by_path = {s.target_path: s for s in stops}
+    assert "Off the import path" in by_path["disconnected.py"].reason
+    assert "Reached" not in by_path["disconnected.py"].reason
+    assert "Directly used" in by_path["a.py"].reason  # reached ones unchanged
+
+
+def test_score_entry_points_withholds_entry_bonuses_from_examples():
+    # examples/*/main.go are entries by *name* only — the library itself
+    # must outrank them.
+    files = [
+        _PF(_FI(path="_examples/hello-world/main.go", is_entry_point=True)),
+        _PF(_FI(path="cmd/app/main.go", is_entry_point=True)),
+    ]
+    pr = {"_examples/hello-world/main.go": 0.9, "cmd/app/main.go": 0.5}
+    scored = {p: s for s, p in score_entry_points(files, pr)}
+    assert scored["cmd/app/main.go"] >= 3.0
+    assert scored.get("_examples/hello-world/main.go", 0.0) < 3.0
+
+
+def test_score_entry_points_withholds_entry_bonuses_from_test_files():
+    # tests/testserver/server.py has an entry-style stem, but a test fixture
+    # must never seed the onboarding walk.
+    files = [
+        _PF(_FI(path="tests/testserver/server.py", is_entry_point=True)),
+        _PF(_FI(path="src/pkg/models.py")),
+    ]
+    pr = {"tests/testserver/server.py": 0.9, "src/pkg/models.py": 0.5}
+    scored = {p: s for s, p in score_entry_points(files, pr)}
+    assert scored.get("tests/testserver/server.py", 0.0) < 3.0
+
+
+def test_build_tour_seedless_repo_reasons_do_not_overclaim():
+    # A flat library with no entry-style file: steps must not reference
+    # entry points that don't exist.
+    files = _repo({"src/pkg/models.py": False, "src/pkg/cookies.py": False})
+    pr = {"src/pkg/models.py": 0.8, "src/pkg/cookies.py": 0.6}
+    stops = build_tour(
+        files, pr, [], file_page_paths={"src/pkg/models.py", "src/pkg/cookies.py"}
+    )
+    for s in stops:
+        assert "An entry point" not in s.reason
+        # the offending phrase referenced entry points that don't exist;
+        # evidence-free parked files now say "Off the import paths walked
+        # above" instead, which references only the walk itself
+        assert "from the entry points" not in s.reason
+
+
+def test_build_tour_seedless_anchor_is_a_code_file():
+    # The fallback anchor must skip docs/config — a CLAUDE.md at the root
+    # outscores deep code files but cannot anchor an import walk.
+    files = [
+        _PF(_FI(path=".claude/CLAUDE.md", language="markdown")),
+        _PF(_FI(path="src/pkg/api.py")),
+        _PF(_FI(path="src/pkg/models.py")),
+    ]
+    pr = {".claude/CLAUDE.md": 0.9, "src/pkg/api.py": 0.5, "src/pkg/models.py": 0.4}
+    edges = [("src/pkg/api.py", "src/pkg/models.py")]
+    documented = {".claude/CLAUDE.md", "src/pkg/api.py", "src/pkg/models.py"}
+    stops = build_tour(files, pr, edges, file_page_paths=documented)
+    anchor = next(s for s in stops if s.depth == 0 and s.kind == "code")
+    assert anchor.target_path == "src/pkg/api.py"
+
+
 def test_build_tour_respects_max_stops():
     files = _repo({f"f{i}.py": (i == 0) for i in range(50)})
     pr = {f"f{i}.py": 1.0 - i * 0.01 for i in range(50)}
@@ -110,3 +196,170 @@ def test_build_tour_respects_max_stops():
     documented = {f"f{i}.py" for i in range(50)}
     stops = build_tour(files, pr, edges, file_page_paths=documented, repo_name="r")
     assert len(stops) <= DEFAULT_MAX_STOPS
+
+
+def test_score_entry_points_withholds_bonuses_from_api_contracts_and_infra():
+    # Schema/data languages (graphql, proto, sql, openapi) and
+    # infra wiring (shell, terraform, dockerfile) never earn entry bonuses,
+    # however entry-like their stems are.
+    files = [
+        _PF(_FI(path="index.graphql", language="graphql", is_entry_point=True)),
+        _PF(_FI(path="main.sql", language="sql", is_entry_point=True)),
+        _PF(_FI(path="run.sh", language="shell", is_entry_point=True)),
+        _PF(_FI(path="main.tf", language="terraform", is_entry_point=True)),
+        _PF(_FI(path="src/main.py")),
+    ]
+    pr = {p.file_info.path: 0.5 for p in files}
+    scored = {p: s for s, p in score_entry_points(files, pr)}
+    assert scored["src/main.py"] >= 3.0
+    for path in ("index.graphql", "main.sql", "run.sh", "main.tf"):
+        assert scored.get(path, 0.0) < 3.0, path
+
+
+def test_build_tour_anchor_reasons_never_claim_entry_points():
+    # Anchor-seeded walks (no genuine entries) must not say "the entry
+    # points above" — there are none.
+    files = [
+        _PF(_FI(path="src/core.py")),
+        _PF(_FI(path="src/helper.py")),
+        _PF(_FI(path="src/deep.py")),
+    ]
+    pr = {"src/core.py": 0.5, "src/helper.py": 0.3, "src/deep.py": 0.2}
+    edges = [("src/core.py", "src/helper.py"), ("src/helper.py", "src/deep.py")]
+    documented = {"src/core.py", "src/helper.py", "src/deep.py"}
+    stops = build_tour(files, pr, edges, file_page_paths=documented)
+    for s in stops:
+        assert "entry point" not in s.reason or s.depth == 0, s.reason
+    anchor = next(s for s in stops if s.depth == 0)
+    assert "anchor" in anchor.reason
+    d1 = next(s for s in stops if s.depth == 1)
+    assert "anchor" in d1.reason and "entry points" not in d1.reason
+
+
+def test_build_tour_unreached_non_code_files_take_no_slot():
+    # D-037 watch item: sparse-mode walks filled their budget with
+    # CHANGELOG.md / *.toml "not on the resolved import paths" slots.
+    # Unreached documents and config can never be on an import path —
+    # they are not worth a step that displaces code.
+    files = [
+        _PF(_FI(path="lib/init.lua", language="luau", is_entry_point=True)),
+        _PF(_FI(path="lib/util.lua", language="luau")),
+        _PF(_FI(path="CHANGELOG.md", language="markdown")),
+        _PF(_FI(path="wally.toml", language="toml")),
+    ]
+    pr = {p: 0.25 for p in ("lib/init.lua", "lib/util.lua", "CHANGELOG.md", "wally.toml")}
+    edges = [("lib/init.lua", "lib/util.lua")]
+    documented = {"lib/init.lua", "lib/util.lua", "CHANGELOG.md", "wally.toml"}
+    stops = build_tour(files, pr, edges, file_page_paths=documented, graph_mode="sparse")
+    paths = {s.target_path for s in stops}
+    assert "CHANGELOG.md" not in paths
+    assert "wally.toml" not in paths
+    assert {"lib/init.lua", "lib/util.lua"} <= paths
+
+
+def test_build_tour_reached_config_keeps_its_slot():
+    # A config file genuinely on an import path (TS importing data.json)
+    # keeps its step — only *unreached* non-code is exempt from parking.
+    files = [
+        _PF(_FI(path="src/index.ts", language="typescript", is_entry_point=True)),
+        _PF(_FI(path="src/config.json", language="json")),
+    ]
+    pr = {"src/index.ts": 0.6, "src/config.json": 0.4}
+    edges = [("src/index.ts", "src/config.json")]
+    documented = {"src/index.ts", "src/config.json"}
+    stops = build_tour(files, pr, edges, file_page_paths=documented)
+    assert "src/config.json" in {s.target_path for s in stops}
+
+
+# ---------------------------------------------------------------------------
+# Wiring-stub entry co-anchor
+# ---------------------------------------------------------------------------
+
+
+def _stub_entry_repo():
+    """An OTP-style library: the only entry is a supervision stub whose
+    forward BFS reaches nothing, while a hub file's imports fan out wide."""
+    paths = {
+        "lib/app/application.ex": True,  # wiring stub — no outgoing imports
+        "lib/encode.ex": False,
+        "lib/codegen.ex": False,
+        "lib/fragment.ex": False,
+        "lib/decoder.ex": False,
+        "lib/helpers.ex": False,
+        "lib/sigil.ex": False,
+        "lib/jason.ex": False,
+    }
+    files = [_PF(_FI(path=p, is_entry_point=e, language="elixir")) for p, e in paths.items()]
+    edges = [
+        ("lib/encode.ex", "lib/codegen.ex"),
+        ("lib/encode.ex", "lib/fragment.ex"),
+        ("lib/encode.ex", "lib/jason.ex"),
+        ("lib/codegen.ex", "lib/decoder.ex"),
+    ]
+    pr = dict.fromkeys(paths, 0.1)
+    return files, pr, edges, set(paths)
+
+
+def test_wiring_stub_entry_gets_a_co_anchor():
+    files, pr, edges, documented = _stub_entry_repo()
+    stops = build_tour(files, pr, edges, file_page_paths=documented)
+    by_path = {s.target_path: s for s in stops}
+    # the entry keeps its step and wording
+    assert "An entry point" in by_path["lib/app/application.ex"].reason
+    # the widest-fanout file co-anchors at depth 0 with anchor wording
+    anchor = by_path["lib/encode.ex"]
+    assert anchor.depth == 0
+    assert "entry point above only wires" in anchor.reason
+    # the walk actually proceeds through the anchor's imports
+    assert by_path["lib/codegen.ex"].depth == 1
+    assert "anchor above" in by_path["lib/codegen.ex"].reason
+    assert by_path["lib/decoder.ex"].depth == 2
+
+
+def test_entry_with_real_reach_gets_no_co_anchor():
+    paths = {
+        "src/main.py": True,
+        "src/a.py": False,
+        "src/b.py": False,
+        "src/c.py": False,
+        "src/hub.py": False,
+        "src/d.py": False,
+        "src/e.py": False,
+        "src/f.py": False,
+    }
+    files = _repo(paths)
+    edges = [
+        ("src/main.py", "src/a.py"),
+        ("src/a.py", "src/b.py"),
+        ("src/b.py", "src/c.py"),
+        # a hub with wide fanout that must NOT displace the real entry walk
+        ("src/hub.py", "src/d.py"),
+        ("src/hub.py", "src/e.py"),
+        ("src/hub.py", "src/f.py"),
+    ]
+    pr = dict.fromkeys(paths, 0.1)
+    stops = build_tour(files, pr, edges, file_page_paths=set(paths))
+    by_path = {s.target_path: s for s in stops}
+    assert "An entry point" in by_path["src/main.py"].reason
+    assert "only wires" not in " ".join(s.reason for s in stops)
+
+
+# ---------------------------------------------------------------------------
+# Manifests never park
+# ---------------------------------------------------------------------------
+
+
+def test_unreached_manifest_never_parks():
+    paths = {
+        "lib/core.ex": False,
+        "lib/util.ex": False,
+        "mix.exs": False,
+        "project.clj": False,
+    }
+    files = [_PF(_FI(path=p, is_entry_point=False, language="elixir")) for p in paths]
+    edges = [("lib/core.ex", "lib/util.ex")]
+    pr = dict.fromkeys(paths, 0.1)
+    stops = build_tour(files, pr, edges, file_page_paths=set(paths))
+    visited = {s.target_path for s in stops}
+    assert "mix.exs" not in visited
+    assert "project.clj" not in visited

--- a/tests/unit/generation/test_wiki_tour_adoption.py
+++ b/tests/unit/generation/test_wiki_tour_adoption.py
@@ -1,0 +1,91 @@
+"""The wiki guided tour adopts the curated KG tour when one exists.
+
+One tour, every surface: when the indexed knowledge graph went through
+curation (marked by ``project.graph_mode``), the page orchestrator must use
+its tour verbatim instead of re-deriving a second, divergent ordering from
+the raw graph. Without a curated KG it falls back to computing the tour.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from repowise.core.generation.kg_context import KnowledgeGraphContext
+from repowise.core.generation.page_generator.orchestrate import _GenerationRun
+
+
+def _write_kg(tmp_path, kg: dict):
+    kg_path = tmp_path / ".repowise" / "knowledge-graph.json"
+    kg_path.parent.mkdir(parents=True, exist_ok=True)
+    kg_path.write_text(json.dumps(kg))
+    return kg_path
+
+
+def _run_stub(kg_ctx) -> SimpleNamespace:
+    """The minimal duck-typed surface _compute_ia touches."""
+    stub = SimpleNamespace(
+        kg_ctx=kg_ctx,
+        tour_stops=[],
+        layer_order=[],
+        parsed_files=[],
+        pagerank={},
+        sel_file_paths=[],
+        sel_infra_paths=[],
+        repo_name="test",
+    )
+    stub._file_import_edges = lambda: []
+    return stub
+
+
+CURATED_TOUR = [
+    {"order": 1, "target_path": "README.md", "page_type": "repo_overview",
+     "title": "README.md", "depth": 0, "kind": "overview",
+     "reason": "Start here for the end-to-end picture before diving into the code.",
+     "layer_id": "layer:app"},
+    {"order": 2, "target_path": "src/main.py", "page_type": "file_page",
+     "title": "main.py", "depth": 1, "kind": "code",
+     "reason": "An entry point — execution and imports fan out from here.",
+     "layer_id": "layer:app"},
+]
+
+
+def test_curated_tour_adopted_verbatim(tmp_path):
+    kg_path = _write_kg(
+        tmp_path,
+        {
+            "project": {"name": "test", "graph_mode": "flow"},
+            "nodes": [], "edges": [], "layers": [],
+            "tour": CURATED_TOUR,
+        },
+    )
+    run = _run_stub(KnowledgeGraphContext(kg_path))
+    _GenerationRun._compute_ia(run)
+    assert [s["target_path"] for s in run.tour_stops] == ["README.md", "src/main.py"]
+    assert run.tour_stops[1]["reason"].startswith("An entry point")
+
+
+def test_uncurated_kg_falls_back_to_computed_tour(tmp_path):
+    # No graph_mode marker: the KG (and its tour, if any) predate curation —
+    # the orchestrator must compute its own tour, not adopt a stale one.
+    kg_path = _write_kg(
+        tmp_path,
+        {
+            "project": {"name": "test"},
+            "nodes": [], "edges": [], "layers": [],
+            "tour": [{"order": 1, "title": "old-style", "description": "x",
+                      "nodeIds": []}],
+        },
+    )
+    run = _run_stub(KnowledgeGraphContext(kg_path))
+    _GenerationRun._compute_ia(run)
+    assert all(s.get("title") != "old-style" for s in run.tour_stops)
+
+
+def test_no_kg_computes_tour(tmp_path):
+    run = _run_stub(KnowledgeGraphContext(None))
+    _GenerationRun._compute_ia(run)
+    # The fallback build_tour ran: with nothing selected it yields just the
+    # overview stop, never an adopted (layer_id-carrying) curated step.
+    assert all("layer_id" not in s for s in run.tour_stops)
+    assert [s["kind"] for s in run.tour_stops] == ["overview"]

--- a/tests/unit/ingestion/test_language_capabilities.py
+++ b/tests/unit/ingestion/test_language_capabilities.py
@@ -1,0 +1,251 @@
+"""Language capability registry — parity goldens and derivation pins.
+
+Per-language knowledge (test filename conventions, entry stems,
+import-support tiers, layer hints) lives on the ``LanguageSpec`` registry;
+``generation/layers.py``, ``generation/tour.py``, the traverser, and
+``analysis/kg_curation.py`` consume registry derivations.
+
+Two kinds of test live here:
+
+1. **Parity goldens** — the derived unions are pinned exactly. Any spec
+   edit that changes a union must update the golden *consciously*: these
+   sets steer test detection, entry scoring, and layer inference globally.
+
+2. **Derivation pins** — constants that used to be drifting hard-coded
+   literals (``_CODE_SUFFIXES``, ``_NON_CODE_LANGUAGES``) are now registry
+   derivations; the pins assert the derivation relationship and its key
+   membership so a regression back to drift cannot land silently.
+"""
+
+from __future__ import annotations
+
+from repowise.core.analysis.kg_curation import _CODE_SUFFIXES
+from repowise.core.generation import layers
+from repowise.core.generation.tour import _ENTRY_FILENAME_STEMS, _NON_CODE_LANGUAGES
+from repowise.core.ingestion.languages.registry import REGISTRY
+
+# ---------------------------------------------------------------------------
+# Parity goldens — derived unions == historical literals
+# ---------------------------------------------------------------------------
+
+
+class TestParityGoldens:
+    def test_entry_filename_stems_match_historical_set(self) -> None:
+        assert frozenset(
+            {
+                "index",
+                "main",
+                "app",
+                "server",
+                "mod",
+                "manage",
+                "wsgi",
+                "asgi",
+                "cli",
+                "__main__",
+                "bootstrap",
+                "entry",
+            }
+        ) == _ENTRY_FILENAME_STEMS
+
+    def test_test_stem_prefixes_match_historical_set(self) -> None:
+        assert set(layers._TEST_FILE_STEM_PREFIXES) == {"test_"}
+
+    def test_test_stem_suffixes_match_historical_set(self) -> None:
+        # "_unittest" (C/C++ GoogleTest convention) was a conscious
+        # addition to the historical {"_test", "_spec"} union.
+        assert set(layers._TEST_FILE_STEM_SUFFIXES) == {"_test", "_spec", "_unittest"}
+
+    def test_test_infixes_match_historical_set(self) -> None:
+        assert set(layers._TEST_FILE_INFIXES) == {".test.", ".spec."}
+
+    def test_test_fixture_stems_match_historical_set(self) -> None:
+        assert frozenset(
+            {"conftest", "spec_helper", "test_helper"}
+        ) == layers._TEST_FIXTURE_STEMS
+
+    def test_suite_anchor_stems(self) -> None:
+        # ruby (rspec/minitest helpers) and elixir (ExUnit's
+        # test_helper.exs) join python's conftest as closing-stop anchors.
+        assert REGISTRY.suite_anchor_stems() == frozenset(
+            {"conftest", "spec_helper", "test_helper"}
+        )
+
+    def test_descriptor_filenames(self) -> None:
+        # JPMS/javadoc descriptors: source files that declare, not implement.
+        assert REGISTRY.descriptor_filenames() == frozenset(
+            {"module-info.java", "package-info.java"}
+        )
+
+    def test_layer_dir_hints_by_language(self) -> None:
+        # Per-language hints (consulted after the generic table, only for
+        # the declaring language's files). csharp's project-suffix hints
+        # await verification against a live .NET repo.
+        assert REGISTRY.layer_dir_hints_by_language() == {
+            "go": (("internal", "Service"), ("pkg", "Service")),
+            "rust": (("-cli", "CLI"), ("src/bin", "CLI")),
+            "ruby": (("jobs", "Service"),),
+            "csharp": (
+                (".Api", "API"),
+                (".Domain", "Service"),
+                (".Infrastructure", "Data"),
+            ),
+            # Root-anchored ("/"): only a TOP-LEVEL include/ is a C/C++
+            # library's public API surface (libuv, fmt — validated live).
+            "c": (("/include", "API"),),
+            "cpp": (("/include", "API"),),
+        }
+
+    def test_camel_suffix_extension_map(self) -> None:
+        # Case-sensitive camel-boundary test suffixes per language.
+        camel = REGISTRY.camel_test_res_by_extension()
+        assert set(camel) == {
+            ".java", ".kt", ".kts", ".scala", ".cs", ".swift", ".php",
+            ".hs", ".lhs",
+        }
+        assert camel[".java"].pattern == r"(?<=[a-z0-9])(?:Tests|Test|IT)$"
+        assert camel[".scala"].pattern == r"(?<=[a-z0-9])(?:Suite|Spec|Test)$"
+
+    def test_test_dir_paths_union(self) -> None:
+        assert REGISTRY.test_dir_paths() == (
+            # "src/*Test" = Gradle source-set wildcard (src/commonTest,
+            # src/jvmTest, … — okio, validated live).
+            "src/*Test",
+            "src/integrationtest/java",
+            "src/it/java",
+            "src/it/scala",
+            "src/test/java",
+            "src/test/kotlin",
+            "src/test/scala",
+        )
+
+    def test_test_dir_suffixes_union(self) -> None:
+        # .Specs = BDD-style sibling test projects (Polly, validated live).
+        assert REGISTRY.test_dir_suffixes() == (".Specs", ".Tests")
+
+
+# ---------------------------------------------------------------------------
+# Import-support tiers
+# ---------------------------------------------------------------------------
+
+_FULL = {
+    "c",
+    "cpp",
+    "csharp",
+    "go",
+    "java",
+    "javascript",
+    "kotlin",
+    # php + swift promoted after live validation (Slim, Alamofire).
+    "php",
+    "python",
+    "ruby",
+    "rust",
+    "swift",
+    "typescript",
+}
+_PARTIAL = {
+    "luau",
+    "scala",
+    # Lightweight regex-tier resolvers (module-name index + import regexes).
+    "elixir",
+    "dart",
+    "clojure",
+    "haskell",
+    "erlang",
+    "fsharp",
+}
+
+
+class TestImportSupportTiers:
+    def test_every_spec_declares_a_valid_tier(self) -> None:
+        for spec in REGISTRY.all_specs():
+            assert spec.import_support in {"full", "partial", "none"}, spec.tag
+
+    def test_full_tier_membership(self) -> None:
+        support = REGISTRY.import_support_map()
+        assert {t for t, v in support.items() if v == "full"} == _FULL
+
+    def test_partial_tier_membership(self) -> None:
+        support = REGISTRY.import_support_map()
+        assert {t for t, v in support.items() if v == "partial"} == _PARTIAL
+
+    def test_unknown_language_reports_none(self) -> None:
+        assert REGISTRY.import_support_for("klingon") == "none"
+
+
+# ---------------------------------------------------------------------------
+# Derivation pins — constants that used to be drifting frozen literals are
+# now registry derivations; pin the relationship, not a literal.
+# ---------------------------------------------------------------------------
+
+# Non-tag defensive aliases inside tour._NON_CODE_LANGUAGES (none is a
+# registry tag; they guard against unnormalized language strings).
+_NON_CODE_ALIASES = {
+    "cmake", "css", "csv", "html", "ini", "md", "rst", "svg", "text", "txt",
+    "xml", "yml",
+}  # fmt: skip
+
+# Entry-point conventions per language, including those recovered from the
+# deleted dead LanguageConfig table. "public/index.php" was intentionally
+# dropped: patterns match bare filenames, and "index.php" subsumes it.
+_ENTRY_PATTERNS_BY_LANGUAGE = {
+    "kotlin": ("Main.kt", "Application.kt"),
+    "ruby": ("main.rb", "app.rb", "config.ru"),
+    "swift": ("main.swift", "App.swift"),
+    "scala": ("Main.scala", "App.scala"),
+    "php": ("index.php", "artisan"),
+    "elixir": ("application.ex",),
+    "clojure": ("core.clj", "main.clj"),
+    "dart": ("main.dart",),
+    "haskell": ("Main.hs",),
+    "ocaml": ("main.ml",),
+    "erlang": ("*_app.erl",),
+    "fsharp": ("Program.fs",),
+    "crystal": ("main.cr",),
+    "nim": ("main.nim",),
+    "dlang": ("app.d",),
+    "elm": ("Main.elm",),
+    "zig": ("main.zig",),
+    "objectivec": ("main.m",),
+}
+
+
+class TestDriftManifests:
+    def test_code_suffixes_are_the_non_infra_code_derivation(self) -> None:
+        assert REGISTRY.non_infra_code_extensions() == _CODE_SUFFIXES
+        # The 32 once-missing extensions are protected now …
+        assert {".dart", ".hs", ".clj", ".erl", ".nim", ".m", ".luau"} <= _CODE_SUFFIXES
+        # … infra languages stay promotable, and the perl orphan is gone.
+        assert {".sh", ".bash", ".zsh", ".tf", ".hcl", ".pl"} & _CODE_SUFFIXES == set()
+
+    def test_non_code_languages_are_config_plus_infra_plus_aliases(self) -> None:
+        assert (
+            REGISTRY.config_languages()
+            | REGISTRY.infra_languages()
+            | frozenset(_NON_CODE_ALIASES)
+        ) == _NON_CODE_LANGUAGES
+        # The once-missing is_code=False tags and infra tags are covered …
+        assert {
+            "graphql", "openapi", "proto", "sql", "unknown", "xaml",
+            "shell", "terraform", "dockerfile", "makefile",
+        } <= _NON_CODE_LANGUAGES  # fmt: skip
+        # … and real (Tier-3 included) code languages never are.
+        assert {"python", "elixir", "dart", "haskell", "go"} & _NON_CODE_LANGUAGES == set()
+
+    def test_merged_entry_patterns_present_on_specs(self) -> None:
+        # Every language with a citable convention declares it. Deliberate
+        # skips: julia (src/<Pkg>.jl is package-named), R (no convention),
+        # PHP bin/console (the bare filename "console" is too generic).
+        for tag, patterns in _ENTRY_PATTERNS_BY_LANGUAGE.items():
+            spec = REGISTRY.get(tag)
+            assert spec is not None, tag
+            assert spec.entry_point_patterns == patterns, tag
+
+    def test_entry_flag_stems_match_historical_traverser_set(self) -> None:
+        # The traverser's is_entry_point stem set, now registry-derived —
+        # parity with the historical hard-coded frozenset (run.py/server.py
+        # extras were redundant with the run/server stems).
+        assert REGISTRY.entry_flag_stems() == frozenset(
+            {"main", "index", "app", "run", "server", "start", "wsgi", "asgi"}
+        )

--- a/tests/unit/persistence/test_kg_pipeline_persist.py
+++ b/tests/unit/persistence/test_kg_pipeline_persist.py
@@ -1,0 +1,107 @@
+"""persist_generation carries curated KG meta (project entry points, node
+summaries/tags/types) into the DB alongside layers and tour steps."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from repowise.core.persistence.crud import (
+    get_kg_layers,
+    get_kg_node_meta,
+    get_kg_project_meta,
+    get_kg_tour_steps,
+)
+from repowise.core.pipeline.persist import persist_generation
+from tests.unit.persistence.helpers import insert_repo
+
+
+@pytest.fixture
+async def repo(async_session):
+    return await insert_repo(async_session)
+
+
+def _result(**kg_fields) -> SimpleNamespace:
+    defaults: dict = {"project": {}, "nodes": [], "layers": [], "tour": []}
+    kg = SimpleNamespace(**{**defaults, **kg_fields})
+    return SimpleNamespace(generated_pages=None, knowledge_graph_result=kg)
+
+
+async def test_persists_entry_points_from_project(async_session, repo):
+    result = _result(
+        project={
+            "name": "demo",
+            "entry_points": ["src/main.py"],
+            "entry_candidates": ["src/main.py", "src/app.py"],
+        }
+    )
+    await persist_generation(result, async_session, repo.id)
+
+    meta = await get_kg_project_meta(async_session, repo.id)
+    assert meta is not None
+    assert json.loads(meta.entry_points_json) == ["src/main.py"]
+    assert json.loads(meta.entry_candidates_json) == ["src/main.py", "src/app.py"]
+
+
+async def test_persists_file_node_meta_with_prefix_stripped(async_session, repo):
+    result = _result(
+        nodes=[
+            {
+                "id": "file:src/main.py",
+                "type": "file",
+                "summary": "CLI entry point.",
+                "tags": ["entry_point", "python"],
+            },
+            {"id": "file:Dockerfile", "type": "service", "summary": "Container build."},
+            # Non-file nodes (concepts, symbols) are not node-meta material.
+            {"id": "concept:auth", "type": "concept", "summary": "Auth concept."},
+        ]
+    )
+    await persist_generation(result, async_session, repo.id)
+
+    rows = {r.node_id: r for r in await get_kg_node_meta(async_session, repo.id)}
+    assert set(rows) == {"src/main.py", "Dockerfile"}
+    assert rows["src/main.py"].summary == "CLI entry point."
+    assert json.loads(rows["src/main.py"].tags_json) == ["entry_point", "python"]
+    assert rows["Dockerfile"].node_type == "service"
+
+
+async def test_no_curated_meta_writes_nothing(async_session, repo):
+    """Uncurated KG (no entry_points, no nodes) leaves the meta tables empty."""
+    await persist_generation(_result(), async_session, repo.id)
+
+    assert await get_kg_project_meta(async_session, repo.id) is None
+    assert await get_kg_node_meta(async_session, repo.id) == []
+
+
+async def test_layers_and_tour_still_persisted(async_session, repo):
+    """Existing layer/tour persistence is unchanged by the meta additions."""
+    result = _result(
+        layers=[{"id": "layer:cli", "name": "CLI", "nodeIds": ["file:src/main.py"]}],
+        tour=[
+            {
+                "order": 1,
+                "title": "main.py",
+                "target_path": "src/main.py",
+                "kind": "code",
+                "reason": "Top of the stack.",
+                "layer_id": "layer:cli",
+            }
+        ],
+    )
+    await persist_generation(result, async_session, repo.id)
+
+    layers = await get_kg_layers(async_session, repo.id)
+    assert [layer.layer_id for layer in layers] == ["layer:cli"]
+    steps = await get_kg_tour_steps(async_session, repo.id)
+    assert steps[0].target_path == "src/main.py"
+    assert steps[0].layer_id == "layer:cli"
+
+
+async def test_missing_kg_result_is_a_noop(async_session, repo):
+    result = SimpleNamespace(generated_pages=None, knowledge_graph_result=None)
+    await persist_generation(result, async_session, repo.id)
+    assert await get_kg_layers(async_session, repo.id) == []
+    assert await get_kg_project_meta(async_session, repo.id) is None

--- a/tests/unit/persistence/test_persist_sweep_pages.py
+++ b/tests/unit/persistence/test_persist_sweep_pages.py
@@ -1,0 +1,216 @@
+"""Tests for the stale generated-page sweep.
+
+Module/scc pages key on clustering ordinals and layer pages on display
+names — identities that drift between runs. A full run's output is
+authoritative for those page types: anything it did not reproduce is a
+stranded duplicate from an earlier run and must be swept.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from sqlalchemy import select
+
+from repowise.core.persistence.models import Page, PageVersion
+from repowise.core.pipeline.persist import _sweep_stale_generated_pages
+from tests.unit.persistence.helpers import insert_repo
+
+
+def _page_row(repo_id: str, page_type: str, target: str) -> Page:
+    now = datetime.now(UTC)
+    return Page(
+        id=f"{page_type}:{target}",
+        repository_id=repo_id,
+        page_type=page_type,
+        title=target,
+        content="body",
+        target_path=target,
+        source_hash="x" * 64,
+        model_name="mock",
+        provider_name="mock",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _generated(page_type: str, target: str) -> SimpleNamespace:
+    return SimpleNamespace(page_id=f"{page_type}:{target}", page_type=page_type)
+
+
+async def test_sweep_removes_pages_absent_from_run(async_session):
+    repo = await insert_repo(async_session)
+    # Two module pages from a previous run; the new run reproduces only one
+    # (under a fresh community ordinal) — the other is stale.
+    async_session.add(_page_row(repo.id, "module_page", "community-155"))
+    async_session.add(_page_row(repo.id, "module_page", "community-75"))
+    async_session.add(
+        PageVersion(
+            page_id="module_page:community-155",
+            repository_id=repo.id,
+            version=1,
+            page_type="module_page",
+            title="old",
+            content="old body",
+            source_hash="x" * 64,
+            model_name="mock",
+            provider_name="mock",
+            archived_at=datetime.now(UTC),
+        )
+    )
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session, repo.id, [_generated("module_page", "community-75")]
+    )
+    await async_session.commit()
+
+    assert swept == ["module_page:community-155"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert remaining == ["module_page:community-75"]
+    # Versions of the swept page go with it (FK would block the delete).
+    versions = (
+        (
+            await async_session.execute(
+                select(PageVersion).where(PageVersion.repository_id == repo.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert versions == []
+
+
+async def test_sweep_skips_types_the_run_did_not_produce(async_session):
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Data"))
+    await async_session.flush()
+
+    # The run produced layer pages but no module pages (e.g. the module level
+    # was skipped) — module pages must survive.
+    swept = await _sweep_stale_generated_pages(
+        async_session, repo.id, [_generated("layer_page", "layer:Data")]
+    )
+    await async_session.commit()
+
+    assert swept == []
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert set(remaining) == {"module_page:community-1", "layer_page:layer:Data"}
+
+
+async def test_sweep_never_touches_unswept_page_types(async_session):
+    repo = await insert_repo(async_session)
+    # file_page ids are stable paths — never swept here even when absent
+    # from the run's output.
+    async_session.add(_page_row(repo.id, "file_page", "src/app.py"))
+    async_session.add(_page_row(repo.id, "module_page", "community-9"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session, repo.id, [_generated("module_page", "community-10")]
+    )
+    await async_session.commit()
+
+    assert swept == ["module_page:community-9"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert "file_page:src/app.py" in remaining
+
+
+async def test_sweep_noop_on_empty_run(async_session):
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, [])
+    assert swept == []
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, None)
+    assert swept == []
+
+
+async def test_authoritative_type_sweeps_when_zero_produced(async_session):
+    """Regression for the live mini-taskq bug.
+
+    A curated full run derived modules 1:1 with layers (every module
+    ``wholeLayer``-skipped), so it emitted layer pages and ZERO module pages
+    while still being authoritative for ``module_page``. The pre-curated
+    community module page must be swept even though the run produced none.
+    """
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-0"))
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Data"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session,
+        repo.id,
+        [_generated("layer_page", "layer:Data")],
+        {"module_page", "layer_page"},
+    )
+    await async_session.commit()
+
+    assert swept == ["module_page:community-0"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert set(remaining) == {"layer_page:layer:Data"}
+
+
+async def test_degraded_run_does_not_wipe_layer_pages(async_session):
+    """A community-fallback (degraded) run is authoritative for nothing.
+
+    It produces module pages but no layer authority, so pre-existing curated
+    layer pages it cannot reproduce must survive — degradation honesty.
+    """
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Core"))
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session,
+        repo.id,
+        [_generated("module_page", "community-2")],
+        set(),  # degraded: no authority
+    )
+    await async_session.commit()
+
+    # The stale community module page is swept (its type was produced), but the
+    # curated layer page is untouched (not produced, not authoritative). The
+    # produced ``community-2`` page is upserted elsewhere, not by the sweep, so
+    # it is not among the seeded rows here.
+    assert swept == ["module_page:community-1"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert set(remaining) == {"layer_page:layer:Core"}
+
+
+async def test_incremental_no_authority_sweeps_nothing(async_session):
+    """Incremental no-KG run: generated_pages None + empty authority → no-op."""
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Core"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, None, set())
+    assert swept == []
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, None, None)
+    assert swept == []

--- a/tests/unit/server/test_job_executor.py
+++ b/tests/unit/server/test_job_executor.py
@@ -8,13 +8,18 @@ are not re-indexed.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from repowise.core.persistence.crud import upsert_generation_job, upsert_repository
-from repowise.server.job_executor import _repo_exclude_patterns, execute_job
+from repowise.server.job_executor import (
+    _incremental_page_regen,
+    _repo_exclude_patterns,
+    execute_job,
+)
 
 
 def _fake_result() -> SimpleNamespace:
@@ -154,3 +159,68 @@ async def test_execute_job_merges_config_yaml_excludes(session_factory, tmp_path
 
     run_pipeline_mock.assert_awaited_once()
     assert run_pipeline_mock.await_args.kwargs["exclude_patterns"] == ["tools/"]
+
+
+@pytest.mark.asyncio
+async def test_incremental_page_regen_passes_repo_path(tmp_path):
+    """Incremental regen must forward repo_path to generate_all.
+
+    Without it, generate_all can't load the curated knowledge-graph.json
+    artifact and silently falls back to community module grouping, which
+    overwrites curated module pages with the wrong ids.
+    """
+    repo_path = tmp_path
+    repowise_dir = repo_path / ".repowise"
+    repowise_dir.mkdir()
+    (repowise_dir / "state.json").write_text(
+        '{"last_sync_commit": "base-sha"}', encoding="utf-8"
+    )
+
+    result = SimpleNamespace(
+        file_count=10,
+        parsed_files=[],
+        source_map={},
+        graph_builder=SimpleNamespace(graph=lambda: object()),
+        repo_structure=object(),
+        repo_name="test-repo",
+        git_meta_map={},
+    )
+
+    # Stub git HEAD lookup to a sha != base so regen proceeds.
+    head_proc = SimpleNamespace(returncode=0, stdout="head-sha\n")
+
+    # Detector reports one changed/affected file so generation runs.
+    detector = MagicMock()
+    detector.get_changed_files.return_value = [object()]
+    affected = SimpleNamespace(regenerate=["foo.py"])
+    detector.get_affected_pages.return_value = affected
+
+    generator = MagicMock()
+    generator.generate_all = AsyncMock(return_value=[])
+
+    with (
+        patch("subprocess.run", return_value=head_proc),
+        patch(
+            "repowise.core.ingestion.ChangeDetector",
+            return_value=detector,
+        ),
+        patch(
+            "repowise.core.ingestion.change_detector.compute_adaptive_budget",
+            return_value=5,
+        ),
+        patch("repowise.core.generation.PageGenerator", return_value=generator),
+        patch("repowise.core.generation.ContextAssembler"),
+        patch("repowise.core.generation.GenerationConfig"),
+        patch("repowise.core.reasoning.resolve_reasoning", return_value="low"),
+        patch("repowise.core.repo_config.load_repo_config", return_value={}),
+    ):
+        await _incremental_page_regen(
+            Path(repo_path),
+            result,
+            llm_client=object(),
+            job_config={},
+            progress=None,
+        )
+
+    generator.generate_all.assert_awaited_once()
+    assert generator.generate_all.await_args.kwargs["repo_path"] == Path(repo_path)


### PR DESCRIPTION
## What

The curation engine that turns the raw community-partitioned knowledge graph into an intuitive, right-sized structure:

- **`analysis/kg_curation.py`** (new): derives wiki **modules** from the curated KG (`derive_modules`) — path-aware merging/splitting of communities into modules with honest names, with merge-shape rules tuned against a 38-repo validation matrix; types infra/CI/data nodes; enforces a never-empty summary floor.
- **`generation/layers.py`**: the architectural **layer spine** — language-aware `infer_layer` guards (a file's own language gates which layer-dir hints apply), stable layer **slug ids** (so LLM naming output joins by id, not list index), deterministic `_dominant_language` tiebreaks.
- **`generation/tour.py`**: guided-tour derivation with registry-driven entry-point detection (entry stems / manifest / suite anchors from the language registry) and honesty rules for sparse or regex-tier graphs.
- **`analysis/communities.py`**: strips repo-dominant namespace segments from community labels.
- **`analysis/knowledge_graph.py`**: graph modes (`flow`/`sparse`/`structural`) for honest degradation when imports are partial, plus the result-shape fields curation consumes.

This is pure computation — nothing persists or serves these results yet (that's the next PRs in the train). Default wiki generation is unchanged.

## Why

Raw Leiden communities make poor wiki modules: they cross layer boundaries, get machine labels, and vary run to run. Deriving modules and layers from path structure + graph evidence + language conventions makes the exported KG intuitive on every index, across all supported languages — including the regex-tier ones enabled by the resolver PR this stacks on.

## How it was tested

- Full `pytest tests/unit -q` green — new suites: `test_kg_curation.py`, `test_kg_modules.py`, `test_kg_invariants.py`, `test_community_labels.py`, plus updated `test_layers.py` / `test_tour.py` and shared fixtures in `kg_fixtures.py`.
- `ruff check` clean on touched files (no new findings vs `main`).
- Tuned against a pinned 38-repo validation matrix (harness lands in a separate PR).
