### PR TITLE
fix(persistence): authority-scoped sweep of stale structurally-keyed wiki pages

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -109,6 +109,13 @@ def select_coverage(
     )
     from repowise.cli.coverage_select import interactive_coverage_select
 
+    # Curated modules from the in-memory index result, so the plan/cost
+    # estimate selects the same module set generation will (the artifact
+    # file is not on disk yet during a fresh init).
+    kg_modules = (
+        getattr(getattr(result, "knowledge_graph_result", None), "modules", None) or None
+    )
+
     if sys.stdin.isatty() and coverage_pct is None and not yes:
         options = compute_coverage_options(
             parsed_files=result.parsed_files,
@@ -119,6 +126,7 @@ def select_coverage(
             repo_path=repo_path,
             skip_tests=skip_tests,
             skip_infra=skip_infra,
+            kg_modules=kg_modules,
         )
         chosen = interactive_coverage_select(console, options)
         chosen_pct = chosen.pct
@@ -135,6 +143,7 @@ def select_coverage(
             gen_config_for_plan,
             skip_tests,
             skip_infra,
+            kg_modules=kg_modules,
         )
         est = estimate_cost(
             plans,
@@ -263,6 +272,22 @@ def run_repo_generation(
                 resume=resume,
                 cost_tracker=cost_tracker,
                 generation_config=gen_config,
+                # In-memory curated modules: on a fresh init the
+                # knowledge-graph.json artifact is only written during
+                # persistence, AFTER this generation pass — without this the
+                # kg_ctx file fallback is empty and module selection silently
+                # degrades to community grouping.
+                kg_modules=(
+                    getattr(
+                        getattr(result, "knowledge_graph_result", None), "modules", None
+                    )
+                    or None
+                ),
+                kg_data=(
+                    result.knowledge_graph_result.to_dict()
+                    if getattr(result, "knowledge_graph_result", None) is not None
+                    else None
+                ),
             )
         )
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/persistence.py
@@ -51,6 +51,7 @@ async def persist_result(result: Any, repo_path: Path) -> None:
         persist_analysis,
         persist_generation,
         persist_pipeline_result,
+        sweep_stale_generated_pages,
     )
 
     engine, sf, _repo_id = await open_repo_db(repo_path, repo_name=result.repo_name)
@@ -88,11 +89,26 @@ async def persist_result(result: Any, repo_path: Path) -> None:
                 existing = {}
             existing["tech_stack"] = result.tech_stack
             repo.settings_json = _json.dumps(existing)
+        swept_page_ids: list[str] = []
         if index_done:
             await persist_analysis(result, session, repo.id)
             await persist_generation(result, session, repo.id)
+            # persist_generation has already upserted the current pages, so the
+            # sweep only retires structurally-keyed pages this run did not
+            # reproduce. Without it the incremental-index path (every normal
+            # single-repo init) strands stale community-N / scc / layer pages
+            # forever. A type is swept when the run produced pages of it OR
+            # declared authority over it (curated runs are authoritative for
+            # module/layer pages even when every module page was skipped as
+            # 1:1 with a layer); types that are neither stay protected.
+            swept_page_ids = await sweep_stale_generated_pages(
+                session,
+                repo.id,
+                result.generated_pages,
+                getattr(result, "authoritative_page_types", None),
+            )
         else:
-            await persist_pipeline_result(result, session, repo.id)
+            swept_page_ids = await persist_pipeline_result(result, session, repo.id)
 
         # Record a completed GenerationJob so the web UI can show
         # "last synced" / "last re-indexed" timestamps.
@@ -109,7 +125,24 @@ async def persist_result(result: Any, repo_path: Path) -> None:
         job.started_at = now
         job.finished_at = now
 
-    # FTS indexing is done outside the session to avoid SQLite write conflicts
+        # Drop swept pages from the vector store *before* the SQL session
+        # commits. The vector store is a separate engine/file (pgvector DB,
+        # LanceDB dir, or in-memory) so there is no SQLite write-lock conflict,
+        # and the delete is idempotent. Keeping the SQL commit last as the
+        # durable source of truth means an interrupted run self-heals: the
+        # vector embedding is already gone, the SQL rows follow on commit.
+        if swept_page_ids:
+            store = getattr(result, "vector_store", None)
+            if store is not None:
+                await store.delete_many(swept_page_ids)
+
+    # FTS deletes/indexing run outside the session: the FTS index lives in the
+    # *same* SQLite file as the session, so touching it while the session still
+    # holds a write lock raises "database is locked". The swept-id delete must
+    # therefore stay here (it cannot move ahead of the SQL commit like the
+    # vector delete can); it is idempotent and narrow (orphan FTS rows only).
+    if fts is not None and swept_page_ids:
+        await fts.delete_many(swept_page_ids)
     if fts is not None and result.generated_pages:
         for page in result.generated_pages:
             await fts.index(page.page_id, page.title, page.content)

--- a/packages/cli/src/repowise/cli/commands/update_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd.py
@@ -1180,6 +1180,7 @@ def update_command(
             repo_structure,
             repo_name,
             git_meta_map=git_meta_map,
+            repo_path=repo_path,
         )
     )
 

--- a/packages/cli/src/repowise/cli/commands/workspace_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/workspace_cmd.py
@@ -545,6 +545,17 @@ def _run_index_for_repo(
             await persist_pipeline_result(result, session, repo.id)
 
         await engine.dispose()
+
+        # Save the curated KG artifact so doc generation can load curated
+        # module grouping (matches the `repowise init` idiom in
+        # init_cmd/command.py). Without it, generation falls back to raw
+        # community grouping and emits wrong module pages.
+        from repowise.cli.state_persistence import save_knowledge_graph_json
+
+        kg = getattr(result, "knowledge_graph_result", None)
+        if kg is not None:
+            save_knowledge_graph_json(repo_path, kg)
+
         return result.file_count, result.symbol_count, page_count
 
     try:
@@ -697,6 +708,7 @@ def _generate_docs_for_added_repo(
             graph_builder,
             repo_structure,
             repo_path.name,
+            repo_path=repo_path,
         )
 
         url = get_db_url_for_repo(repo_path)

--- a/packages/cli/src/repowise/cli/state_persistence.py
+++ b/packages/cli/src/repowise/cli/state_persistence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -22,16 +23,33 @@ def build_kg_state(kg: Any) -> dict[str, Any]:
     }
 
 
-def save_knowledge_graph_json(repo_path: Path, kg: Any) -> None:
+def save_knowledge_graph_json(repo_path: Path, kg: Any, *, portable: bool = False) -> None:
     """Write ``.repowise/knowledge-graph.json`` for a KG result.
 
     No-op when the result can't serialize itself (``to_dict`` missing), so
     callers only need to guard against a ``None`` knowledge graph.
+
+    When ``portable`` is set, write the self-contained, self-validated artifact
+    (curated layers + tour + entry points + summaries + a ``meta``/``validation``
+    block) instead of the bare ``to_dict`` output. Hard invariant violations are
+    logged but the artifact is still emitted, with the failures recorded under
+    ``meta.validation`` so a consumer can see them ("repaired, not rejected").
     """
     if not hasattr(kg, "to_dict"):
         return
     import json
 
+    if portable:
+        from repowise.core.analysis.kg_curation import build_portable_kg
+
+        data, validation = build_portable_kg(kg)
+        if not validation.ok:
+            logging.getLogger(__name__).warning(
+                "portable KG failed invariants: %s", "; ".join(validation.errors)
+            )
+    else:
+        data = kg.to_dict()
+
     kg_json_path = repo_path / ".repowise" / "knowledge-graph.json"
     kg_json_path.parent.mkdir(parents=True, exist_ok=True)
-    kg_json_path.write_text(json.dumps(kg.to_dict(), indent=2), encoding="utf-8")
+    kg_json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/packages/core/src/repowise/core/generation/models.py
+++ b/packages/core/src/repowise/core/generation/models.py
@@ -121,7 +121,7 @@ class GenerationConfig:
     # "top_dir" by top-level directory.
     # min_module_size is the floor below which a group doesn't get its own
     # page (its files still appear under file_page).
-    module_grouping: Literal["community", "top_dir", "curated"] = "community"
+    module_grouping: Literal["community", "top_dir", "curated"] = "curated"
     min_module_size: int = 3
     # Phase 3: emit the curated Onboarding collection at level 8. Each
     # subkind defines its own gate; slots whose gates fail are silently

--- a/packages/core/src/repowise/core/pipeline/__init__.py
+++ b/packages/core/src/repowise/core/pipeline/__init__.py
@@ -12,6 +12,9 @@ Usage::
 
 from .orchestrator import PipelineResult, run_generation, run_pipeline
 from .persist import (
+    _sweep_stale_generated_pages as sweep_stale_generated_pages,
+)
+from .persist import (
     persist_analysis,
     persist_generation,
     persist_git,
@@ -35,4 +38,5 @@ __all__ = [
     "rehydrate_graph_builder",
     "run_generation",
     "run_pipeline",
+    "sweep_stale_generated_pages",
 ]

--- a/packages/core/src/repowise/core/pipeline/orchestrator.py
+++ b/packages/core/src/repowise/core/pipeline/orchestrator.py
@@ -136,6 +136,16 @@ class PipelineResult:
     it is already on disk — and writes only analysis + generation. False for
     every non-resume caller, which persist the full result as before."""
 
+    authoritative_page_types: set[str] = field(default_factory=set)
+    """Structural page types this run fully decided — i.e. its emitted set is
+    "exactly these, possibly none". The stale-page sweep retires prior rows of
+    a type when it was produced OR is named here, so a legitimately-empty
+    authoritative type (e.g. every curated module collapsed into its layer via
+    wholeLayer) still wipes the previous run's stragglers. Populated only on a
+    curated run with a real KG; left empty on degraded/community fallback and
+    on incremental no-KG paths, which preserves degradation honesty (a fallback
+    run never wipes curated pages it could not reproduce)."""
+
 
 # ---------------------------------------------------------------------------
 # Pipeline
@@ -525,6 +535,34 @@ async def run_pipeline(
                     f"{len(knowledge_graph_result.layers)} layers",
                 )
         _phase_done(progress, "knowledge_graph.skeleton")
+
+        # ---- KG curation/presentation pass (flagged, default on) ---------
+        # Reshapes only the exported KG (layers/tour/entry-points/summaries);
+        # never touches the AST graph, communities, or centrality. No-op when
+        # REPOWISE_KG_CURATION is set to a falsy value (the raw uncurated
+        # export). Runs in BOTH FAST and STANDARD (before the generate branch).
+        if knowledge_graph_result is not None:
+            from repowise.core.analysis.kg_curation import (
+                curate_knowledge_graph,
+                curation_enabled,
+            )
+
+            try:
+                # In generate mode the summary floor is deferred to run after
+                # the wiki-page backfill (in ``enrich_knowledge_graph``), so
+                # rich page summaries win; FAST mode floors here.
+                will_generate = generate_docs and llm_client is not None
+                knowledge_graph_result = curate_knowledge_graph(
+                    knowledge_graph_result,
+                    parsed_files=parsed_files,
+                    graph_builder=graph_builder,
+                    repo_structure=repo_structure,
+                    community_info=graph_builder.community_info(),
+                    enabled=curation_enabled(),
+                    defer_summary_floor=will_generate,
+                )
+            except (ValueError, KeyError, RuntimeError) as cur_err:
+                logger.error("kg_curation_failed", error=str(cur_err), exc_info=True)
     except (ValueError, KeyError, OSError, RuntimeError) as kg_err:
         logger.error("kg_skeleton_building_failed", error=str(kg_err), exc_info=True)
 
@@ -543,6 +581,10 @@ async def run_pipeline(
 
     # ---- Phase 3: Generation (optional) ------------------------------------
     generated_pages: list[Any] | None = None
+    # Structural page types this run was authoritative for (see
+    # PipelineResult.authoritative_page_types). Stays empty unless curated
+    # generation engaged below.
+    authoritative_page_types: set[str] = set()
     if generate_docs and llm_client is not None:
         if progress:
             progress.on_message("info", "Phase 3: Generation")
@@ -590,7 +632,38 @@ async def run_pipeline(
             decision_report=gen_decision_report,
             external_systems=external_systems,
             on_page_ready=on_page_ready,
+            # In-memory KG — the artifact file is written after generation,
+            # so it cannot carry layers/tour/modules on a fresh init.
+            kg_modules=(
+                knowledge_graph_result.modules or None
+                if knowledge_graph_result is not None
+                else None
+            ),
+            kg_data=(
+                knowledge_graph_result.to_dict()
+                if knowledge_graph_result is not None
+                else None
+            ),
         )
+
+        # Record which structural page types this run authoritatively decided,
+        # so the sweep can retire prior rows of a type even when this run
+        # legitimately emitted zero pages of it. Mirrors the selector's curated
+        # engagement test (_build_curated_module_groups returns None — i.e.
+        # falls back to community — only when kg_modules is empty) so the signal
+        # is set iff the curated grouping actually engaged. On the degraded
+        # community fallback both stay unset, preserving degradation honesty.
+        kg_modules_present = bool(
+            knowledge_graph_result is not None and knowledge_graph_result.modules
+        )
+        kg_layers_present = bool(
+            knowledge_graph_result is not None and knowledge_graph_result.layers
+        )
+        module_grouping = getattr(resolved_generation_config, "module_grouping", "community")
+        if module_grouping == "curated" and kg_modules_present:
+            authoritative_page_types.add("module_page")
+        if kg_layers_present:
+            authoritative_page_types.add("layer_page")
 
     # ---- Knowledge Graph LLM enrichment (layer naming + tour) -----------------
     if knowledge_graph_result is not None and generate_docs and llm_client is not None:
@@ -674,6 +747,7 @@ async def run_pipeline(
         index_persisted_incrementally=(
             resume_controller.index_persisted if resume_controller is not None else False
         ),
+        authoritative_page_types=authoritative_page_types,
     )
 
 

--- a/packages/core/src/repowise/core/pipeline/persist.py
+++ b/packages/core/src/repowise/core/pipeline/persist.py
@@ -216,6 +216,74 @@ async def _prune_stale_file_rows(
     await _delete_stale_by_paths(GitMetadata, GitMetadata.file_path, current_git_file_paths)
 
 
+# Generated page types keyed on run-scoped structure: module/scc pages on
+# clustering ordinals, layer pages on display names. Those keys shift between
+# runs, so re-runs mint fresh page ids and the previous rows linger as
+# duplicates unless swept against the current run's output.
+_SWEPT_GENERATED_PAGE_TYPES = ("module_page", "layer_page", "scc_page")
+
+
+async def _sweep_stale_generated_pages(
+    session: Any,
+    repo_id: str,
+    generated_pages: list[Any] | None,
+    authoritative_page_types: set[str] | None = None,
+) -> list[str]:
+    """Delete structurally-keyed generated pages this run did not produce.
+
+    Sweeps a page type when the run either produced at least one page of it OR
+    declared itself authoritative for it (``authoritative_page_types`` — set by
+    the generation layer when it fully decided the type, even if that decision
+    was "emit none"; e.g. a curated run whose modules all collapsed into their
+    layers via ``wholeLayer``). A type that is neither produced nor authoritative
+    is left untouched, so a skipped/failed/degraded level never wipes the last
+    good set. When authoritative-but-empty, the current set is empty and every
+    prior row of that type is retired. Page versions go with their page (FK
+    enforcement requires it, and a retired structural id never comes back to
+    claim its history). Returns the swept page ids so the caller can drop them
+    from FTS after the session closes (the FTS store must not be touched
+    in-session).
+    """
+    from sqlalchemy import delete, select
+
+    from repowise.core.persistence.models import Page, PageVersion
+
+    produced: dict[str, set[str]] = {}
+    for page in generated_pages or []:
+        produced.setdefault(page.page_type, set()).add(page.page_id)
+    authoritative = authoritative_page_types or set()
+
+    swept: list[str] = []
+    for page_type in _SWEPT_GENERATED_PAGE_TYPES:
+        current = produced.get(page_type)
+        if not current and page_type not in authoritative:
+            continue
+        current = current or set()
+        existing = (
+            (
+                await session.execute(
+                    select(Page.id).where(
+                        Page.repository_id == repo_id, Page.page_type == page_type
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        stale = [pid for pid in existing if pid not in current]
+        for i in range(0, len(stale), _PRUNE_CHUNK):
+            batch = stale[i : i + _PRUNE_CHUNK]
+            await session.execute(delete(PageVersion).where(PageVersion.page_id.in_(batch)))
+            await session.execute(
+                delete(Page).where(Page.repository_id == repo_id, Page.id.in_(batch))
+            )
+        swept.extend(stale)
+
+    if swept:
+        logger.info("stale_generated_pages_swept", repo_id=repo_id, count=len(swept))
+    return swept
+
+
 async def persist_ingestion(result: Any, session: Any, repo_id: str) -> int:
     """Persist ingestion-phase outputs: graph nodes/edges, external systems,
     symbols, and the per-file security scan.
@@ -479,22 +547,45 @@ async def persist_generation(result: Any, session: Any, repo_id: str) -> None:
         for page in result.generated_pages:
             await upsert_page_from_generated(session, page, repo_id)
 
-    # ---- Knowledge graph layers & tour steps --------------------------------
+    # ---- Knowledge graph layers, tour steps & curated meta ------------------
     kg = getattr(result, "knowledge_graph_result", None)
     if kg is not None:
-        from repowise.core.persistence.crud import upsert_kg_layers, upsert_kg_tour_steps
+        from repowise.core.persistence.crud import (
+            file_node_meta_from_kg_nodes,
+            upsert_kg_layers,
+            upsert_kg_node_meta,
+            upsert_kg_project_meta,
+            upsert_kg_tour_steps,
+        )
 
         if hasattr(kg, "layers") and kg.layers:
             await upsert_kg_layers(session, repo_id, kg.layers)
         if hasattr(kg, "tour") and kg.tour:
             await upsert_kg_tour_steps(session, repo_id, kg.tour)
 
+        # Project-level curated meta (ranked entry points from the curation pass).
+        project = getattr(kg, "project", None)
+        if isinstance(project, dict) and project.get("entry_points"):
+            await upsert_kg_project_meta(
+                session,
+                repo_id,
+                entry_points=project["entry_points"],
+                entry_candidates=project.get("entry_candidates", []),
+            )
+
+        # Per-node curated meta (type/summary/tags) for file nodes, stored with
+        # the "file:" prefix stripped so the architecture view can match its
+        # node ids (plain repo-relative paths) directly.
+        file_node_meta = file_node_meta_from_kg_nodes(getattr(kg, "nodes", None) or [])
+        if file_node_meta:
+            await upsert_kg_node_meta(session, repo_id, file_node_meta)
+
 
 async def persist_pipeline_result(
     result: Any,
     session: Any,
     repo_id: str,
-) -> None:
+) -> list[str]:
     """Persist all outputs from a :class:`PipelineResult` into the database.
 
     Thin composition of the four phase-scoped persisters
@@ -511,6 +602,11 @@ async def persist_pipeline_result(
         An active SQLAlchemy ``AsyncSession`` (caller manages commit/rollback).
     repo_id:
         The repository ID to associate all records with.
+
+    Returns
+    -------
+    The page ids of stale generated pages swept by this run. Callers should
+    remove them from the FTS index after the session closes.
 
     Note
     ----
@@ -537,6 +633,17 @@ async def persist_pipeline_result(
     await persist_analysis(result, session, repo_id)
     await persist_generation(result, session, repo_id)
 
+    # Sweep structurally-keyed generated pages (module/layer/scc) that this
+    # run did not reproduce — their ids drift between runs, so without the
+    # sweep every re-index strands the previous set as duplicates. Full runs
+    # only, same rule as _prune_stale_file_rows.
+    swept_page_ids = await _sweep_stale_generated_pages(
+        session,
+        repo_id,
+        result.generated_pages,
+        getattr(result, "authoritative_page_types", None),
+    )
+
     logger.info(
         "pipeline_result_persisted",
         repo_id=repo_id,
@@ -545,3 +652,4 @@ async def persist_pipeline_result(
         symbols=symbol_count,
         git_files=len(result.git_metadata_list),
     )
+    return swept_page_ids

--- a/packages/core/src/repowise/core/pipeline/phases/generation.py
+++ b/packages/core/src/repowise/core/pipeline/phases/generation.py
@@ -40,6 +40,8 @@ async def run_generation(
     external_systems: list[dict] | None = None,
     on_page_ready: Any | None = None,
     prior_pages: dict[str, Any] | None = None,
+    kg_modules: list[dict] | None = None,
+    kg_data: dict | None = None,
 ) -> list[Any]:
     """Run LLM-powered page generation.
 
@@ -137,6 +139,8 @@ async def run_generation(
         decision_report=decision_report,
         external_systems=external_systems,
         on_page_ready=on_page_ready,
+        kg_modules=kg_modules,
+        kg_data=kg_data,
     )
 
     # Onboarding summary — count generated slots and surface which ones

--- a/packages/server/src/repowise/server/job_executor.py
+++ b/packages/server/src/repowise/server/job_executor.py
@@ -311,7 +311,7 @@ async def execute_job(
 
         # ---- Persist results -----------------------------------------------
         async with get_session(session_factory) as session:
-            await persist_pipeline_result(result, session, repo_id)
+            swept_page_ids = await persist_pipeline_result(result, session, repo_id)
 
             # Persist incrementally regenerated pages
             if incremental_pages:
@@ -320,8 +320,22 @@ async def execute_job(
                 for page in incremental_pages:
                     await upsert_page_from_generated(session, page, repo_id)
 
-        # FTS indexing runs after session closes to avoid SQLite write conflicts
+            # Drop swept pages from the vector store *before* the SQL session
+            # commits. The vector store is a separate engine/file (pgvector DB,
+            # LanceDB dir, or in-memory), so there is no SQLite write-lock
+            # conflict and the idempotent delete leaves the durable SQL commit
+            # last: an interrupted run self-heals (embedding already gone, SQL
+            # rows follow on commit).
+            if swept_page_ids and vector_store is not None:
+                await vector_store.delete_many(swept_page_ids)
+
+        # FTS deletes/indexing run after the session closes: the FTS index can
+        # share the SQLite file with the session, so writing it while the
+        # session holds a write lock raises "database is locked". The swept-id
+        # delete is idempotent (orphan FTS rows only) and must stay here.
         all_pages = (result.generated_pages or []) + incremental_pages
+        if fts is not None and swept_page_ids:
+            await fts.delete_many(swept_page_ids)
         if fts is not None and all_pages:
             for page in all_pages:
                 await fts.index(page.page_id, page.title, page.content)
@@ -528,6 +542,7 @@ async def _incremental_page_regen(
             result.repo_structure,
             result.repo_name,
             git_meta_map=result.git_meta_map,
+            repo_path=repo_path,
         )
 
         logger.info("incremental_page_regen_done", pages=len(pages))

--- a/tests/unit/cli/test_persist_result_sweep.py
+++ b/tests/unit/cli/test_persist_result_sweep.py
@@ -1,0 +1,227 @@
+"""End-to-end sweep behaviour of the CLI ``persist_result`` path.
+
+The normal single-repo ``repowise init`` persists the INDEX phase
+incrementally during the run, so ``persist_result`` takes the
+``index_persisted_incrementally=True`` branch. Before the fix that branch
+called ``persist_analysis`` + ``persist_generation`` but never swept stale
+structurally-keyed pages (community-N / scc / layer), so they survived every
+re-index forever — and their FTS + vector embeddings leaked with them.
+
+These tests drive ``persist_result`` against a real repo-local SQLite DB with
+a pre-seeded stale ``module_page`` and assert it is swept from the DB, the FTS
+index, and an attached vector store, while the run's current page survives.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+from repowise.cli._repo_session import open_repo_db
+from repowise.cli.commands.init_cmd.persistence import persist_result
+from repowise.core.generation.models import GeneratedPage
+from repowise.core.persistence import FullTextSearch, get_session
+from repowise.core.persistence.models import Page
+from repowise.core.persistence.vector_store.in_memory import InMemoryVectorStore
+from repowise.core.providers.embedding.base import MockEmbedder
+
+
+def _generated_page(page_type: str, target: str) -> GeneratedPage:
+    now = datetime.now(UTC).isoformat()
+    pid = f"{page_type}:{target}"
+    return GeneratedPage(
+        page_id=pid,
+        page_type=page_type,
+        title=target,
+        content=f"content for {target}",
+        source_hash="x" * 64,
+        model_name="mock",
+        provider_name="mock",
+        input_tokens=1,
+        output_tokens=1,
+        cached_tokens=0,
+        generation_level=1,
+        target_path=target,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _result(
+    repo_name: str,
+    generated_pages: list[GeneratedPage],
+    *,
+    vector_store=None,
+    authoritative_page_types: set[str] | None = None,
+) -> SimpleNamespace:
+    """A minimal PipelineResult stand-in for the ``index_done`` branch.
+
+    persist_analysis / persist_generation read these attributes; everything is
+    falsy so they no-op except the page upsert + the sweep.
+    """
+    return SimpleNamespace(
+        repo_name=repo_name,
+        index_persisted_incrementally=True,
+        generated_pages=generated_pages,
+        tech_stack=None,
+        vector_store=vector_store,
+        dead_code_report=None,
+        health_report=None,
+        decision_report=None,
+        git_metadata_list=[],
+        knowledge_graph_result=None,
+        authoritative_page_types=authoritative_page_types or set(),
+    )
+
+
+async def _seed_stale_module_page(repo_path, page_id: str) -> str:
+    """Insert a stale module_page directly and return the repo id."""
+    engine, sf, repo_id = await open_repo_db(repo_path, repo_name="r")
+    try:
+        now = datetime.now(UTC)
+        async with get_session(sf) as session:
+            session.add(
+                Page(
+                    id=page_id,
+                    repository_id=repo_id,
+                    page_type="module_page",
+                    title="stale",
+                    content="stale body",
+                    target_path="community-155",
+                    source_hash="x" * 64,
+                    model_name="mock",
+                    provider_name="mock",
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+    finally:
+        await engine.dispose()
+    return repo_id
+
+
+async def test_persist_result_index_done_sweeps_stale_module_page(tmp_path):
+    """The incremental-index branch must sweep stale structural pages.
+
+    Pre-fix this fails: the ``index_done`` branch never called the sweep, so
+    the pre-seeded ``module_page:community-155`` survived alongside the new
+    ``module_page:community-75``.
+    """
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-155"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    current = _generated_page("module_page", "community-75")
+    await persist_result(_result("r", [current]), repo_path)
+
+    engine, sf, _ = await open_repo_db(repo_path, repo_name="r")
+    try:
+        async with get_session(sf) as session:
+            ids = (
+                (await session.execute(select(Page.id).where(Page.page_type == "module_page")))
+                .scalars()
+                .all()
+            )
+        assert set(ids) == {"module_page:community-75"}
+        assert stale_id not in ids
+    finally:
+        await engine.dispose()
+
+
+async def test_persist_result_index_done_sweeps_fts_and_vector(tmp_path):
+    """Swept ids are removed from FTS + vector store; current ids survive."""
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-155"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    # Seed the FTS index for the stale page through the same engine
+    # persist_result will reuse.
+    engine, _sf, _ = await open_repo_db(repo_path, repo_name="r")
+    fts = FullTextSearch(engine)
+    await fts.ensure_index()
+    await fts.index(stale_id, "stale", "stale body about widgets")
+    await engine.dispose()
+
+    # Seed the vector store with both the stale page and the page the run keeps.
+    store = InMemoryVectorStore(MockEmbedder())
+    current = _generated_page("module_page", "community-75")
+    await store.embed_batch(
+        [
+            (stale_id, "stale body about widgets", {}),
+            (current.page_id, "current body", {}),
+        ]
+    )
+
+    await persist_result(_result("r", [current], vector_store=store), repo_path)
+
+    # Vector store: stale gone, current survives.
+    assert await store.list_page_ids() == {"module_page:community-75"}
+
+    # FTS: the stale page is no longer searchable; the current page is indexed.
+    engine, _sf, _ = await open_repo_db(repo_path, repo_name="r")
+    fts = FullTextSearch(engine)
+    await fts.ensure_index()
+    hits = {r.page_id for r in await fts.search("widgets", limit=10)}
+    assert stale_id not in hits
+    # The run's current page is freshly FTS-indexed (its content mentions its
+    # target_path "community-75").
+    current_hits = {r.page_id for r in await fts.search("community-75", limit=10)}
+    assert current.page_id in current_hits
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_persist_result_index_done_keeps_pages_when_no_module_run(tmp_path):
+    """A run with no module pages must not wipe existing module pages."""
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-1"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    # Run produces only a file_page — module pages are an unproduced type.
+    current = _generated_page("file_page", "src/app.py")
+    await persist_result(_result("r", [current]), repo_path)
+
+    engine, sf, _ = await open_repo_db(repo_path, repo_name="r")
+    try:
+        async with get_session(sf) as session:
+            ids = (await session.execute(select(Page.id))).scalars().all()
+        assert stale_id in ids
+        assert "file_page:src/app.py" in ids
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_persist_result_curated_zero_modules_sweeps_stale(tmp_path):
+    """Live mini-taskq regression through the CLI path.
+
+    A curated run authoritative for ``module_page`` that emitted ZERO module
+    pages (every module collapsed into its layer via wholeLayer) must still
+    sweep the pre-curated ``module_page:community-0``.
+    """
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    stale_id = "module_page:community-0"
+    await _seed_stale_module_page(repo_path, stale_id)
+
+    # Run emits only a layer page but is authoritative for module_page too.
+    current = _generated_page("layer_page", "layer:Data")
+    await persist_result(
+        _result("r", [current], authoritative_page_types={"module_page", "layer_page"}),
+        repo_path,
+    )
+
+    engine, sf, _ = await open_repo_db(repo_path, repo_name="r")
+    try:
+        async with get_session(sf) as session:
+            ids = (await session.execute(select(Page.id))).scalars().all()
+        assert stale_id not in ids
+        assert "layer_page:layer:Data" in ids
+    finally:
+        await engine.dispose()

--- a/tests/unit/cli/test_workspace_curated_grouping.py
+++ b/tests/unit/cli/test_workspace_curated_grouping.py
@@ -1,0 +1,91 @@
+"""Tests for curated-grouping wiring in ``repowise workspace add``.
+
+``module_grouping="curated"`` is the default. Doc generation can only engage
+curated module grouping if (a) the KG artifact (``.repowise/knowledge-graph.json``)
+was saved during indexing and (b) the generator is told the ``repo_path`` so it
+can load that artifact. These tests pin both seams so a regression to community
+grouping is caught.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from repowise.cli.commands.workspace_cmd import _generate_docs_for_added_repo
+
+
+def test_do_index_save_idiom_writes_artifact(tmp_path):
+    """The ``_do_index`` save idiom must persist the curated KG artifact.
+
+    ``_do_index`` is a nested closure, so we exercise the exact save call it
+    performs: when the pipeline result carries a ``knowledge_graph_result``,
+    ``save_knowledge_graph_json`` writes ``.repowise/knowledge-graph.json``.
+    """
+    from repowise.cli.state_persistence import save_knowledge_graph_json
+
+    kg = SimpleNamespace(to_dict=lambda: {"nodes": [], "layers": []})
+    result = SimpleNamespace(knowledge_graph_result=kg)
+
+    saved = getattr(result, "knowledge_graph_result", None)
+    assert saved is not None
+    save_knowledge_graph_json(tmp_path, saved)
+
+    assert (tmp_path / ".repowise" / "knowledge-graph.json").is_file()
+
+
+def test_generate_docs_for_added_repo_passes_repo_path(tmp_path):
+    """``generate_all`` must receive ``repo_path`` so the curated KG loads."""
+    repo_path = tmp_path
+
+    generator = MagicMock()
+    generator.generate_all = AsyncMock(return_value=[])
+
+    traverser = MagicMock()
+    traverser.traverse.return_value = []
+    traverser.get_repo_structure.return_value = object()
+
+    fts = MagicMock()
+    fts.ensure_index = AsyncMock()
+    fts.index = AsyncMock()
+
+    engine = MagicMock()
+    engine.dispose = AsyncMock()
+
+    class _SessionCtx:
+        async def __aenter__(self):
+            return MagicMock()
+
+        async def __aexit__(self, *a):
+            return False
+
+    def _fake_get_session(_sf):
+        return _SessionCtx()
+
+    with (
+        patch("repowise.cli.helpers.get_db_url_for_repo", return_value="sqlite://"),
+        patch("repowise.core.generation.PageGenerator", return_value=generator),
+        patch("repowise.core.generation.ContextAssembler"),
+        patch("repowise.core.generation.GenerationConfig"),
+        patch("repowise.core.ingestion.FileTraverser", return_value=traverser),
+        patch("repowise.core.ingestion.ASTParser"),
+        patch("repowise.core.ingestion.GraphBuilder", return_value=MagicMock()),
+        patch("repowise.core.persistence.create_engine", return_value=engine),
+        patch("repowise.core.persistence.create_session_factory", return_value=MagicMock()),
+        patch("repowise.core.persistence.init_db", AsyncMock()),
+        patch("repowise.core.persistence.get_session", _fake_get_session),
+        patch("repowise.core.persistence.upsert_repository", AsyncMock()),
+        patch("repowise.core.persistence.upsert_page_from_generated", AsyncMock()),
+        patch("repowise.core.persistence.FullTextSearch", return_value=fts),
+    ):
+        _generate_docs_for_added_repo(
+            repo_path=repo_path,
+            provider=object(),
+            embedder_name="fake",
+            concurrency=1,
+            reasoning="low",
+            exclude_patterns=[],
+        )
+
+    generator.generate_all.assert_awaited_once()
+    assert generator.generate_all.await_args.kwargs["repo_path"] == repo_path

--- a/tests/unit/generation/test_models.py
+++ b/tests/unit/generation/test_models.py
@@ -153,7 +153,7 @@ def test_generation_config_defaults():
     assert config.staleness_threshold_days == 7
     assert config.expiry_threshold_days == 30
     assert config.top_symbol_percentile == 0.20
-    assert config.module_grouping == "community"
+    assert config.module_grouping == "curated"
     assert config.min_module_size == 3
     assert config.large_file_source_pct == 0.4
     assert config.reasoning == "auto"

--- a/tests/unit/persistence/test_kg_pipeline_persist.py
+++ b/tests/unit/persistence/test_kg_pipeline_persist.py
@@ -1,0 +1,107 @@
+"""persist_generation carries curated KG meta (project entry points, node
+summaries/tags/types) into the DB alongside layers and tour steps."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from repowise.core.persistence.crud import (
+    get_kg_layers,
+    get_kg_node_meta,
+    get_kg_project_meta,
+    get_kg_tour_steps,
+)
+from repowise.core.pipeline.persist import persist_generation
+from tests.unit.persistence.helpers import insert_repo
+
+
+@pytest.fixture
+async def repo(async_session):
+    return await insert_repo(async_session)
+
+
+def _result(**kg_fields) -> SimpleNamespace:
+    defaults: dict = {"project": {}, "nodes": [], "layers": [], "tour": []}
+    kg = SimpleNamespace(**{**defaults, **kg_fields})
+    return SimpleNamespace(generated_pages=None, knowledge_graph_result=kg)
+
+
+async def test_persists_entry_points_from_project(async_session, repo):
+    result = _result(
+        project={
+            "name": "demo",
+            "entry_points": ["src/main.py"],
+            "entry_candidates": ["src/main.py", "src/app.py"],
+        }
+    )
+    await persist_generation(result, async_session, repo.id)
+
+    meta = await get_kg_project_meta(async_session, repo.id)
+    assert meta is not None
+    assert json.loads(meta.entry_points_json) == ["src/main.py"]
+    assert json.loads(meta.entry_candidates_json) == ["src/main.py", "src/app.py"]
+
+
+async def test_persists_file_node_meta_with_prefix_stripped(async_session, repo):
+    result = _result(
+        nodes=[
+            {
+                "id": "file:src/main.py",
+                "type": "file",
+                "summary": "CLI entry point.",
+                "tags": ["entry_point", "python"],
+            },
+            {"id": "file:Dockerfile", "type": "service", "summary": "Container build."},
+            # Non-file nodes (concepts, symbols) are not node-meta material.
+            {"id": "concept:auth", "type": "concept", "summary": "Auth concept."},
+        ]
+    )
+    await persist_generation(result, async_session, repo.id)
+
+    rows = {r.node_id: r for r in await get_kg_node_meta(async_session, repo.id)}
+    assert set(rows) == {"src/main.py", "Dockerfile"}
+    assert rows["src/main.py"].summary == "CLI entry point."
+    assert json.loads(rows["src/main.py"].tags_json) == ["entry_point", "python"]
+    assert rows["Dockerfile"].node_type == "service"
+
+
+async def test_no_curated_meta_writes_nothing(async_session, repo):
+    """Uncurated KG (no entry_points, no nodes) leaves the meta tables empty."""
+    await persist_generation(_result(), async_session, repo.id)
+
+    assert await get_kg_project_meta(async_session, repo.id) is None
+    assert await get_kg_node_meta(async_session, repo.id) == []
+
+
+async def test_layers_and_tour_still_persisted(async_session, repo):
+    """Existing layer/tour persistence is unchanged by the meta additions."""
+    result = _result(
+        layers=[{"id": "layer:cli", "name": "CLI", "nodeIds": ["file:src/main.py"]}],
+        tour=[
+            {
+                "order": 1,
+                "title": "main.py",
+                "target_path": "src/main.py",
+                "kind": "code",
+                "reason": "Top of the stack.",
+                "layer_id": "layer:cli",
+            }
+        ],
+    )
+    await persist_generation(result, async_session, repo.id)
+
+    layers = await get_kg_layers(async_session, repo.id)
+    assert [layer.layer_id for layer in layers] == ["layer:cli"]
+    steps = await get_kg_tour_steps(async_session, repo.id)
+    assert steps[0].target_path == "src/main.py"
+    assert steps[0].layer_id == "layer:cli"
+
+
+async def test_missing_kg_result_is_a_noop(async_session, repo):
+    result = SimpleNamespace(generated_pages=None, knowledge_graph_result=None)
+    await persist_generation(result, async_session, repo.id)
+    assert await get_kg_layers(async_session, repo.id) == []
+    assert await get_kg_project_meta(async_session, repo.id) is None

--- a/tests/unit/persistence/test_persist_sweep_pages.py
+++ b/tests/unit/persistence/test_persist_sweep_pages.py
@@ -1,0 +1,216 @@
+"""Tests for the stale generated-page sweep.
+
+Module/scc pages key on clustering ordinals and layer pages on display
+names — identities that drift between runs. A full run's output is
+authoritative for those page types: anything it did not reproduce is a
+stranded duplicate from an earlier run and must be swept.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from sqlalchemy import select
+
+from repowise.core.persistence.models import Page, PageVersion
+from repowise.core.pipeline.persist import _sweep_stale_generated_pages
+from tests.unit.persistence.helpers import insert_repo
+
+
+def _page_row(repo_id: str, page_type: str, target: str) -> Page:
+    now = datetime.now(UTC)
+    return Page(
+        id=f"{page_type}:{target}",
+        repository_id=repo_id,
+        page_type=page_type,
+        title=target,
+        content="body",
+        target_path=target,
+        source_hash="x" * 64,
+        model_name="mock",
+        provider_name="mock",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _generated(page_type: str, target: str) -> SimpleNamespace:
+    return SimpleNamespace(page_id=f"{page_type}:{target}", page_type=page_type)
+
+
+async def test_sweep_removes_pages_absent_from_run(async_session):
+    repo = await insert_repo(async_session)
+    # Two module pages from a previous run; the new run reproduces only one
+    # (under a fresh community ordinal) — the other is stale.
+    async_session.add(_page_row(repo.id, "module_page", "community-155"))
+    async_session.add(_page_row(repo.id, "module_page", "community-75"))
+    async_session.add(
+        PageVersion(
+            page_id="module_page:community-155",
+            repository_id=repo.id,
+            version=1,
+            page_type="module_page",
+            title="old",
+            content="old body",
+            source_hash="x" * 64,
+            model_name="mock",
+            provider_name="mock",
+            archived_at=datetime.now(UTC),
+        )
+    )
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session, repo.id, [_generated("module_page", "community-75")]
+    )
+    await async_session.commit()
+
+    assert swept == ["module_page:community-155"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert remaining == ["module_page:community-75"]
+    # Versions of the swept page go with it (FK would block the delete).
+    versions = (
+        (
+            await async_session.execute(
+                select(PageVersion).where(PageVersion.repository_id == repo.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert versions == []
+
+
+async def test_sweep_skips_types_the_run_did_not_produce(async_session):
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Data"))
+    await async_session.flush()
+
+    # The run produced layer pages but no module pages (e.g. the module level
+    # was skipped) — module pages must survive.
+    swept = await _sweep_stale_generated_pages(
+        async_session, repo.id, [_generated("layer_page", "layer:Data")]
+    )
+    await async_session.commit()
+
+    assert swept == []
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert set(remaining) == {"module_page:community-1", "layer_page:layer:Data"}
+
+
+async def test_sweep_never_touches_unswept_page_types(async_session):
+    repo = await insert_repo(async_session)
+    # file_page ids are stable paths — never swept here even when absent
+    # from the run's output.
+    async_session.add(_page_row(repo.id, "file_page", "src/app.py"))
+    async_session.add(_page_row(repo.id, "module_page", "community-9"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session, repo.id, [_generated("module_page", "community-10")]
+    )
+    await async_session.commit()
+
+    assert swept == ["module_page:community-9"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert "file_page:src/app.py" in remaining
+
+
+async def test_sweep_noop_on_empty_run(async_session):
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, [])
+    assert swept == []
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, None)
+    assert swept == []
+
+
+async def test_authoritative_type_sweeps_when_zero_produced(async_session):
+    """Regression for the live mini-taskq bug.
+
+    A curated full run derived modules 1:1 with layers (every module
+    ``wholeLayer``-skipped), so it emitted layer pages and ZERO module pages
+    while still being authoritative for ``module_page``. The pre-curated
+    community module page must be swept even though the run produced none.
+    """
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-0"))
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Data"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session,
+        repo.id,
+        [_generated("layer_page", "layer:Data")],
+        {"module_page", "layer_page"},
+    )
+    await async_session.commit()
+
+    assert swept == ["module_page:community-0"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert set(remaining) == {"layer_page:layer:Data"}
+
+
+async def test_degraded_run_does_not_wipe_layer_pages(async_session):
+    """A community-fallback (degraded) run is authoritative for nothing.
+
+    It produces module pages but no layer authority, so pre-existing curated
+    layer pages it cannot reproduce must survive — degradation honesty.
+    """
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Core"))
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(
+        async_session,
+        repo.id,
+        [_generated("module_page", "community-2")],
+        set(),  # degraded: no authority
+    )
+    await async_session.commit()
+
+    # The stale community module page is swept (its type was produced), but the
+    # curated layer page is untouched (not produced, not authoritative). The
+    # produced ``community-2`` page is upserted elsewhere, not by the sweep, so
+    # it is not among the seeded rows here.
+    assert swept == ["module_page:community-1"]
+    remaining = (
+        (await async_session.execute(select(Page.id).where(Page.repository_id == repo.id)))
+        .scalars()
+        .all()
+    )
+    assert set(remaining) == {"layer_page:layer:Core"}
+
+
+async def test_incremental_no_authority_sweeps_nothing(async_session):
+    """Incremental no-KG run: generated_pages None + empty authority → no-op."""
+    repo = await insert_repo(async_session)
+    async_session.add(_page_row(repo.id, "module_page", "community-1"))
+    async_session.add(_page_row(repo.id, "layer_page", "layer:Core"))
+    await async_session.flush()
+
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, None, set())
+    assert swept == []
+    swept = await _sweep_stale_generated_pages(async_session, repo.id, None, None)
+    assert swept == []

--- a/tests/unit/server/test_job_executor.py
+++ b/tests/unit/server/test_job_executor.py
@@ -8,13 +8,18 @@ are not re-indexed.
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from repowise.core.persistence.crud import upsert_generation_job, upsert_repository
-from repowise.server.job_executor import _repo_exclude_patterns, execute_job
+from repowise.server.job_executor import (
+    _incremental_page_regen,
+    _repo_exclude_patterns,
+    execute_job,
+)
 
 
 def _fake_result() -> SimpleNamespace:
@@ -154,3 +159,68 @@ async def test_execute_job_merges_config_yaml_excludes(session_factory, tmp_path
 
     run_pipeline_mock.assert_awaited_once()
     assert run_pipeline_mock.await_args.kwargs["exclude_patterns"] == ["tools/"]
+
+
+@pytest.mark.asyncio
+async def test_incremental_page_regen_passes_repo_path(tmp_path):
+    """Incremental regen must forward repo_path to generate_all.
+
+    Without it, generate_all can't load the curated knowledge-graph.json
+    artifact and silently falls back to community module grouping, which
+    overwrites curated module pages with the wrong ids.
+    """
+    repo_path = tmp_path
+    repowise_dir = repo_path / ".repowise"
+    repowise_dir.mkdir()
+    (repowise_dir / "state.json").write_text(
+        '{"last_sync_commit": "base-sha"}', encoding="utf-8"
+    )
+
+    result = SimpleNamespace(
+        file_count=10,
+        parsed_files=[],
+        source_map={},
+        graph_builder=SimpleNamespace(graph=lambda: object()),
+        repo_structure=object(),
+        repo_name="test-repo",
+        git_meta_map={},
+    )
+
+    # Stub git HEAD lookup to a sha != base so regen proceeds.
+    head_proc = SimpleNamespace(returncode=0, stdout="head-sha\n")
+
+    # Detector reports one changed/affected file so generation runs.
+    detector = MagicMock()
+    detector.get_changed_files.return_value = [object()]
+    affected = SimpleNamespace(regenerate=["foo.py"])
+    detector.get_affected_pages.return_value = affected
+
+    generator = MagicMock()
+    generator.generate_all = AsyncMock(return_value=[])
+
+    with (
+        patch("subprocess.run", return_value=head_proc),
+        patch(
+            "repowise.core.ingestion.ChangeDetector",
+            return_value=detector,
+        ),
+        patch(
+            "repowise.core.ingestion.change_detector.compute_adaptive_budget",
+            return_value=5,
+        ),
+        patch("repowise.core.generation.PageGenerator", return_value=generator),
+        patch("repowise.core.generation.ContextAssembler"),
+        patch("repowise.core.generation.GenerationConfig"),
+        patch("repowise.core.reasoning.resolve_reasoning", return_value="low"),
+        patch("repowise.core.repo_config.load_repo_config", return_value={}),
+    ):
+        await _incremental_page_regen(
+            Path(repo_path),
+            result,
+            llm_client=object(),
+            job_config={},
+            progress=None,
+        )
+
+    generator.generate_all.assert_awaited_once()
+    assert generator.generate_all.await_args.kwargs["repo_path"] == Path(repo_path)


### PR DESCRIPTION
## What

Stale-page sweep with authority semantics, plus curated-KG persistence at index time:

- **`pipeline/persist.py`**: full runs sweep stale structurally-keyed wiki pages (module/layer/etc. pages whose key no longer exists in the current generation plan). The sweep is scoped by **`authoritative_page_types`** — a run only deletes page types it actually (re)generated, so a partial/augment run can never wipe page families it didn't produce.
- **`pipeline/orchestrator.py`**: computes the authority signal for each run and persists curated KG project + node meta at index time; module-grouping selection consults persisted curated modules when present.
- **`cli/init_cmd/persistence.py`**: the incremental-index init path sweeps stale pages on `index_done` and cleans the paired vector + FTS entries via `delete_many` (vector backends gained this in the earlier vector-store PR).

## Why

Before this, renamed/merged modules left orphan wiki pages (and orphan vectors) behind on every re-index — stale pages accumulated and search kept surfacing them. The authority scoping is the safety core of the sweep semantics: **a run may only delete what it was authoritative for**. Reviewers should focus on `authoritative_page_types` derivation in `orchestrator.py` and the sweep filter in `persist.py` — an over-broad authority set would delete user-visible pages on partial runs.

## Behavior change

Yes — full and incremental index runs now delete stale structurally-keyed pages (and their vector/FTS entries) for page types the run regenerated. Pages from page types not covered by the run are never touched. Manual/augment-only page types are excluded.

## How it was tested

- Full `pytest tests/unit -q` green — `test_persist_sweep_pages.py`, `test_kg_pipeline_persist.py`, `test_persist_result_sweep.py` cover: sweep scoping by authority, vector+FTS pairing, incremental-path sweep, and no-delete on non-authoritative runs.
- `ruff check` clean on touched files (no new findings vs `main`).
