### PR TITLE
feat(server): curated KG on architecture views + community_slice graph API

### DIFF
--- a/packages/server/src/repowise/server/routers/c4.py
+++ b/packages/server/src/repowise/server/routers/c4.py
@@ -22,6 +22,7 @@ from repowise.server.schemas import (
     ArchitectureViewResponse,
     ArchLayerResponse,
     ArchNodeResponse,
+    ArchSubGroupResponse,
     ArchTourStepResponse,
     C4ComponentResponse,
     C4ContainerResponse,
@@ -222,6 +223,11 @@ def _arch_layer(layer: ArchLayer) -> ArchLayerResponse:
         file_count=layer.file_count,
         complexity_distribution=layer.complexity_distribution,
         health_score=layer.health_score,
+        sub_groups=[
+            ArchSubGroupResponse(id=sg.id, name=sg.name, node_ids=sg.node_ids)
+            for sg in layer.sub_groups
+        ],
+        display_order=layer.display_order,
     )
 
 
@@ -270,6 +276,12 @@ def _arch_tour_step(s: ArchTourStep) -> ArchTourStepResponse:
         title=s.title,
         description=s.description,
         node_ids=s.node_ids,
+        target_path=s.target_path,
+        layer_id=s.layer_id,
+        reason=s.reason,
+        depth=s.depth,
+        kind=s.kind,
+        page_type=s.page_type,
     )
 
 
@@ -287,4 +299,6 @@ def _architecture_view_response(view: ArchitectureView) -> ArchitectureViewRespo
         languages=view.languages,
         frameworks=view.frameworks,
         external_systems=[_external(e) for e in view.external_systems],
+        entry_points=view.entry_points,
+        entry_candidates=view.entry_candidates,
     )

--- a/packages/server/src/repowise/server/routers/graph/community.py
+++ b/packages/server/src/repowise/server/routers/graph/community.py
@@ -3,24 +3,42 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from repowise.core.persistence import crud
 from repowise.core.persistence.models import GraphEdge, GraphNode
 from repowise.server.deps import get_db_session
 from repowise.server.mcp_server._graph_utils import community_cohesion, community_label
-from repowise.server.routers.graph._common import with_repo
-from repowise.server.routers.graph.signals import _EMPTY_SIGNALS, _collect_node_signals
+from repowise.server.routers.graph._common import _edge_response, with_repo
+from repowise.server.routers.graph.signals import (
+    _EMPTY_SIGNALS,
+    _collect_node_signals,
+    _node_to_response,
+)
 from repowise.server.schemas import (
     ArchitectureEdgeResponse,
     ArchitectureGraphResponse,
     ArchitectureNodeResponse,
     CommunityDetailResponse,
     CommunityMember,
+    CommunitySliceNodeResponse,
+    CommunitySliceResponse,
     CommunitySummaryItem,
     NeighboringCommunity,
 )
+
+# Cap on slice member nodes. Communities are small relative to the repo, but a
+# few mega-clusters exist; this keeps the blossom payload in the 50-300 target
+# band and the satellite layout responsive.
+_SLICE_MEMBER_CAP = 300
+# Boundary stubs per slice: only the most-connected outside neighbors survive,
+# so a blossom shows its strongest cross-cluster ties instead of a dust cloud.
+_SLICE_BOUNDARY_CAP = 40
+# Chunk size for member-id IN lists. The slice edge filter ORs two IN clauses
+# (source + target) in one statement, so we cap each chunk well under SQLite's
+# 999-parameter limit to leave room for both lists plus the repo_id bind.
+_SLICE_IN_CHUNK = 400
 
 router = APIRouter()
 
@@ -120,6 +138,118 @@ async def architecture_graph(
     ]
 
     return ArchitectureGraphResponse(nodes=arch_nodes, edges=arch_edges)
+
+
+@router.get(
+    "/{repo_id}/communities/{community_id}/slice",
+    response_model=CommunitySliceResponse,
+)
+async def community_slice(
+    repo_id: str,
+    community_id: int,
+    member_limit: int = Query(_SLICE_MEMBER_CAP, ge=1, le=600),
+    session: AsyncSession = Depends(get_db_session),  # noqa: B008
+    _repo: object = Depends(with_repo),
+) -> CommunitySliceResponse:
+    """Return a single community's sub-graph for the constellation blossom.
+
+    Payload = the community's member file nodes, the edges among them, and a
+    thin ring of one-hop *boundary stubs*: neighbor nodes outside the community
+    that share an edge with a member, returned as minimal nodes flagged
+    ``is_boundary=true`` so cross-cluster edges can render without dragging the
+    whole neighbor cluster in. Sized to ~50-300 nodes.
+    """
+    members = await crud.get_community_members(
+        session, repo_id, community_id, node_type="file", limit=member_limit + 1
+    )
+    truncated = len(members) > member_limit
+    if truncated:
+        members = members[:member_limit]
+    member_ids = {m.node_id for m in members}
+
+    # Edges touching any member: among-members stay; member<->outside become
+    # cross-cluster links that pull in a boundary stub for the outside endpoint.
+    # The membership filter is pushed into SQL (source OR target in members) so
+    # we never load the whole repo's edge table into Python; the IN lists are
+    # chunked under SQLite's parameter limit. The Python filter below is kept
+    # as-is for correctness — the SQL only bounds the rows fetched (a
+    # superset-or-equal of what the Python filter keeps).
+    member_id_list = list(member_ids)
+    edge_rows: dict[str, GraphEdge] = {}
+    for start in range(0, len(member_id_list), _SLICE_IN_CHUNK):
+        chunk = member_id_list[start : start + _SLICE_IN_CHUNK]
+        chunk_result = await session.execute(
+            select(GraphEdge).where(
+                GraphEdge.repository_id == repo_id,
+                or_(
+                    GraphEdge.source_node_id.in_(chunk),
+                    GraphEdge.target_node_id.in_(chunk),
+                ),
+            )
+        )
+        # Dedup across chunks: an edge whose endpoints fall in different chunks
+        # matches twice. The PK keeps each edge once.
+        for e in chunk_result.scalars():
+            edge_rows[e.id] = e
+
+    kept_edges: list[GraphEdge] = []
+    boundary_degree: dict[str, int] = {}
+    for e in edge_rows.values():
+        src_in = e.source_node_id in member_ids
+        tgt_in = e.target_node_id in member_ids
+        if not src_in and not tgt_in:
+            continue
+        kept_edges.append(e)
+        if not src_in:
+            boundary_degree[e.source_node_id] = boundary_degree.get(e.source_node_id, 0) + 1
+        if not tgt_in:
+            boundary_degree[e.target_node_id] = boundary_degree.get(e.target_node_id, 0) + 1
+
+    # Cap boundary stubs to the most-connected neighbors: hub communities can
+    # touch thousands of outside files, which would flood the blossom with
+    # dust. Edges to dropped stubs are filtered by the visible_ids pass below.
+    boundary_ids = set(
+        sorted(boundary_degree, key=lambda n: (-boundary_degree[n], n))[:_SLICE_BOUNDARY_CAP]
+    )
+
+    # Resolve boundary stub rows (minimal: just need a node row to render).
+    boundary_nodes: list[GraphNode] = []
+    if boundary_ids:
+        stub_result = await session.execute(
+            select(GraphNode).where(
+                GraphNode.repository_id == repo_id,
+                GraphNode.node_id.in_(boundary_ids),
+            )
+        )
+        boundary_nodes = list(stub_result.scalars().all())
+    resolved_boundary = {n.node_id for n in boundary_nodes}
+
+    # Drop edges whose outside endpoint has no resolvable node (orphan ref).
+    visible_ids = member_ids | resolved_boundary
+    links = [
+        _edge_response(e)
+        for e in kept_edges
+        if e.source_node_id in visible_ids and e.target_node_id in visible_ids
+    ]
+
+    # Member signals only (boundary stubs stay minimal / all-false signals).
+    signals = await _collect_node_signals(session, repo_id, list(member_ids))
+    nodes = [
+        _node_to_response(m, signals.get(m.node_id, _EMPTY_SIGNALS), CommunitySliceNodeResponse)
+        for m in members
+    ]
+    nodes.extend(
+        _node_to_response(n, _EMPTY_SIGNALS, CommunitySliceNodeResponse, is_boundary=True)
+        for n in boundary_nodes
+    )
+
+    return CommunitySliceResponse(
+        nodes=nodes,
+        links=links,
+        community_id=community_id,
+        member_count=len(members),
+        truncated=truncated,
+    )
 
 
 @router.get("/{repo_id}/communities", response_model=list[CommunitySummaryItem])

--- a/packages/server/src/repowise/server/routers/graph/full_graph.py
+++ b/packages/server/src/repowise/server/routers/graph/full_graph.py
@@ -17,8 +17,9 @@ from repowise.server.routers.graph.signals import (
 from repowise.server.schemas import GraphExportResponse, NodeSearchResult
 
 # Cap on full-graph export; above this we return top-N by PageRank with truncated=True.
-# Sized to fit a modern client-side force layout without hitching.
-_FULL_GRAPH_NODE_CAP = 5000
+# Sized to keep the client-side force layout responsive; clients can step the
+# limit up via the truncation banner.
+_FULL_GRAPH_NODE_CAP = 1500
 
 router = APIRouter()
 
@@ -54,8 +55,8 @@ async def export_graph(
     limit: int = Query(
         _FULL_GRAPH_NODE_CAP,
         ge=1,
-        le=100_000,
-        description="Maximum nodes to return (top-N by PageRank). Set very high to fetch all.",
+        le=6000,
+        description="Maximum nodes to return (top-N by PageRank). Stepped up by the client.",
     ),
     session: AsyncSession = Depends(get_db_session),  # noqa: B008
     _repo: object = Depends(with_repo),

--- a/packages/server/src/repowise/server/schemas/__init__.py
+++ b/packages/server/src/repowise/server/schemas/__init__.py
@@ -12,6 +12,7 @@ from .architecture import (
     ArchitectureViewResponse,
     ArchLayerResponse,
     ArchNodeResponse,
+    ArchSubGroupResponse,
     ArchTourStepResponse,
 )
 from .blast_radius import (
@@ -69,6 +70,8 @@ from .graph import (
     ArchitectureEdgeResponse,
     ArchitectureGraphResponse,
     ArchitectureNodeResponse,
+    CommunitySliceNodeResponse,
+    CommunitySliceResponse,
     DeadCodeGraphNodeResponse,
     DeadCodeGraphResponse,
     EgoGraphResponse,
@@ -163,6 +166,7 @@ __all__ = [
     "ArchEdgeResponse",
     "ArchLayerResponse",
     "ArchNodeResponse",
+    "ArchSubGroupResponse",
     "ArchTourStepResponse",
     "ArchitectureEdgeResponse",
     "ArchitectureGraphResponse",
@@ -188,6 +192,8 @@ __all__ = [
     "CommitResponse",
     "CommunityDetailResponse",
     "CommunityMember",
+    "CommunitySliceNodeResponse",
+    "CommunitySliceResponse",
     "CommunitySummaryItem",
     "ConversationResponse",
     "CoordinatorHealthResponse",

--- a/packages/server/src/repowise/server/schemas/architecture.py
+++ b/packages/server/src/repowise/server/schemas/architecture.py
@@ -7,6 +7,12 @@ from pydantic import BaseModel
 from .c4 import C4ExternalSystemResponse
 
 
+class ArchSubGroupResponse(BaseModel):
+    id: str
+    name: str
+    node_ids: list[str]
+
+
 class ArchLayerResponse(BaseModel):
     id: str
     name: str
@@ -15,6 +21,8 @@ class ArchLayerResponse(BaseModel):
     file_count: int
     complexity_distribution: dict[str, int]
     health_score: float | None
+    sub_groups: list[ArchSubGroupResponse] = []
+    display_order: int = 0
 
 
 class ArchNodeResponse(BaseModel):
@@ -57,6 +65,13 @@ class ArchTourStepResponse(BaseModel):
     title: str
     description: str
     node_ids: list[str]
+    # Curated, layer-aware fields (None/empty for legacy LLM tours).
+    target_path: str | None = None
+    layer_id: str | None = None
+    reason: str = ""
+    depth: int | None = None
+    kind: str = ""
+    page_type: str | None = None
 
 
 class ArchitectureViewResponse(BaseModel):
@@ -72,3 +87,6 @@ class ArchitectureViewResponse(BaseModel):
     languages: list[str]
     frameworks: list[str]
     external_systems: list[C4ExternalSystemResponse]
+    # Curated, ranked entry points (repo-relative paths; empty when uncurated).
+    entry_points: list[str] = []
+    entry_candidates: list[str] = []

--- a/packages/server/src/repowise/server/schemas/graph.py
+++ b/packages/server/src/repowise/server/schemas/graph.py
@@ -69,6 +69,23 @@ class ArchitectureGraphResponse(BaseModel):
     edges: list[ArchitectureEdgeResponse]
 
 
+class CommunitySliceNodeResponse(GraphNodeResponse):
+    # True for one-hop neighbor stubs outside the community: rendered tiny/dimmed
+    # so cross-cluster edges can draw, without pulling the whole neighbor cluster in.
+    is_boundary: bool = False
+
+
+class CommunitySliceResponse(BaseModel):
+    # Member nodes of the community plus minimal one-hop boundary stubs.
+    nodes: list[CommunitySliceNodeResponse]
+    # Edges among members, plus member<->boundary edges (cross-cluster links).
+    links: list[GraphEdgeResponse]
+    community_id: int
+    member_count: int
+    # True if members were capped (very large community).
+    truncated: bool = False
+
+
 class EgoGraphResponse(BaseModel):
     nodes: list[GraphNodeResponse]
     links: list[GraphEdgeResponse]

--- a/packages/server/src/repowise/server/services/c4_builder/architecture.py
+++ b/packages/server/src/repowise/server/services/c4_builder/architecture.py
@@ -8,7 +8,8 @@ from bisect import bisect_left
 from collections import defaultdict
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from repowise.core.persistence import (
     ExternalSystem,
@@ -16,9 +17,14 @@ from repowise.core.persistence import (
     GraphNode,
 )
 from repowise.core.persistence.crud import (
+    file_node_meta_from_kg_nodes,
     get_kg_layers,
+    get_kg_node_meta,
+    get_kg_project_meta,
     get_kg_tour_steps,
     upsert_kg_layers,
+    upsert_kg_node_meta,
+    upsert_kg_project_meta,
     upsert_kg_tour_steps,
 )
 from repowise.core.persistence.models import DeadCodeFinding, GitMetadata, Page
@@ -28,35 +34,59 @@ from .models import (
     ArchitectureView,
     ArchLayer,
     ArchNode,
+    ArchSubGroup,
     ArchTourStep,
     ExternalSystemView,
 )
 
 logger = logging.getLogger(__name__)
 
-_ENTRY_POINT_NAMES = frozenset({
-    "main.py", "app.py", "cli.py", "index.ts", "index.js",
-    "index.tsx", "index.jsx", "server.py", "server.ts",
-    "__main__.py", "manage.py",
-})
+_ENTRY_POINT_NAMES = frozenset(
+    {
+        "main.py",
+        "app.py",
+        "cli.py",
+        "index.ts",
+        "index.js",
+        "index.tsx",
+        "index.jsx",
+        "server.py",
+        "server.ts",
+        "__main__.py",
+        "manage.py",
+    }
+)
 
-_SYMBOL_EDGE_TYPES = frozenset({
-    "contains", "defines", "has_method",
-})
+_SYMBOL_EDGE_TYPES = frozenset(
+    {
+        "contains",
+        "defines",
+        "has_method",
+    }
+)
 
 _EXT_MAP = {
-    ".py": "python", ".pyx": "python",
-    ".ts": "typescript", ".tsx": "typescript",
-    ".js": "javascript", ".jsx": "javascript",
-    ".go": "go", ".rs": "rust",
-    ".java": "java", ".kt": "kotlin",
-    ".cs": "csharp", ".rb": "ruby",
-    ".swift": "swift", ".cpp": "cpp", ".c": "c",
+    ".py": "python",
+    ".pyx": "python",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".go": "go",
+    ".rs": "rust",
+    ".java": "java",
+    ".kt": "kotlin",
+    ".cs": "csharp",
+    ".rb": "ruby",
+    ".swift": "swift",
+    ".cpp": "cpp",
+    ".c": "c",
 }
 
 
 async def _external_views(
-    session: AsyncSession, repo_id: str,
+    session: AsyncSession,
+    repo_id: str,
 ) -> list[ExternalSystemView]:
     result = await session.execute(
         select(ExternalSystem).where(ExternalSystem.repository_id == repo_id)
@@ -131,20 +161,42 @@ def _load_knowledge_graph(path: str) -> dict | None:
         return json.load(f)
 
 
+def _sub_groups_from_raw(raw_sub_groups: list[dict] | None, node_ids: set[str]) -> list[dict]:
+    """Map curated subGroups to plain dicts, dropping ids absent from the graph."""
+    groups: list[dict] = []
+    for sg in raw_sub_groups or []:
+        mapped = [nid.removeprefix("file:") for nid in sg.get("nodeIds", sg.get("node_ids", []))]
+        matched = [nid for nid in mapped if nid in node_ids]
+        if matched:
+            groups.append(
+                {
+                    "id": sg.get("id", ""),
+                    "name": sg.get("name", ""),
+                    "node_ids": matched,
+                }
+            )
+    return groups
+
+
 def _layers_from_knowledge_graph(
-    kg: dict, node_ids: set[str],
+    kg: dict,
+    node_ids: set[str],
 ) -> list[dict]:
     layers = []
-    for layer in kg.get("layers", []):
+    for i, layer in enumerate(kg.get("layers", [])):
         raw_ids = layer.get("nodeIds", [])
         mapped = [nid.removeprefix("file:") for nid in raw_ids]
         matched = [nid for nid in mapped if nid in node_ids]
-        layers.append({
-            "id": layer.get("id", ""),
-            "name": layer.get("name", ""),
-            "description": layer.get("description", ""),
-            "node_ids": matched,
-        })
+        layers.append(
+            {
+                "id": layer.get("id", ""),
+                "name": layer.get("name", ""),
+                "description": layer.get("description", ""),
+                "node_ids": matched,
+                "display_order": layer.get("display_order", i),
+                "sub_groups": _sub_groups_from_raw(layer.get("subGroups"), node_ids),
+            }
+        )
     return layers
 
 
@@ -165,12 +217,14 @@ def _layers_from_communities(
         if cid in meta:
             with contextlib.suppress(json.JSONDecodeError, TypeError):
                 cm = json.loads(meta[cid])
-        layers.append({
-            "id": f"layer:community-{cid}",
-            "name": cm.get("name", f"Community {cid}"),
-            "description": cm.get("description", ""),
-            "node_ids": groups[cid],
-        })
+        layers.append(
+            {
+                "id": f"layer:community-{cid}",
+                "name": cm.get("name", f"Community {cid}"),
+                "description": cm.get("description", ""),
+                "node_ids": groups[cid],
+            }
+        )
     return layers
 
 
@@ -195,12 +249,22 @@ def _tour_from_knowledge_graph(kg: dict) -> list[ArchTourStep]:
     steps = []
     for entry in kg.get("tour", []):
         node_ids = [nid.removeprefix("file:") for nid in entry.get("nodeIds", [])]
+        target_path = entry.get("target_path")
+        if not node_ids and target_path:
+            # Curated steps address one file by path, not a nodeIds list.
+            node_ids = [target_path]
         steps.append(
             ArchTourStep(
                 order=entry.get("order", 0),
                 title=entry.get("title", ""),
                 description=entry.get("description", ""),
                 node_ids=node_ids,
+                target_path=target_path,
+                layer_id=entry.get("layer_id"),
+                reason=entry.get("reason", ""),
+                depth=entry.get("depth"),
+                kind=entry.get("kind", ""),
+                page_type=entry.get("page_type"),
             )
         )
     return steps
@@ -208,16 +272,22 @@ def _tour_from_knowledge_graph(kg: dict) -> list[ArchTourStep]:
 
 def _layers_from_db(db_layers: list, node_ids: set[str]) -> list[dict]:
     layers = []
-    for row in db_layers:
+    for i, row in enumerate(db_layers):
         raw_ids = json.loads(row.node_ids_json) if row.node_ids_json else []
         mapped = [nid.removeprefix("file:") for nid in raw_ids]
         matched = [nid for nid in mapped if nid in node_ids]
-        layers.append({
-            "id": row.layer_id,
-            "name": row.name,
-            "description": row.description or "",
-            "node_ids": matched,
-        })
+        raw_sub_groups_json = getattr(row, "sub_groups_json", None)
+        raw_sub_groups = json.loads(raw_sub_groups_json) if raw_sub_groups_json else []
+        layers.append(
+            {
+                "id": row.layer_id,
+                "name": row.name,
+                "description": row.description or "",
+                "node_ids": matched,
+                "display_order": getattr(row, "display_order", i),
+                "sub_groups": _sub_groups_from_raw(raw_sub_groups, node_ids),
+            }
+        )
     return layers
 
 
@@ -226,26 +296,70 @@ def _tour_from_db(db_steps: list) -> list[ArchTourStep]:
     for row in db_steps:
         node_ids = json.loads(row.node_ids_json) if row.node_ids_json else []
         node_ids = [nid.removeprefix("file:") for nid in node_ids]
+        target_path = getattr(row, "target_path", None)
+        if not node_ids and target_path:
+            node_ids = [target_path]
         steps.append(
             ArchTourStep(
                 order=row.step_order,
                 title=row.title,
                 description=row.description or "",
                 node_ids=node_ids,
+                target_path=target_path,
+                layer_id=getattr(row, "layer_id", None),
+                reason=getattr(row, "reason", "") or "",
+                depth=getattr(row, "depth", None),
+                kind=getattr(row, "kind", "") or "",
+                page_type=getattr(row, "page_type", None),
             )
         )
     return steps
 
 
 async def _migrate_kg_file_to_db(
-    session: AsyncSession, repo_id: str, kg: dict,
+    caller_session: AsyncSession,
+    repo_id: str,
+    kg: dict,
 ) -> None:
-    layers = kg.get("layers", [])
-    if layers:
-        await upsert_kg_layers(session, repo_id, layers)
-    tour = kg.get("tour", [])
-    if tour:
-        await upsert_kg_tour_steps(session, repo_id, tour)
+    """Auto-migrate a file-based KG into the DB on first read.
+
+    Runs in its OWN session (a fresh sessionmaker bound to the caller's
+    engine) so a rollback here can never clobber writes that share the
+    request-scoped caller session. The migration is delete-then-insert and
+    carries no concurrency guard, so two concurrent first-readers can race to
+    the unique constraints; we treat an ``IntegrityError`` as "another request
+    migrated first" — the DB now holds the curated rows either way, so we
+    swallow it and let the caller fall back to reading those rows. Any other
+    failure propagates to the caller, which degrades to the file-based KG.
+    """
+    # ``caller_session.bind`` is the AsyncEngine; ``get_bind()`` would hand back
+    # the sync engine, which ``async_sessionmaker`` rejects.
+    migration_factory = async_sessionmaker(
+        caller_session.bind, expire_on_commit=False, class_=AsyncSession
+    )
+    async with migration_factory() as session:
+        try:
+            layers = kg.get("layers", [])
+            if layers:
+                await upsert_kg_layers(session, repo_id, layers)
+            tour = kg.get("tour", [])
+            if tour:
+                await upsert_kg_tour_steps(session, repo_id, tour)
+            project = kg.get("project") or {}
+            if project.get("entry_points"):
+                await upsert_kg_project_meta(
+                    session,
+                    repo_id,
+                    entry_points=project["entry_points"],
+                    entry_candidates=project.get("entry_candidates", []),
+                )
+            node_meta = file_node_meta_from_kg_nodes(kg.get("nodes", []))
+            if node_meta:
+                await upsert_kg_node_meta(session, repo_id, node_meta)
+            await session.commit()
+        except IntegrityError:
+            # Concurrent first-reader already migrated; their rows win.
+            await session.rollback()
 
 
 async def build_architecture_view(
@@ -254,14 +368,22 @@ async def build_architecture_view(
     include_symbols: bool = False,
 ) -> ArchitectureView:
     from . import load_repo
+
     repo = await load_repo(session, repo_id)
 
     empty = ArchitectureView(
         project_name=repo.name if repo else repo_id,
         project_description="",
-        layers=[], nodes=[], edges=[], tour=[],
-        total_files=0, total_symbols=0, total_edges=0,
-        languages=[], frameworks=[], external_systems=[],
+        layers=[],
+        nodes=[],
+        edges=[],
+        tour=[],
+        total_files=0,
+        total_symbols=0,
+        total_edges=0,
+        languages=[],
+        frameworks=[],
+        external_systems=[],
     )
     if repo is None:
         return empty
@@ -279,9 +401,7 @@ async def build_architecture_view(
     file_nodes = [n for n in all_nodes if n.node_type == "file"]
 
     # -- Load edges --
-    edge_result = await session.execute(
-        select(GraphEdge).where(GraphEdge.repository_id == repo_id)
-    )
+    edge_result = await session.execute(select(GraphEdge).where(GraphEdge.repository_id == repo_id))
     all_edges: list[GraphEdge] = list(edge_result.scalars())
 
     in_degree: dict[str, int] = defaultdict(int)
@@ -297,9 +417,7 @@ async def build_architecture_view(
     git_result = await session.execute(
         select(GitMetadata).where(GitMetadata.repository_id == repo_id)
     )
-    git_by_path: dict[str, GitMetadata] = {
-        gm.file_path: gm for gm in git_result.scalars()
-    }
+    git_by_path: dict[str, GitMetadata] = {gm.file_path: gm for gm in git_result.scalars()}
 
     # -- Enrichment: dead code --
     dead_result = await session.execute(
@@ -350,45 +468,60 @@ async def build_architecture_view(
                     kg = _load_knowledge_graph(candidate)
                     break
         if kg and kg.get("layers"):
+            # Migration runs in its own session and commits there; a failure
+            # cannot roll back the caller's session. On failure we degrade to
+            # serving this read from the already-loaded file-based KG.
             try:
                 await _migrate_kg_file_to_db(session, repo_id, kg)
-                await session.flush()
             except Exception:
                 logger.warning("kg_file_to_db_migration_failed", exc_info=True)
-                await session.rollback()
             raw_layers = _layers_from_knowledge_graph(kg, node_id_set)
         elif any(n.community_id and n.community_id > 0 for n in file_nodes):
             raw_layers = _layers_from_communities(file_nodes)
         else:
             raw_layers = _layers_from_directories(file_nodes)
 
+    # -- Curated node meta (type/summary/tags) — file if just loaded, else DB --
+    # node_id -> (node_type, summary, tags)
+    curated_meta: dict[str, tuple[str, str, list[str]]] = {}
+    if kg:
+        for meta in file_node_meta_from_kg_nodes(kg.get("nodes", [])):
+            curated_meta[meta["node_id"]] = (meta["node_type"], meta["summary"], meta["tags"])
+    else:
+        for row in await get_kg_node_meta(session, repo_id):
+            row_tags = json.loads(row.tags_json) if row.tags_json else []
+            curated_meta[row.node_id] = (row.node_type, row.summary, row_tags)
+
     # -- Build ArchNodes --
     arch_nodes: list[ArchNode] = []
     for i, n in enumerate(all_nodes):
         gm = git_by_path.get(n.node_id) or git_by_path.get(n.file_path or "")
         page_summary = _find_page_summary(n.node_id)
+        curated_type, curated_summary, curated_tags = curated_meta.get(n.node_id, ("", "", []))
 
         if n.node_type == "file":
             name = n.node_id.rsplit("/", 1)[-1]
             file_path = n.node_id
             line_range = None
-            summary = page_summary or f"Handles {_top_dir(n.node_id)} logic"
+            summary = curated_summary or page_summary or f"Handles {_top_dir(n.node_id)} logic"
         else:
             name = n.name or n.node_id.rsplit("::", 1)[-1]
             file_path = n.file_path
             line_range = (n.start_line, n.end_line) if n.start_line and n.end_line else None
-            summary = page_summary or ""
+            summary = curated_summary or page_summary or ""
 
         arch_nodes.append(
             ArchNode(
                 id=n.node_id,
-                node_type=n.node_type,
+                node_type=curated_type or n.node_type,
                 name=name,
                 file_path=file_path,
                 line_range=line_range,
                 summary=summary,
-                complexity=_classify_complexity(n.symbol_count, (n.end_line or 0) - (n.start_line or 0)),
-                tags=_tags_for(n.node_id, n.node_type, n.language),
+                complexity=_classify_complexity(
+                    n.symbol_count, (n.end_line or 0) - (n.start_line or 0)
+                ),
+                tags=curated_tags or _tags_for(n.node_id, n.node_type, n.language),
                 language=n.language or None,
                 pagerank=n.pagerank,
                 pagerank_percentile=round(pr_pcts.get(i, 0.0), 1),
@@ -433,10 +566,25 @@ async def build_architecture_view(
     elif kg:
         tour = _tour_from_knowledge_graph(kg)
 
+    # -- Curated entry points (file if just loaded, else DB; empty otherwise) --
+    entry_points: list[str] = []
+    entry_candidates: list[str] = []
+    if kg:
+        project = kg.get("project") or {}
+        entry_points = list(project.get("entry_points", []))
+        entry_candidates = list(project.get("entry_candidates", []))
+    else:
+        project_meta = await get_kg_project_meta(session, repo_id)
+        if project_meta:
+            entry_points = json.loads(project_meta.entry_points_json or "[]")
+            entry_candidates = json.loads(project_meta.entry_candidates_json or "[]")
+    entry_points = [p for p in entry_points if p in node_id_set]
+    entry_candidates = [p for p in entry_candidates if p in node_id_set]
+
     # -- Finalize layers with complexity distribution --
     node_complexity: dict[str, str] = {an.id: an.complexity for an in arch_nodes}
     arch_layers: list[ArchLayer] = []
-    for rl in raw_layers:
+    for idx, rl in enumerate(raw_layers):
         dist: dict[str, int] = {"simple": 0, "moderate": 0, "complex": 0}
         for nid in rl["node_ids"]:
             c = node_complexity.get(nid, "simple")
@@ -450,6 +598,11 @@ async def build_architecture_view(
                 file_count=len(rl["node_ids"]),
                 complexity_distribution=dist,
                 health_score=None,
+                sub_groups=[
+                    ArchSubGroup(id=sg["id"], name=sg["name"], node_ids=sg["node_ids"])
+                    for sg in rl.get("sub_groups", [])
+                ],
+                display_order=rl.get("display_order", idx),
             )
         )
 
@@ -474,4 +627,6 @@ async def build_architecture_view(
         languages=sorted(langs),
         frameworks=sorted(fw_names),
         external_systems=externals,
+        entry_points=entry_points,
+        entry_candidates=entry_candidates,
     )

--- a/packages/server/src/repowise/server/services/c4_builder/mermaid.py
+++ b/packages/server/src/repowise/server/services/c4_builder/mermaid.py
@@ -9,11 +9,23 @@ Mermaid's C4 plugin syntax: https://mermaid.js.org/syntax/c4.html
 from __future__ import annotations
 
 import re
+from collections import defaultdict
 
 from .models import C4L1, C4L2, C4L3, Container, ExternalSystemView
 
-
 _SAFE = re.compile(r"[^a-zA-Z0-9_]")
+
+# Beyond this many external systems the L1/L2 diagram groups them into labelled
+# category boundaries ("Frameworks", "Services & Infrastructure", …) instead of
+# rendering N loose boxes, so the context view stays legible (plan §Phase 5).
+_EXTERNAL_GROUP_THRESHOLD = 8
+_CATEGORY_TITLES: dict[str, str] = {
+    "framework": "Frameworks",
+    "service": "Services & Infrastructure",
+    "tool": "Tools",
+    "library": "Libraries",
+}
+_CATEGORY_ORDER = ("framework", "service", "tool", "library")
 
 
 def _sid(node_id: str) -> str:
@@ -46,13 +58,7 @@ def to_mermaid_l1(view: C4L1) -> str:
         f'"{_q(view.system.description or "System under analysis")}")'
     )
 
-    for ext in view.external_systems:
-        kind = _ext_kind(ext.category)
-        version = f" {ext.version}" if ext.version else ""
-        lines.append(
-            f'    {kind}({_sid(ext.id)}, "{_q(ext.display_name)}", '
-            f'"{_q(ext.ecosystem + version)}")'
-        )
+    lines.extend(_emit_externals(view.external_systems))
 
     if view.relations:
         lines.append("")
@@ -69,8 +75,7 @@ def to_mermaid_l2(view: C4L2, system_name: str) -> str:
         lines.append(_container_line(c, indent="        "))
     lines.append("    }")
 
-    for ext in view.external_systems:
-        lines.append(_external_line(ext))
+    lines.extend(_emit_externals(view.external_systems))
 
     if view.relations:
         lines.append("")
@@ -111,6 +116,33 @@ def _container_line(c: Container, indent: str = "    ") -> str:
         f'{indent}Container({_sid(c.id)}, "{_q(c.name)}", '
         f'"{_q(c.language)}", "{_q(desc)}")'
     )
+
+
+def _emit_externals(externals: list[ExternalSystemView]) -> list[str]:
+    """Render external systems, grouping by category once there are many.
+
+    Below the threshold they stay as flat boxes (today's behaviour). Above it,
+    each non-empty category is wrapped in a labelled ``Boundary`` so the diagram
+    reads as a handful of buckets rather than a wall of dependency boxes.
+    """
+    if len(externals) <= _EXTERNAL_GROUP_THRESHOLD:
+        return [_external_line(ext) for ext in externals]
+
+    by_cat: dict[str, list[ExternalSystemView]] = defaultdict(list)
+    for ext in externals:
+        by_cat[ext.category].append(ext)
+
+    ordered = [c for c in _CATEGORY_ORDER if c in by_cat]
+    ordered += sorted(c for c in by_cat if c not in _CATEGORY_ORDER)
+
+    lines: list[str] = []
+    for cat in ordered:
+        title = _CATEGORY_TITLES.get(cat, f"{cat.title()}s")
+        lines.append(f'    Boundary(extgrp_{_sid(cat)}, "{_q(title)}") {{')
+        for ext in sorted(by_cat[cat], key=lambda e: e.name):
+            lines.append("    " + _external_line(ext))
+        lines.append("    }")
+    return lines
 
 
 def _external_line(ext: ExternalSystemView) -> str:

--- a/packages/server/src/repowise/server/services/c4_builder/models.py
+++ b/packages/server/src/repowise/server/services/c4_builder/models.py
@@ -111,6 +111,16 @@ class C4L3:
 
 
 @dataclass(frozen=True)
+class ArchSubGroup:
+    """A curated sub-group inside a layer (drill-down tier between layer
+    cards and file cards). Produced by the KG curation pass."""
+
+    id: str
+    name: str
+    node_ids: list[str]
+
+
+@dataclass(frozen=True)
 class ArchLayer:
     id: str
     name: str
@@ -119,6 +129,8 @@ class ArchLayer:
     file_count: int
     complexity_distribution: dict[str, int]
     health_score: float | None
+    sub_groups: list[ArchSubGroup] = field(default_factory=list)
+    display_order: int = 0
 
 
 @dataclass(frozen=True)
@@ -164,6 +176,13 @@ class ArchTourStep:
     title: str
     description: str
     node_ids: list[str]
+    # Curated, layer-aware fields (None/empty for legacy LLM tours).
+    target_path: str | None = None
+    layer_id: str | None = None
+    reason: str = ""
+    depth: int | None = None
+    kind: str = ""
+    page_type: str | None = None
 
 
 @dataclass(frozen=True)
@@ -180,3 +199,6 @@ class ArchitectureView:
     languages: list[str]
     frameworks: list[str]
     external_systems: list[ExternalSystemView]
+    # Curated, ranked entry points (repo-relative paths; empty when uncurated).
+    entry_points: list[str] = field(default_factory=list)
+    entry_candidates: list[str] = field(default_factory=list)

--- a/tests/unit/server/services/test_c4_curation.py
+++ b/tests/unit/server/services/test_c4_curation.py
@@ -1,0 +1,404 @@
+"""C4 legibility: curated KG layers feed the architecture view, and the L1/L2
+Mermaid groups externals by category once there are many (plan §Phase 5).
+
+Also pins the Phase-A data contract of the viewer plan: every curated field
+(sub-groups, layer-aware tour, entry points, node summaries/tags/types)
+survives JSON → DB → builder with zero loss, and uncurated repos behave
+exactly as before."""
+
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from repowise.core.persistence import (
+    batch_upsert_graph_nodes,
+    upsert_repository,
+)
+from repowise.server.services.c4_builder.architecture import (
+    _layers_from_db,
+    _layers_from_knowledge_graph,
+    _migrate_kg_file_to_db,
+    _tour_from_knowledge_graph,
+    build_architecture_view,
+)
+from repowise.server.services.c4_builder.mermaid import to_mermaid_l1
+from repowise.server.services.c4_builder.models import (
+    C4L1,
+    ExternalSystemView,
+    Person,
+    Relation,
+    System,
+)
+
+# ---------------------------------------------------------------------------
+# Curated layers flow through the architecture cascade (tier 2: KG file)
+# ---------------------------------------------------------------------------
+
+
+def test_architecture_view_consumes_curated_layers():
+    kg = {
+        "layers": [
+            {
+                "id": "layer:ui",
+                "name": "UI",
+                "description": "front end",
+                "nodeIds": ["file:src/ui/a.tsx", "file:src/ui/b.tsx"],
+            },
+            {
+                "id": "layer:service",
+                "name": "Service",
+                "description": "core",
+                "nodeIds": ["file:src/core/x.py"],
+            },
+        ]
+    }
+    node_ids = {"src/ui/a.tsx", "src/ui/b.tsx", "src/core/x.py"}
+    layers = _layers_from_knowledge_graph(kg, node_ids)
+
+    # Curated names/ids/order preserved — not community-N / cluster-N.
+    assert [layer["name"] for layer in layers] == ["UI", "Service"]
+    assert [layer["id"] for layer in layers] == ["layer:ui", "layer:service"]
+    assert layers[0]["node_ids"] == ["src/ui/a.tsx", "src/ui/b.tsx"]
+
+
+def test_layers_carry_sub_groups_and_display_order():
+    kg = {
+        "layers": [
+            {
+                "id": "layer:ui",
+                "name": "UI",
+                "nodeIds": ["file:src/ui/a.tsx", "file:src/ui/b.tsx"],
+                "display_order": 3,
+                "subGroups": [
+                    {"id": "layer:ui:forms", "name": "forms", "nodeIds": ["file:src/ui/a.tsx"]},
+                    {"id": "layer:ui:gone", "name": "gone", "nodeIds": ["file:src/ui/zz.tsx"]},
+                ],
+            },
+        ]
+    }
+    layers = _layers_from_knowledge_graph(kg, {"src/ui/a.tsx", "src/ui/b.tsx"})
+
+    assert layers[0]["display_order"] == 3
+    # Sub-group node ids are prefix-stripped; groups with no surviving nodes drop.
+    assert layers[0]["sub_groups"] == [
+        {"id": "layer:ui:forms", "name": "forms", "node_ids": ["src/ui/a.tsx"]},
+    ]
+
+
+def test_layers_from_db_tolerate_pre_migration_rows():
+    """Rows from a DB created before migration 0030 lack the new columns."""
+    row = SimpleNamespace(
+        layer_id="layer:ui",
+        name="UI",
+        description="",
+        node_ids_json=json.dumps(["file:src/ui/a.tsx"]),
+    )
+    layers = _layers_from_db([row], {"src/ui/a.tsx"})
+    assert layers[0]["sub_groups"] == []
+    assert layers[0]["display_order"] == 0
+
+
+def test_tour_steps_carry_curated_fields():
+    kg = {
+        "tour": [
+            {
+                "order": 1,
+                "title": "main.py",
+                "target_path": "src/main.py",
+                "page_type": "file_page",
+                "depth": 0,
+                "kind": "code",
+                "reason": "Top of the stack.",
+                "layer_id": "layer:cli",
+            },
+            # Legacy LLM step: nodeIds, no curated fields.
+            {"order": 2, "title": "Core", "description": "d", "nodeIds": ["file:core.py"]},
+        ]
+    }
+    steps = _tour_from_knowledge_graph(kg)
+
+    curated = steps[0]
+    assert curated.target_path == "src/main.py"
+    assert curated.layer_id == "layer:cli"
+    assert curated.reason == "Top of the stack."
+    assert curated.depth == 0
+    assert curated.kind == "code"
+    assert curated.page_type == "file_page"
+    # Curated steps address one file: node_ids falls back to the target path.
+    assert curated.node_ids == ["src/main.py"]
+
+    legacy = steps[1]
+    assert legacy.node_ids == ["core.py"]
+    assert legacy.target_path is None
+    assert legacy.kind == ""
+
+
+# ---------------------------------------------------------------------------
+# Round trip: curated JSON → auto-migrate → DB → architecture view (zero loss)
+# ---------------------------------------------------------------------------
+
+_CURATED_KG = {
+    "version": "1.0.0",
+    "project": {
+        "name": "demo",
+        "entry_points": ["src/main.py"],
+        "entry_candidates": ["src/main.py", "src/api/routes.py", "missing/file.py"],
+    },
+    "nodes": [
+        {
+            "id": "file:src/main.py",
+            "filePath": "src/main.py",
+            "type": "file",
+            "summary": "SENTINEL: CLI entry point wiring commands.",
+            "tags": ["entry_point", "python"],
+        },
+        {
+            "id": "file:src/api/routes.py",
+            "filePath": "src/api/routes.py",
+            "type": "file",
+            "summary": "SENTINEL: HTTP routes.",
+            "tags": ["python"],
+        },
+        {
+            "id": "file:src/ui/form.tsx",
+            "filePath": "src/ui/form.tsx",
+            "type": "file",
+            "summary": "SENTINEL: form component.",
+            "tags": ["typescript"],
+        },
+        {
+            "id": "file:Dockerfile",
+            "filePath": "Dockerfile",
+            "type": "service",
+            "summary": "SENTINEL: container build.",
+            "tags": ["infra"],
+        },
+        {"id": "concept:auth", "type": "concept", "summary": "not file meta"},
+    ],
+    "edges": [],
+    "layers": [
+        {
+            "id": "layer:ui",
+            "name": "UI",
+            "description": "Presentation",
+            "nodeIds": ["file:src/ui/form.tsx"],
+            "display_order": 0,
+            "subGroups": [
+                {"id": "layer:ui:forms", "name": "forms", "nodeIds": ["file:src/ui/form.tsx"]},
+            ],
+        },
+        {
+            "id": "layer:api",
+            "name": "API",
+            "description": "Routes",
+            "nodeIds": ["file:src/api/routes.py", "file:src/main.py"],
+            "display_order": 1,
+        },
+        {
+            "id": "layer:config",
+            "name": "Config",
+            "description": "Infra",
+            "nodeIds": ["file:Dockerfile"],
+            "display_order": 2,
+        },
+    ],
+    "tour": [
+        {
+            "order": 1,
+            "title": "main.py",
+            "target_path": "src/main.py",
+            "page_type": "file_page",
+            "depth": 0,
+            "kind": "code",
+            "reason": "SENTINEL: start of the control flow.",
+            "layer_id": "layer:api",
+        },
+    ],
+}
+
+
+async def _seed_curated_repo(session, tmp_path):
+    kg_dir = tmp_path / ".repowise"
+    kg_dir.mkdir()
+    (kg_dir / "knowledge-graph.json").write_text(json.dumps(_CURATED_KG))
+
+    repo = await upsert_repository(session, name="demo", local_path=str(tmp_path))
+    files = ["src/main.py", "src/api/routes.py", "src/ui/form.tsx", "Dockerfile"]
+    await batch_upsert_graph_nodes(
+        session,
+        repo.id,
+        [
+            {
+                "node_id": f,
+                "node_type": "file",
+                "language": "python" if f.endswith(".py") else "",
+                "symbol_count": 1,
+            }
+            for f in files
+        ],
+    )
+    return repo
+
+
+def _assert_curated_view(view) -> None:
+    by_id = {layer.id: layer for layer in view.layers}
+    ui = by_id["layer:ui"]
+    assert ui.display_order == 0
+    assert [(sg.id, sg.name, sg.node_ids) for sg in ui.sub_groups] == [
+        ("layer:ui:forms", "forms", ["src/ui/form.tsx"]),
+    ]
+    assert by_id["layer:api"].display_order == 1
+    assert by_id["layer:api"].sub_groups == []
+
+    step = view.tour[0]
+    assert step.target_path == "src/main.py"
+    assert step.layer_id == "layer:api"
+    assert step.reason == "SENTINEL: start of the control flow."
+    assert step.depth == 0
+    assert step.kind == "code"
+    assert step.page_type == "file_page"
+    assert step.node_ids == ["src/main.py"]
+
+    assert view.entry_points == ["src/main.py"]
+    # Candidates are filtered to nodes that exist in the graph.
+    assert view.entry_candidates == ["src/main.py", "src/api/routes.py"]
+
+    nodes = {n.id: n for n in view.nodes}
+    assert nodes["src/main.py"].summary == "SENTINEL: CLI entry point wiring commands."
+    assert nodes["src/main.py"].tags == ["entry_point", "python"]
+    assert nodes["Dockerfile"].node_type == "service"
+    assert nodes["Dockerfile"].summary == "SENTINEL: container build."
+
+
+async def test_round_trip_zero_curated_field_loss(async_session, tmp_path):
+    """First read auto-migrates the file; second read serves from the DB.
+
+    Both views must carry every curated field — the Phase-A acceptance."""
+    repo = await _seed_curated_repo(async_session, tmp_path)
+
+    view_from_file = await build_architecture_view(async_session, repo.id)
+    _assert_curated_view(view_from_file)
+
+    # Remove the workspace file: the second read must come purely from the DB.
+    os.remove(tmp_path / ".repowise" / "knowledge-graph.json")
+    view_from_db = await build_architecture_view(async_session, repo.id)
+    _assert_curated_view(view_from_db)
+
+
+async def test_migration_twice_is_idempotent(async_session, tmp_path):
+    """Two first-readers racing into the migration must be idempotent.
+
+    The delete-then-insert migration carries no concurrency guard, so a
+    concurrent first-reader can hit the unique constraints. Running it twice in
+    a row (the serialized analogue of that race) must raise nothing and leave
+    the DB holding exactly one curated set."""
+    repo = await _seed_curated_repo(async_session, tmp_path)
+
+    # Both calls open their own sessions and commit; neither raises.
+    await _migrate_kg_file_to_db(async_session, repo.id, _CURATED_KG)
+    await _migrate_kg_file_to_db(async_session, repo.id, _CURATED_KG)
+
+    # The view (served from the migrated DB rows) carries every curated field.
+    os.remove(tmp_path / ".repowise" / "knowledge-graph.json")
+    view = await build_architecture_view(async_session, repo.id)
+    _assert_curated_view(view)
+
+
+async def test_failed_migration_does_not_roll_back_caller_writes(async_session, tmp_path):
+    """A failed migration runs in its own session, so the caller's pending
+    writes survive — the old broad ``except: session.rollback()`` would have
+    discarded them."""
+    repo = await _seed_curated_repo(async_session, tmp_path)
+
+    # An unrelated write pending on the CALLER's session.
+    sentinel = await upsert_repository(
+        session=async_session, name="caller-sentinel", local_path=str(tmp_path / "x")
+    )
+
+    # A KG whose layer is missing the required "id" key makes upsert_kg_layers
+    # raise inside the migration's own session.
+    broken_kg = {"layers": [{"name": "no id key"}]}
+    with pytest.raises(KeyError):
+        await _migrate_kg_file_to_db(async_session, repo.id, broken_kg)
+
+    # The caller's session was never touched by the migration's rollback.
+    await async_session.flush()
+    found = await async_session.get(type(sentinel), sentinel.id)
+    assert found is not None
+    assert found.name == "caller-sentinel"
+
+
+async def test_uncurated_repo_unchanged(async_session, tmp_path):
+    """Flag-off contract: no KG file, no DB rows → behaviour identical to today."""
+    repo = await upsert_repository(session=async_session, name="plain", local_path=str(tmp_path))
+    await batch_upsert_graph_nodes(
+        async_session,
+        repo.id,
+        [{"node_id": "src/a.py", "node_type": "file", "language": "python", "symbol_count": 1}],
+    )
+
+    view = await build_architecture_view(async_session, repo.id)
+
+    assert view.entry_points == []
+    assert view.entry_candidates == []
+    assert all(layer.sub_groups == [] for layer in view.layers)
+    node = view.nodes[0]
+    assert node.summary == "Handles src logic"  # heuristic fallback intact
+    assert node.node_type == "file"
+
+
+def _ext(name: str, category: str) -> ExternalSystemView:
+    return ExternalSystemView(
+        id=f"ext:{name}",
+        name=name,
+        display_name=name,
+        category=category,
+        ecosystem="pypi",
+        version="",
+    )
+
+
+def _l1(externals: list[ExternalSystemView]) -> C4L1:
+    system = System(id="sys:r", name="r")
+    return C4L1(
+        system=system,
+        people=[Person(id="person:user", name="User", description="")],
+        external_systems=externals,
+        relations=[
+            Relation(source_id=system.id, target_id=e.id, label=e.category) for e in externals
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mermaid external grouping
+# ---------------------------------------------------------------------------
+
+
+def test_few_externals_stay_flat():
+    externals = [_ext(f"lib{i}", "library") for i in range(4)]
+    out = to_mermaid_l1(_l1(externals))
+    assert "Boundary(extgrp_" not in out
+
+
+def test_many_externals_group_by_category():
+    externals = (
+        [_ext(f"fw{i}", "framework") for i in range(4)]
+        + [_ext(f"svc{i}", "service") for i in range(3)]
+        + [_ext(f"lib{i}", "library") for i in range(5)]
+    )
+    out = to_mermaid_l1(_l1(externals))
+    assert "Boundary(extgrp_framework" in out
+    assert "Boundary(extgrp_service" in out
+    assert "Boundary(extgrp_library" in out
+    assert '"Frameworks"' in out
+    assert '"Services & Infrastructure"' in out
+    # Frameworks group is rendered before Libraries (category priority order).
+    assert out.index("extgrp_framework") < out.index("extgrp_library")
+    # Every external still appears as a box.
+    for i in range(5):
+        assert f"ext_lib{i}" in out

--- a/tests/unit/server/test_architecture_api.py
+++ b/tests/unit/server/test_architecture_api.py
@@ -10,6 +10,10 @@ from repowise.core.persistence import (
     batch_upsert_graph_nodes,
     bulk_upsert_external_systems,
     link_graph_nodes_to_external_systems,
+    upsert_kg_layers,
+    upsert_kg_node_meta,
+    upsert_kg_project_meta,
+    upsert_kg_tour_steps,
 )
 
 
@@ -80,6 +84,93 @@ async def test_api_architecture_endpoint(client: AsyncClient, app) -> None:
     for edge in body["edges"]:
         assert edge["direction"] == "forward"
         assert edge["confidence"] > 0
+
+
+async def test_api_architecture_curated_fields(client: AsyncClient, app) -> None:
+    """Curated KG fields (sub_groups, tour, entry points, node meta) reach the
+    HTTP response — the Phase-A acceptance, DB-served path."""
+    repo_id = await _seed(client, app)
+
+    async with app.state.session_factory() as session:
+        await upsert_kg_layers(session, repo_id, [
+            {
+                "id": "layer:api",
+                "name": "API",
+                "description": "Service edge",
+                "nodeIds": ["file:src/app.py", "file:src/db.py"],
+                "display_order": 0,
+                "subGroups": [
+                    {"id": "layer:api:app", "name": "app", "nodeIds": ["file:src/app.py"]},
+                    {"id": "layer:api:db", "name": "db", "nodeIds": ["file:src/db.py"]},
+                ],
+            },
+        ])
+        await upsert_kg_tour_steps(session, repo_id, [
+            {
+                "order": 1,
+                "title": "app.py",
+                "target_path": "src/app.py",
+                "page_type": "file_page",
+                "depth": 0,
+                "kind": "code",
+                "reason": "Top of the stack.",
+                "layer_id": "layer:api",
+            },
+        ])
+        await upsert_kg_project_meta(
+            session, repo_id,
+            entry_points=["src/app.py"],
+            entry_candidates=["src/app.py", "src/db.py"],
+        )
+        await upsert_kg_node_meta(session, repo_id, [
+            {"id": "src/app.py", "type": "file",
+             "summary": "Curated app summary.", "tags": ["entry_point", "python"]},
+        ])
+        await session.commit()
+
+    resp = await client.get(f"/api/graph/{repo_id}/architecture-view")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    layer = next(la for la in body["layers"] if la["id"] == "layer:api")
+    assert layer["display_order"] == 0
+    assert layer["sub_groups"] == [
+        {"id": "layer:api:app", "name": "app", "node_ids": ["src/app.py"]},
+        {"id": "layer:api:db", "name": "db", "node_ids": ["src/db.py"]},
+    ]
+
+    step = body["tour"][0]
+    assert step["target_path"] == "src/app.py"
+    assert step["layer_id"] == "layer:api"
+    assert step["reason"] == "Top of the stack."
+    assert step["depth"] == 0
+    assert step["kind"] == "code"
+    assert step["page_type"] == "file_page"
+    assert step["node_ids"] == ["src/app.py"]
+
+    assert body["entry_points"] == ["src/app.py"]
+    assert body["entry_candidates"] == ["src/app.py", "src/db.py"]
+
+    app_node = next(n for n in body["nodes"] if n["id"] == "src/app.py")
+    assert app_node["summary"] == "Curated app summary."
+    assert app_node["tags"] == ["entry_point", "python"]
+
+
+async def test_api_architecture_uncurated_defaults(client: AsyncClient, app) -> None:
+    """Flag-off contract: uncurated repos serve the new keys as safe defaults."""
+    repo_id = await _seed(client, app)
+
+    resp = await client.get(f"/api/graph/{repo_id}/architecture-view")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["entry_points"] == []
+    assert body["entry_candidates"] == []
+    for layer in body["layers"]:
+        assert layer["sub_groups"] == []
+    for step in body["tour"]:
+        assert step["target_path"] is None
+        assert step["kind"] == ""
 
 
 async def test_api_architecture_with_symbols(client: AsyncClient, app) -> None:

--- a/tests/unit/server/test_graph.py
+++ b/tests/unit/server/test_graph.py
@@ -227,6 +227,206 @@ async def test_architecture_graph(client: AsyncClient, app) -> None:
     assert data["edges"] == []
 
 
+# ---------------------------------------------------------------------------
+# Community slice (Phase G4 — constellation blossom)
+# ---------------------------------------------------------------------------
+
+
+async def _populate_two_communities(session_factory, repo_id: str) -> None:
+    """Two members in community 0, one in community 1, with a cross edge."""
+    async with get_session(session_factory) as session:
+        await crud.batch_upsert_graph_nodes(
+            session,
+            repo_id,
+            [
+                {
+                    "node_id": "src/a.py",
+                    "node_type": "file",
+                    "language": "python",
+                    "symbol_count": 3,
+                    "pagerank": 0.8,
+                    "betweenness": 0.5,
+                    "community_id": 0,
+                },
+                {
+                    "node_id": "src/b.py",
+                    "node_type": "file",
+                    "language": "python",
+                    "symbol_count": 2,
+                    "pagerank": 0.4,
+                    "betweenness": 0.1,
+                    "community_id": 0,
+                },
+                {
+                    "node_id": "src/c.py",
+                    "node_type": "file",
+                    "language": "python",
+                    "symbol_count": 1,
+                    "pagerank": 0.2,
+                    "betweenness": 0.0,
+                    "community_id": 1,
+                },
+            ],
+        )
+        await crud.batch_upsert_graph_edges(
+            session,
+            repo_id,
+            [
+                # Intra-community (0)
+                {"source_node_id": "src/a.py", "target_node_id": "src/b.py"},
+                # Cross-community (0 -> 1): pulls c.py in as a boundary stub
+                {"source_node_id": "src/b.py", "target_node_id": "src/c.py"},
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_community_slice_members_edges_and_boundary(client: AsyncClient, app) -> None:
+    repo = await create_test_repo(client)
+    await _populate_two_communities(app.state.session_factory, repo["id"])
+
+    resp = await client.get(f"/api/graph/{repo['id']}/communities/0/slice")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["community_id"] == 0
+    assert data["member_count"] == 2
+    assert data["truncated"] is False
+
+    by_id = {n["node_id"]: n for n in data["nodes"]}
+    # Both members present and NOT boundary
+    assert by_id["src/a.py"]["is_boundary"] is False
+    assert by_id["src/b.py"]["is_boundary"] is False
+    # Neighbor from community 1 pulled in as a boundary stub
+    assert by_id["src/c.py"]["is_boundary"] is True
+
+    # Edges: intra (a->b) + cross (b->c) both render
+    pairs = {(link["source"], link["target"]) for link in data["links"]}
+    assert ("src/a.py", "src/b.py") in pairs
+    assert ("src/b.py", "src/c.py") in pairs
+
+
+@pytest.mark.asyncio
+async def test_community_slice_member_signals(client: AsyncClient, app) -> None:
+    repo = await create_test_repo(client)
+    await _populate_two_communities(app.state.session_factory, repo["id"])
+    async with get_session(app.state.session_factory) as session:
+        await crud.upsert_git_metadata(
+            session,
+            repository_id=repo["id"],
+            file_path="src/a.py",
+            is_hotspot=True,
+            churn_percentile=0.99,
+            primary_owner_name="Bob",
+            commit_count_30d=5,
+            commit_count_90d=12,
+        )
+
+    resp = await client.get(f"/api/graph/{repo['id']}/communities/0/slice")
+    assert resp.status_code == 200
+    by_id = {n["node_id"]: n for n in resp.json()["nodes"]}
+    assert by_id["src/a.py"]["is_hotspot"] is True
+    assert by_id["src/a.py"]["primary_owner"] == "Bob"
+    # Boundary stub carries no signals
+    assert by_id["src/c.py"]["is_hotspot"] is False
+
+
+@pytest.mark.asyncio
+async def test_community_slice_excludes_non_member_edges(client: AsyncClient, app) -> None:
+    """The SQL membership filter must drop edges that touch no member.
+
+    Seeds an extra node ``src/d.py`` in community 1 and an edge c->d that
+    touches neither community-0 member. That edge must not appear in the slice,
+    and the slice result must otherwise match the baseline expectations.
+    """
+    repo = await create_test_repo(client)
+    async with get_session(app.state.session_factory) as session:
+        await crud.batch_upsert_graph_nodes(
+            session,
+            repo["id"],
+            [
+                {
+                    "node_id": "src/a.py",
+                    "node_type": "file",
+                    "language": "python",
+                    "symbol_count": 3,
+                    "pagerank": 0.8,
+                    "community_id": 0,
+                },
+                {
+                    "node_id": "src/b.py",
+                    "node_type": "file",
+                    "language": "python",
+                    "symbol_count": 2,
+                    "pagerank": 0.4,
+                    "community_id": 0,
+                },
+                {
+                    "node_id": "src/c.py",
+                    "node_type": "file",
+                    "language": "python",
+                    "symbol_count": 1,
+                    "pagerank": 0.2,
+                    "community_id": 1,
+                },
+                {
+                    "node_id": "src/d.py",
+                    "node_type": "file",
+                    "language": "python",
+                    "symbol_count": 1,
+                    "pagerank": 0.1,
+                    "community_id": 1,
+                },
+            ],
+        )
+        await crud.batch_upsert_graph_edges(
+            session,
+            repo["id"],
+            [
+                # Intra-community 0 (touches members)
+                {"source_node_id": "src/a.py", "target_node_id": "src/b.py"},
+                # Cross 0->1 (touches a member -> boundary stub c.py)
+                {"source_node_id": "src/b.py", "target_node_id": "src/c.py"},
+                # Touches NO community-0 member: must be excluded entirely
+                {"source_node_id": "src/c.py", "target_node_id": "src/d.py"},
+            ],
+        )
+
+    resp = await client.get(f"/api/graph/{repo['id']}/communities/0/slice")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["community_id"] == 0
+    assert data["member_count"] == 2
+    assert data["truncated"] is False
+
+    by_id = {n["node_id"]: n for n in data["nodes"]}
+    assert by_id["src/a.py"]["is_boundary"] is False
+    assert by_id["src/b.py"]["is_boundary"] is False
+    assert by_id["src/c.py"]["is_boundary"] is True
+    # d.py is only reachable via the excluded edge — it must not be pulled in.
+    assert "src/d.py" not in by_id
+
+    pairs = {(link["source"], link["target"]) for link in data["links"]}
+    assert ("src/a.py", "src/b.py") in pairs
+    assert ("src/b.py", "src/c.py") in pairs
+    # The non-member-touching edge is excluded.
+    assert ("src/c.py", "src/d.py") not in pairs
+
+
+@pytest.mark.asyncio
+async def test_community_slice_empty_community(client: AsyncClient, app) -> None:
+    repo = await create_test_repo(client)
+    await _populate_two_communities(app.state.session_factory, repo["id"])
+
+    resp = await client.get(f"/api/graph/{repo['id']}/communities/999/slice")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["nodes"] == []
+    assert data["links"] == []
+    assert data["member_count"] == 0
+
+
 @pytest.mark.asyncio
 async def test_module_graph_aggregates_signals(client: AsyncClient, app) -> None:
     repo = await create_test_repo(client)

--- a/tests/unit/server/test_modules_health.py
+++ b/tests/unit/server/test_modules_health.py
@@ -74,3 +74,23 @@ async def test_get_module_health_detail(client: AsyncClient, app) -> None:
     assert data["module_path"] == "src"
     assert data["file_count"] == 2
     assert any(o["name"] == "Alice" for o in data["owners"])
+
+
+@pytest.mark.asyncio
+async def test_get_module_health_nested_path_falls_back_to_parent(
+    client: AsyncClient, app
+) -> None:
+    """Path-shaped wiki module ids (``src/api``) roll up to the parent module.
+
+    Curated module pages key on the module's directory path; health rollups
+    aggregate by top-level dir, so a nested module path resolves through the
+    exact → single-file → parent fallback chain to its top-level aggregate.
+    """
+    repo = await create_test_repo(client)
+    await _seed(app.state.session_factory, repo["id"])
+
+    resp = await client.get(f"/api/repos/{repo['id']}/modules/health/{quote('src/api')}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["module_path"] == "src"
+    assert data["file_count"] == 2


### PR DESCRIPTION
## What

Server-side architecture surfaces learn the curated KG:

- **`services/c4_builder/`**: the architecture builder carries curated KG fields (layers, module meta, tour) through to the C4 view; on-read KG migration runs in its **own session**, isolated from the request session; externals grouped by category; curated-layer inheritance locked for nested nodes.
- **`routers/graph/community.py`**: `community_slice` endpoint — SQL-level edge filter with a bounded edge query and boundary-stub cap (one-hop neighbor stubs outside the community), powering hub expand/collapse in the graph UI.
- **`routers/graph/full_graph.py`**: capped full-scope loading with stepped load-more.
- **`schemas/`** (`architecture.py`, `graph.py`): response models for the above, including curated KG fields on the architecture-view response.
- `routers/c4.py`: exposure of the curated fields.

## Why

The web UI's C4 canvas and constellation graph view (later PRs in this train) need curated layers/modules and a community-slice API. Doing the slice filter in SQL instead of loading the full edge set keeps large repos responsive; the on-read migration isolation prevents a failed KG migration from corrupting an unrelated request transaction.

## Behavior change

API responses gain optional curated-KG fields (additive). `community_slice` is new; existing endpoints keep their shapes.

## Dependencies

Stacks on the KG-persistence PR (curated KG CRUD: `file_node_meta_from_kg_nodes` etc.). Retarget to `main` once that merges.

## How it was tested

- Full `pytest tests/unit -q` green — `tests/unit/server/services/test_c4_curation.py`, `test_architecture_api.py`, `test_graph.py`, `test_modules_health.py`.
- `ruff check` clean on touched files (no new findings vs `main`).
