### PR TITLE
feat(generation)!: curated module pages, authority-scoped sweep, KG threading, curated default + doctor

### DIFF
--- a/packages/cli/src/repowise/cli/commands/doctor_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/doctor_cmd.py
@@ -23,6 +23,26 @@ def _check(name: str, ok: bool, detail: str = "") -> tuple[str, str, str]:
     return (name, status, detail)
 
 
+async def _decision_vector_ids(session, repository_id: str) -> set[str]:
+    """Vector-store ids for this repo's decision records.
+
+    Decisions are co-located in the *page* vector store under the
+    ``decision:<record_id>`` namespace (no separate table). The store therefore
+    legitimately holds page vectors *and* decision vectors, so any SQL↔vector
+    reconciliation must count decisions on the SQL side — otherwise every
+    decision embedding reads as an orphan.
+    """
+    from sqlalchemy import text as _sql_text
+
+    from repowise.core.analysis.decisions.semantic_match import DECISION_VECTOR_PREFIX
+
+    rows = await session.execute(
+        _sql_text("SELECT id FROM decision_records WHERE repository_id = :rid"),
+        {"rid": repository_id},
+    )
+    return {f"{DECISION_VECTOR_PREFIX}{r[0]}" for r in rows}
+
+
 def _print_cli_version_status() -> None:
     """Print a best-effort CLI update-check line.
 
@@ -228,6 +248,14 @@ def _run_repo_checks(repo_path: _DoctorPath, repair: bool) -> bool:
                         return set(), set(), set(), set()
                     pages = await list_pages(session, repo.id, limit=10000)
                     sql_ids = {p.page_id for p in pages}
+                    # The page vector store also holds decision embeddings under
+                    # the "decision:<id>" namespace, so they belong on the SQL
+                    # side of the ORPHAN check (but NOT FTS, which only indexes
+                    # pages). They are deliberately excluded from the MISSING
+                    # check: a decision can legitimately have no vector (empty
+                    # match text, swallowed embed failure) and repair cannot
+                    # re-embed it, so flagging it would be permanent noise.
+                    vector_sql_ids = sql_ids | await _decision_vector_ids(session, repo.id)
 
                 # Check vector store
                 vs_ids: set[str] = set()
@@ -242,7 +270,7 @@ def _run_repo_checks(repo_path: _DoctorPath, repair: bool) -> bool:
                         pass  # LanceDB not available
 
                 m_vec = sql_ids - vs_ids if vs_ids else set()
-                o_vec = vs_ids - sql_ids if vs_ids else set()
+                o_vec = vs_ids - vector_sql_ids if vs_ids else set()
 
                 # Check FTS
                 fts = FullTextSearch(engine)
@@ -289,6 +317,7 @@ def _run_repo_checks(repo_path: _DoctorPath, repair: bool) -> bool:
                 from repowise.core.persistence import (
                     create_engine,
                     create_session_factory,
+                    get_repository_by_path,
                     get_session,
                 )
                 from repowise.core.persistence.coordinator import AtomicStorageCoordinator
@@ -313,6 +342,33 @@ def _run_repo_checks(repo_path: _DoctorPath, repair: bool) -> bool:
                         session, graph_builder=None, vector_store=vector_store
                     )
                     result = await coord.health_check()
+
+                    # The coordinator's drift compares wiki_pages count against
+                    # the vector count, but the vector store also holds decision
+                    # embeddings ("decision:<id>" namespace). Without counting
+                    # decisions on the SQL side, every decision reads as drift.
+                    # Recompute drift with a decision-aware SQL count so a
+                    # consistent store reports ~0% rather than a false FAIL.
+                    # Count only decisions that actually have a vector: a
+                    # decision can legitimately be unembedded (empty match
+                    # text, swallowed embed failure), and counting it would
+                    # bias drift positive (SQL > Vector) forever.
+                    repo = await get_repository_by_path(session, str(repo_path))
+                    if repo is not None:
+                        dec_ids = await _decision_vector_ids(session, repo.id)
+                        decision_count = len(dec_ids)
+                        if vector_store is not None:
+                            with contextlib.suppress(Exception):
+                                store_ids = await vector_store.list_page_ids()
+                                decision_count = len(dec_ids & store_ids)
+                        sql_pages = result.get("sql_pages")
+                        vector_count = result.get("vector_count")
+                        if sql_pages is not None:
+                            adjusted_sql = sql_pages + decision_count
+                            result["sql_pages"] = adjusted_sql
+                            if vector_count is not None and vector_count != -1:
+                                denom = max(adjusted_sql, 1)
+                                result["drift"] = abs(adjusted_sql - vector_count) / denom
 
                 if vector_store is not None:
                     with contextlib.suppress(Exception):

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -109,6 +109,13 @@ def select_coverage(
     )
     from repowise.cli.coverage_select import interactive_coverage_select
 
+    # Curated modules from the in-memory index result, so the plan/cost
+    # estimate selects the same module set generation will (the artifact
+    # file is not on disk yet during a fresh init).
+    kg_modules = (
+        getattr(getattr(result, "knowledge_graph_result", None), "modules", None) or None
+    )
+
     if sys.stdin.isatty() and coverage_pct is None and not yes:
         options = compute_coverage_options(
             parsed_files=result.parsed_files,
@@ -119,6 +126,7 @@ def select_coverage(
             repo_path=repo_path,
             skip_tests=skip_tests,
             skip_infra=skip_infra,
+            kg_modules=kg_modules,
         )
         chosen = interactive_coverage_select(console, options)
         chosen_pct = chosen.pct
@@ -135,6 +143,7 @@ def select_coverage(
             gen_config_for_plan,
             skip_tests,
             skip_infra,
+            kg_modules=kg_modules,
         )
         est = estimate_cost(
             plans,
@@ -263,6 +272,22 @@ def run_repo_generation(
                 resume=resume,
                 cost_tracker=cost_tracker,
                 generation_config=gen_config,
+                # In-memory curated modules: on a fresh init the
+                # knowledge-graph.json artifact is only written during
+                # persistence, AFTER this generation pass — without this the
+                # kg_ctx file fallback is empty and module selection silently
+                # degrades to community grouping.
+                kg_modules=(
+                    getattr(
+                        getattr(result, "knowledge_graph_result", None), "modules", None
+                    )
+                    or None
+                ),
+                kg_data=(
+                    result.knowledge_graph_result.to_dict()
+                    if getattr(result, "knowledge_graph_result", None) is not None
+                    else None
+                ),
             )
         )
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/persistence.py
@@ -51,6 +51,7 @@ async def persist_result(result: Any, repo_path: Path) -> None:
         persist_analysis,
         persist_generation,
         persist_pipeline_result,
+        sweep_stale_generated_pages,
     )
 
     engine, sf, _repo_id = await open_repo_db(repo_path, repo_name=result.repo_name)
@@ -88,11 +89,26 @@ async def persist_result(result: Any, repo_path: Path) -> None:
                 existing = {}
             existing["tech_stack"] = result.tech_stack
             repo.settings_json = _json.dumps(existing)
+        swept_page_ids: list[str] = []
         if index_done:
             await persist_analysis(result, session, repo.id)
             await persist_generation(result, session, repo.id)
+            # persist_generation has already upserted the current pages, so the
+            # sweep only retires structurally-keyed pages this run did not
+            # reproduce. Without it the incremental-index path (every normal
+            # single-repo init) strands stale community-N / scc / layer pages
+            # forever. A type is swept when the run produced pages of it OR
+            # declared authority over it (curated runs are authoritative for
+            # module/layer pages even when every module page was skipped as
+            # 1:1 with a layer); types that are neither stay protected.
+            swept_page_ids = await sweep_stale_generated_pages(
+                session,
+                repo.id,
+                result.generated_pages,
+                getattr(result, "authoritative_page_types", None),
+            )
         else:
-            await persist_pipeline_result(result, session, repo.id)
+            swept_page_ids = await persist_pipeline_result(result, session, repo.id)
 
         # Record a completed GenerationJob so the web UI can show
         # "last synced" / "last re-indexed" timestamps.
@@ -109,7 +125,24 @@ async def persist_result(result: Any, repo_path: Path) -> None:
         job.started_at = now
         job.finished_at = now
 
-    # FTS indexing is done outside the session to avoid SQLite write conflicts
+        # Drop swept pages from the vector store *before* the SQL session
+        # commits. The vector store is a separate engine/file (pgvector DB,
+        # LanceDB dir, or in-memory) so there is no SQLite write-lock conflict,
+        # and the delete is idempotent. Keeping the SQL commit last as the
+        # durable source of truth means an interrupted run self-heals: the
+        # vector embedding is already gone, the SQL rows follow on commit.
+        if swept_page_ids:
+            store = getattr(result, "vector_store", None)
+            if store is not None:
+                await store.delete_many(swept_page_ids)
+
+    # FTS deletes/indexing run outside the session: the FTS index lives in the
+    # *same* SQLite file as the session, so touching it while the session still
+    # holds a write lock raises "database is locked". The swept-id delete must
+    # therefore stay here (it cannot move ahead of the SQL commit like the
+    # vector delete can); it is idempotent and narrow (orphan FTS rows only).
+    if fts is not None and swept_page_ids:
+        await fts.delete_many(swept_page_ids)
     if fts is not None and result.generated_pages:
         for page in result.generated_pages:
             await fts.index(page.page_id, page.title, page.content)

--- a/packages/cli/src/repowise/cli/commands/update_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd.py
@@ -1180,6 +1180,7 @@ def update_command(
             repo_structure,
             repo_name,
             git_meta_map=git_meta_map,
+            repo_path=repo_path,
         )
     )
 

--- a/packages/cli/src/repowise/cli/commands/workspace_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/workspace_cmd.py
@@ -545,6 +545,17 @@ def _run_index_for_repo(
             await persist_pipeline_result(result, session, repo.id)
 
         await engine.dispose()
+
+        # Save the curated KG artifact so doc generation can load curated
+        # module grouping (matches the `repowise init` idiom in
+        # init_cmd/command.py). Without it, generation falls back to raw
+        # community grouping and emits wrong module pages.
+        from repowise.cli.state_persistence import save_knowledge_graph_json
+
+        kg = getattr(result, "knowledge_graph_result", None)
+        if kg is not None:
+            save_knowledge_graph_json(repo_path, kg)
+
         return result.file_count, result.symbol_count, page_count
 
     try:
@@ -697,6 +708,7 @@ def _generate_docs_for_added_repo(
             graph_builder,
             repo_structure,
             repo_path.name,
+            repo_path=repo_path,
         )
 
         url = get_db_url_for_repo(repo_path)

--- a/packages/cli/src/repowise/cli/cost_estimator/coverage.py
+++ b/packages/cli/src/repowise/cli/cost_estimator/coverage.py
@@ -52,6 +52,7 @@ def compute_coverage_options(
     repo_path: Path | str | None = None,
     skip_tests: bool = False,
     skip_infra: bool = False,
+    kg_modules: list[dict] | None = None,
     percentages: tuple[float, ...] = DEFAULT_COVERAGE_OPTIONS,
     recommended: float = RECOMMENDED_COVERAGE,
 ) -> list[CoverageOption]:
@@ -66,7 +67,8 @@ def compute_coverage_options(
     for pct in percentages:
         cfg = replace(base_config, coverage_pct=pct, max_pages_pct=pct)
         plans = build_generation_plan(
-            parsed_files, graph_builder, cfg, skip_tests, skip_infra
+            parsed_files, graph_builder, cfg, skip_tests, skip_infra,
+            kg_modules=kg_modules,
         )
         est = estimate_cost(
             plans,

--- a/packages/cli/src/repowise/cli/cost_estimator/plans.py
+++ b/packages/cli/src/repowise/cli/cost_estimator/plans.py
@@ -22,6 +22,7 @@ def build_generation_plan(
     config: Any,
     skip_tests: bool = False,
     skip_infra: bool = False,
+    kg_modules: list[dict] | None = None,
 ) -> list[PageTypePlan]:
     """Return the per-page-type plan that ``generate_all`` will execute.
 
@@ -35,6 +36,11 @@ def build_generation_plan(
         Finalized GraphBuilder (build() already called).
     config:
         GenerationConfig — its ``coverage_pct`` drives the budget.
+    kg_modules:
+        Curated wiki modules from the KG artifact, when available. Must be
+        passed for ``module_grouping="curated"`` estimates to match the
+        actual run — without it the selector falls back to community
+        grouping, exactly as generation itself would without an artifact.
     """
     files = parsed_files
     if skip_tests:
@@ -63,6 +69,7 @@ def build_generation_plan(
             sccs=sccs,
             git_meta_map=None,
             config=config,
+            kg_modules=kg_modules,
         )
     )
 

--- a/packages/cli/src/repowise/cli/state_persistence.py
+++ b/packages/cli/src/repowise/cli/state_persistence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -22,16 +23,33 @@ def build_kg_state(kg: Any) -> dict[str, Any]:
     }
 
 
-def save_knowledge_graph_json(repo_path: Path, kg: Any) -> None:
+def save_knowledge_graph_json(repo_path: Path, kg: Any, *, portable: bool = False) -> None:
     """Write ``.repowise/knowledge-graph.json`` for a KG result.
 
     No-op when the result can't serialize itself (``to_dict`` missing), so
     callers only need to guard against a ``None`` knowledge graph.
+
+    When ``portable`` is set, write the self-contained, self-validated artifact
+    (curated layers + tour + entry points + summaries + a ``meta``/``validation``
+    block) instead of the bare ``to_dict`` output. Hard invariant violations are
+    logged but the artifact is still emitted, with the failures recorded under
+    ``meta.validation`` so a consumer can see them ("repaired, not rejected").
     """
     if not hasattr(kg, "to_dict"):
         return
     import json
 
+    if portable:
+        from repowise.core.analysis.kg_curation import build_portable_kg
+
+        data, validation = build_portable_kg(kg)
+        if not validation.ok:
+            logging.getLogger(__name__).warning(
+                "portable KG failed invariants: %s", "; ".join(validation.errors)
+            )
+    else:
+        data = kg.to_dict()
+
     kg_json_path = repo_path / ".repowise" / "knowledge-graph.json"
     kg_json_path.parent.mkdir(parents=True, exist_ok=True)
-    kg_json_path.write_text(json.dumps(kg.to_dict(), indent=2), encoding="utf-8")
+    kg_json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/packages/core/src/repowise/core/generation/context/assembler.py
+++ b/packages/core/src/repowise/core/generation/context/assembler.py
@@ -201,6 +201,7 @@ class ContextAssembler:
             community_cohesion=community_cohesion,
             decision_records=decision_records or [],
             kg_layer_name=kg_context.layer_name if kg_context else "",
+            kg_layer_id=kg_context.layer_id if kg_context else "",
             kg_layer_description=kg_context.layer_description if kg_context else "",
             kg_layer_role=kg_context.role if kg_context else "",
             kg_neighbors=kg_context.neighbors if kg_context else [],

--- a/packages/core/src/repowise/core/generation/context/contexts.py
+++ b/packages/core/src/repowise/core/generation/context/contexts.py
@@ -53,6 +53,9 @@ class FilePageContext:
     decision_records: list[dict] = field(default_factory=list)
     # KG layer context (populated when knowledge graph available)
     kg_layer_name: str = ""
+    # Stable slug id of the layer (``layer:<slug>``) — used to join a file
+    # page to its layer page; ``kg_layer_name`` is the mutable display label.
+    kg_layer_id: str = ""
     kg_layer_description: str = ""
     kg_layer_role: str = ""
     kg_neighbors: list[dict] = field(default_factory=list)
@@ -106,6 +109,9 @@ class LayerPageContext:
     layer_name: str
     layer_description: str
     file_count: int
+    # Stable slug id (``layer:<slug>``) — the layer page's target_path and
+    # page_id derive from this, never from the mutable ``layer_name``.
+    layer_id: str = ""
     key_files: list[dict] = field(default_factory=list)
     deps_out: list[dict] = field(default_factory=list)
     deps_in: list[dict] = field(default_factory=list)

--- a/packages/core/src/repowise/core/generation/models.py
+++ b/packages/core/src/repowise/core/generation/models.py
@@ -112,10 +112,16 @@ class GenerationConfig:
     file_page_min_symbols: int = 1
     skip_trivial_files: bool = True
     dedupe_near_clones: bool = True
-    # Phase 2: switch module_page grouping from top-directory to graph
-    # communities. min_module_size is the floor below which a community
-    # doesn't get its own page (its files still appear under file_page).
-    module_grouping: Literal["community", "top_dir"] = "community"
+    # Module-page grouping source. "curated" (default) groups by the wiki
+    # modules the KG curation pass derives (stable path ids, human names,
+    # right-sized groups) and silently falls back to "community" when no
+    # curated modules are available (curation off, degraded, or no KG
+    # artifact), so it is always safe. "community" groups by raw graph
+    # communities (the pre-curation behavior, kept as the escape hatch),
+    # "top_dir" by top-level directory.
+    # min_module_size is the floor below which a group doesn't get its own
+    # page (its files still appear under file_page).
+    module_grouping: Literal["community", "top_dir", "curated"] = "community"
     min_module_size: int = 3
     # Phase 3: emit the curated Onboarding collection at level 8. Each
     # subkind defines its own gate; slots whose gates fail are silently

--- a/packages/core/src/repowise/core/generation/models.py
+++ b/packages/core/src/repowise/core/generation/models.py
@@ -121,7 +121,7 @@ class GenerationConfig:
     # "top_dir" by top-level directory.
     # min_module_size is the floor below which a group doesn't get its own
     # page (its files still appear under file_page).
-    module_grouping: Literal["community", "top_dir", "curated"] = "community"
+    module_grouping: Literal["community", "top_dir", "curated"] = "curated"
     min_module_size: int = 3
     # Phase 3: emit the curated Onboarding collection at level 8. Each
     # subkind defines its own gate; slots whose gates fail are silently

--- a/packages/core/src/repowise/core/generation/onboarding/subkinds/how_it_works.py
+++ b/packages/core/src/repowise/core/generation/onboarding/subkinds/how_it_works.py
@@ -139,11 +139,29 @@ def _collect_flows(signals: OnboardingSignals) -> list[FlowTrace]:
     return flows
 
 
+def _normalize_tour_step(step: dict) -> dict:
+    """One template-facing shape for both tour-step generations.
+
+    Legacy steps carry ``nodeIds`` + ``description``; curated steps carry a
+    single ``target_path`` + evidence in ``reason``. The strict template
+    (``step.nodeIds`` / ``step.description``) must never see a missing key.
+    """
+    node_ids = list(step.get("nodeIds") or [])
+    if step.get("target_path"):
+        node_ids.append(f"file:{step['target_path']}")
+    return {
+        "order": step.get("order", 0),
+        "title": step.get("title", ""),
+        "description": step.get("description") or step.get("reason") or "",
+        "nodeIds": node_ids,
+    }
+
+
 def _build(signals: OnboardingSignals) -> HowItWorksContext | None:
     archetype, evidence = _classify_archetype(signals)
     flows = _collect_flows(signals)
 
-    kg_tour = list(signals.kg_tour_steps) if signals.kg_tour_steps else []
+    kg_tour = [_normalize_tour_step(s) for s in signals.kg_tour_steps or ()]
 
     # Gate: need either a real trace, tour steps, or a non-trivial archetype.
     if not flows and not kg_tour and archetype == "module":

--- a/packages/core/src/repowise/core/generation/page_generator/core.py
+++ b/packages/core/src/repowise/core/generation/page_generator/core.py
@@ -60,15 +60,23 @@ def _attach_file_provenance(page: GeneratedPage, ctx: FilePageContext) -> None:
     """
     if ctx.kg_layer_name:
         page.metadata["layer_name"] = ctx.kg_layer_name
+        # Stable slug id of the layer page this file links to. The layer page
+        # is keyed by slug (``layer:<slug>``) so the join survives the LLM
+        # layer-name enrichment that mutates ``layer_name`` after generation.
+        if ctx.kg_layer_id:
+            page.metadata["layer_id"] = ctx.kg_layer_id
         if ctx.kg_layer_role:
             page.metadata["layer_role"] = ctx.kg_layer_role
     else:
         # Guarantee every file page carries a layer so the Architecture tree
         # can group it. When the knowledge graph has no layer, fall back to
         # path-based inference.
+        from ...analysis.knowledge_graph import _slugify
         from ..layers import infer_layer
 
-        page.metadata["layer_name"] = infer_layer(ctx.file_path)
+        inferred = infer_layer(ctx.file_path, getattr(ctx, "language", None))
+        page.metadata["layer_name"] = inferred
+        page.metadata["layer_id"] = f"layer:{_slugify(inferred)}"
 
     sources: list[dict[str, str]] = []
     seen: set[str] = set()
@@ -171,6 +179,8 @@ class PageGenerator(PerTypeGenerationMixin):
         decision_report: Any | None = None,
         external_systems: list[dict] | None = None,
         on_page_ready: Callable[[GeneratedPage], None] | None = None,
+        kg_modules: list[dict] | None = None,
+        kg_data: dict | None = None,
     ) -> list[GeneratedPage]:
         """Generate all wiki pages for a repository.
 
@@ -198,6 +208,8 @@ class PageGenerator(PerTypeGenerationMixin):
             decision_report=decision_report,
             external_systems=external_systems,
             on_page_ready=on_page_ready,
+            kg_modules=kg_modules,
+            kg_data=kg_data,
         )
 
     # ------------------------------------------------------------------

--- a/packages/core/src/repowise/core/generation/page_generator/levels.py
+++ b/packages/core/src/repowise/core/generation/page_generator/levels.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
+from ...analysis.knowledge_graph import _slugify
 from .. import onboarding as _onboarding
 from ..context_assembler import FilePageContext
 from ..models import compute_page_id
@@ -317,7 +318,13 @@ def build_level5_coros(run: _GenerationRun) -> list[tuple[str, Any]]:
             continue
 
         layer_name = layer.get("name", "")
-        page_id = compute_page_id("layer_page", f"layer:{layer_name}")
+        # Key the page by the layer's STABLE slug id (``layer:<slug>``), not its
+        # display name: the LLM layer-name enrichment rewrites ``name`` after
+        # generation, so a name-keyed page would no longer join to its KG layer.
+        # ``id`` is derived from the deterministic heuristic name at curation
+        # time and never changes under enrichment.
+        layer_id = layer.get("id", "") or f"layer:{_slugify(layer_name)}"
+        page_id = compute_page_id("layer_page", layer_id)
         if page_id in run.completed_ids:
             continue
 
@@ -354,6 +361,7 @@ def build_level5_coros(run: _GenerationRun) -> list[tuple[str, Any]]:
 
         ctx = LayerPageContext(
             layer_name=layer_name,
+            layer_id=layer_id,
             layer_description=layer.get("description", ""),
             file_count=len(file_paths),
             key_files=key_files,

--- a/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
+++ b/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
@@ -60,6 +60,8 @@ class _GenerationRun:
         decision_report: Any | None,
         external_systems: list[dict] | None,
         on_page_ready: Callable[[GeneratedPage], None] | None = None,
+        kg_modules: list[dict] | None = None,
+        kg_data: dict | None = None,
     ) -> None:
         self.gen = gen
         self.config = gen._config
@@ -83,6 +85,11 @@ class _GenerationRun:
         self.resume = resume
         self.repo_path = repo_path
         self.external_systems = external_systems or []
+        # Curated wiki modules from the IN-MEMORY pipeline result. The kg_ctx
+        # file fallback below is one run stale on update and absent on a
+        # fresh init (the artifact is written AFTER generation) — the live
+        # repowise run shipped community-grouped module pages because of it.
+        self.kg_modules = kg_modules or []
 
         # ---- Graph metrics ----
         self.graph = graph_builder.graph()
@@ -98,17 +105,27 @@ class _GenerationRun:
         # ---- KG context (per-file knowledge graph lookups) ----
         from repowise.core.generation.kg_context import KnowledgeGraphContext
 
-        kg_path = None
+        # Prefer the in-memory KG (the pipeline result's export dict): the
+        # artifact file is only written during persistence — AFTER this
+        # generation pass — so on a fresh init the file path below finds
+        # nothing and every kg_ctx-derived page (layer pages, tour context,
+        # file layers) silently vanished from first-run wikis.
+        rp = None
         if repo_path:
             rp = Path(repo_path) if not isinstance(repo_path, Path) else repo_path
-            for candidate in [
-                rp / ".repowise" / "knowledge-graph.json",
-                rp / ".understand-anything" / "knowledge-graph.json",
-            ]:
-                if candidate.exists():
-                    kg_path = candidate
-                    break
-        self.kg_ctx = KnowledgeGraphContext(kg_path)
+        if kg_data is not None:
+            self.kg_ctx = KnowledgeGraphContext(None, rp, data=kg_data)
+        else:
+            kg_path = None
+            if rp:
+                for candidate in [
+                    rp / ".repowise" / "knowledge-graph.json",
+                    rp / ".understand-anything" / "knowledge-graph.json",
+                ]:
+                    if candidate.exists():
+                        kg_path = candidate
+                        break
+            self.kg_ctx = KnowledgeGraphContext(kg_path)
 
         # ---- Run bookkeeping ----
         self.semaphore = asyncio.Semaphore(self.config.max_concurrency)
@@ -214,6 +231,11 @@ class _GenerationRun:
                 git_meta_map=self.git_meta_map,
                 config=self.config,
                 kg_file_scores=kg_scores or None,
+                # Curated wiki modules: prefer the in-memory pipeline
+                # result (fresh); the artifact file is absent on first init
+                # and one run stale on update. Inert unless
+                # module_grouping == "curated".
+                kg_modules=self.kg_modules or self.kg_ctx.get_modules() or None,
             )
         )
 
@@ -293,24 +315,40 @@ class _GenerationRun:
 
         import_edges = self._file_import_edges()
 
-        # Tour: ordered stops over the selected file/infra pages + overview.
-        stops = build_tour(
-            self.parsed_files,
-            self.pagerank,
-            import_edges,
-            file_page_paths=self.sel_file_paths,
-            infra_paths=self.sel_infra_paths,
-            repo_name=self.repo_name,
-        )
-        self.tour_stops = [s.as_dict() for s in stops]
+        # When the indexed KG carries the curated tour (project.graph_mode is
+        # written only by the curation pass), adopt it wholesale instead of
+        # re-deriving a second, divergent tour from the raw graph: the curated
+        # tour knows the repo's honesty mode (flow/sparse/structural), walks
+        # imports-type edges only, and excludes support paths — and the wiki's
+        # file cards already cite its steps. One tour, every surface.
+        if self.kg_ctx.available and self.kg_ctx.get_graph_mode():
+            self.tour_stops = [dict(s) for s in self.kg_ctx.get_tour()]
+        if not self.tour_stops:
+            # Tour: ordered stops over the selected file/infra pages + overview.
+            stops = build_tour(
+                self.parsed_files,
+                self.pagerank,
+                import_edges,
+                file_page_paths=self.sel_file_paths,
+                infra_paths=self.sel_infra_paths,
+                repo_name=self.repo_name,
+            )
+            self.tour_stops = [s.as_dict() for s in stops]
 
         # Layer spine: every documented file gets a layer (KG when present,
         # path-based inference otherwise), then layers are ordered top→bottom
         # by inter-layer dependency direction.
+        lang_by_path = {
+            p.file_info.path: (getattr(p.file_info, "language", "") or "").lower()
+            for p in self.parsed_files
+            if getattr(p, "file_info", None)
+        }
         file_layers: dict[str, str] = {}
         for path in self.sel_file_paths:
             kg_fc = self.kg_ctx.get_file_context(path) if self.kg_ctx.available else None
-            file_layers[path] = (kg_fc.layer_name if kg_fc and kg_fc.layer_name else "") or infer_layer(path)
+            file_layers[path] = (kg_fc.layer_name if kg_fc and kg_fc.layer_name else "") or infer_layer(
+                path, lang_by_path.get(path)
+            )
         self.layer_order = compute_layer_order(file_layers, import_edges)
 
     # ------------------------------------------------------------------

--- a/packages/core/src/repowise/core/generation/page_generator/pertype.py
+++ b/packages/core/src/repowise/core/generation/page_generator/pertype.py
@@ -310,7 +310,10 @@ class PerTypeGenerationMixin:
         ctx: LayerPageContext,
     ) -> GeneratedPage:
         user_prompt = self._render("layer_page.j2", ctx=ctx)
-        target = f"layer:{ctx.layer_name}"
+        # target_path = the layer's STABLE slug id, so the page key survives
+        # the post-generation LLM rename of ``layer_name``. The title still
+        # uses the (heuristic) display name.
+        target = ctx.layer_id
         response = await self._call_provider(
             "layer_page", user_prompt, str(uuid.uuid4()), target_path=target
         )

--- a/packages/core/src/repowise/core/generation/selection/selector.py
+++ b/packages/core/src/repowise/core/generation/selection/selector.py
@@ -45,8 +45,9 @@ class ModuleGroup:
     """One ``module_page`` worth of files.
 
     ``key`` is the stable identifier persisted as ``target_path``:
-    ``community-<id>`` when grouping by community, the top-level
-    directory when falling back to ``top_dir``.
+    the module's real directory path when grouping by curated KG modules
+    (so path-prefix child lookups work), ``community-<id>`` when grouping
+    by community, the top-level directory when falling back to ``top_dir``.
     """
 
     key: str
@@ -108,6 +109,11 @@ class SelectionInputs:
     git_meta_map: dict[str, dict] | None
     config: Any  # GenerationConfig — duck-typed to avoid the import cycle
     kg_file_scores: dict[str, float] | None = None
+    # Curated wiki modules from the KG artifact (``modules`` top-level key),
+    # passed through — never re-derived here. Only read when
+    # ``config.module_grouping == "curated"``; ``None``/empty falls back to
+    # community grouping (the fallback-matrix "degraded" row).
+    kg_modules: list[dict] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -184,11 +190,84 @@ def _build_symbol_candidates(
     return scored
 
 
+def _build_curated_module_groups(
+    inputs: SelectionInputs, min_size: int
+) -> list[tuple[float, ModuleGroup]] | None:
+    """Scored groups from curated KG modules, or ``None`` when unavailable.
+
+    ``key`` = the module's real directory path (its ``target_path``, so the
+    MCP child lookup ``target_path LIKE 'dir/%'`` works), ``display``/``label``
+    = the curated human name, ``cohesion`` = None (the community block in the
+    template is conditional and has no meaning for directory groups). Ranked
+    by Σ PageRank of members — better than ``score_module``'s cohesion term,
+    which is meaningless here. Returns ``None`` only when no curated modules
+    were passed in (→ community fallback); an artifact whose modules all fall
+    below the floor yields an empty list, not a vocabulary mix.
+    """
+    if not inputs.kg_modules:
+        return None
+
+    code_by_path = {
+        p.file_info.path: p for p in inputs.parsed_files if _is_code_file(p)
+    }
+    scored: list[tuple[float, ModuleGroup]] = []
+    seen_keys: set[str] = set()
+    for module in inputs.kg_modules:
+        if module.get("wholeLayer"):
+            # 1:1 with a layer page (single-module layers, flat libs) — a
+            # module doc would re-document the layer. Skip the page; the
+            # module stays in the KG artifact for canvas/coverage.
+            continue
+        member_paths = sorted(
+            path
+            for nid in module.get("nodeIds", [])
+            if isinstance(nid, str)
+            and (path := nid.removeprefix("file:")) in code_by_path
+        )
+        if len(member_paths) < min_size:
+            continue
+        key = module.get("path") or (module.get("id") or "").removeprefix("module:")
+        if not key or key in seen_keys:
+            # Rare cross-layer dir collision: the slug id is still unique.
+            key = (module.get("id") or "").removeprefix("module:")
+        if not key or key in seen_keys:
+            continue
+        seen_keys.add(key)
+        name = module.get("name") or key
+        language = module.get("language") or code_by_path[
+            member_paths[0]
+        ].file_info.language
+        score = sum(inputs.pagerank.get(p, 0.0) for p in member_paths)
+        scored.append(
+            (
+                score,
+                ModuleGroup(
+                    key=key,
+                    display=name,
+                    language=language,
+                    file_paths=tuple(member_paths),
+                    label=name,
+                    cohesion=None,
+                ),
+            )
+        )
+    scored.sort(key=lambda x: (-x[0], x[1].key))
+    return scored
+
+
 def _build_module_groups(inputs: SelectionInputs) -> list[tuple[float, ModuleGroup]]:
-    """Return scored module groups — either community-based or top-dir."""
+    """Return scored module groups — curated, community-based, or top-dir."""
     cfg = inputs.config
     min_size = max(1, getattr(cfg, "min_module_size", 3))
-    use_communities = getattr(cfg, "module_grouping", "community") == "community"
+    grouping = getattr(cfg, "module_grouping", "community")
+
+    if grouping == "curated":
+        curated = _build_curated_module_groups(inputs, min_size)
+        if curated is not None:
+            return curated
+        grouping = "community"  # no curated artifact → today's path, unchanged
+
+    use_communities = grouping == "community"
 
     # Bucket files into groups.
     groups: dict[str, list[Any]] = {}

--- a/packages/core/src/repowise/core/pipeline/__init__.py
+++ b/packages/core/src/repowise/core/pipeline/__init__.py
@@ -12,6 +12,9 @@ Usage::
 
 from .orchestrator import PipelineResult, run_generation, run_pipeline
 from .persist import (
+    _sweep_stale_generated_pages as sweep_stale_generated_pages,
+)
+from .persist import (
     persist_analysis,
     persist_generation,
     persist_git,
@@ -35,4 +38,5 @@ __all__ = [
     "rehydrate_graph_builder",
     "run_generation",
     "run_pipeline",
+    "sweep_stale_generated_pages",
 ]

--- a/packages/core/src/repowise/core/pipeline/orchestrator.py
+++ b/packages/core/src/repowise/core/pipeline/orchestrator.py
@@ -136,6 +136,16 @@ class PipelineResult:
     it is already on disk — and writes only analysis + generation. False for
     every non-resume caller, which persist the full result as before."""
 
+    authoritative_page_types: set[str] = field(default_factory=set)
+    """Structural page types this run fully decided — i.e. its emitted set is
+    "exactly these, possibly none". The stale-page sweep retires prior rows of
+    a type when it was produced OR is named here, so a legitimately-empty
+    authoritative type (e.g. every curated module collapsed into its layer via
+    wholeLayer) still wipes the previous run's stragglers. Populated only on a
+    curated run with a real KG; left empty on degraded/community fallback and
+    on incremental no-KG paths, which preserves degradation honesty (a fallback
+    run never wipes curated pages it could not reproduce)."""
+
 
 # ---------------------------------------------------------------------------
 # Pipeline
@@ -525,6 +535,34 @@ async def run_pipeline(
                     f"{len(knowledge_graph_result.layers)} layers",
                 )
         _phase_done(progress, "knowledge_graph.skeleton")
+
+        # ---- KG curation/presentation pass (flagged, default on) ---------
+        # Reshapes only the exported KG (layers/tour/entry-points/summaries);
+        # never touches the AST graph, communities, or centrality. No-op when
+        # REPOWISE_KG_CURATION is set to a falsy value (the raw uncurated
+        # export). Runs in BOTH FAST and STANDARD (before the generate branch).
+        if knowledge_graph_result is not None:
+            from repowise.core.analysis.kg_curation import (
+                curate_knowledge_graph,
+                curation_enabled,
+            )
+
+            try:
+                # In generate mode the summary floor is deferred to run after
+                # the wiki-page backfill (in ``enrich_knowledge_graph``), so
+                # rich page summaries win; FAST mode floors here.
+                will_generate = generate_docs and llm_client is not None
+                knowledge_graph_result = curate_knowledge_graph(
+                    knowledge_graph_result,
+                    parsed_files=parsed_files,
+                    graph_builder=graph_builder,
+                    repo_structure=repo_structure,
+                    community_info=graph_builder.community_info(),
+                    enabled=curation_enabled(),
+                    defer_summary_floor=will_generate,
+                )
+            except (ValueError, KeyError, RuntimeError) as cur_err:
+                logger.error("kg_curation_failed", error=str(cur_err), exc_info=True)
     except (ValueError, KeyError, OSError, RuntimeError) as kg_err:
         logger.error("kg_skeleton_building_failed", error=str(kg_err), exc_info=True)
 
@@ -543,6 +581,10 @@ async def run_pipeline(
 
     # ---- Phase 3: Generation (optional) ------------------------------------
     generated_pages: list[Any] | None = None
+    # Structural page types this run was authoritative for (see
+    # PipelineResult.authoritative_page_types). Stays empty unless curated
+    # generation engaged below.
+    authoritative_page_types: set[str] = set()
     if generate_docs and llm_client is not None:
         if progress:
             progress.on_message("info", "Phase 3: Generation")
@@ -590,7 +632,38 @@ async def run_pipeline(
             decision_report=gen_decision_report,
             external_systems=external_systems,
             on_page_ready=on_page_ready,
+            # In-memory KG — the artifact file is written after generation,
+            # so it cannot carry layers/tour/modules on a fresh init.
+            kg_modules=(
+                knowledge_graph_result.modules or None
+                if knowledge_graph_result is not None
+                else None
+            ),
+            kg_data=(
+                knowledge_graph_result.to_dict()
+                if knowledge_graph_result is not None
+                else None
+            ),
         )
+
+        # Record which structural page types this run authoritatively decided,
+        # so the sweep can retire prior rows of a type even when this run
+        # legitimately emitted zero pages of it. Mirrors the selector's curated
+        # engagement test (_build_curated_module_groups returns None — i.e.
+        # falls back to community — only when kg_modules is empty) so the signal
+        # is set iff the curated grouping actually engaged. On the degraded
+        # community fallback both stay unset, preserving degradation honesty.
+        kg_modules_present = bool(
+            knowledge_graph_result is not None and knowledge_graph_result.modules
+        )
+        kg_layers_present = bool(
+            knowledge_graph_result is not None and knowledge_graph_result.layers
+        )
+        module_grouping = getattr(resolved_generation_config, "module_grouping", "community")
+        if module_grouping == "curated" and kg_modules_present:
+            authoritative_page_types.add("module_page")
+        if kg_layers_present:
+            authoritative_page_types.add("layer_page")
 
     # ---- Knowledge Graph LLM enrichment (layer naming + tour) -----------------
     if knowledge_graph_result is not None and generate_docs and llm_client is not None:
@@ -674,6 +747,7 @@ async def run_pipeline(
         index_persisted_incrementally=(
             resume_controller.index_persisted if resume_controller is not None else False
         ),
+        authoritative_page_types=authoritative_page_types,
     )
 
 

--- a/packages/core/src/repowise/core/pipeline/persist.py
+++ b/packages/core/src/repowise/core/pipeline/persist.py
@@ -216,6 +216,74 @@ async def _prune_stale_file_rows(
     await _delete_stale_by_paths(GitMetadata, GitMetadata.file_path, current_git_file_paths)
 
 
+# Generated page types keyed on run-scoped structure: module/scc pages on
+# clustering ordinals, layer pages on display names. Those keys shift between
+# runs, so re-runs mint fresh page ids and the previous rows linger as
+# duplicates unless swept against the current run's output.
+_SWEPT_GENERATED_PAGE_TYPES = ("module_page", "layer_page", "scc_page")
+
+
+async def _sweep_stale_generated_pages(
+    session: Any,
+    repo_id: str,
+    generated_pages: list[Any] | None,
+    authoritative_page_types: set[str] | None = None,
+) -> list[str]:
+    """Delete structurally-keyed generated pages this run did not produce.
+
+    Sweeps a page type when the run either produced at least one page of it OR
+    declared itself authoritative for it (``authoritative_page_types`` — set by
+    the generation layer when it fully decided the type, even if that decision
+    was "emit none"; e.g. a curated run whose modules all collapsed into their
+    layers via ``wholeLayer``). A type that is neither produced nor authoritative
+    is left untouched, so a skipped/failed/degraded level never wipes the last
+    good set. When authoritative-but-empty, the current set is empty and every
+    prior row of that type is retired. Page versions go with their page (FK
+    enforcement requires it, and a retired structural id never comes back to
+    claim its history). Returns the swept page ids so the caller can drop them
+    from FTS after the session closes (the FTS store must not be touched
+    in-session).
+    """
+    from sqlalchemy import delete, select
+
+    from repowise.core.persistence.models import Page, PageVersion
+
+    produced: dict[str, set[str]] = {}
+    for page in generated_pages or []:
+        produced.setdefault(page.page_type, set()).add(page.page_id)
+    authoritative = authoritative_page_types or set()
+
+    swept: list[str] = []
+    for page_type in _SWEPT_GENERATED_PAGE_TYPES:
+        current = produced.get(page_type)
+        if not current and page_type not in authoritative:
+            continue
+        current = current or set()
+        existing = (
+            (
+                await session.execute(
+                    select(Page.id).where(
+                        Page.repository_id == repo_id, Page.page_type == page_type
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        stale = [pid for pid in existing if pid not in current]
+        for i in range(0, len(stale), _PRUNE_CHUNK):
+            batch = stale[i : i + _PRUNE_CHUNK]
+            await session.execute(delete(PageVersion).where(PageVersion.page_id.in_(batch)))
+            await session.execute(
+                delete(Page).where(Page.repository_id == repo_id, Page.id.in_(batch))
+            )
+        swept.extend(stale)
+
+    if swept:
+        logger.info("stale_generated_pages_swept", repo_id=repo_id, count=len(swept))
+    return swept
+
+
 async def persist_ingestion(result: Any, session: Any, repo_id: str) -> int:
     """Persist ingestion-phase outputs: graph nodes/edges, external systems,
     symbols, and the per-file security scan.
@@ -479,22 +547,45 @@ async def persist_generation(result: Any, session: Any, repo_id: str) -> None:
         for page in result.generated_pages:
             await upsert_page_from_generated(session, page, repo_id)
 
-    # ---- Knowledge graph layers & tour steps --------------------------------
+    # ---- Knowledge graph layers, tour steps & curated meta ------------------
     kg = getattr(result, "knowledge_graph_result", None)
     if kg is not None:
-        from repowise.core.persistence.crud import upsert_kg_layers, upsert_kg_tour_steps
+        from repowise.core.persistence.crud import (
+            file_node_meta_from_kg_nodes,
+            upsert_kg_layers,
+            upsert_kg_node_meta,
+            upsert_kg_project_meta,
+            upsert_kg_tour_steps,
+        )
 
         if hasattr(kg, "layers") and kg.layers:
             await upsert_kg_layers(session, repo_id, kg.layers)
         if hasattr(kg, "tour") and kg.tour:
             await upsert_kg_tour_steps(session, repo_id, kg.tour)
 
+        # Project-level curated meta (ranked entry points from the curation pass).
+        project = getattr(kg, "project", None)
+        if isinstance(project, dict) and project.get("entry_points"):
+            await upsert_kg_project_meta(
+                session,
+                repo_id,
+                entry_points=project["entry_points"],
+                entry_candidates=project.get("entry_candidates", []),
+            )
+
+        # Per-node curated meta (type/summary/tags) for file nodes, stored with
+        # the "file:" prefix stripped so the architecture view can match its
+        # node ids (plain repo-relative paths) directly.
+        file_node_meta = file_node_meta_from_kg_nodes(getattr(kg, "nodes", None) or [])
+        if file_node_meta:
+            await upsert_kg_node_meta(session, repo_id, file_node_meta)
+
 
 async def persist_pipeline_result(
     result: Any,
     session: Any,
     repo_id: str,
-) -> None:
+) -> list[str]:
     """Persist all outputs from a :class:`PipelineResult` into the database.
 
     Thin composition of the four phase-scoped persisters
@@ -511,6 +602,11 @@ async def persist_pipeline_result(
         An active SQLAlchemy ``AsyncSession`` (caller manages commit/rollback).
     repo_id:
         The repository ID to associate all records with.
+
+    Returns
+    -------
+    The page ids of stale generated pages swept by this run. Callers should
+    remove them from the FTS index after the session closes.
 
     Note
     ----
@@ -537,6 +633,17 @@ async def persist_pipeline_result(
     await persist_analysis(result, session, repo_id)
     await persist_generation(result, session, repo_id)
 
+    # Sweep structurally-keyed generated pages (module/layer/scc) that this
+    # run did not reproduce — their ids drift between runs, so without the
+    # sweep every re-index strands the previous set as duplicates. Full runs
+    # only, same rule as _prune_stale_file_rows.
+    swept_page_ids = await _sweep_stale_generated_pages(
+        session,
+        repo_id,
+        result.generated_pages,
+        getattr(result, "authoritative_page_types", None),
+    )
+
     logger.info(
         "pipeline_result_persisted",
         repo_id=repo_id,
@@ -545,3 +652,4 @@ async def persist_pipeline_result(
         symbols=symbol_count,
         git_files=len(result.git_metadata_list),
     )
+    return swept_page_ids

--- a/packages/core/src/repowise/core/pipeline/phases/generation.py
+++ b/packages/core/src/repowise/core/pipeline/phases/generation.py
@@ -40,6 +40,8 @@ async def run_generation(
     external_systems: list[dict] | None = None,
     on_page_ready: Any | None = None,
     prior_pages: dict[str, Any] | None = None,
+    kg_modules: list[dict] | None = None,
+    kg_data: dict | None = None,
 ) -> list[Any]:
     """Run LLM-powered page generation.
 
@@ -137,6 +139,8 @@ async def run_generation(
         decision_report=decision_report,
         external_systems=external_systems,
         on_page_ready=on_page_ready,
+        kg_modules=kg_modules,
+        kg_data=kg_data,
     )
 
     # Onboarding summary — count generated slots and surface which ones

--- a/packages/server/src/repowise/server/job_executor.py
+++ b/packages/server/src/repowise/server/job_executor.py
@@ -311,7 +311,7 @@ async def execute_job(
 
         # ---- Persist results -----------------------------------------------
         async with get_session(session_factory) as session:
-            await persist_pipeline_result(result, session, repo_id)
+            swept_page_ids = await persist_pipeline_result(result, session, repo_id)
 
             # Persist incrementally regenerated pages
             if incremental_pages:
@@ -320,8 +320,22 @@ async def execute_job(
                 for page in incremental_pages:
                     await upsert_page_from_generated(session, page, repo_id)
 
-        # FTS indexing runs after session closes to avoid SQLite write conflicts
+            # Drop swept pages from the vector store *before* the SQL session
+            # commits. The vector store is a separate engine/file (pgvector DB,
+            # LanceDB dir, or in-memory), so there is no SQLite write-lock
+            # conflict and the idempotent delete leaves the durable SQL commit
+            # last: an interrupted run self-heals (embedding already gone, SQL
+            # rows follow on commit).
+            if swept_page_ids and vector_store is not None:
+                await vector_store.delete_many(swept_page_ids)
+
+        # FTS deletes/indexing run after the session closes: the FTS index can
+        # share the SQLite file with the session, so writing it while the
+        # session holds a write lock raises "database is locked". The swept-id
+        # delete is idempotent (orphan FTS rows only) and must stay here.
         all_pages = (result.generated_pages or []) + incremental_pages
+        if fts is not None and swept_page_ids:
+            await fts.delete_many(swept_page_ids)
         if fts is not None and all_pages:
             for page in all_pages:
                 await fts.index(page.page_id, page.title, page.content)
@@ -528,6 +542,7 @@ async def _incremental_page_regen(
             result.repo_structure,
             result.repo_name,
             git_meta_map=result.git_meta_map,
+            repo_path=repo_path,
         )
 
         logger.info("incremental_page_regen_done", pages=len(pages))

--- a/tests/unit/cli/test_doctor_vector_decisions.py
+++ b/tests/unit/cli/test_doctor_vector_decisions.py
@@ -1,0 +1,185 @@
+"""Regression tests for the doctor SQL<->vector reconciliation.
+
+The page vector store also holds *decision* embeddings under the
+``decision:<record_id>`` namespace. The drift / orphan check used to compare
+vector ids against ``wiki_pages`` only, so every decision embedding was counted
+as an orphan vector — a false "Coordinator drift FAIL" on a consistent store,
+and (with ``--repair``) a *destructive* deletion of valid decision vectors.
+
+These tests pin the corrected behavior:
+  * the SQL-side id set used for vector reconciliation is
+    ``page_ids | {"decision:<id>"}``;
+  * a genuinely orphaned vector (id in neither table) is still detected;
+  * the repair deletion targets only the genuine orphan, never a decision.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from repowise.cli.commands.doctor_cmd import _decision_vector_ids
+from repowise.core.analysis.decisions.semantic_match import DECISION_VECTOR_PREFIX
+from repowise.core.persistence.database import init_db
+from repowise.core.persistence.models import DecisionRecord
+from repowise.core.persistence.vector_store import InMemoryVectorStore
+from repowise.core.providers.embedding.base import MockEmbedder
+
+
+async def _setup_session() -> tuple[object, AsyncSession]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    await init_db(engine)
+    factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    session = factory()
+    return engine, session
+
+
+async def _insert_repo(session: AsyncSession):
+    from repowise.core.persistence.crud import upsert_repository
+
+    repo = await upsert_repository(
+        session,
+        name="taskq",
+        local_path="/tmp/taskq",
+        url="https://github.com/example/taskq",
+    )
+    await session.commit()
+    return repo
+
+
+async def _insert_page(session: AsyncSession, repo_id: str, page_id: str) -> None:
+    from repowise.core.persistence.crud import upsert_page
+
+    await upsert_page(
+        session,
+        page_id=page_id,
+        repository_id=repo_id,
+        page_type="file_page",
+        title=page_id,
+        content="body",
+        target_path=page_id,
+        source_hash="h",
+        model_name="mock",
+        provider_name="mock",
+        input_tokens=1,
+        output_tokens=1,
+    )
+    await session.commit()
+
+
+async def _insert_decision(session: AsyncSession, repo_id: str, title: str) -> str:
+    rec = DecisionRecord(repository_id=repo_id, title=title, decision="because")
+    session.add(rec)
+    await session.commit()
+    return rec.id
+
+
+@pytest.mark.asyncio
+async def test_decision_vector_ids_returns_namespaced_ids():
+    engine, session = await _setup_session()
+    try:
+        repo = await _insert_repo(session)
+        d1 = await _insert_decision(session, repo.id, "Adopt Redis")
+        d2 = await _insert_decision(session, repo.id, "Use Postgres")
+
+        ids = await _decision_vector_ids(session, repo.id)
+        assert ids == {f"{DECISION_VECTOR_PREFIX}{d1}", f"{DECISION_VECTOR_PREFIX}{d2}"}
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_decisions_not_counted_as_orphans():
+    """Consistent store: pages + decisions both embedded => zero orphan/drift."""
+    engine, session = await _setup_session()
+    try:
+        repo = await _insert_repo(session)
+        await _insert_page(session, repo.id, "file_page:a.py")
+        await _insert_page(session, repo.id, "file_page:b.py")
+        d1 = await _insert_decision(session, repo.id, "Adopt Redis")
+
+        vs = InMemoryVectorStore(MockEmbedder())
+        await vs.embed_and_upsert("file_page:a.py", "a", {})
+        await vs.embed_and_upsert("file_page:b.py", "b", {})
+        await vs.embed_and_upsert(f"{DECISION_VECTOR_PREFIX}{d1}", "redis", {})
+
+        page_ids = {"file_page:a.py", "file_page:b.py"}
+        vector_sql_ids = page_ids | await _decision_vector_ids(session, repo.id)
+        vs_ids = await vs.list_page_ids()
+
+        # This mirrors the doctor reconciliation arithmetic.
+        orphaned = vs_ids - vector_sql_ids
+        missing = vector_sql_ids - vs_ids
+        assert orphaned == set()
+        assert missing == set()
+
+        # Coordinator-style drift: SQL (pages + decisions) vs vector count.
+        adjusted_sql = len(page_ids) + len(await _decision_vector_ids(session, repo.id))
+        drift = abs(adjusted_sql - len(vs_ids)) / max(adjusted_sql, 1)
+        assert drift == 0.0
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_genuine_orphan_still_detected():
+    engine, session = await _setup_session()
+    try:
+        repo = await _insert_repo(session)
+        await _insert_page(session, repo.id, "file_page:a.py")
+        d1 = await _insert_decision(session, repo.id, "Adopt Redis")
+
+        vs = InMemoryVectorStore(MockEmbedder())
+        await vs.embed_and_upsert("file_page:a.py", "a", {})
+        await vs.embed_and_upsert(f"{DECISION_VECTOR_PREFIX}{d1}", "redis", {})
+        # A vector whose id is in neither wiki_pages nor decision_records.
+        await vs.embed_and_upsert("file_page:ghost.py", "ghost", {})
+
+        page_ids = {"file_page:a.py"}
+        vector_sql_ids = page_ids | await _decision_vector_ids(session, repo.id)
+        vs_ids = await vs.list_page_ids()
+
+        orphaned = vs_ids - vector_sql_ids
+        assert orphaned == {"file_page:ghost.py"}
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_repair_deletes_only_genuine_orphan_not_decisions():
+    engine, session = await _setup_session()
+    try:
+        repo = await _insert_repo(session)
+        await _insert_page(session, repo.id, "file_page:a.py")
+        d1 = await _insert_decision(session, repo.id, "Adopt Redis")
+        decision_vid = f"{DECISION_VECTOR_PREFIX}{d1}"
+
+        vs = InMemoryVectorStore(MockEmbedder())
+        await vs.embed_and_upsert("file_page:a.py", "a", {})
+        await vs.embed_and_upsert(decision_vid, "redis", {})
+        await vs.embed_and_upsert("file_page:ghost.py", "ghost", {})
+
+        page_ids = {"file_page:a.py"}
+        vector_sql_ids = page_ids | await _decision_vector_ids(session, repo.id)
+        vs_ids = await vs.list_page_ids()
+        orphaned = vs_ids - vector_sql_ids
+
+        # Repair deletes exactly the orphan set (doctor's --repair loop).
+        for pid in orphaned:
+            await vs.delete(pid)
+
+        surviving = await vs.list_page_ids()
+        assert decision_vid in surviving, "decision embedding must survive repair"
+        assert "file_page:a.py" in surviving
+        assert "file_page:ghost.py" not in surviving
+    finally:
+        await session.close()
+        await engine.dispose()

--- a/tests/unit/cli/test_persist_result_sweep.py
+++ b/tests/unit/cli/test_persist_result_sweep.py
@@ -1,0 +1,227 @@
+"""End-to-end sweep behaviour of the CLI ``persist_result`` path.
+
+The normal single-repo ``repowise init`` persists the INDEX phase
+incrementally during the run, so ``persist_result`` takes the
+``index_persisted_incrementally=True`` branch. Before the fix that branch
+called ``persist_analysis`` + ``persist_generation`` but never swept stale
+structurally-keyed pages (community-N / scc / layer), so they survived every
+re-index forever — and their FTS + vector embeddings leaked with them.
+
+These tests drive ``persist_result`` against a real repo-local SQLite DB with
+a pre-seeded stale ``module_page`` and assert it is swept from the DB, the FTS
+index, and an attached vector store, while the run's current page survives.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+from repowise.cli._repo_session import open_repo_db
+from repowise.cli.commands.init_cmd.persistence import persist_result
+from repowise.core.generation.models import GeneratedPage
+from repowise.core.persistence import FullTextSearch, get_session
+from repowise.core.persistence.models import Page
+from repowise.core.persistence.vector_store.in_memory import InMemoryVectorStore
+from repowise.core.providers.embedding.base import MockEmbedder
+
+
+def _generated_page(page_type: str, target: str) -> GeneratedPage:
+    now = datetime.now(UTC).isoformat()
+    pid = f"{page_type}:{target}"
+    return GeneratedPage(
+        page_id=pid,
+        page_type=page_type,
+        title=target,
+        content=f"content for {target}",
+        source_hash="x" * 64,
+        model_name="mock",
+        provider_name="mock",
+        input_tokens=1,
+        output_tokens=1,
+        cached_tokens=0,
+        generation_level=1,
+        target_path=target,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _result(
+    repo_name: str,
+    generated_pages: list[GeneratedPage],
+    *,
+    vector_store=None,
+    authoritative_page_types: set[str] | None = None,
+) -> SimpleNamespace:
+    """A minimal PipelineResult stand-in for the ``index_done`` branch.
+
+    persist_analysis / persist_generation read these attributes; everything is
+    falsy so they no-op except the page upsert + the sweep.
+    """
+    return SimpleNamespace(
+        repo_name=repo_name,
+        index_persisted_incrementally=True,
+        generated_pages=generated_pages,
+        tech_stack=None,
+        vector_store=vector_store,
+        dead_code_report=None,
+        health_report=None,
+        decision_report=None,
+        git_metadata_list=[],
+        knowledge_graph_result=None,
+        authoritative_page_types=authoritative_page_types or set(),
+    )
+
+
+async def _seed_stale_module_page(repo_path, page_id: str) -> str:
+    """Insert a stale module_page directly and return the repo id."""
+    engine, sf, repo_id = await open_repo_db(repo_path, repo_name="r")
+    try:
+        now = datetime.now(UTC)
+        async with get_session(sf) as session:
+            session.add(
+                Page(
+                    id=page_id,
+                    repository_id=repo_id,
+                    page_type="module_page",
+                    title="stale",
+                    content="stale body",
+                    target_path="community-155",
+                    source_hash="x" * 64,
+                    model_name="mock",
+                    provider_name="mock",
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+    finally:
+        await engine.dispose()
+    return repo_id
+
+
+async def test_persist_result_index_done_sweeps_stale_module_page(tmp_path):
+    """The incremental-index branch must sweep stale structural pages.
+
+    Pre-fix this fails: the ``index_done`` branch never called the sweep, so
+    the pre-seeded ``module_page:community-155`` survived alongside the new
+    ``module_page:community-75``.
+    """
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-155"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    current = _generated_page("module_page", "community-75")
+    await persist_result(_result("r", [current]), repo_path)
+
+    engine, sf, _ = await open_repo_db(repo_path, repo_name="r")
+    try:
+        async with get_session(sf) as session:
+            ids = (
+                (await session.execute(select(Page.id).where(Page.page_type == "module_page")))
+                .scalars()
+                .all()
+            )
+        assert set(ids) == {"module_page:community-75"}
+        assert stale_id not in ids
+    finally:
+        await engine.dispose()
+
+
+async def test_persist_result_index_done_sweeps_fts_and_vector(tmp_path):
+    """Swept ids are removed from FTS + vector store; current ids survive."""
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-155"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    # Seed the FTS index for the stale page through the same engine
+    # persist_result will reuse.
+    engine, _sf, _ = await open_repo_db(repo_path, repo_name="r")
+    fts = FullTextSearch(engine)
+    await fts.ensure_index()
+    await fts.index(stale_id, "stale", "stale body about widgets")
+    await engine.dispose()
+
+    # Seed the vector store with both the stale page and the page the run keeps.
+    store = InMemoryVectorStore(MockEmbedder())
+    current = _generated_page("module_page", "community-75")
+    await store.embed_batch(
+        [
+            (stale_id, "stale body about widgets", {}),
+            (current.page_id, "current body", {}),
+        ]
+    )
+
+    await persist_result(_result("r", [current], vector_store=store), repo_path)
+
+    # Vector store: stale gone, current survives.
+    assert await store.list_page_ids() == {"module_page:community-75"}
+
+    # FTS: the stale page is no longer searchable; the current page is indexed.
+    engine, _sf, _ = await open_repo_db(repo_path, repo_name="r")
+    fts = FullTextSearch(engine)
+    await fts.ensure_index()
+    hits = {r.page_id for r in await fts.search("widgets", limit=10)}
+    assert stale_id not in hits
+    # The run's current page is freshly FTS-indexed (its content mentions its
+    # target_path "community-75").
+    current_hits = {r.page_id for r in await fts.search("community-75", limit=10)}
+    assert current.page_id in current_hits
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_persist_result_index_done_keeps_pages_when_no_module_run(tmp_path):
+    """A run with no module pages must not wipe existing module pages."""
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-1"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    # Run produces only a file_page — module pages are an unproduced type.
+    current = _generated_page("file_page", "src/app.py")
+    await persist_result(_result("r", [current]), repo_path)
+
+    engine, sf, _ = await open_repo_db(repo_path, repo_name="r")
+    try:
+        async with get_session(sf) as session:
+            ids = (await session.execute(select(Page.id))).scalars().all()
+        assert stale_id in ids
+        assert "file_page:src/app.py" in ids
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_persist_result_curated_zero_modules_sweeps_stale(tmp_path):
+    """Live mini-taskq regression through the CLI path.
+
+    A curated run authoritative for ``module_page`` that emitted ZERO module
+    pages (every module collapsed into its layer via wholeLayer) must still
+    sweep the pre-curated ``module_page:community-0``.
+    """
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-0"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    # Run emits only a layer page but is authoritative for module_page too.
+    current = _generated_page("layer_page", "layer:Data")
+    await persist_result(
+        _result("r", [current], authoritative_page_types={"module_page", "layer_page"}),
+        repo_path,
+    )
+
+    engine, sf, _ = await open_repo_db(repo_path, repo_name="r")
+    try:
+        async with get_session(sf) as session:
+            ids = (await session.execute(select(Page.id))).scalars().all()
+        assert stale_id not in ids
+        assert "layer_page:layer:Data" in ids
+    finally:
+        await engine.dispose()

--- a/tests/unit/cli/test_workspace_curated_grouping.py
+++ b/tests/unit/cli/test_workspace_curated_grouping.py
@@ -1,0 +1,91 @@
+"""Tests for curated-grouping wiring in ``repowise workspace add``.
+
+``module_grouping="curated"`` is the default. Doc generation can only engage
+curated module grouping if (a) the KG artifact (``.repowise/knowledge-graph.json``)
+was saved during indexing and (b) the generator is told the ``repo_path`` so it
+can load that artifact. These tests pin both seams so a regression to community
+grouping is caught.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from repowise.cli.commands.workspace_cmd import _generate_docs_for_added_repo
+
+
+def test_do_index_save_idiom_writes_artifact(tmp_path):
+    """The ``_do_index`` save idiom must persist the curated KG artifact.
+
+    ``_do_index`` is a nested closure, so we exercise the exact save call it
+    performs: when the pipeline result carries a ``knowledge_graph_result``,
+    ``save_knowledge_graph_json`` writes ``.repowise/knowledge-graph.json``.
+    """
+    from repowise.cli.state_persistence import save_knowledge_graph_json
+
+    kg = SimpleNamespace(to_dict=lambda: {"nodes": [], "layers": []})
+    result = SimpleNamespace(knowledge_graph_result=kg)
+
+    saved = getattr(result, "knowledge_graph_result", None)
+    assert saved is not None
+    save_knowledge_graph_json(tmp_path, saved)
+
+    assert (tmp_path / ".repowise" / "knowledge-graph.json").is_file()
+
+
+def test_generate_docs_for_added_repo_passes_repo_path(tmp_path):
+    """``generate_all`` must receive ``repo_path`` so the curated KG loads."""
+    repo_path = tmp_path
+
+    generator = MagicMock()
+    generator.generate_all = AsyncMock(return_value=[])
+
+    traverser = MagicMock()
+    traverser.traverse.return_value = []
+    traverser.get_repo_structure.return_value = object()
+
+    fts = MagicMock()
+    fts.ensure_index = AsyncMock()
+    fts.index = AsyncMock()
+
+    engine = MagicMock()
+    engine.dispose = AsyncMock()
+
+    class _SessionCtx:
+        async def __aenter__(self):
+            return MagicMock()
+
+        async def __aexit__(self, *a):
+            return False
+
+    def _fake_get_session(_sf):
+        return _SessionCtx()
+
+    with (
+        patch("repowise.cli.helpers.get_db_url_for_repo", return_value="sqlite://"),
+        patch("repowise.core.generation.PageGenerator", return_value=generator),
+        patch("repowise.core.generation.ContextAssembler"),
+        patch("repowise.core.generation.GenerationConfig"),
+        patch("repowise.core.ingestion.FileTraverser", return_value=traverser),
+        patch("repowise.core.ingestion.ASTParser"),
+        patch("repowise.core.ingestion.GraphBuilder", return_value=MagicMock()),
+        patch("repowise.core.persistence.create_engine", return_value=engine),
+        patch("repowise.core.persistence.create_session_factory", return_value=MagicMock()),
+        patch("repowise.core.persistence.init_db", AsyncMock()),
+        patch("repowise.core.persistence.get_session", _fake_get_session),
+        patch("repowise.core.persistence.upsert_repository", AsyncMock()),
+        patch("repowise.core.persistence.upsert_page_from_generated", AsyncMock()),
+        patch("repowise.core.persistence.FullTextSearch", return_value=fts),
+    ):
+        _generate_docs_for_added_repo(
+            repo_path=repo_path,
+            provider=object(),
+            embedder_name="fake",
+            concurrency=1,
+            reasoning="low",
+            exclude_patterns=[],
+        )
+
+    generator.generate_all.assert_awaited_once()
+    assert generator.generate_all.await_args.kwargs["repo_path"] == repo_path

--- a/tests/unit/generation/test_layer_pages.py
+++ b/tests/unit/generation/test_layer_pages.py
@@ -241,7 +241,8 @@ class TestBuildLevel5Coros:
         run = self._make_run(tmp_path, layers)
         coros = build_level5_coros(run)
         assert len(coros) == 1
-        assert coros[0][0] == "layer_page:layer:Core"
+        # Page keyed by the layer's stable slug id, not its display name.
+        assert coros[0][0] == "layer_page:layer:core"
 
     def test_skips_small_layers(self, tmp_path):
         from repowise.core.generation.page_generator.levels import build_level5_coros
@@ -279,7 +280,7 @@ class TestBuildLevel5Coros:
              "nodeIds": ["file:a.py", "file:b.py", "file:c.py"]},
         ]
         run = self._make_run(tmp_path, layers)
-        run.completed_ids = {"layer_page:layer:Core"}
+        run.completed_ids = {"layer_page:layer:core"}
         coros = build_level5_coros(run)
         assert len(coros) == 0
 
@@ -298,5 +299,50 @@ class TestBuildLevel5Coros:
         coros = build_level5_coros(run)
         assert len(coros) == 2
         page_ids = {c[0] for c in coros}
-        assert "layer_page:layer:Core" in page_ids
-        assert "layer_page:layer:API" in page_ids
+        assert "layer_page:layer:core" in page_ids
+        assert "layer_page:layer:api" in page_ids
+
+    def test_page_key_uses_slug_not_display_name(self, tmp_path):
+        """The page key derives from the stable slug id, never the mutable
+        display name — a layer named "Task Queue Core" with id ``layer:queue``
+        is keyed by ``layer:queue`` so an LLM rename can't churn the key."""
+        from repowise.core.generation.page_generator.levels import build_level5_coros
+
+        layers = [
+            {"id": "layer:queue", "name": "Task Queue Core",
+             "nodeIds": ["file:a.py", "file:b.py", "file:c.py"]},
+        ]
+        run = self._make_run(tmp_path, layers)
+        coros = build_level5_coros(run)
+        assert len(coros) == 1
+        assert coros[0][0] == "layer_page:layer:queue"
+
+
+# ---------------------------------------------------------------------------
+# Slug identity stability under enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestLayerIdStability:
+    def test_enrichment_renames_name_not_id_so_page_key_is_stable(self, tmp_path):
+        """The LLM layer-name enrichment mutates ``name`` only; the slug ``id``
+        — and therefore the layer page key — is unchanged across the rename."""
+        from repowise.core.generation.page_generator.levels import build_level5_coros
+
+        node_ids = ["file:a.py", "file:b.py", "file:c.py"]
+
+        def key_for(name: str) -> str:
+            layers = [{"id": "layer:queue", "name": name, "nodeIds": node_ids}]
+            run = self._make_run(tmp_path, layers)
+            coros = build_level5_coros(run)
+            assert len(coros) == 1
+            return coros[0][0]
+
+        # Heuristic name -> page key.
+        before = key_for("Application")
+        # Enrichment rewrites the display name; id (and key) must not move.
+        after = key_for("Task Queue Core")
+        assert before == after == "layer_page:layer:queue"
+
+    # Reuse the level-5 fixture harness verbatim.
+    _make_run = TestBuildLevel5Coros._make_run

--- a/tests/unit/generation/test_models.py
+++ b/tests/unit/generation/test_models.py
@@ -153,7 +153,7 @@ def test_generation_config_defaults():
     assert config.staleness_threshold_days == 7
     assert config.expiry_threshold_days == 30
     assert config.top_symbol_percentile == 0.20
-    assert config.module_grouping == "community"
+    assert config.module_grouping == "curated"
     assert config.min_module_size == 3
     assert config.large_file_source_pct == 0.4
     assert config.reasoning == "auto"

--- a/tests/unit/generation/test_onboarding.py
+++ b/tests/unit/generation/test_onboarding.py
@@ -610,3 +610,60 @@ def test_subkind_template_renders(subkind_slot: str, ctx_factory: Any) -> None:
     rendered = template.render(ctx=ctx, slot=subkind_slot)
     assert rendered.strip()  # non-empty
     assert "{{" not in rendered  # no unrendered Jinja
+
+
+def test_how_it_works_renders_curated_tour_steps() -> None:
+    """Curated tour steps (target_path + reason, no nodeIds/description) must
+    normalize into the strict template's expected shape — regression for the
+    first docs run against a curated KG ('dict object' has no attribute
+    'nodeIds')."""
+    import dataclasses
+
+    spec = onboarding.get_spec(SLOT_HOW_IT_WORKS)
+    assert spec is not None
+    sig = _signals(
+        files=[_file("src/main.py", is_entry_point=True)],
+        entry_points=["src/main.py"],
+    )
+    curated_steps = (
+        {"order": 1, "target_path": "README.md", "page_type": "repo_overview",
+         "title": "README.md", "depth": 0, "kind": "overview",
+         "reason": "Start here for the end-to-end picture."},
+        {"order": 2, "target_path": "src/main.py", "page_type": "file_page",
+         "title": "main.py", "depth": 1, "kind": "code",
+         "reason": "An entry point — execution and imports fan out from here."},
+    )
+    sig = dataclasses.replace(sig, kg_tour_steps=curated_steps)
+    ctx = spec.build_context(sig)
+    assert ctx is not None
+    # Normalized: description fed from reason, nodeIds synthesized from target_path.
+    assert ctx.kg_tour_steps[0]["description"].startswith("Start here")
+    assert ctx.kg_tour_steps[1]["nodeIds"] == ["file:src/main.py"]
+
+    rendered = _jinja_env().get_template("onboarding/how_it_works.j2").render(ctx=ctx)
+    assert "`src/main.py`" in rendered
+    assert "An entry point" in rendered
+
+
+def test_how_it_works_renders_legacy_tour_steps() -> None:
+    """The pre-curation step shape (nodeIds + description) keeps working."""
+    import dataclasses
+
+    spec = onboarding.get_spec(SLOT_HOW_IT_WORKS)
+    assert spec is not None
+    sig = _signals(
+        files=[_file("src/main.py", is_entry_point=True)],
+        entry_points=["src/main.py"],
+    )
+    legacy_steps = (
+        {"order": 1, "title": "Start Here",
+         "description": "Begin with the entry point.",
+         "nodeIds": ["file:src/main.py"]},
+    )
+    sig = dataclasses.replace(sig, kg_tour_steps=legacy_steps)
+    ctx = spec.build_context(sig)
+    assert ctx is not None
+    assert ctx.kg_tour_steps[0]["description"] == "Begin with the entry point."
+    assert ctx.kg_tour_steps[0]["nodeIds"] == ["file:src/main.py"]
+    rendered = _jinja_env().get_template("onboarding/how_it_works.j2").render(ctx=ctx)
+    assert "`src/main.py`" in rendered

--- a/tests/unit/generation/test_page_generator.py
+++ b/tests/unit/generation/test_page_generator.py
@@ -448,3 +448,154 @@ def test_compute_cache_key_varies_by_language():
     assert gen_en._compute_cache_key("file_page", "x") != gen_ru._compute_cache_key(
         "file_page", "x"
     )
+
+
+async def test_generate_all_uses_in_memory_kg_modules_without_artifact_file():
+    """Curated module pages must come from the IN-MEMORY pipeline modules.
+
+    The knowledge-graph.json artifact is written AFTER generation, so on a
+    fresh init it does not exist when selection runs — relying on the file
+    silently fell back to community grouping (caught live on repowise's own
+    wiki: 20 community-N module pages on a curated run).
+    """
+    config = GenerationConfig(
+        max_tokens=256,
+        token_budget=100_000,
+        max_concurrency=2,
+        module_grouping="curated",
+        min_module_size=2,
+        coverage_pct=1.0,
+        module_page_share=1.0,
+        dedupe_near_clones=False,  # synthetic files are identical by design
+    )
+    provider = MockProvider()
+    assembler = ContextAssembler(config)
+    gen = PageGenerator(provider, assembler, config)
+
+    paths = [f"pkg/core/m{i}.py" for i in range(3)] + [f"pkg/web/w{i}.py" for i in range(3)]
+    parsed = []
+    for p in paths:
+        fi = _make_file_info(p, language="python")
+        sym = _make_symbol(file_path=p)
+        parsed.append(
+            ParsedFile(
+                file_info=fi, symbols=[sym], imports=[], exports=[],
+                docstring=None, parse_errors=[],
+            )
+        )
+    repo = RepoStructure(
+        is_monorepo=False,
+        packages=[],
+        root_language_distribution={"python": 1.0},
+        total_files=len(paths),
+        total_loc=100,
+        entry_points=[],
+    )
+    kg_modules = [
+        {
+            "id": "module:pkg-core",
+            "name": "core",
+            "path": "pkg/core",
+            "layerId": "layer:service",
+            "nodeIds": [f"file:{p}" for p in paths if "/core/" in p],
+            "language": "python",
+        },
+        {
+            "id": "module:pkg-web",
+            "name": "web",
+            "path": "pkg/web",
+            "layerId": "layer:ui",
+            "nodeIds": [f"file:{p}" for p in paths if "/web/" in p],
+            "language": "python",
+        },
+    ]
+
+    builder = _make_builder_with(parsed)
+    # repo_path deliberately omitted → no knowledge-graph.json on disk.
+    pages = await gen.generate_all(
+        parsed,
+        {p: b"pass" for p in paths},
+        builder,
+        repo,
+        "test-repo",
+        kg_modules=kg_modules,
+    )
+
+    module_pages = [p for p in pages if p.page_type == "module_page"]
+    targets = {p.target_path for p in module_pages}
+    assert targets, "no module pages generated"
+    assert targets <= {"pkg/core", "pkg/web"}, targets
+    assert not any(t.startswith("community-") for t in targets)
+
+
+async def test_generate_all_builds_kg_ctx_from_in_memory_kg_data():
+    """Layer pages must generate on a FRESH init via the in-memory KG.
+
+    kg_ctx previously only read knowledge-graph.json, which is written during
+    persistence — after generation — so first-run wikis silently had zero
+    layer pages (caught live: fresh repowise wiki had 37 module pages and no
+    Architecture layers).
+    """
+    config = GenerationConfig(
+        max_tokens=256,
+        token_budget=100_000,
+        max_concurrency=2,
+        coverage_pct=1.0,
+        dedupe_near_clones=False,
+    )
+    provider = MockProvider()
+    assembler = ContextAssembler(config)
+    gen = PageGenerator(provider, assembler, config)
+
+    paths = [f"pkg/core/m{i}.py" for i in range(4)]
+    parsed = []
+    for p in paths:
+        fi = _make_file_info(p, language="python")
+        sym = _make_symbol(file_path=p)
+        parsed.append(
+            ParsedFile(
+                file_info=fi, symbols=[sym], imports=[], exports=[],
+                docstring=None, parse_errors=[],
+            )
+        )
+    repo = RepoStructure(
+        is_monorepo=False,
+        packages=[],
+        root_language_distribution={"python": 1.0},
+        total_files=len(paths),
+        total_loc=100,
+        entry_points=[],
+    )
+    kg_data = {
+        "version": "1.0.0",
+        "project": {"name": "test-repo", "total_files": len(paths), "entry_points": []},
+        "nodes": [
+            {"id": f"file:{p}", "type": "file", "filePath": p, "language": "python"}
+            for p in paths
+        ],
+        "edges": [],
+        "layers": [
+            {
+                "id": "layer:service",
+                "name": "Service",
+                "nodeIds": [f"file:{p}" for p in paths],
+                "display_order": 0,
+            }
+        ],
+        "tour": [],
+    }
+
+    builder = _make_builder_with(parsed)
+    # repo_path deliberately omitted → no knowledge-graph.json on disk.
+    pages = await gen.generate_all(
+        parsed,
+        {p: b"pass" for p in paths},
+        builder,
+        repo,
+        "test-repo",
+        kg_data=kg_data,
+    )
+
+    layer_pages = [p for p in pages if p.page_type == "layer_page"]
+    assert layer_pages, "no layer pages generated from in-memory KG"
+    assert any("Service" in p.title for p in layer_pages)

--- a/tests/unit/generation/test_provenance.py
+++ b/tests/unit/generation/test_provenance.py
@@ -31,6 +31,7 @@ def _ctx(**over):
     base = dict(
         file_path="pkg/foo.py",
         kg_layer_name="",
+        kg_layer_id="",
         kg_layer_role="",
         dependencies=[],
         decision_records=[],
@@ -41,17 +42,28 @@ def _ctx(**over):
 
 def test_layer_metadata_attached():
     page = _page()
-    _attach_file_provenance(page, _ctx(kg_layer_name="Domain", kg_layer_role="entry_point"))
+    _attach_file_provenance(
+        page,
+        _ctx(
+            kg_layer_name="Domain",
+            kg_layer_id="layer:domain",
+            kg_layer_role="entry_point",
+        ),
+    )
     assert page.metadata["layer_name"] == "Domain"
+    # Stable slug id is attached so the UI joins file -> layer page by id.
+    assert page.metadata["layer_id"] == "layer:domain"
     assert page.metadata["layer_role"] == "entry_point"
 
 
 def test_no_kg_layer_falls_back_to_inferred_layer():
     # Every file page must carry a layer_name so the Architecture tree can
-    # group it; with no KG layer it is inferred from the path.
+    # group it; with no KG layer it is inferred from the path, and the
+    # layer_id is the slug of that inferred name.
     page = _page()
     _attach_file_provenance(page, _ctx(file_path="src/api/users.py"))
     assert page.metadata["layer_name"] == "API"
+    assert page.metadata["layer_id"] == "layer:api"
     # No KG role is invented for the fallback path.
     assert "layer_role" not in page.metadata
 

--- a/tests/unit/generation/test_selection_curated_modules.py
+++ b/tests/unit/generation/test_selection_curated_modules.py
@@ -1,0 +1,278 @@
+"""Curated module grouping in the selection layer.
+
+Covers the ``module_grouping="curated"`` source (key = real dir path,
+display = curated name, cohesion = None, Σ-PageRank ranking), every row of
+the fallback matrix, and the golden inertness contract: with the default
+``"community"`` grouping, passing ``kg_modules`` changes NOTHING — the
+ship-dark guarantee that every existing path stays byte-identical.
+"""
+
+from __future__ import annotations
+
+from repowise.core.generation.models import GenerationConfig
+from repowise.core.generation.selection import SelectionInputs, select_pages
+from repowise.core.generation.selection.selector import _build_module_groups
+from tests.unit.generation.test_selection_budget import (
+    FakeFileInfo,
+    FakeParsedFile,
+    FakeSymbol,
+    _build_synthetic_repo,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _repo_with_modules():
+    """A synthetic repo plus a matching curated-modules artifact."""
+    paths = (
+        [f"packages/app/src/core/ingestion/f{i}.py" for i in range(8)]
+        + [f"packages/app/src/core/analysis/f{i}.py" for i in range(6)]
+        + [f"packages/app/src/ui/c4/f{i}.py" for i in range(5)]
+        + ["packages/app/src/ui/tiny/f0.py", "packages/app/src/ui/tiny/f1.py"]
+    )
+    parsed = [
+        FakeParsedFile(file_info=FakeFileInfo(path=p), symbols=[FakeSymbol(name="fn")])
+        for p in paths
+    ]
+    # ui/c4 members carry the highest PageRank so Σ-PageRank must rank that
+    # module first despite it being smaller than core/ingestion.
+    pagerank = {p: (1.0 if "/ui/c4/" in p else 0.1) for p in paths}
+    community = {p: (0 if "/core/" in p else 1) for p in paths}
+
+    modules = [
+        {
+            "id": "module:packages-app-src-core-ingestion",
+            "name": "core/ingestion",
+            "path": "packages/app/src/core/ingestion",
+            "layerId": "layer:service",
+            "nodeIds": [f"file:{p}" for p in paths if "/core/ingestion/" in p],
+            "language": "python",
+        },
+        {
+            "id": "module:packages-app-src-core-analysis",
+            "name": "core/analysis",
+            "path": "packages/app/src/core/analysis",
+            "layerId": "layer:service",
+            "nodeIds": [f"file:{p}" for p in paths if "/core/analysis/" in p],
+            "language": "python",
+        },
+        {
+            "id": "module:packages-app-src-ui-c4",
+            "name": "ui/c4",
+            "path": "packages/app/src/ui/c4",
+            "layerId": "layer:ui",
+            "nodeIds": [f"file:{p}" for p in paths if "/ui/c4/" in p],
+            "language": "python",
+        },
+        {
+            # Below min_module_size=3 → must be skipped, never a page.
+            "id": "module:packages-app-src-ui-tiny",
+            "name": "ui/tiny",
+            "path": "packages/app/src/ui/tiny",
+            "layerId": "layer:ui",
+            "nodeIds": [f"file:{p}" for p in paths if "/ui/tiny/" in p],
+            "language": "python",
+        },
+    ]
+    return parsed, pagerank, community, modules
+
+
+def _inputs(parsed, pagerank, community, *, cfg=None, kg_modules=None):
+    return SelectionInputs(
+        parsed_files=parsed,
+        pagerank=pagerank,
+        betweenness=dict.fromkeys(pagerank, 0.0),
+        community=community,
+        community_info=None,
+        sccs=[],
+        git_meta_map=None,
+        config=cfg or GenerationConfig(),
+        kg_modules=kg_modules,
+    )
+
+
+def _cfg(grouping: str) -> GenerationConfig:
+    return GenerationConfig(module_grouping=grouping)
+
+
+# ---------------------------------------------------------------------------
+# Curated grouping source
+# ---------------------------------------------------------------------------
+
+
+class TestCuratedGrouping:
+    def test_groups_keyed_by_dir_path_with_curated_names(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        by_key = {g.key: g for _, g in groups}
+        assert "packages/app/src/core/ingestion" in by_key
+        g = by_key["packages/app/src/core/ingestion"]
+        assert g.display == "core/ingestion"
+        assert g.label == "core/ingestion"
+        assert g.cohesion is None
+        assert g.language == "python"
+        assert len(g.file_paths) == 8
+
+    def test_ranked_by_sum_pagerank_of_members(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        # ui/c4: 5 x 1.0 = 5.0 beats core/ingestion: 8 x 0.1 = 0.8.
+        assert groups[0][1].display == "ui/c4"
+        scores = [s for s, _ in groups]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_min_module_size_floor_kills_tiny_modules(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        assert "packages/app/src/ui/tiny" not in {g.key for _, g in groups}
+
+    def test_members_restricted_to_parsed_code_files(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        modules[0]["nodeIds"].append("file:packages/app/src/core/ingestion/ghost.py")
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        by_key = {g.key: g for _, g in groups}
+        assert not any(
+            "ghost" in p
+            for p in by_key["packages/app/src/core/ingestion"].file_paths
+        )
+
+    def test_no_community_ids_in_curated_keys(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        assert not any(g.key.startswith("community-") for _, g in groups)
+
+
+# ---------------------------------------------------------------------------
+# Fallback matrix (one test per row)
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackMatrix:
+    def test_curated_without_artifact_falls_back_to_community(self):
+        """curation off / degraded / no KG json → today's community path."""
+        parsed, pr, _bet, comm = _build_synthetic_repo(100)
+        curated_no_artifact = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=None)
+        )
+        community = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("community"))
+        )
+        assert curated_no_artifact == community
+
+    def test_curated_with_all_modules_below_floor_emits_none_not_community(self):
+        """A present-but-filtered artifact must not mix vocabularies."""
+        parsed, pr, comm, modules = _repo_with_modules()
+        tiny_only = [m for m in modules if m["name"] == "ui/tiny"]
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=tiny_only)
+        )
+        assert groups == []
+
+    def test_explicit_community_honored_even_with_artifact(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        with_artifact = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("community"), kg_modules=modules)
+        )
+        without = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("community"))
+        )
+        assert with_artifact == without
+        assert not any(g.key.startswith("packages/") for _, g in with_artifact)
+
+    def test_explicit_top_dir_honored_even_with_artifact(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        with_artifact = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("top_dir"), kg_modules=modules)
+        )
+        without = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("top_dir"))
+        )
+        assert with_artifact == without
+        assert {g.key for _, g in with_artifact} == {"packages"}
+
+
+# ---------------------------------------------------------------------------
+# Golden inertness — the ship-dark contract
+# ---------------------------------------------------------------------------
+
+
+class TestGoldenByteIdentity:
+    def test_community_selection_identical_with_and_without_kg_modules(self):
+        """With the "community" escape hatch, kg_modules must change NOTHING.
+
+        This was the ship-dark rollout guarantee while "community" was the
+        default; post-flip it pins the revert story — setting
+        module_grouping="community" restores the pre-curation selection
+        byte-for-byte regardless of what the KG artifact carries.
+        """
+        parsed, pr, bet, comm = _build_synthetic_repo(300)
+        _, _, _, modules = _repo_with_modules()
+        cfg = GenerationConfig(module_grouping="community")
+
+        def run(kg_modules):
+            return select_pages(
+                SelectionInputs(
+                    parsed_files=parsed,
+                    pagerank=pr,
+                    betweenness=bet,
+                    community=comm,
+                    community_info=None,
+                    sccs=[],
+                    git_meta_map=None,
+                    config=cfg,
+                    kg_modules=kg_modules,
+                )
+            )
+
+        assert run(None) == run(modules)
+
+    def test_curated_selection_is_deterministic(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        cfg = _cfg("curated")
+
+        def run():
+            return select_pages(
+                _inputs(parsed, pr, comm, cfg=cfg, kg_modules=modules)
+            )
+
+        a, b = run(), run()
+        assert a.module_groups == b.module_groups
+        assert a == b
+
+
+class TestWholeLayerDedupe:
+    """Modules 1:1 with a layer never get a module page (layer_page covers them)."""
+
+    def test_whole_layer_module_skipped(self):
+        parsed, pr, comm, modules = _repo_with_modules()
+        modules = [dict(m) for m in modules]
+        modules[0]["wholeLayer"] = True  # core/ingestion now 1:1 with its layer
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        keys = {g.key for _, g in groups}
+        assert "packages/app/src/core/ingestion" not in keys
+        assert "packages/app/src/ui/c4" in keys
+
+    def test_all_whole_layer_yields_no_module_pages_not_community(self):
+        # Flat-lib shape: every module is 1:1 with a layer → zero module
+        # pages, and NO fallback to community grouping (vocabulary stays
+        # curated; the layer pages carry the documentation).
+        parsed, pr, comm, modules = _repo_with_modules()
+        modules = [dict(m, wholeLayer=True) for m in modules]
+        groups = _build_module_groups(
+            _inputs(parsed, pr, comm, cfg=_cfg("curated"), kg_modules=modules)
+        )
+        assert groups == []

--- a/tests/unit/generation/test_wiki_tour_adoption.py
+++ b/tests/unit/generation/test_wiki_tour_adoption.py
@@ -1,0 +1,91 @@
+"""The wiki guided tour adopts the curated KG tour when one exists.
+
+One tour, every surface: when the indexed knowledge graph went through
+curation (marked by ``project.graph_mode``), the page orchestrator must use
+its tour verbatim instead of re-deriving a second, divergent ordering from
+the raw graph. Without a curated KG it falls back to computing the tour.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from repowise.core.generation.kg_context import KnowledgeGraphContext
+from repowise.core.generation.page_generator.orchestrate import _GenerationRun
+
+
+def _write_kg(tmp_path, kg: dict):
+    kg_path = tmp_path / ".repowise" / "knowledge-graph.json"
+    kg_path.parent.mkdir(parents=True, exist_ok=True)
+    kg_path.write_text(json.dumps(kg))
+    return kg_path
+
+
+def _run_stub(kg_ctx) -> SimpleNamespace:
+    """The minimal duck-typed surface _compute_ia touches."""
+    stub = SimpleNamespace(
+        kg_ctx=kg_ctx,
+        tour_stops=[],
+        layer_order=[],
+        parsed_files=[],
+        pagerank={},
+        sel_file_paths=[],
+        sel_infra_paths=[],
+        repo_name="test",
+    )
+    stub._file_import_edges = lambda: []
+    return stub
+
+
+CURATED_TOUR = [
+    {"order": 1, "target_path": "README.md", "page_type": "repo_overview",
+     "title": "README.md", "depth": 0, "kind": "overview",
+     "reason": "Start here for the end-to-end picture before diving into the code.",
+     "layer_id": "layer:app"},
+    {"order": 2, "target_path": "src/main.py", "page_type": "file_page",
+     "title": "main.py", "depth": 1, "kind": "code",
+     "reason": "An entry point — execution and imports fan out from here.",
+     "layer_id": "layer:app"},
+]
+
+
+def test_curated_tour_adopted_verbatim(tmp_path):
+    kg_path = _write_kg(
+        tmp_path,
+        {
+            "project": {"name": "test", "graph_mode": "flow"},
+            "nodes": [], "edges": [], "layers": [],
+            "tour": CURATED_TOUR,
+        },
+    )
+    run = _run_stub(KnowledgeGraphContext(kg_path))
+    _GenerationRun._compute_ia(run)
+    assert [s["target_path"] for s in run.tour_stops] == ["README.md", "src/main.py"]
+    assert run.tour_stops[1]["reason"].startswith("An entry point")
+
+
+def test_uncurated_kg_falls_back_to_computed_tour(tmp_path):
+    # No graph_mode marker: the KG (and its tour, if any) predate curation —
+    # the orchestrator must compute its own tour, not adopt a stale one.
+    kg_path = _write_kg(
+        tmp_path,
+        {
+            "project": {"name": "test"},
+            "nodes": [], "edges": [], "layers": [],
+            "tour": [{"order": 1, "title": "old-style", "description": "x",
+                      "nodeIds": []}],
+        },
+    )
+    run = _run_stub(KnowledgeGraphContext(kg_path))
+    _GenerationRun._compute_ia(run)
+    assert all(s.get("title") != "old-style" for s in run.tour_stops)
+
+
+def test_no_kg_computes_tour(tmp_path):
+    run = _run_stub(KnowledgeGraphContext(None))
+    _GenerationRun._compute_ia(run)
+    # The fallback build_tour ran: with nothing selected it yields just the
+    # overview stop, never an adopted (layer_id-carrying) curated step.
+    assert all("layer_id" not in s for s in run.tour_stops)
+    assert [s["kind"] for s in run.tour_stops] == ["overview"]

--- a/tests/unit/persistence/test_kg_pipeline_persist.py
+++ b/tests/unit/persistence/test_kg_pipeline_persist.py
@@ -1,0 +1,107 @@
+"""persist_generation carries curated KG meta (project entry points, node
+summaries/tags/types) into the DB alongside layers and tour steps."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from repowise.core.persistence.crud import (
+    get_kg_layers,
+    get_kg_node_meta,
+    get_kg_project_meta,
+    get_kg_tour_steps,
+)
+from repowise.core.pipeline.persist import persist_generation
+from tests.unit.persistence.helpers import insert_repo
+
+
+@pytest.fixture
+async def repo(async_session):
+    return await insert_repo(async_session)
+
+
+def _result(**kg_fields) -> SimpleNamespace:
+    defaults: dict = {"project": {}, "nodes": [], "layers": [], "tour": []}
+    kg = SimpleNamespace(**{**defaults, **kg_fields})
+    return SimpleNamespace(generated_pages=None, knowledge_graph_result=kg)
+
+
+async def test_persists_entry_points_from_project(async_session, repo):
+    result = _result(
+        project={
+            "name": "demo",
+            "entry_points": ["src/main.py"],
+            "entry_candidates": ["src/main.py", "src/app.py"],
+        }
+    )
+    await persist_generation(result, async_session, repo.id)
+
+    meta = await get_kg_project_meta(async_session, repo.id)
+    assert meta is not None
+    assert json.loads(meta.entry_points_json) == ["src/main.py"]
+    assert json.loads(meta.entry_candidates_json) == ["src/main.py", "src/app.py"]
+
+
+async def test_persists_file_node_meta_with_prefix_stripped(async_session, repo):
+    result = _result(
+        nodes=[
+            {
+                "id": "file:src/main.py",
+                "type": "file",
+                "summary": "CLI entry point.",
+                "tags": ["entry_point", "python"],
+            },
+            {"id": "file:Dockerfile", "type": "service", "summary": "Container build."},
+            # Non-file nodes (concepts, symbols) are not node-meta material.
+            {"id": "concept:auth", "type": "concept", "summary": "Auth concept."},
+        ]
+    )
+    await persist_generation(result, async_session, repo.id)
+
+    rows = {r.node_id: r for r in await get_kg_node_meta(async_session, repo.id)}
+    assert set(rows) == {"src/main.py", "Dockerfile"}
+    assert rows["src/main.py"].summary == "CLI entry point."
+    assert json.loads(rows["src/main.py"].tags_json) == ["entry_point", "python"]
+    assert rows["Dockerfile"].node_type == "service"
+
+
+async def test_no_curated_meta_writes_nothing(async_session, repo):
+    """Uncurated KG (no entry_points, no nodes) leaves the meta tables empty."""
+    await persist_generation(_result(), async_session, repo.id)
+
+    assert await get_kg_project_meta(async_session, repo.id) is None
+    assert await get_kg_node_meta(async_session, repo.id) == []
+
+
+async def test_layers_and_tour_still_persisted(async_session, repo):
+    """Existing layer/tour persistence is unchanged by the meta additions."""
+    result = _result(
+        layers=[{"id": "layer:cli", "name": "CLI", "nodeIds": ["file:src/main.py"]}],
+        tour=[
+            {
+                "order": 1,
+                "title": "main.py",
+                "target_path": "src/main.py",
+                "kind": "code",
+                "reason": "Top of the stack.",
+                "layer_id": "layer:cli",
+            }
+        ],
+    )
+    await persist_generation(result, async_session, repo.id)
+
+    layers = await get_kg_layers(async_session, repo.id)
+    assert [layer.layer_id for layer in layers] == ["layer:cli"]
+    steps = await get_kg_tour_steps(async_session, repo.id)
+    assert steps[0].target_path == "src/main.py"
+    assert steps[0].layer_id == "layer:cli"
+
+
+async def test_missing_kg_result_is_a_noop(async_session, repo):
+    result = SimpleNamespace(generated_pages=None, knowledge_graph_result=None)
+    await persist_generation(result, async_session, repo.id)
+    assert await get_kg_layers(async_session, repo.id) == []
+    assert await get_kg_project_meta(async_session, repo.id) is None

--- a/tests/unit/persistence/test_persist_sweep_pages.py
+++ b/tests/unit/persistence/test_persist_sweep_pages.py
@@ -1,0 +1,216 @@
+"""Tests for the stale generated-page sweep.
+
+Module/scc pages key on clustering ordinals and layer pages on display
+names — identities that drift between runs. A full run's output is
+authoritative for those page types: anything it did not reproduce is a
+stranded duplicate from an earlier run and must be swept.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from sqlalchemy import select
+
+from repowise.core.persistence.models import Page, PageVersion
+from repowise.core.pipeline.persist import _sweep_stale_generated_pages
+from tests.unit.persistence.helpers import insert_repo
+
+
+def _page_row(repo_id: str, page_type: str, target: str) -> Page:
+    now = datetime.now(UTC)
+    return Page(
+        id=f"{page_type}:{target}",
+        repository_id=repo_id,
+        page_type=page_type,
+        title=target,
+        content="body",
+        target_path=target,
+        source_hash="x" * 64,
+        model_name="mock",
+        provider_name="mock",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _generated(page_type: str, target: str) -> SimpleNamespace:
+    return SimpleNamespace(page_id=f"{page_type}:{target}", page_type=page_type)
+
+
+async def test_sweep_removes_pages_absent_from_run(async_session):
+    repo = await insert_repo(async_session)
+    # Two module pages from a previous run; the new run reproduces only one
+    # (under a fresh community ordinal) — the other is stale.
+    async_session.add(_page_row(repo.id, "module_page", "community-155"))
+    async_session.add(_page_row(repo.id, "module_page", "community-75"))
+    async_session.add(
+        PageVersion(
+            page_id="module_page:community-155",
+            repository_id=repo.id,
+            version=1,
+            page_type="module_page",
+            title="old",
+            content="old body",
+            source_hash="x" * 64,
+            model_name="mock",
+            provider_name="mock",
+            archived_at=datetime.now(UTC),
+        )
+    )
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session, repo.id, [_generated("module_page", "community-75")]
+    )
+    await async_session.commit()
+
+    assert swept == ["module_page:community-155"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert remaining == ["module_page:community-75"]
+    # Versions of the swept page go with it (FK would block the delete).
+    versions = (
+        (
+            await async_session.execute(
+                select(PageVersion).where(PageVersion.repository_id == repo.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert versions == []
+
+
+async def test_sweep_skips_types_the_run_did_not_produce(async_session):
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Data"))
+    await async_session.flush()
+
+    # The run produced layer pages but no module pages (e.g. the module level
+    # was skipped) — module pages must survive.
+    swept = await _sweep_stale_generated_pages(
+        async_session, repo.id, [_generated("layer_page", "layer:Data")]
+    )
+    await async_session.commit()
+
+    assert swept == []
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert set(remaining) == {"module_page:community-1", "layer_page:layer:Data"}
+
+
+async def test_sweep_never_touches_unswept_page_types(async_session):
+    repo = await insert_repo(async_session)
+    # file_page ids are stable paths — never swept here even when absent
+    # from the run's output.
+    async_session.add(_page_row(repo.id, "file_page", "src/app.py"))
+    async_session.add(_page_row(repo.id, "module_page", "community-9"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session, repo.id, [_generated("module_page", "community-10")]
+    )
+    await async_session.commit()
+
+    assert swept == ["module_page:community-9"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert "file_page:src/app.py" in remaining
+
+
+async def test_sweep_noop_on_empty_run(async_session):
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, [])
+    assert swept == []
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, None)
+    assert swept == []
+
+
+async def test_authoritative_type_sweeps_when_zero_produced(async_session):
+    """Regression for the live mini-taskq bug.
+
+    A curated full run derived modules 1:1 with layers (every module
+    ``wholeLayer``-skipped), so it emitted layer pages and ZERO module pages
+    while still being authoritative for ``module_page``. The pre-curated
+    community module page must be swept even though the run produced none.
+    """
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-0"))
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Data"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session,
+        repo.id,
+        [_generated("layer_page", "layer:Data")],
+        {"module_page", "layer_page"},
+    )
+    await async_session.commit()
+
+    assert swept == ["module_page:community-0"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert set(remaining) == {"layer_page:layer:Data"}
+
+
+async def test_degraded_run_does_not_wipe_layer_pages(async_session):
+    """A community-fallback (degraded) run is authoritative for nothing.
+
+    It produces module pages but no layer authority, so pre-existing curated
+    layer pages it cannot reproduce must survive — degradation honesty.
+    """
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Core"))
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session,
+        repo.id,
+        [_generated("module_page", "community-2")],
+        set(),  # degraded: no authority
+    )
+    await async_session.commit()
+
+    # The stale community module page is swept (its type was produced), but the
+    # curated layer page is untouched (not produced, not authoritative). The
+    # produced ``community-2`` page is upserted elsewhere, not by the sweep, so
+    # it is not among the seeded rows here.
+    assert swept == ["module_page:community-1"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert set(remaining) == {"layer_page:layer:Core"}
+
+
+async def test_incremental_no_authority_sweeps_nothing(async_session):
+    """Incremental no-KG run: generated_pages None + empty authority → no-op."""
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Core"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, None, set())
+    assert swept == []
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, None, None)
+    assert swept == []

--- a/tests/unit/server/test_job_executor.py
+++ b/tests/unit/server/test_job_executor.py
@@ -8,13 +8,18 @@ are not re-indexed.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from repowise.core.persistence.crud import upsert_generation_job, upsert_repository
-from repowise.server.job_executor import _repo_exclude_patterns, execute_job
+from repowise.server.job_executor import (
+    _incremental_page_regen,
+    _repo_exclude_patterns,
+    execute_job,
+)
 
 
 def _fake_result() -> SimpleNamespace:
@@ -154,3 +159,68 @@ async def test_execute_job_merges_config_yaml_excludes(session_factory, tmp_path
 
     run_pipeline_mock.assert_awaited_once()
     assert run_pipeline_mock.await_args.kwargs["exclude_patterns"] == ["tools/"]
+
+
+@pytest.mark.asyncio
+async def test_incremental_page_regen_passes_repo_path(tmp_path):
+    """Incremental regen must forward repo_path to generate_all.
+
+    Without it, generate_all can't load the curated knowledge-graph.json
+    artifact and silently falls back to community module grouping, which
+    overwrites curated module pages with the wrong ids.
+    """
+    repo_path = tmp_path
+    repowise_dir = repo_path / ".repowise"
+    repowise_dir.mkdir()
+    (repowise_dir / "state.json").write_text(
+        '{"last_sync_commit": "base-sha"}', encoding="utf-8"
+    )
+
+    result = SimpleNamespace(
+        file_count=10,
+        parsed_files=[],
+        source_map={},
+        graph_builder=SimpleNamespace(graph=lambda: object()),
+        repo_structure=object(),
+        repo_name="test-repo",
+        git_meta_map={},
+    )
+
+    # Stub git HEAD lookup to a sha != base so regen proceeds.
+    head_proc = SimpleNamespace(returncode=0, stdout="head-sha\n")
+
+    # Detector reports one changed/affected file so generation runs.
+    detector = MagicMock()
+    detector.get_changed_files.return_value = [object()]
+    affected = SimpleNamespace(regenerate=["foo.py"])
+    detector.get_affected_pages.return_value = affected
+
+    generator = MagicMock()
+    generator.generate_all = AsyncMock(return_value=[])
+
+    with (
+        patch("subprocess.run", return_value=head_proc),
+        patch(
+            "repowise.core.ingestion.ChangeDetector",
+            return_value=detector,
+        ),
+        patch(
+            "repowise.core.ingestion.change_detector.compute_adaptive_budget",
+            return_value=5,
+        ),
+        patch("repowise.core.generation.PageGenerator", return_value=generator),
+        patch("repowise.core.generation.ContextAssembler"),
+        patch("repowise.core.generation.GenerationConfig"),
+        patch("repowise.core.reasoning.resolve_reasoning", return_value="low"),
+        patch("repowise.core.repo_config.load_repo_config", return_value={}),
+    ):
+        await _incremental_page_regen(
+            Path(repo_path),
+            result,
+            llm_client=object(),
+            job_config={},
+            progress=None,
+        )
+
+    generator.generate_all.assert_awaited_once()
+    assert generator.generate_all.await_args.kwargs["repo_path"] == Path(repo_path)


### PR DESCRIPTION
> ⚠️ **This PR now contains the back half of the generation train** — the sweep (#398), threading (#399), default-flip (#400), and doctor/cost (#403) PRs were stack-merged into this branch. Two behavior changes ship here: the authority-scoped stale-page sweep and the `module_grouping="curated"` default. Individual descriptions follow.

## What

Page selection and generation learn the curated-module vocabulary — **shipped dark**: `module_grouping` stays `"community"` by default in this PR.

- **`generation/selection/selector.py`**: curated module grouping with community fallback — when `module_grouping == "curated"` and curated modules exist, module pages are selected from curated modules (path-shaped ids); otherwise the existing community grouping is used unchanged. In-memory curated modules thread into selection so fresh init doesn't depend on a persisted KG.
- **`page_generator/`** (`levels`, `pertype`, `orchestrate`, `contexts`, `core`): module/layer page keys, layer pages keyed by **stable layer id** (not display name), provenance + `layer_id` carried on generated pages, skip module pages that are 1:1 with a layer page.
- **`generation/models.py`**: `module_grouping: Literal["community", "top_dir", "curated"]` config field (default `"community"` in this PR).
- **`generation/tour.py` consumers**: the wiki guided tour adopts the curated KG tour when present (`onboarding/how_it_works.py` accepts curated tour steps).

## Why

Module pages keyed to curated, path-shaped module ids are stable across re-indexes and humanly navigable. Keying layer pages by slug id instead of display name means an LLM rename doesn't orphan a page. The default flip to `"curated"` is intentionally **not** in this PR — it lands at the end of the train once persistence sweep and all regen paths are wired, so flipping is a one-line change on a fully-plumbed system.

## Behavior change

None by default. The curated path only activates for configs that explicitly opt into `module_grouping="curated"`.

## How it was tested

- Full `pytest tests/unit -q` green — `test_selection_curated_modules.py`, `test_page_generator.py`, `test_layer_pages.py`, `test_provenance.py`, `test_wiki_tour_adoption.py`, `test_onboarding.py`, `test_models.py`.
- `ruff check` clean on touched files (no new findings vs `main`).

---

## What

Stale-page sweep with authority semantics, plus curated-KG persistence at index time:

- **`pipeline/persist.py`**: full runs sweep stale structurally-keyed wiki pages (module/layer/etc. pages whose key no longer exists in the current generation plan). The sweep is scoped by **`authoritative_page_types`** — a run only deletes page types it actually (re)generated, so a partial/augment run can never wipe page families it didn't produce.
- **`pipeline/orchestrator.py`**: computes the authority signal for each run and persists curated KG project + node meta at index time; module-grouping selection consults persisted curated modules when present.
- **`cli/init_cmd/persistence.py`**: the incremental-index init path sweeps stale pages on `index_done` and cleans the paired vector + FTS entries via `delete_many` (vector backends gained this in the earlier vector-store PR).

## Why

Before this, renamed/merged modules left orphan wiki pages (and orphan vectors) behind on every re-index — stale pages accumulated and search kept surfacing them. The authority scoping is the safety core of the sweep semantics: **a run may only delete what it was authoritative for**. Reviewers should focus on `authoritative_page_types` derivation in `orchestrator.py` and the sweep filter in `persist.py` — an over-broad authority set would delete user-visible pages on partial runs.

## Behavior change

Yes — full and incremental index runs now delete stale structurally-keyed pages (and their vector/FTS entries) for page types the run regenerated. Pages from page types not covered by the run are never touched. Manual/augment-only page types are excluded.

## How it was tested

- Full `pytest tests/unit -q` green — `test_persist_sweep_pages.py`, `test_kg_pipeline_persist.py`, `test_persist_result_sweep.py` cover: sweep scoping by authority, vector+FTS pairing, incremental-path sweep, and no-delete on non-authoritative runs.
- `ruff check` clean on touched files (no new findings vs `main`).

---

## What

Threads the curated KG and repo context through every generation entry path:

- **`cli/init_cmd/generation.py`**: fresh init passes the in-memory curated modules (`kg_modules`/`kg_data`) and `repo_path` into generation + cost planning.
- **`cli/update_cmd.py` / `cli/workspace_cmd.py`**: update and workspace regeneration load or thread curated KG context the same way; workspace artifact save included.
- **`cli/state_persistence.py`**: state carrier for the threaded fields.
- **`server/job_executor.py`**: server-side regen jobs get the same threading, plus paired vector+FTS cleanup of swept pages (parity with the CLI path from the sweep PR).

## Why

The curated grouping only behaves identically across entry points if every path hands generation the same KG context. Without this, a fresh init produced curated modules while an update or server-triggered regen silently fell back to community grouping — same repo, different wiki shape depending on which command ran. This PR makes the upcoming default flip safe.

## Behavior change

None by default (`module_grouping` is still `"community"`). For opted-in configs, update/workspace/server regen now produce the same curated grouping as fresh init.

## How it was tested

- Full `pytest tests/unit -q` green — `test_job_executor.py`, `test_workspace_curated_grouping.py`.
- `ruff check` clean on touched files (no new findings vs `main`).

---

## What

One-line flip: `module_grouping` defaults to **`"curated"`** (`generation/models.py`).

## Why

Everything the curated path needs is already on this train's base:

1. persisted KG fields (migration `0031`),
2. the curation engine (modules/layers/tour),
3. curated export + generation context,
4. selection/page generation keyed by curated ids — shipped dark,
5. authority-scoped stale-page sweep (so the regrouping cleans up after itself),
6. KG threading through init / update / workspace / server regen.

Flipping last means this PR is trivially revertable — reverting restores community grouping with zero collateral.

## Behavior change

**Yes — default behavior changes.** The next full index of a repo will:

- group module wiki pages by curated, path-shaped module ids (instead of `community-N`),
- generate layer pages keyed by stable layer slugs,
- sweep the now-stale community-keyed module pages (and their vector/FTS entries) under the sweep's authority rules.

Existing repos converge on the first full re-index. Configs that explicitly set `module_grouping="community"` or `"top_dir"` are unaffected.

## How it was tested

- Full `pytest tests/unit -q` green with the flipped default (suites from earlier PRs in this train exercise the curated path end-to-end).
- `ruff check` clean on the touched file.

---

## What

CLI maintenance and planning improvements, independent of the KG train:

- **`doctor_cmd.py`**: vector-store reconciliation becomes **decision-aware** — decision records live in the page vector store under the `decision:<record_id>` namespace, so the SQL↔vector drift check now treats those vectors as legitimate instead of flagging (or worse, repairing away) every decision embedding. Repair stays conservative: it only removes vectors provably orphaned on both counts.
- **`cost_estimator/`** (`coverage.py`, `plans.py`): cost plans account for curated module estimates when a curated KG is passed; coverage math updated to match.

## Why

`repowise doctor` previously reported false drift on every repo with decision records, and an unlucky `--repair` could delete valid decision vectors. The cost-estimator change keeps `init` cost predictions accurate for both grouping vocabularies.

## Dependencies

Stacks on the page-generation PR (cost plans pass `kg_modules` into `SelectionInputs`). Retarget to `main` once the train ahead merges.

## How it was tested

- Full `pytest tests/unit -q` green — `tests/unit/cli/test_doctor_vector_decisions.py` covers decision-vector recognition and safe-repair behavior.
- `ruff check` clean on touched files (no new findings vs `main`).
