### PR TITLE
feat(generation)!: curated module grouping becomes the default

### DIFF
--- a/packages/core/src/repowise/core/generation/models.py
+++ b/packages/core/src/repowise/core/generation/models.py
@@ -121,7 +121,7 @@ class GenerationConfig:
     # "top_dir" by top-level directory.
     # min_module_size is the floor below which a group doesn't get its own
     # page (its files still appear under file_page).
-    module_grouping: Literal["community", "top_dir", "curated"] = "community"
+    module_grouping: Literal["community", "top_dir", "curated"] = "curated"
     min_module_size: int = 3
     # Phase 3: emit the curated Onboarding collection at level 8. Each
     # subkind defines its own gate; slots whose gates fail are silently

--- a/tests/unit/generation/test_models.py
+++ b/tests/unit/generation/test_models.py
@@ -153,7 +153,7 @@ def test_generation_config_defaults():
     assert config.staleness_threshold_days == 7
     assert config.expiry_threshold_days == 30
     assert config.top_symbol_percentile == 0.20
-    assert config.module_grouping == "community"
+    assert config.module_grouping == "curated"
     assert config.min_module_size == 3
     assert config.large_file_source_pct == 0.4
     assert config.reasoning == "auto"


### PR DESCRIPTION
## What

One-line flip: `module_grouping` defaults to **`"curated"`** (`generation/models.py`).

## Why

Everything the curated path needs is already on this train's base:

1. persisted KG fields (migration `0031`),
2. the curation engine (modules/layers/tour),
3. curated export + generation context,
4. selection/page generation keyed by curated ids — shipped dark,
5. authority-scoped stale-page sweep (so the regrouping cleans up after itself),
6. KG threading through init / update / workspace / server regen.

Flipping last means this PR is trivially revertable — reverting restores community grouping with zero collateral.

## Behavior change

**Yes — default behavior changes.** The next full index of a repo will:

- group module wiki pages by curated, path-shaped module ids (instead of `community-N`),
- generate layer pages keyed by stable layer slugs,
- sweep the now-stale community-keyed module pages (and their vector/FTS entries) under the sweep's authority rules.

Existing repos converge on the first full re-index. Configs that explicitly set `module_grouping="community"` or `"top_dir"` are unaffected.

## How it was tested

- Full `pytest tests/unit -q` green with the flipped default (suites from earlier PRs in this train exercise the curated path end-to-end).
- `ruff check` clean on the touched file.
