### PR TITLE
feat(ui): blueprint C4 canvas — ink node system, scope frames, unified click grammar

### DIFF
--- a/packages/ui/__tests__/c4/arch-nodes.test.tsx
+++ b/packages/ui/__tests__/c4/arch-nodes.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
+import type { NodeProps } from "@xyflow/react";
 import { NodeShell } from "../../src/graph-primitives/node-shell";
+import { ArchFileNode } from "../../src/c4/nodes/ArchFileNode";
+import { LayerClusterNode } from "../../src/c4/nodes/LayerClusterNode";
+import { useArchitectureStore } from "../../src/c4/store/use-architecture-store";
+import { createMockView } from "./fixtures";
 import type { ArchNode, ArchLayer } from "../../src/c4/types";
 
 vi.mock("@xyflow/react", () => ({
@@ -9,12 +14,12 @@ vi.mock("@xyflow/react", () => ({
 }));
 
 describe("NodeShell", () => {
-  it("renders selected state with golden border", () => {
+  it("renders selected state with the brand selection token", () => {
     const { container } = render(
       <NodeShell tone="file" kindLabel="FILE" title="test.py" selected={true} />,
     );
     const root = container.firstElementChild as HTMLElement;
-    expect(root.style.border).toContain("rgb(251, 191, 36)");
+    expect(root.style.borderLeft).toContain("--color-viz-selection");
   });
 
   it("renders tour highlight with accentPulse animation", () => {
@@ -33,12 +38,12 @@ describe("NodeShell", () => {
     expect(root.style.opacity).toBe("0.25");
   });
 
-  it("renders diff changed state with red border", () => {
+  it("renders diff changed state with the diff-changed token", () => {
     const { container } = render(
       <NodeShell tone="file" kindLabel="FILE" title="test.py" diffState="changed" />,
     );
     const root = container.firstElementChild as HTMLElement;
-    expect(root.style.border).toContain("rgb(252, 165, 165)");
+    expect(root.style.border).toContain("--color-viz-diff-changed");
   });
 
   it("renders search highlight with dashed border", () => {
@@ -101,6 +106,88 @@ describe("ArchFileNode (via NodeShell)", () => {
   });
 });
 
+describe("ArchFileNode barrels + tour badge (plan C-2/C-3)", () => {
+  function renderArchFile(overrides: Partial<ArchNode>, dataExtra: object = {}) {
+    const node = { ...mockNode, ...overrides };
+    const props = {
+      data: { node, ...dataExtra },
+      selected: false,
+    } as unknown as NodeProps;
+    return render(<ArchFileNode {...props} />);
+  }
+
+  it("de-emphasizes barrel-tagged nodes and suppresses their entry badge", () => {
+    const { container, queryByLabelText, getByText } = renderArchFile({
+      tags: ["barrel", "typescript"],
+      is_entry_point: true,
+      summary: "Re-export barrel for ui/.",
+    });
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.opacity).toBe("0.55");
+    expect(queryByLabelText("Entry point")).toBeNull();
+    expect(getByText("barrel")).toBeDefined(); // honest kind label
+    expect(getByText("Re-export barrel for ui/.")).toBeDefined(); // honest summary
+  });
+
+  it("keeps the entry badge for genuine entry points", () => {
+    const { getByLabelText, container } = renderArchFile({ is_entry_point: true });
+    expect(getByLabelText("Entry point")).toBeDefined();
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.opacity).not.toBe("0.55");
+  });
+
+  it("shows the numbered tour-step badge when highlighted by the tour", () => {
+    const { getByLabelText } = renderArchFile({}, { tourStepNumber: 3, tourHighlight: true });
+    expect(getByLabelText("Tour step 3")).toBeDefined();
+  });
+
+  it("selection dimming fades unrelated cards to 0.45, never vanishes them", () => {
+    const { container } = renderArchFile({}, { dimmed: true });
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.opacity).toBe("0.45");
+    // The diff overlay keeps its own stronger fade — dimming must not hijack it.
+    const inner = wrapper.firstElementChild as HTMLElement;
+    expect(inner.style.opacity).not.toBe("0.25");
+  });
+});
+
+describe("a11y: tier cards are keyboard-operable (plan D)", () => {
+  function renderCard(kind: "layer" | "subGroup", layerId: string) {
+    const store = useArchitectureStore;
+    store.setState(store.getInitialState());
+    const view = createMockView();
+    // Give layer:api curated sub-groups so drilling lands on the groups tier.
+    view.layers[0]!.sub_groups = [
+      { id: "layer:api:app", name: "app", node_ids: ["src/app.py"] },
+      { id: "layer:api:routes", name: "routes", node_ids: ["src/routes.py"] },
+    ];
+    store.getState().setView(view);
+    const layer = { ...view.layers[0]!, id: layerId, name: "API" };
+    const props = {
+      data: { layer, kind },
+      selected: false,
+    } as unknown as NodeProps;
+    return render(<LayerClusterNode {...props} />);
+  }
+
+  // Unified click grammar (kg-ux plan B5): single activation = select +
+  // inspect, never drill. Drilling is double-click (page handler) or the
+  // inspect panel's "Open layer/group" button.
+  it("Enter on a layer card selects it without drilling", () => {
+    const { getByRole } = renderCard("layer", "layer:api");
+    fireEvent.keyDown(getByRole("button"), { key: "Enter" });
+    expect(useArchitectureStore.getState().selectedNodeId).toBe("layer:api");
+    expect(useArchitectureStore.getState().navigationLevel).toBe("overview");
+  });
+
+  it("Space on a sub-group card selects it without drilling", () => {
+    const { getByRole } = renderCard("subGroup", "layer:api:app");
+    fireEvent.keyDown(getByRole("button"), { key: " " });
+    expect(useArchitectureStore.getState().selectedNodeId).toBe("layer:api:app");
+    expect(useArchitectureStore.getState().activeSubGroupId).toBeNull();
+  });
+});
+
 describe("LayerClusterNode (via NodeShell)", () => {
   const mockLayer: ArchLayer = {
     id: "layer:api",
@@ -110,6 +197,8 @@ describe("LayerClusterNode (via NodeShell)", () => {
     file_count: 42,
     complexity_distribution: { simple: 20, moderate: 15, complex: 7 },
     health_score: 85,
+    sub_groups: [],
+    display_order: 0,
   };
 
   it("renders layer cluster with name, file count, and health score", () => {

--- a/packages/ui/__tests__/c4/architecture-store.test.ts
+++ b/packages/ui/__tests__/c4/architecture-store.test.ts
@@ -359,3 +359,33 @@ describe("useArchitectureStore", () => {
     });
   });
 });
+
+describe("setView legacy-payload hardening (kg-ux)", () => {
+  it("survives an API response that predates the curated-KG schema", () => {
+    // A pre-curation backend serves layers without sub_groups and no
+    // entry_points/tour — the page must degrade, never crash
+    // ("layer.sub_groups is not iterable" regression).
+    const legacy = createMockView();
+    for (const layer of legacy.layers) {
+      delete (layer as Partial<ArchLayer>).sub_groups;
+      delete (layer as Partial<ArchLayer>).display_order;
+    }
+    delete (legacy as Partial<typeof legacy>).entry_points;
+    delete (legacy as Partial<typeof legacy>).entry_candidates;
+    delete (legacy as Partial<typeof legacy>).tour;
+    for (const node of legacy.nodes) {
+      delete (node as Partial<ArchNode>).tags;
+    }
+
+    expect(() => store.getState().setView(legacy)).not.toThrow();
+
+    const view = store.getState().view!;
+    expect(view.layers.every((l) => Array.isArray(l.sub_groups))).toBe(true);
+    expect(view.layers.map((l) => l.display_order)).toEqual(
+      view.layers.map((_, i) => i),
+    );
+    expect(view.entry_points).toEqual([]);
+    expect(view.tour).toEqual([]);
+    expect(view.nodes.every((n) => Array.isArray(n.tags))).toBe(true);
+  });
+});

--- a/packages/ui/__tests__/c4/containers.test.ts
+++ b/packages/ui/__tests__/c4/containers.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { buildContainers, getStandaloneNodeIds } from "../../src/c4/layout/containers";
+import {
+  buildContainers,
+  enforceBoxBudget,
+  getStandaloneNodeIds,
+  MAX_VISIBLE_BOXES,
+} from "../../src/c4/layout/containers";
 import type { ArchNode, ArchEdge } from "../../src/c4/types";
 
 function makeNode(overrides: Partial<ArchNode> & { id: string }): ArchNode {
@@ -122,6 +127,58 @@ describe("buildContainers", () => {
     });
   });
 
+  describe("curated strategy", () => {
+    const subGroups = [
+      { id: "layer:ui:forms", name: "forms", node_ids: ["src/ui/form.tsx", "src/ui/input.tsx"] },
+      { id: "layer:ui:tables", name: "tables", node_ids: ["src/ui/table.tsx", "src/ui/row.tsx"] },
+    ];
+
+    it("builds containers verbatim from sub-groups (id/name/members)", () => {
+      const nodes = subGroups.flatMap((g) =>
+        g.node_ids.map((id) => makeNode({ id, file_path: id })),
+      );
+      const containers = buildContainers(nodes, [], "curated", subGroups);
+      expect(containers).toHaveLength(2);
+      expect(containers[0]).toEqual({
+        id: "layer:ui:forms",
+        label: "forms",
+        childNodeIds: ["src/ui/form.tsx", "src/ui/input.tsx"],
+      });
+      expect(containers[1]!.label).toBe("tables");
+    });
+
+    it("drops members hidden by upstream filters and flattens singletons", () => {
+      // Only one forms file and both table files visible.
+      const nodes = [
+        makeNode({ id: "src/ui/form.tsx", file_path: "src/ui/form.tsx" }),
+        makeNode({ id: "src/ui/table.tsx", file_path: "src/ui/table.tsx" }),
+        makeNode({ id: "src/ui/row.tsx", file_path: "src/ui/row.tsx" }),
+      ];
+      const containers = buildContainers(nodes, [], "curated", subGroups);
+      // forms collapsed to a singleton → flattened away; tables survives.
+      expect(containers.map((c) => c.id)).toEqual(["layer:ui:tables"]);
+    });
+
+    it("falls back to heuristics when the layer has no sub-groups", () => {
+      const nodes: ArchNode[] = [
+        makeNode({ id: "src/api/app.py", file_path: "src/api/app.py" }),
+        makeNode({ id: "src/api/routes.py", file_path: "src/api/routes.py" }),
+      ];
+      const containers = buildContainers(nodes, [], "curated", []);
+      expect(containers.some((c) => c.id.startsWith("dir:"))).toBe(true);
+    });
+
+    it("falls back to heuristics when no sub-group survives filtering", () => {
+      const nodes: ArchNode[] = [
+        makeNode({ id: "src/api/app.py", file_path: "src/api/app.py" }),
+        makeNode({ id: "src/api/routes.py", file_path: "src/api/routes.py" }),
+      ];
+      // Sub-groups reference nodes that are all filtered out.
+      const containers = buildContainers(nodes, [], "curated", subGroups);
+      expect(containers.some((c) => c.id.startsWith("dir:"))).toBe(true);
+    });
+  });
+
   describe("single-node container flattening", () => {
     it("eliminates containers with only 1 node", () => {
       const nodes: ArchNode[] = [
@@ -146,5 +203,53 @@ describe("getStandaloneNodeIds", () => {
     const containers = [{ id: "c1", label: "C1", childNodeIds: ["a", "b"] }];
     const standalone = getStandaloneNodeIds(nodes, containers);
     expect(standalone).toEqual(["c"]);
+  });
+});
+
+describe("enforceBoxBudget", () => {
+  const pr = new Map<string, number>([
+    ["hot1", 0.9], ["hot2", 0.8],
+    ["mid1", 0.5], ["mid2", 0.4],
+    ["cold1", 0.1], ["cold2", 0.05], ["cold3", 0.01],
+  ]);
+  const rank = (id: string) => pr.get(id) ?? 0;
+
+  it("passes through when within budget", () => {
+    const containers = [{ id: "c1", label: "C1", childNodeIds: ["hot1", "mid1"] }];
+    const out = enforceBoxBudget(containers, ["hot2"], rank);
+    expect(out.containers).toEqual(containers);
+    expect(out.standaloneIds).toEqual(["hot2"]);
+    expect(out.collapsedCount).toBe(0);
+  });
+
+  it("collapses the lowest-pagerank boxes into one '+N more' container", () => {
+    const containers = [
+      { id: "c-hot", label: "hot", childNodeIds: ["hot1", "hot2"] },
+      { id: "c-cold", label: "cold", childNodeIds: ["cold1", "cold2"] },
+    ];
+    const standalone = ["mid1", "mid2", "cold3"];
+    // Budget 4: keep the 3 strongest boxes, fold the rest.
+    const out = enforceBoxBudget(containers, standalone, rank, 4);
+
+    expect(out.containers.length + out.standaloneIds.length).toBeLessThanOrEqual(4);
+    const overflow = out.containers.find((c) => c.id === "container:__overflow");
+    expect(overflow).toBeDefined();
+    expect(overflow!.label).toBe(`+${out.collapsedCount} more`);
+    // The weakest boxes (cold container + cold3) live inside the overflow.
+    expect(overflow!.childNodeIds).toEqual(
+      expect.arrayContaining(["cold1", "cold2", "cold3"]),
+    );
+    // The strongest boxes survive untouched.
+    expect(out.containers.some((c) => c.id === "c-hot")).toBe(true);
+    expect(out.standaloneIds).toContain("mid1");
+  });
+
+  it("never exceeds the default budget", () => {
+    const standalone = Array.from({ length: 40 }, (_, i) => `f${i}`);
+    const out = enforceBoxBudget([], standalone, () => 0);
+    expect(out.containers.length + out.standaloneIds.length).toBeLessThanOrEqual(
+      MAX_VISIBLE_BOXES,
+    );
+    expect(out.collapsedCount).toBe(40 - (MAX_VISIBLE_BOXES - 1));
   });
 });

--- a/packages/ui/__tests__/c4/edge-aggregation.test.ts
+++ b/packages/ui/__tests__/c4/edge-aggregation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { aggregateEdges } from "../../src/c4/layout/edge-aggregation";
+import {
+  aggregateEdges,
+  capAggregatedEdges,
+  MAX_VISIBLE_AGGREGATED_EDGES,
+} from "../../src/c4/layout/edge-aggregation";
 import type { ArchEdge } from "../../src/c4/types";
 
 function makeEdge(source: string, target: string, edge_type: string): ArchEdge {
@@ -97,5 +101,43 @@ describe("aggregateEdges", () => {
     ]);
     const result = aggregateEdges(edges, nodeToBox);
     expect(result[0]!.count).toBeGreaterThan(result[1]!.count);
+  });
+});
+
+describe("capAggregatedEdges", () => {
+  function agg(i: number, count: number) {
+    return {
+      id: `agg:s${i}→t${i}`,
+      source: `s${i}`,
+      target: `t${i}`,
+      count,
+      dominantType: "imports",
+      types: ["imports"],
+    };
+  }
+
+  it("passes through when under the budget", () => {
+    const edges = [agg(1, 5), agg(2, 3)];
+    const { visible, hiddenCount } = capAggregatedEdges(edges);
+    expect(visible).toHaveLength(2);
+    expect(hiddenCount).toBe(0);
+  });
+
+  it("keeps the heaviest arrows and reports the dropped count", () => {
+    // 30 aggregated arrows with descending weight (pre-sorted contract).
+    const edges = Array.from({ length: 30 }, (_, i) => agg(i, 30 - i));
+    const { visible, hiddenCount } = capAggregatedEdges(edges);
+    expect(visible).toHaveLength(MAX_VISIBLE_AGGREGATED_EDGES);
+    expect(hiddenCount).toBe(30 - MAX_VISIBLE_AGGREGATED_EDGES);
+    // Heaviest survive; the weakest are the ones dropped.
+    expect(visible[0]!.count).toBe(30);
+    expect(visible.at(-1)!.count).toBe(30 - MAX_VISIBLE_AGGREGATED_EDGES + 1);
+  });
+
+  it("honours a custom budget", () => {
+    const edges = Array.from({ length: 5 }, (_, i) => agg(i, 5 - i));
+    const { visible, hiddenCount } = capAggregatedEdges(edges, 2);
+    expect(visible.map((e) => e.count)).toEqual([5, 4]);
+    expect(hiddenCount).toBe(3);
   });
 });

--- a/packages/ui/__tests__/c4/export.test.ts
+++ b/packages/ui/__tests__/c4/export.test.ts
@@ -124,12 +124,14 @@ function makeArchView(overrides?: Partial<ArchitectureView>): ArchitectureView {
         node_ids: ["file1", "func1"], file_count: 2,
         complexity_distribution: { simple: 1, moderate: 1, complex: 0 },
         health_score: 90,
+        sub_groups: [], display_order: 0,
       },
       {
         id: "layer:core", name: "Core", description: "Core layer",
         node_ids: ["class1"], file_count: 1,
         complexity_distribution: { simple: 0, moderate: 0, complex: 1 },
         health_score: 70,
+        sub_groups: [], display_order: 1,
       },
     ],
     nodes,
@@ -141,6 +143,8 @@ function makeArchView(overrides?: Partial<ArchitectureView>): ArchitectureView {
     languages: ["typescript"],
     frameworks: [],
     external_systems: [],
+    entry_points: [],
+    entry_candidates: [],
     ...overrides,
   };
 }
@@ -174,7 +178,7 @@ describe("SVG export - new node types", () => {
     expect(svg).toContain("7 files");
   });
 
-  it("test_svg_export_tone_colors: fill colors match TONE_STYLES", () => {
+  it("test_svg_export_ink_palette: arch nodes render blueprint ink (kg-ux B7)", () => {
     const nodes: Node[] = [
       makeArchFileNode("f1", "file"),
       makeLayerClusterNode("lc1"),
@@ -182,15 +186,21 @@ describe("SVG export - new node types", () => {
     ];
     const svg = buildC4Svg(nodes, []);
 
-    expect(svg).toContain(TONE_STYLES.file.bg);
-    expect(svg).toContain(TONE_STYLES.file.border);
-    expect(svg).toContain(TONE_STYLES.file.band);
+    // Headless export resolves the light-mode fallbacks of the kg tokens.
+    expect(svg).toContain("#fffdf8"); // --color-kg-node-fill (paper card)
+    expect(svg).toContain("#241b2c"); // --color-kg-node-text / ink outline
+    expect(svg).toContain("#826aa0"); // --color-diagram-cluster-border (ghost portal)
+    expect(svg).toContain("#f4eae1"); // warm paper canvas
+    expect(svg).toContain("kg-grid"); // graph-paper pattern
+    expect(svg).toContain('stroke-dasharray="8 5"'); // dashed ghost boundary
+  });
 
-    expect(svg).toContain(TONE_STYLES.layerCluster.bg);
-    expect(svg).toContain(TONE_STYLES.layerCluster.band);
-
-    expect(svg).toContain(TONE_STYLES.portal.border);
-    expect(svg).toContain(TONE_STYLES.portal.band);
+  it("test_svg_export_entry_accent: entry points render the ember gradient", () => {
+    const entry = makeArchFileNode("e1", "file");
+    (entry.data as { node: { is_entry_point: boolean } }).node.is_entry_point = true;
+    const svg = buildC4Svg([entry], []);
+    expect(svg).toContain("url(#kg-ember)");
+    expect(svg).toContain("#f59520");
   });
 
   it("test_svg_export_backward_compat: existing C4 node types still render", () => {

--- a/packages/ui/__tests__/c4/fixtures.ts
+++ b/packages/ui/__tests__/c4/fixtures.ts
@@ -5,8 +5,8 @@ export function createMockView(overrides?: Partial<ArchitectureView>): Architect
     project_name: "test-project",
     project_description: "A test project",
     layers: [
-      { id: "layer:api", name: "API", description: "API layer", node_ids: ["src/app.py", "src/routes.py"], file_count: 2, complexity_distribution: { simple: 1, moderate: 1, complex: 0 }, health_score: 85 },
-      { id: "layer:core", name: "Core", description: "Core logic", node_ids: ["src/models.py"], file_count: 1, complexity_distribution: { simple: 0, moderate: 0, complex: 1 }, health_score: 72 },
+      { id: "layer:api", name: "API", description: "API layer", node_ids: ["src/app.py", "src/routes.py"], file_count: 2, complexity_distribution: { simple: 1, moderate: 1, complex: 0 }, health_score: 85, sub_groups: [], display_order: 0 },
+      { id: "layer:core", name: "Core", description: "Core logic", node_ids: ["src/models.py"], file_count: 1, complexity_distribution: { simple: 0, moderate: 0, complex: 1 }, health_score: 72, sub_groups: [], display_order: 1 },
     ],
     nodes: [
       { id: "src/app.py", node_type: "file", name: "app.py", file_path: "src/app.py", line_range: null, summary: "Main application entry point", complexity: "simple", tags: ["python", "entry"], language: "python", pagerank: 0.5, pagerank_percentile: 90, betweenness: 0.3, in_degree: 2, out_degree: 3, community_id: 1, is_entry_point: true, is_test: false, is_hotspot: false, is_dead: false, has_doc: true, primary_owner: "dev1", primary_owner_pct: 0.75, bus_factor: 2 },
@@ -19,9 +19,9 @@ export function createMockView(overrides?: Partial<ArchitectureView>): Architect
       { source: "src/routes.py", target: "src/models.py", edge_type: "calls", direction: "forward", weight: 0.8, confidence: 0.9 },
     ],
     tour: [
-      { order: 1, title: "Entry Point", description: "Start here", node_ids: ["src/app.py"] },
-      { order: 2, title: "Routes", description: "HTTP handlers", node_ids: ["src/routes.py"] },
-      { order: 3, title: "Models", description: "Data layer", node_ids: ["src/models.py"] },
+      { order: 1, title: "Entry Point", description: "Start here", node_ids: ["src/app.py"], target_path: null, layer_id: null, reason: "", depth: null, kind: "" as const, page_type: null },
+      { order: 2, title: "Routes", description: "HTTP handlers", node_ids: ["src/routes.py"], target_path: null, layer_id: null, reason: "", depth: null, kind: "" as const, page_type: null },
+      { order: 3, title: "Models", description: "Data layer", node_ids: ["src/models.py"], target_path: null, layer_id: null, reason: "", depth: null, kind: "" as const, page_type: null },
     ],
     total_files: 3,
     total_symbols: 25,
@@ -29,6 +29,8 @@ export function createMockView(overrides?: Partial<ArchitectureView>): Architect
     languages: ["python"],
     frameworks: ["fastapi"],
     external_systems: [],
+    entry_points: [],
+    entry_candidates: [],
     ...overrides,
   };
 }

--- a/packages/ui/__tests__/c4/graph-primitives.test.ts
+++ b/packages/ui/__tests__/c4/graph-primitives.test.ts
@@ -46,12 +46,14 @@ describe("ARCH_NODE_SIZES", () => {
 });
 
 describe("edge stroke width formula", () => {
+  // Blueprint edges are thin by design (kg-ux plan §2.3): 1px floor,
+  // gentle log growth, 2.5px cap so heavy aggregates never dominate.
   it("returns expected values for various counts", () => {
-    expect(computeEdgeStrokeWidth(0)).toBeCloseTo(1.5);
-    expect(computeEdgeStrokeWidth(1)).toBeCloseTo(2.5);
-    expect(computeEdgeStrokeWidth(5)).toBeCloseTo(1.5 + Math.log2(6));
-    expect(computeEdgeStrokeWidth(15)).toBe(5);
-    expect(computeEdgeStrokeWidth(100)).toBe(5); // capped at 5
-    expect(computeEdgeStrokeWidth(1000)).toBe(5); // still capped
+    expect(computeEdgeStrokeWidth(0)).toBeCloseTo(1);
+    expect(computeEdgeStrokeWidth(1)).toBeCloseTo(1.5);
+    expect(computeEdgeStrokeWidth(5)).toBeCloseTo(1 + Math.log2(6) * 0.5);
+    expect(computeEdgeStrokeWidth(15)).toBe(2.5);
+    expect(computeEdgeStrokeWidth(100)).toBe(2.5); // capped at 2.5
+    expect(computeEdgeStrokeWidth(1000)).toBe(2.5); // still capped
   });
 });

--- a/packages/ui/__tests__/c4/layer-groups-tier.test.tsx
+++ b/packages/ui/__tests__/c4/layer-groups-tier.test.tsx
@@ -1,0 +1,378 @@
+/**
+ * The curated "layer-groups" navigation tier (viewer plan B-2).
+ *
+ * Overview → layer cards; drilling into a layer with curated sub_groups lands
+ * on sub-group cards only; drilling into one group shows its files with the
+ * sibling groups as collapsed cards. Layers without sub-groups skip the tier
+ * entirely (locked decision 1).
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useArchitectureStore } from "../../src/c4/store/use-architecture-store";
+import { useArchitectureLayout } from "../../src/c4/hooks/use-architecture-layout";
+import { createMockView } from "./fixtures";
+import type { ArchitectureView } from "../../src/c4/types";
+
+const store = useArchitectureStore;
+
+/** Fixture view: layer:api curated into two sub-groups, layer:core uncurated. */
+function createCuratedView(): ArchitectureView {
+  const base = createMockView();
+  return {
+    ...base,
+    layers: [
+      {
+        ...base.layers[0]!,
+        id: "layer:api",
+        name: "API",
+        node_ids: ["src/app.py", "src/routes.py"],
+        sub_groups: [
+          { id: "layer:api:app", name: "app", node_ids: ["src/app.py"] },
+          { id: "layer:api:routes", name: "routes", node_ids: ["src/routes.py"] },
+        ],
+        display_order: 0,
+      },
+      {
+        ...base.layers[1]!,
+        id: "layer:core",
+        name: "Core",
+        node_ids: ["src/models.py"],
+        sub_groups: [],
+        display_order: 1,
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  store.setState(store.getInitialState());
+});
+
+describe("store: layer-groups navigation", () => {
+  it("drillIntoLayer lands on layer-groups when the layer has sub_groups", () => {
+    store.getState().setView(createCuratedView());
+    store.getState().drillIntoLayer("layer:api");
+    const state = store.getState();
+    expect(state.navigationLevel).toBe("layer-groups");
+    expect(state.activeLayerId).toBe("layer:api");
+    expect(state.activeSubGroupId).toBeNull();
+  });
+
+  it("drillIntoLayer skips the tier for layers without sub_groups (decision 1)", () => {
+    store.getState().setView(createCuratedView());
+    store.getState().drillIntoLayer("layer:core");
+    expect(store.getState().navigationLevel).toBe("layer-detail");
+    expect(store.getState().activeSubGroupId).toBeNull();
+  });
+
+  it("drillIntoSubGroup scopes layer-detail to the group", () => {
+    store.getState().setView(createCuratedView());
+    store.getState().drillIntoLayer("layer:api");
+    store.getState().drillIntoSubGroup("layer:api:app");
+    const state = store.getState();
+    expect(state.navigationLevel).toBe("layer-detail");
+    expect(state.activeLayerId).toBe("layer:api");
+    expect(state.activeSubGroupId).toBe("layer:api:app");
+  });
+
+  it("drillOut steps detail → groups → overview", () => {
+    store.getState().setView(createCuratedView());
+    store.getState().drillIntoLayer("layer:api");
+    store.getState().drillIntoSubGroup("layer:api:app");
+
+    store.getState().drillOut();
+    expect(store.getState().navigationLevel).toBe("layer-groups");
+    expect(store.getState().activeLayerId).toBe("layer:api");
+    expect(store.getState().activeSubGroupId).toBeNull();
+
+    store.getState().drillOut();
+    expect(store.getState().navigationLevel).toBe("overview");
+    expect(store.getState().activeLayerId).toBeNull();
+  });
+
+  it("drillOut from an uncurated layer goes straight to overview", () => {
+    store.getState().setView(createCuratedView());
+    store.getState().drillIntoLayer("layer:core");
+    store.getState().drillOut();
+    expect(store.getState().navigationLevel).toBe("overview");
+  });
+
+  it("selectNode auto-drills to the node's layer AND sub-group", () => {
+    store.getState().setView(createCuratedView());
+    store.getState().selectNode("src/routes.py");
+    const state = store.getState();
+    expect(state.navigationLevel).toBe("layer-detail");
+    expect(state.activeLayerId).toBe("layer:api");
+    expect(state.activeSubGroupId).toBe("layer:api:routes");
+    expect(state.selectedNodeId).toBe("src/routes.py");
+  });
+
+  it("tour steps drill into the step node's sub-group", () => {
+    store.getState().setView(createCuratedView());
+    store.getState().startTour();
+    // First tour step targets src/app.py (fixture).
+    expect(store.getState().activeSubGroupId).toBe("layer:api:app");
+    store.getState().nextTourStep();
+    expect(store.getState().activeSubGroupId).toBe("layer:api:routes");
+  });
+});
+
+describe("layout: visible-box budget + test-layer demotion (B-5)", () => {
+  it("caps the layer-groups tier at 12 cards with a '+N more groups' card", async () => {
+    const view = createCuratedView();
+    // 16 single-file sub-groups, each with a distinct pagerank.
+    const fileIds = Array.from({ length: 16 }, (_, i) => `src/big/f${i}.py`);
+    view.nodes = [
+      ...view.nodes,
+      ...fileIds.map((id, i) => ({
+        ...view.nodes[0]!,
+        id,
+        file_path: id,
+        pagerank: 1 - i * 0.05,
+      })),
+    ];
+    view.layers = [
+      {
+        ...view.layers[0]!,
+        id: "layer:big",
+        name: "Big",
+        node_ids: fileIds,
+        sub_groups: fileIds.map((id, i) => ({
+          id: `layer:big:g${i}`,
+          name: `g${i}`,
+          node_ids: [id],
+        })),
+      },
+    ];
+    act(() => {
+      store.getState().setView(view);
+      store.getState().drillIntoLayer("layer:big");
+    });
+    const { result } = renderHook(() => useArchitectureLayout());
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+
+    const cards = result.current.nodes.filter((n) => n.type === "subGroupCluster");
+    expect(cards.length).toBeLessThanOrEqual(12);
+    const more = cards.find((n) => n.id === "layer:big:__more");
+    expect(more).toBeDefined();
+    expect((more!.data as { layer: { name: string } }).layer.name).toBe("+5 more groups");
+    // The strongest groups stay visible; the weakest fold into "+N more".
+    expect(cards.some((n) => n.id === "layer:big:g0")).toBe(true);
+    expect(cards.some((n) => n.id === "layer:big:g15")).toBe(false);
+  });
+
+  it("demotes the Test layer card by default and restores it via showTests", async () => {
+    const view = createCuratedView();
+    view.layers = [
+      ...view.layers,
+      {
+        ...view.layers[1]!,
+        id: "layer:test",
+        name: "Test",
+        node_ids: [],
+        sub_groups: [],
+        display_order: 9,
+      },
+    ];
+    act(() => {
+      store.getState().setView(view);
+    });
+    const { result } = renderHook(() => useArchitectureLayout());
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+    const testCard = () => result.current.nodes.find((n) => n.id === "layer:test")!;
+    expect((testCard().data as { demoted?: boolean }).demoted).toBe(true);
+    // Other layers are not demoted.
+    const api = result.current.nodes.find((n) => n.id === "layer:api")!;
+    expect((api.data as { demoted?: boolean }).demoted).toBe(false);
+
+    act(() => {
+      store.getState().setShowTests(true);
+    });
+    await waitFor(() => {
+      expect((testCard().data as { demoted?: boolean }).demoted).toBe(false);
+    });
+  });
+});
+
+describe("layout: curated overview stacking", () => {
+  it("stacks layer cards by display_order, not edge direction", async () => {
+    const view = createCuratedView();
+    // Curated order says API (0) above Core (1); add a contrarian edge
+    // core → api that unseeded ELK would stack the other way.
+    view.edges = [
+      ...view.edges,
+      {
+        source: "src/models.py",
+        target: "src/app.py",
+        edge_type: "imports",
+        direction: "forward",
+        weight: 1,
+        confidence: 1,
+      },
+    ];
+    act(() => {
+      store.getState().setView(view);
+    });
+    const { result } = renderHook(() => useArchitectureLayout());
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+
+    const api = result.current.nodes.find((n) => n.id === "layer:api")!;
+    const core = result.current.nodes.find((n) => n.id === "layer:core")!;
+    expect(api.position.y).toBeLessThan(core.position.y);
+  });
+});
+
+describe("layout: layer-groups tier", () => {
+  it("renders only sub-group cards (+ portals) — never file cards", async () => {
+    act(() => {
+      store.getState().setView(createCuratedView());
+      store.getState().drillIntoLayer("layer:api");
+    });
+    const { result } = renderHook(() => useArchitectureLayout());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+
+    const types = result.current.nodes.map((n) => n.type);
+    expect(types).not.toContain("archFile");
+    expect(types.filter((t) => t === "subGroupCluster")).toHaveLength(2);
+    // Cross-layer edges to layer:core collapse into a portal stub.
+    expect(types).toContain("portal");
+
+    const cardIds = result.current.nodes.map((n) => n.id);
+    expect(cardIds).toContain("layer:api:app");
+    expect(cardIds).toContain("layer:api:routes");
+
+    // One aggregated, labelled arrow between the two visible cards.
+    const aggEdge = result.current.edges.find(
+      (e) => e.source === "layer:api:app" && e.target === "layer:api:routes",
+    );
+    expect(aggEdge).toBeDefined();
+  });
+
+  it("collects curation leftovers into an 'Other files' card", async () => {
+    const view = createCuratedView();
+    view.layers[0]!.sub_groups = [
+      { id: "layer:api:app", name: "app", node_ids: ["src/app.py"] },
+    ];
+    act(() => {
+      store.getState().setView(view);
+      store.getState().drillIntoLayer("layer:api");
+    });
+    const { result } = renderHook(() => useArchitectureLayout());
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+
+    const ungrouped = result.current.nodes.find((n) => n.id === "layer:api:__ungrouped");
+    expect(ungrouped).toBeDefined();
+    expect(ungrouped!.type).toBe("subGroupCluster");
+    expect((ungrouped!.data as { layer: { node_ids: string[] } }).layer.node_ids).toEqual([
+      "src/routes.py",
+    ]);
+  });
+
+  it("layer-detail scoped to one group shows its files + sibling collapsed cards", async () => {
+    act(() => {
+      store.getState().setView(createCuratedView());
+      store.getState().drillIntoLayer("layer:api");
+      store.getState().drillIntoSubGroup("layer:api:app");
+    });
+    const { result } = renderHook(() => useArchitectureLayout());
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+
+    const fileIds = result.current.nodes.filter((n) => n.type === "archFile").map((n) => n.id);
+    expect(fileIds).toEqual(["src/app.py"]); // scoped — never the whole layer
+
+    const sibling = result.current.nodes.find((n) => n.id === "layer:api:routes");
+    expect(sibling).toBeDefined();
+    expect(sibling!.type).toBe("subGroupCluster");
+
+    // The in-layer cross-group edge aggregates file/card → sibling card.
+    const toSibling = result.current.edges.find((e) => e.target === "layer:api:routes");
+    expect(toSibling).toBeDefined();
+  });
+
+  it("uncurated layers keep today's layer-detail behaviour", async () => {
+    act(() => {
+      store.getState().setView(createCuratedView());
+      store.getState().drillIntoLayer("layer:core");
+    });
+    const { result } = renderHook(() => useArchitectureLayout());
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+
+    const types = result.current.nodes.map((n) => n.type);
+    expect(types).toContain("archFile");
+    expect(types).not.toContain("subGroupCluster");
+  });
+});
+
+describe("scope frame — dashed 'you are here' boundary (kg-ux plan B4)", () => {
+  it("wraps the groups tier in a frame labeled with the layer name", async () => {
+    act(() => {
+      store.getState().setView(createCuratedView());
+      store.getState().drillIntoLayer("layer:api");
+    });
+    const { result } = renderHook(() => useArchitectureLayout());
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+
+    const frame = result.current.nodes.find((n) => n.type === "scopeFrame");
+    expect(frame).toBeDefined();
+    expect((frame!.data as { label: string }).label).toBe("API");
+    // Pure underlay: behind cards, never interactive.
+    expect(frame!.zIndex).toBe(-1);
+    expect(frame!.selectable).toBe(false);
+    expect(frame!.draggable).toBe(false);
+  });
+
+  it("labels the detail-tier frame 'Layer › Group' when a sub-group is active", async () => {
+    act(() => {
+      store.getState().setView(createCuratedView());
+      store.getState().drillIntoLayer("layer:api");
+      store.getState().drillIntoSubGroup("layer:api:app");
+    });
+    const { result } = renderHook(() => useArchitectureLayout());
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+
+    const frame = result.current.nodes.find((n) => n.type === "scopeFrame");
+    expect(frame).toBeDefined();
+    expect((frame!.data as { label: string }).label).toBe("API › app");
+  });
+
+  it("draws no frame on the overview tier", async () => {
+    act(() => {
+      store.getState().setView(createCuratedView());
+    });
+    const { result } = renderHook(() => useArchitectureLayout());
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+
+    expect(result.current.nodes.find((n) => n.type === "scopeFrame")).toBeUndefined();
+  });
+});

--- a/packages/ui/__tests__/c4/learn-panel-tour.test.tsx
+++ b/packages/ui/__tests__/c4/learn-panel-tour.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tour wiring end-to-end (viewer plan C-2): LearnPanel renders the curated
+ * step fields (reason as body, layer pill, kind icon), the canvas follows
+ * the step's layer/sub-group, and the highlighted node carries a numbered
+ * step badge. Curated text is sentinel-tagged so we know the rendered
+ * content came from the artifact, not a heuristic.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
+import { LearnPanel } from "../../src/c4/panels/LearnPanel";
+import { useArchitectureStore } from "../../src/c4/store/use-architecture-store";
+import { useArchitectureLayout } from "../../src/c4/hooks/use-architecture-layout";
+import { createMockView } from "./fixtures";
+import type { ArchitectureView } from "../../src/c4/types";
+
+const store = useArchitectureStore;
+
+beforeEach(() => {
+  store.setState(store.getInitialState());
+});
+
+function createCuratedTourView(): ArchitectureView {
+  const base = createMockView();
+  return {
+    ...base,
+    tour: [
+      {
+        order: 1,
+        title: "app.py",
+        description: "",
+        node_ids: ["src/app.py"],
+        target_path: "src/app.py",
+        layer_id: "layer:api",
+        reason: "SENTINEL-REASON: top of the stack, start here.",
+        depth: 0,
+        kind: "code",
+        page_type: "file_page",
+      },
+      {
+        order: 2,
+        title: "models.py",
+        description: "",
+        node_ids: ["src/models.py"],
+        target_path: "src/models.py",
+        layer_id: "layer:core",
+        reason: "SENTINEL-REASON: foundational layer.",
+        depth: 1,
+        kind: "code",
+        page_type: "file_page",
+      },
+    ],
+  };
+}
+
+describe("LearnPanel with curated tour steps", () => {
+  it("renders reason as the step body, with layer pill and kind icon", () => {
+    act(() => {
+      store.getState().setView(createCuratedTourView());
+      store.getState().startTour();
+    });
+    const { getByText, getByLabelText } = render(<LearnPanel />);
+
+    expect(getByText("SENTINEL-REASON: top of the stack, start here.")).toBeDefined();
+    expect(getByText("API")).toBeDefined(); // layer pill
+    expect(getByLabelText("Code step")).toBeDefined(); // kind icon
+  });
+
+  it("falls back to description for legacy LLM steps", () => {
+    act(() => {
+      store.getState().setView(createMockView()); // legacy fixture tour
+      store.getState().startTour();
+    });
+    const { getByText } = render(<LearnPanel />);
+    expect(getByText("Start here")).toBeDefined();
+  });
+});
+
+describe("canvas follows the tour", () => {
+  it("each step drills the canvas to the step's layer", () => {
+    act(() => {
+      store.getState().setView(createCuratedTourView());
+      store.getState().startTour();
+    });
+    expect(store.getState().activeLayerId).toBe("layer:api");
+
+    act(() => {
+      store.getState().nextTourStep();
+    });
+    expect(store.getState().activeLayerId).toBe("layer:core");
+    expect(store.getState().selectedNodeId).toBe("src/models.py");
+  });
+
+  it("uses the curated layer_id when the step's node is not in the graph", () => {
+    const view = createCuratedTourView();
+    view.tour[0]!.node_ids = ["ghost/file.py"];
+    view.tour[0]!.target_path = "ghost/file.py";
+    act(() => {
+      store.getState().setView(view);
+      store.getState().startTour();
+    });
+    expect(store.getState().navigationLevel).toBe("layer-detail");
+    expect(store.getState().activeLayerId).toBe("layer:api");
+  });
+
+  it("puts a numbered step badge on the highlighted node", async () => {
+    act(() => {
+      store.getState().setView(createCuratedTourView());
+      store.getState().startTour();
+      store.getState().nextTourStep(); // step 2 → src/models.py in layer:core
+    });
+    const { result } = renderHook(() => useArchitectureLayout());
+
+    await waitFor(() => {
+      expect(result.current.nodes.length).toBeGreaterThan(0);
+    });
+
+    const target = result.current.nodes.find((n) => n.id === "src/models.py")!;
+    expect((target.data as { tourStepNumber?: number }).tourStepNumber).toBe(2);
+    const other = result.current.nodes.find((n) => n.id !== "src/models.py" && n.type === "archFile");
+    if (other) {
+      expect((other.data as { tourStepNumber?: number }).tourStepNumber).toBeUndefined();
+    }
+  });
+});

--- a/packages/ui/__tests__/c4/project-overview.test.tsx
+++ b/packages/ui/__tests__/c4/project-overview.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Orientation-first ProjectOverview (viewer plan C-1): summary, Start tour
+ * CTA, clickable entry points, layer stack mini-map — stats below the fold.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { ProjectOverview } from "../../src/c4/panels/ProjectOverview";
+import { useArchitectureStore } from "../../src/c4/store/use-architecture-store";
+import { createMockView } from "./fixtures";
+
+const store = useArchitectureStore;
+
+beforeEach(() => {
+  store.setState(store.getInitialState());
+});
+
+function setCuratedView() {
+  const view = createMockView({
+    entry_points: ["src/app.py", "src/routes.py"],
+  });
+  store.getState().setView(view);
+  return view;
+}
+
+describe("ProjectOverview (orientation-first)", () => {
+  it("leads with Start tour, entry points and the layer stack", () => {
+    setCuratedView();
+    const { getByText, getByLabelText } = render(<ProjectOverview />);
+
+    const tourButton = getByText(/Start tour \(3 steps\)/);
+    const entryPoint = getByLabelText("Open entry point src/app.py");
+    const layerRow = getByLabelText("Explore layer API");
+    const stats = getByText("Stats");
+
+    // Orientation content appears above the stats fold in DOM order.
+    expect(
+      tourButton.compareDocumentPosition(stats) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      entryPoint.compareDocumentPosition(stats) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      layerRow.compareDocumentPosition(stats) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("clicking an entry point selects (and auto-drills to) the node", () => {
+    setCuratedView();
+    const { getByLabelText } = render(<ProjectOverview />);
+
+    fireEvent.click(getByLabelText("Open entry point src/app.py"));
+    expect(store.getState().selectedNodeId).toBe("src/app.py");
+    expect(store.getState().activeLayerId).toBe("layer:api");
+  });
+
+  it("clicking a layer row drills into the layer", () => {
+    setCuratedView();
+    const { getByLabelText } = render(<ProjectOverview />);
+
+    fireEvent.click(getByLabelText("Explore layer Core"));
+    expect(store.getState().activeLayerId).toBe("layer:core");
+  });
+
+  it("orders the layer stack by curated display_order", () => {
+    const view = createMockView();
+    // Reverse the natural order: Core(0) above API(1).
+    view.layers[0]!.display_order = 1;
+    view.layers[1]!.display_order = 0;
+    store.getState().setView(view);
+    const { getByLabelText } = render(<ProjectOverview />);
+
+    const api = getByLabelText("Explore layer API");
+    const core = getByLabelText("Explore layer Core");
+    expect(
+      core.compareDocumentPosition(api) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("starting the tour from the CTA activates it", () => {
+    setCuratedView();
+    const { getByText } = render(<ProjectOverview />);
+
+    fireEvent.click(getByText(/Start tour/));
+    expect(store.getState().tourActive).toBe(true);
+  });
+
+  it("hides entry points section for uncurated repos", () => {
+    store.getState().setView(createMockView());
+    const { queryByText } = render(<ProjectOverview />);
+    expect(queryByText("Entry points")).toBeNull();
+  });
+});

--- a/packages/ui/__tests__/c4/search-filter-tour.test.tsx
+++ b/packages/ui/__tests__/c4/search-filter-tour.test.tsx
@@ -9,7 +9,10 @@ import { PersonaSelector } from "../../src/c4/panels/PersonaSelector";
 import { fuzzyMatch, scoreField } from "../../src/c4/utils/fuzzy-match";
 import { createMockView } from "./fixtures";
 
-vi.mock("lucide-react", () => ({
+vi.mock("lucide-react", async (importOriginal) => ({
+  // Partial mock: kind-icons.ts pulls many glyphs; only the ones these
+  // tests assert on are replaced with testid stubs.
+  ...(await importOriginal<typeof import("lucide-react")>()),
   Search: ({ size }: { size?: number }) => <span data-testid="icon-search">S</span>,
   Filter: ({ size }: { size?: number }) => <span data-testid="icon-filter">F</span>,
   Compass: ({ size }: { size?: number }) => <span data-testid="icon-compass">C</span>,

--- a/packages/ui/__tests__/c4/sidebar.test.tsx
+++ b/packages/ui/__tests__/c4/sidebar.test.tsx
@@ -87,17 +87,17 @@ describe("ProjectOverview", () => {
     expect(screen.getByText("fastapi")).toBeInTheDocument();
   });
 
-  it("shows Start Guided Tour button when tour exists", () => {
+  it("shows Start tour button when tour exists", () => {
     act(() => store.getState().setView(mockView));
     render(<ProjectOverview />);
-    expect(screen.getByText("Start Guided Tour (3 steps)")).toBeInTheDocument();
+    expect(screen.getByText("Start tour (3 steps)")).toBeInTheDocument();
   });
 
   it("hides tour button when tour is empty", () => {
     const viewNoTour = { ...mockView, tour: [] };
     act(() => store.getState().setView(viewNoTour));
     render(<ProjectOverview />);
-    expect(screen.queryByText(/Start Guided Tour/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Start tour/)).not.toBeInTheDocument();
   });
 
   it("hides tour button when tour is already active", () => {
@@ -106,7 +106,7 @@ describe("ProjectOverview", () => {
       store.getState().startTour();
     });
     render(<ProjectOverview />);
-    expect(screen.queryByText(/Start Guided Tour/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Start tour/)).not.toBeInTheDocument();
   });
 
   it("shows most connected nodes sorted by degree", () => {

--- a/packages/ui/__tests__/c4/theme-mobile.test.tsx
+++ b/packages/ui/__tests__/c4/theme-mobile.test.tsx
@@ -77,9 +77,9 @@ describe("Theme Variables", () => {
     expect(THEME.accent.primary).toContain("--color-accent-primary");
     expect(THEME.selection).toBeDefined();
     expect(THEME.complexity).toBeDefined();
-    expect(THEME.complexity.simple).toBe("#22c55e");
-    expect(THEME.complexity.moderate).toBe("#f59e0b");
-    expect(THEME.complexity.complex).toBe("#ef4444");
+    expect(THEME.complexity.simple).toContain("--color-success");
+    expect(THEME.complexity.moderate).toContain("--color-warning");
+    expect(THEME.complexity.complex).toContain("--color-error");
     expect(THEME.diff).toBeDefined();
     expect(THEME.font).toBeDefined();
     expect(THEME.radius).toBeDefined();

--- a/packages/ui/__tests__/c4/two-stage-layout.test.ts
+++ b/packages/ui/__tests__/c4/two-stage-layout.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
+  assignSlotsByRank,
   computeStage1Layout,
+  hoistPrioritySlots,
   computeStage2Layout,
   repairElkInput,
   estimateContainerSize,
@@ -141,5 +143,89 @@ describe("computeStage2Layout", () => {
     expect(result.positions.size).toBe(0);
     expect(result.actualSize.width).toBe(0);
     expect(result.actualSize.height).toBe(0);
+  });
+});
+
+describe("assignSlotsByRank (curated display_order, plan B-4)", () => {
+  function pos(x: number, y: number) {
+    return { x, y, width: 360, height: 220 };
+  }
+
+  it("re-ranks card slots even when edges stacked them the other way", () => {
+    // ELK stacked persistence above ui (edge persistence → ui); the curated
+    // ranks say ui(0) < service(1) < persistence(2) top→bottom.
+    const positions = new Map([
+      ["layer:persistence", pos(20, 40)],
+      ["layer:ui", pos(20, 340)],
+      ["layer:service", pos(20, 640)],
+    ]);
+    const ranks = new Map([
+      ["layer:ui", 0],
+      ["layer:service", 1],
+      ["layer:persistence", 2],
+    ]);
+    const out = assignSlotsByRank(positions, ranks);
+    expect(out.get("layer:ui")!.y).toBeLessThan(out.get("layer:service")!.y);
+    expect(out.get("layer:service")!.y).toBeLessThan(out.get("layer:persistence")!.y);
+    // The slot set itself is preserved — only the occupants change.
+    const ys = [...out.values()].map((p) => p.y).sort((a, b) => a - b);
+    expect(ys).toEqual([40, 340, 640]);
+  });
+
+  it("reads same-row slots left→right by rank", () => {
+    const positions = new Map([
+      ["b", pos(440, 40)],
+      ["a", pos(20, 40)],
+      ["c", pos(20, 340)],
+    ]);
+    const ranks = new Map([["a", 0], ["b", 1], ["c", 2]]);
+    const out = assignSlotsByRank(positions, ranks);
+    expect(out.get("a")).toEqual(pos(20, 40));
+    expect(out.get("b")).toEqual(pos(440, 40));
+    expect(out.get("c")).toEqual(pos(20, 340));
+  });
+
+  it("leaves unranked entries (portals) and tiny inputs untouched", () => {
+    const positions = new Map([
+      ["layer:a", pos(20, 40)],
+      ["portal:x", { x: 500, y: 40, width: 180, height: 60 }],
+    ]);
+    const out = assignSlotsByRank(positions, new Map([["layer:a", 0]]));
+    expect(out).toEqual(positions);
+  });
+});
+
+describe("hoistPrioritySlots (entry-point anchoring, plan C-3)", () => {
+  const children = [
+    { id: "a.py", width: 300, height: 140 },
+    { id: "b.py", width: 300, height: 140 },
+    { id: "main.py", width: 300, height: 140 },
+    { id: "conf.yaml", width: 240, height: 100 },
+  ];
+
+  it("bubbles entry points to the top-left slot of their size group", () => {
+    const positions = new Map([
+      ["a.py", { x: 20, y: 20 }],
+      ["b.py", { x: 20, y: 180 }],
+      ["main.py", { x: 20, y: 340 }],
+      ["conf.yaml", { x: 360, y: 20 }],
+    ]);
+    const out = hoistPrioritySlots(positions, children, (id) => id === "main.py");
+
+    expect(out.get("main.py")).toEqual({ x: 20, y: 20 });
+    // Non-priority nodes keep their relative order in the remaining slots.
+    expect(out.get("a.py")).toEqual({ x: 20, y: 180 });
+    expect(out.get("b.py")).toEqual({ x: 20, y: 340 });
+    // Different-size nodes are never disturbed (overlap safety).
+    expect(out.get("conf.yaml")).toEqual({ x: 360, y: 20 });
+  });
+
+  it("is a no-op when no priority node is present", () => {
+    const positions = new Map([
+      ["a.py", { x: 20, y: 20 }],
+      ["b.py", { x: 20, y: 180 }],
+    ]);
+    const out = hoistPrioritySlots(positions, children, () => false);
+    expect(out).toEqual(positions);
   });
 });

--- a/packages/ui/src/c4/C4Diagram.tsx
+++ b/packages/ui/src/c4/C4Diagram.tsx
@@ -12,6 +12,7 @@
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import {
   Background,
+  BackgroundVariant,
   Controls,
   MiniMap,
   ReactFlow,
@@ -151,7 +152,7 @@ function C4DiagramInner({
         height: "100%",
         display: "flex",
         flexDirection: "column",
-        background: "var(--color-bg-canvas, #0b1220)",
+        background: "var(--color-bg-canvas)",
       }}
     >
       {/* Toolbar row */}
@@ -161,7 +162,7 @@ function C4DiagramInner({
           alignItems: "center",
           gap: 16,
           padding: "8px 12px",
-          borderBottom: "1px solid var(--color-border-default, #334155)",
+          borderBottom: "1px solid var(--color-border-default)",
           background: "var(--color-bg-surface, rgba(15,23,42,0.6))",
         }}
       >
@@ -170,7 +171,7 @@ function C4DiagramInner({
           onLevelChange={onLevelChange}
           l3Enabled={activeContainerId != null || level === 3}
         />
-        <div style={{ width: 1, height: 20, background: "var(--color-border-default, #334155)" }} />
+        <div style={{ width: 1, height: 20, background: "var(--color-border-default)" }} />
         <C4Breadcrumb
           level={level}
           systemName={systemName}
@@ -215,9 +216,12 @@ function C4DiagramInner({
           nodesDraggable={false}
           nodesConnectable={false}
         >
-          <Background gap={28} size={1} color="rgba(148,163,184,0.18)" />
+          {/* Blueprint graph paper: 24px line grid on the warm canvas, matching
+              the mermaid container (kg-ux plan §2.1). */}
+          <Background variant={BackgroundVariant.Lines} gap={24} size={1} color="var(--color-diagram-grid)" />
           <Controls showInteractive={false} />
-          <MiniMap pannable zoomable maskColor="rgba(11,18,32,0.85)" />
+          {/* maskColor comes from --xy-minimap-mask-background (theme-aware). */}
+          <MiniMap pannable zoomable />
         </ReactFlow>
 
         {selectedData && renderInspector
@@ -254,10 +258,10 @@ function exportFileStem(systemName: string, level: C4Level, activePath: string |
 function CenteredMessage({ tone, text }: { tone: "info" | "empty" | "error"; text: string }) {
   const color =
     tone === "error"
-      ? "#fca5a5"
+      ? "var(--color-error)"
       : tone === "empty"
-      ? "var(--color-text-tertiary, #64748b)"
-      : "var(--color-text-secondary, #94a3b8)";
+      ? "var(--color-text-tertiary)"
+      : "var(--color-text-secondary)";
   return (
     <div
       role="status"

--- a/packages/ui/src/c4/edges/RelationEdge.tsx
+++ b/packages/ui/src/c4/edges/RelationEdge.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 /**
- * Styled C4 relation edge — a bezier line with an optional label pill
- * showing edge count and dominant edge type.
+ * Styled C4 relation edge — blueprint dashed smooth-step line with an
+ * optional paper chip showing edge count and dominant edge type.
  */
 
 import { memo } from "react";
 import {
   BaseEdge,
   EdgeLabelRenderer,
-  getBezierPath,
+  getSmoothStepPath,
   type EdgeProps,
 } from "@xyflow/react";
+import { THEME } from "../theme/theme-variables";
 import type { C4EdgeData } from "../types";
 
 function RelationEdgeImpl(props: EdgeProps) {
@@ -29,16 +30,17 @@ function RelationEdgeImpl(props: EdgeProps) {
   } = props;
   const relation = (data as C4EdgeData | undefined)?.relation;
 
-  const [edgePath, labelX, labelY] = getBezierPath({
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
     sourceX,
     sourceY,
     sourcePosition,
     targetX,
     targetY,
     targetPosition,
+    borderRadius: 8,
   });
 
-  const stroke = selected ? "#fbbf24" : "#94a3b8";
+  const stroke = selected ? THEME.selection.ring : "var(--color-diagram-edge)";
   const strokeWidth = relation && relation.edge_count > 5 ? 2 : 1.25;
 
   const label = relation
@@ -50,21 +52,27 @@ function RelationEdgeImpl(props: EdgeProps) {
 
   return (
     <>
-      <BaseEdge id={id} path={edgePath} {...(markerEnd ? { markerEnd } : {})} style={{ stroke, strokeWidth }} />
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        {...(markerEnd ? { markerEnd } : {})}
+        style={{ stroke, strokeWidth, strokeDasharray: selected ? "none" : "6 4" }}
+      />
       {label && (
         <EdgeLabelRenderer>
           <div
             style={{
               position: "absolute",
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-              background: "rgba(15, 23, 42, 0.92)",
-              color: "#e2e8f0",
-              padding: "2px 6px",
-              borderRadius: 4,
-              fontSize: 10,
+              background: "var(--color-bg-surface)",
+              color: THEME.text.secondary,
+              padding: "2px 7px",
+              borderRadius: 6,
+              fontFamily: "var(--font-mono, ui-monospace, monospace)",
+              fontSize: 9.5,
               fontWeight: 500,
               pointerEvents: "none",
-              border: "1px solid rgba(148, 163, 184, 0.25)",
+              border: `1px solid ${THEME.border.default}`,
               whiteSpace: "nowrap",
             }}
             className="nodrag nopan"

--- a/packages/ui/src/c4/export/ExportMenu.tsx
+++ b/packages/ui/src/c4/export/ExportMenu.tsx
@@ -132,9 +132,9 @@ export function C4ExportMenu({
           padding: "4px 10px",
           fontSize: 11,
           fontWeight: 500,
-          color: "var(--color-text-secondary, #cbd5e1)",
+          color: "var(--color-text-secondary)",
           background: "transparent",
-          border: "1px solid var(--color-border-default, #334155)",
+          border: "1px solid var(--color-border-default)",
           borderRadius: 4,
           cursor: disabled ? "not-allowed" : "pointer",
           opacity: disabled ? 0.5 : 1,
@@ -151,8 +151,8 @@ export function C4ExportMenu({
             top: "calc(100% + 4px)",
             right: 0,
             minWidth: 200,
-            background: "var(--color-bg-elevated, #111827)",
-            border: "1px solid var(--color-border-default, #334155)",
+            background: "var(--color-bg-elevated)",
+            border: "1px solid var(--color-border-default)",
             borderRadius: 6,
             boxShadow: "0 10px 30px rgba(0,0,0,0.4)",
             padding: 4,
@@ -187,7 +187,7 @@ export function C4ExportMenu({
             </>
           )}
           {status === "error" && (
-            <div style={{ padding: "6px 10px", fontSize: 10, color: "#fca5a5" }}>
+            <div style={{ padding: "6px 10px", fontSize: 10, color: "var(--color-error)" }}>
               Export failed. Try again.
             </div>
           )}
@@ -219,13 +219,13 @@ function MenuItem({
         padding: "6px 10px",
         background: "transparent",
         border: "none",
-        color: "var(--color-text-primary, #f1f5f9)",
+        color: "var(--color-text-primary)",
         fontSize: 12,
         textAlign: "left",
         cursor: "pointer",
         borderRadius: 4,
       }}
-      onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(148,163,184,0.12)")}
+      onMouseEnter={(e) => (e.currentTarget.style.background = "var(--color-border-subtle)")}
       onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
     >
       {icon}
@@ -239,7 +239,7 @@ function Divider() {
     <div
       style={{
         height: 1,
-        background: "var(--color-border-default, #334155)",
+        background: "var(--color-border-default)",
         margin: "4px 2px",
       }}
     />

--- a/packages/ui/src/c4/export/svg-exporter.ts
+++ b/packages/ui/src/c4/export/svg-exporter.ts
@@ -9,7 +9,36 @@
 import type { Edge, Node } from "@xyflow/react";
 import type { C4EdgeData, C4NodeData } from "../types";
 import { TONE_STYLES, type ToneName } from "../../graph-primitives/tone-styles";
-import { THEME } from "../theme/theme-variables";
+import { resolveToken } from "../../shared/use-theme-tokens";
+
+/**
+ * Blueprint ink palette, resolved from the LIVE theme at export time so the
+ * file matches what the user sees (kg-ux plan B7). The literals are
+ * light-mode fallbacks for headless export (jsdom/tests) where computed
+ * styles are empty.
+ */
+function resolveInkPalette() {
+  return {
+    canvas: resolveToken("--color-bg-canvas", "#f4eae1"),
+    grid: resolveToken("--color-diagram-grid", "rgba(245,149,32,0.10)"),
+    ink: resolveToken("--color-kg-node-fill", "#fffdf8"),
+    ink2: resolveToken("--color-kg-node-fill-2", "#f3ece2"),
+    inkText: resolveToken("--color-kg-node-text", "#241b2c"),
+    inkBorder: resolveToken("--color-kg-node-border", "#241b2c"),
+    edge: resolveToken("--color-diagram-edge", "#4a3d59"),
+    cluster: resolveToken("--color-diagram-cluster-border", "#826aa0"),
+    accent: resolveToken("--color-accent-fill", "#f59520"),
+    accentEnd: "#f7a94d", // --gradient-ember end stop
+    textOnAccent: resolveToken("--color-text-on-accent", "#241b2c"),
+    paper: resolveToken("--color-bg-surface", "#ffffff"),
+    textPrimary: resolveToken("--color-text-primary", "#241b2c"),
+    textSecondary: resolveToken("--color-text-secondary", "#5e5360"),
+    success: resolveToken("--color-success", "#1d8155"),
+    warning: resolveToken("--color-warning", "#9a6614"),
+    error: resolveToken("--color-error", "#b23a2e"),
+  };
+}
+type InkPalette = ReturnType<typeof resolveInkPalette>;
 
 interface ArchFileNodeData {
   node: {
@@ -53,6 +82,7 @@ interface PortalNodeData {
 const PADDING = 40;
 const BAND_HEIGHT = 18;
 const FONT_FAMILY = "system-ui, -apple-system, Segoe UI, sans-serif";
+const MONO_FONT = "ui-monospace, Menlo, Consolas, monospace";
 
 function escapeXml(value: string): string {
   return value
@@ -180,7 +210,7 @@ function renderNode(n: Node): string {
   return parts.join("");
 }
 
-function renderArchNode(n: Node): string {
+function renderArchNode(n: Node, pal: InkPalette): string {
   const type = n.type ?? "";
   const w = (n.width as number | undefined) ?? 200;
   const h = (n.height as number | undefined) ?? 100;
@@ -188,71 +218,73 @@ function renderArchNode(n: Node): string {
   const y = n.position.y;
   const parts: string[] = [];
 
-  if (type === "archFile") {
+  // Shared ink-block scaffolding (mirrors InkNodeShell anatomy).
+  const inkBox = (fill: string, dashed = false, gradient = false) =>
+    `<rect width="${w}" height="${h}" rx="12" ry="12" fill="${gradient ? "url(#kg-ember)" : fill}" stroke="${dashed ? pal.cluster : pal.inkBorder}" stroke-width="1.5"${dashed ? ' stroke-dasharray="8 5"' : ""}/>`;
+
+  if (type === "scopeFrame") {
+    const data = n.data as unknown as { label: string };
+    parts.push(`<g transform="translate(${x},${y})">`);
+    parts.push(`<rect width="${w}" height="${h}" rx="16" ry="16" fill="none" stroke="${pal.cluster}" stroke-width="1.5" stroke-dasharray="8 5"/>`);
+    parts.push(`<rect x="20" y="-9" width="${Math.min(w - 40, data.label.length * 7 + 20)}" height="18" rx="6" fill="${pal.canvas}" stroke="${pal.cluster}" stroke-width="1" stroke-dasharray="4 3"/>`);
+    parts.push(`<text x="30" y="4" font-family="${MONO_FONT}" font-size="9" font-weight="600" letter-spacing="1" fill="${pal.textSecondary}">${escapeXml(data.label.toUpperCase())}</text>`);
+    parts.push(`</g>`);
+  } else if (type === "archFile") {
     const data = n.data as unknown as ArchFileNodeData;
     const nodeData = data.node;
-    const tone = nodeData.node_type as ToneName;
-    const style = TONE_STYLES[tone] ?? TONE_STYLES.file;
+    const isEntry = nodeData.is_entry_point;
+    const text = isEntry ? pal.textOnAccent : pal.inkText;
     const kindLabel = nodeData.language
       ? `${nodeData.node_type.toUpperCase()} · ${nodeData.language}`
       : nodeData.node_type.toUpperCase();
     const title = escapeXml(truncate(nodeData.name, Math.floor(w / 8)));
     const subtitle = escapeXml(truncate(nodeData.summary, Math.floor(w / 6)));
-    const complexityColor = THEME.complexity[nodeData.complexity] ?? "#94a3b8";
+    const complexityColor =
+      nodeData.complexity === "simple" ? pal.success : nodeData.complexity === "moderate" ? pal.warning : pal.error;
 
     parts.push(`<g transform="translate(${x},${y})">`);
-    parts.push(`<rect width="${w}" height="${h}" rx="8" ry="8" fill="${style.bg}" stroke="${style.border}" stroke-width="1.5"/>`);
-    parts.push(`<rect width="${w}" height="${BAND_HEIGHT}" rx="8" ry="8" fill="${style.band}"/>`);
-    parts.push(`<rect y="${BAND_HEIGHT - 8}" width="${w}" height="8" fill="${style.band}"/>`);
-    parts.push(`<text x="8" y="${BAND_HEIGHT - 5}" font-family="${FONT_FAMILY}" font-size="9" font-weight="600" letter-spacing="0.6" fill="${style.text}" opacity="0.85">${escapeXml(kindLabel)}</text>`);
-    parts.push(`<text x="10" y="${BAND_HEIGHT + 20}" font-family="${FONT_FAMILY}" font-size="13" font-weight="600" fill="${style.text}">${title}</text>`);
-    parts.push(`<text x="10" y="${BAND_HEIGHT + 36}" font-family="${FONT_FAMILY}" font-size="11" fill="${style.text}" opacity="0.75">${subtitle}</text>`);
-    parts.push(`<circle cx="14" cy="${h - 12}" r="4" fill="${complexityColor}"/>`);
-    parts.push(`<text x="24" y="${h - 8}" font-family="${FONT_FAMILY}" font-size="10" fill="${style.text}" opacity="0.8">↓${nodeData.in_degree} ↑${nodeData.out_degree}</text>`);
+    parts.push(inkBox(pal.ink, false, isEntry));
+    parts.push(`<text x="12" y="22" font-family="${MONO_FONT}" font-size="12" font-weight="600" fill="${text}">${title}</text>`);
+    parts.push(`<text x="12" y="40" font-family="${FONT_FAMILY}" font-size="10.5" fill="${text}" opacity="0.72">${subtitle}</text>`);
+    parts.push(`<text x="12" y="${h - 10}" font-family="${MONO_FONT}" font-size="8.5" font-weight="600" letter-spacing="0.8" fill="${text}" opacity="0.6">${escapeXml(kindLabel)}</text>`);
+    parts.push(`<circle cx="${w - 64}" cy="${h - 13}" r="4" fill="${complexityColor}"/>`);
+    parts.push(`<text x="${w - 54}" y="${h - 10}" font-family="${FONT_FAMILY}" font-size="10" fill="${text}" opacity="0.85">↓${nodeData.in_degree} ↑${nodeData.out_degree}</text>`);
     parts.push(`</g>`);
-  } else if (type === "layerCluster") {
-    const data = n.data as unknown as LayerClusterNodeData;
+  } else if (type === "layerCluster" || type === "subGroupCluster") {
+    const data = n.data as unknown as LayerClusterNodeData & { kind?: string; sibling?: boolean; demoted?: boolean };
     const layer = data.layer;
-    const style = TONE_STYLES.layerCluster;
+    const isGroup = data.kind === "subGroup";
+    const recessed = Boolean(data.sibling || data.demoted);
     const title = escapeXml(truncate(layer.name, Math.floor(w / 8)));
     const subtitle = escapeXml(truncate(layer.description, Math.floor(w / 6)));
 
     parts.push(`<g transform="translate(${x},${y})">`);
-    parts.push(`<rect width="${w}" height="${h}" rx="8" ry="8" fill="${style.bg}" stroke="${style.border}" stroke-width="1.5"/>`);
-    parts.push(`<rect width="${w}" height="${BAND_HEIGHT}" rx="8" ry="8" fill="${style.band}"/>`);
-    parts.push(`<rect y="${BAND_HEIGHT - 8}" width="${w}" height="8" fill="${style.band}"/>`);
-    parts.push(`<text x="8" y="${BAND_HEIGHT - 5}" font-family="${FONT_FAMILY}" font-size="9" font-weight="600" letter-spacing="0.6" fill="${style.text}" opacity="0.85">LAYER</text>`);
-    parts.push(`<text x="10" y="${BAND_HEIGHT + 20}" font-family="${FONT_FAMILY}" font-size="13" font-weight="600" fill="${style.text}">${title}</text>`);
-    parts.push(`<text x="10" y="${BAND_HEIGHT + 36}" font-family="${FONT_FAMILY}" font-size="11" fill="${style.text}" opacity="0.75">${subtitle}</text>`);
-    parts.push(`<text x="10" y="${h - 8}" font-family="${FONT_FAMILY}" font-size="10" fill="${style.text}" opacity="0.8">${layer.file_count} files</text>`);
+    parts.push(inkBox(recessed ? pal.ink2 : pal.ink));
+    parts.push(`<text x="14" y="26" font-family="${MONO_FONT}" font-size="15" font-weight="600" fill="${pal.inkText}">${title}</text>`);
+    parts.push(`<text x="14" y="44" font-family="${FONT_FAMILY}" font-size="11" fill="${pal.inkText}" opacity="0.72">${subtitle}</text>`);
+    parts.push(`<text x="14" y="${h - 12}" font-family="${MONO_FONT}" font-size="9" font-weight="600" letter-spacing="1" fill="${pal.inkText}" opacity="0.6">${isGroup ? "GROUP" : "LAYER"} · ${layer.file_count} FILES</text>`);
     if (layer.health_score !== null) {
-      const healthColor = layer.health_score >= 80 ? "#4ade80" : layer.health_score >= 60 ? "#fbbf24" : "#f87171";
-      parts.push(`<text x="${w - 10}" y="${h - 8}" font-family="${FONT_FAMILY}" font-size="12" font-weight="600" fill="${healthColor}" text-anchor="end">${Math.round(layer.health_score)}</text>`);
+      const healthColor = layer.health_score >= 80 ? pal.success : layer.health_score >= 60 ? pal.warning : pal.error;
+      parts.push(`<text x="${w - 14}" y="${h - 12}" font-family="${FONT_FAMILY}" font-size="12" font-weight="600" fill="${healthColor}" text-anchor="end">${Math.round(layer.health_score)}</text>`);
     }
     parts.push(`</g>`);
   } else if (type === "archContainer") {
     const data = n.data as unknown as ArchContainerNodeData;
-    const style = TONE_STYLES.container;
     const title = escapeXml(truncate(`${data.childCount} files`, Math.floor(w / 8)));
 
     parts.push(`<g transform="translate(${x},${y})">`);
-    parts.push(`<rect width="${w}" height="${h}" rx="8" ry="8" fill="${style.bg}" stroke="${style.border}" stroke-width="1.5" stroke-dasharray="6 3"/>`);
-    parts.push(`<rect width="${w}" height="${BAND_HEIGHT}" rx="8" ry="8" fill="${style.band}"/>`);
-    parts.push(`<rect y="${BAND_HEIGHT - 8}" width="${w}" height="8" fill="${style.band}"/>`);
-    parts.push(`<text x="8" y="${BAND_HEIGHT - 5}" font-family="${FONT_FAMILY}" font-size="9" font-weight="600" letter-spacing="0.6" fill="${style.text}" opacity="0.85">${escapeXml(data.label)}</text>`);
-    parts.push(`<text x="10" y="${BAND_HEIGHT + 20}" font-family="${FONT_FAMILY}" font-size="13" font-weight="600" fill="${style.text}">${title}</text>`);
+    parts.push(inkBox("none", true));
+    parts.push(`<text x="12" y="22" font-family="${MONO_FONT}" font-size="12" font-weight="600" fill="${pal.textPrimary}">${escapeXml(data.label)}</text>`);
+    parts.push(`<text x="12" y="40" font-family="${FONT_FAMILY}" font-size="10.5" fill="${pal.textSecondary}">${title}</text>`);
     parts.push(`</g>`);
   } else if (type === "portal") {
     const data = n.data as unknown as PortalNodeData;
-    const style = TONE_STYLES.portal;
 
     parts.push(`<g transform="translate(${x},${y})">`);
-    parts.push(`<rect width="${w}" height="${h}" rx="8" ry="8" fill="${style.bg}" stroke="${style.border}" stroke-width="1.5" stroke-dasharray="6 3"/>`);
-    parts.push(`<rect width="${w}" height="${BAND_HEIGHT}" rx="8" ry="8" fill="${style.band}"/>`);
-    parts.push(`<rect y="${BAND_HEIGHT - 8}" width="${w}" height="8" fill="${style.band}"/>`);
-    parts.push(`<text x="8" y="${BAND_HEIGHT - 5}" font-family="${FONT_FAMILY}" font-size="9" font-weight="600" letter-spacing="0.6" fill="${style.text}" opacity="0.85">PORTAL</text>`);
-    parts.push(`<text x="10" y="${BAND_HEIGHT + 20}" font-family="${FONT_FAMILY}" font-size="13" font-weight="600" fill="${style.text}">→ ${escapeXml(data.targetLayerName)}</text>`);
-    parts.push(`<text x="10" y="${BAND_HEIGHT + 36}" font-family="${FONT_FAMILY}" font-size="11" fill="${style.text}" opacity="0.75">${data.edgeCount} connections</text>`);
+    parts.push(inkBox("none", true));
+    parts.push(`<text x="12" y="22" font-family="${MONO_FONT}" font-size="12" font-weight="600" fill="${pal.textPrimary}">→ ${escapeXml(data.targetLayerName)}</text>`);
+    parts.push(`<text x="12" y="40" font-family="${FONT_FAMILY}" font-size="10.5" fill="${pal.textSecondary}">${data.edgeCount} connections</text>`);
+    parts.push(`<text x="12" y="${h - 8}" font-family="${MONO_FONT}" font-size="8.5" font-weight="600" letter-spacing="0.8" fill="${pal.textSecondary}" opacity="0.8">PORTAL</text>`);
     parts.push(`</g>`);
   }
 
@@ -265,7 +297,7 @@ function nodeCenter(n: Node): { x: number; y: number; w: number; h: number } {
   return { x: n.position.x + w / 2, y: n.position.y + h / 2, w, h };
 }
 
-function renderEdge(e: Edge, nodesById: Map<string, Node>): string {
+function renderEdge(e: Edge, nodesById: Map<string, Node>, pal: InkPalette): string {
   const source = nodesById.get(e.source);
   const target = nodesById.get(e.target);
   if (!source || !target) return "";
@@ -284,18 +316,18 @@ function renderEdge(e: Edge, nodesById: Map<string, Node>): string {
 
   const parts: string[] = [];
   parts.push(
-    `<path d="${path}" fill="none" stroke="#475569" stroke-width="1.2" marker-end="url(#c4-arrow)"/>`,
+    `<path d="${path}" fill="none" stroke="${pal.edge}" stroke-width="1.25" stroke-dasharray="6 4" marker-end="url(#c4-arrow)"/>`,
   );
   if (label) {
     const lx = (sx + tx) / 2;
     const ly = midY;
     const text = escapeXml(truncate(label, 32));
-    const padW = text.length * 6 + 10;
+    const padW = text.length * 6 + 14;
     parts.push(
-      `<rect x="${lx - padW / 2}" y="${ly - 9}" width="${padW}" height="16" rx="3" fill="rgba(15,23,42,0.85)" stroke="#334155" stroke-width="0.5"/>`,
+      `<rect x="${lx - padW / 2}" y="${ly - 9}" width="${padW}" height="17" rx="6" fill="${pal.paper}" stroke="${pal.cluster}" stroke-width="0.75"/>`,
     );
     parts.push(
-      `<text x="${lx}" y="${ly + 3}" font-family="${FONT_FAMILY}" font-size="10" fill="#cbd5e1" text-anchor="middle">${text}</text>`,
+      `<text x="${lx}" y="${ly + 3}" font-family="${MONO_FONT}" font-size="9.5" fill="${pal.textSecondary}" text-anchor="middle">${text}</text>`,
     );
   }
   return parts.join("");
@@ -319,23 +351,32 @@ export function buildC4Svg(
   const ty = -bounds.minY + PADDING + titleOffset;
 
   const nodesById = new Map(nodes.map((n) => [n.id, n]));
+  const pal = resolveInkPalette();
 
-  const ARCH_NODE_TYPES = new Set(["archFile", "archContainer", "layerCluster", "portal"]);
+  const ARCH_NODE_TYPES = new Set(["archFile", "archContainer", "layerCluster", "subGroupCluster", "portal", "scopeFrame"]);
 
-  const edgeMarkup = edges.map((e) => renderEdge(e, nodesById)).join("");
+  const edgeMarkup = edges.map((e) => renderEdge(e, nodesById, pal)).join("");
   const nodeMarkup = nodes.map((n) =>
-    ARCH_NODE_TYPES.has(n.type ?? "") ? renderArchNode(n) : renderNode(n)
+    ARCH_NODE_TYPES.has(n.type ?? "") ? renderArchNode(n, pal) : renderNode(n)
   ).join("");
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="${Math.round(width)}" height="${Math.round(height)}" viewBox="0 0 ${Math.round(width)} ${Math.round(height)}">
   <defs>
     <marker id="c4-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#475569"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="${pal.edge}"/>
     </marker>
+    <linearGradient id="kg-ember" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="${pal.accent}"/>
+      <stop offset="100%" stop-color="${pal.accentEnd}"/>
+    </linearGradient>
+    <pattern id="kg-grid" width="24" height="24" patternUnits="userSpaceOnUse">
+      <path d="M 24 0 L 0 0 0 24" fill="none" stroke="${pal.grid}" stroke-width="1"/>
+    </pattern>
   </defs>
-  <rect width="100%" height="100%" fill="#0b1220"/>
-  ${options.title ? `<text x="${PADDING}" y="22" font-family="${FONT_FAMILY}" font-size="14" font-weight="600" fill="#e5e7eb">${escapeXml(options.title)}</text>` : ""}
+  <rect width="100%" height="100%" fill="${pal.canvas}"/>
+  <rect width="100%" height="100%" fill="url(#kg-grid)"/>
+  ${options.title ? `<text x="${PADDING}" y="22" font-family="${FONT_FAMILY}" font-size="14" font-weight="600" fill="${pal.textPrimary}">${escapeXml(options.title)}</text>` : ""}
   <g transform="translate(${tx},${ty})">
     ${edgeMarkup}
     ${nodeMarkup}

--- a/packages/ui/src/c4/hooks/use-architecture-layout.ts
+++ b/packages/ui/src/c4/hooks/use-architecture-layout.ts
@@ -5,38 +5,51 @@ import { MarkerType, type Node, type Edge } from "@xyflow/react";
 import { useArchitectureStore } from "../store/use-architecture-store";
 import type { ArchitectureView, ArchNode, ArchEdge, ArchLayer } from "../types";
 import { PERSONA_NODE_TYPES } from "../types";
-import { buildContainers, getStandaloneNodeIds } from "../layout/containers";
-import { aggregateEdges } from "../layout/edge-aggregation";
 import {
+  buildContainers,
+  enforceBoxBudget,
+  getStandaloneNodeIds,
+  MAX_VISIBLE_BOXES,
+} from "../layout/containers";
+import { aggregateEdges, capAggregatedEdges } from "../layout/edge-aggregation";
+import {
+  assignSlotsByRank,
   computeStage1Layout,
   computeStage2Layout,
   estimateContainerSize,
+  hoistPrioritySlots,
   ARCH_NODE_SIZES,
   type ContainerAtom,
   type PortalSpec,
 } from "../layout/two-stage-layout";
-import { THEME } from "../theme/theme-variables";
+import { THEME, edgeColor } from "../theme/theme-variables";
 
 export interface ArchitectureLayoutResult {
   nodes: Node[];
   edges: Edge[];
   loading: boolean;
   issues: string[];
+  /** Aggregated arrows dropped by the visible-tier budget ("+N weaker links"). */
+  hiddenEdgeCount: number;
 }
 
 export function useArchitectureLayout(): ArchitectureLayoutResult {
   const view = useArchitectureStore((s) => s.view);
   const navigationLevel = useArchitectureStore((s) => s.navigationLevel);
   const activeLayerId = useArchitectureStore((s) => s.activeLayerId);
+  const activeSubGroupId = useArchitectureStore((s) => s.activeSubGroupId);
   const detailLevel = useArchitectureStore((s) => s.detailLevel);
   const persona = useArchitectureStore((s) => s.persona);
   const filters = useArchitectureStore((s) => s.filters);
+  const showTests = useArchitectureStore((s) => s.showTests);
   const expandedContainers = useArchitectureStore((s) => s.expandedContainers);
   const expandedContainersVersion = useArchitectureStore((s) => s.expandedContainers.size);
   const stage1Tick = useArchitectureStore((s) => s.stage1Tick);
   const focusNodeId = useArchitectureStore((s) => s.focusNodeId);
   const selectedNodeId = useArchitectureStore((s) => s.selectedNodeId);
   const tourHighlightedNodeIds = useArchitectureStore((s) => s.tourHighlightedNodeIds);
+  const tourActive = useArchitectureStore((s) => s.tourActive);
+  const currentTourStep = useArchitectureStore((s) => s.currentTourStep);
   const searchResults = useArchitectureStore((s) => s.searchResults);
   const diffMode = useArchitectureStore((s) => s.diffMode);
   const changedNodeIds = useArchitectureStore((s) => s.changedNodeIds);
@@ -47,11 +60,12 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
     edges: [],
     loading: false,
     issues: [],
+    hiddenEdgeCount: 0,
   });
 
   useEffect(() => {
     if (!view) {
-      setResult({ nodes: [], edges: [], loading: false, issues: [] });
+      setResult({ nodes: [], edges: [], loading: false, issues: [], hiddenEdgeCount: 0 });
       return;
     }
 
@@ -61,6 +75,9 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
     const run = async () => {
       if (navigationLevel === "overview") {
         return computeOverviewLayout(view);
+      }
+      if (navigationLevel === "layer-groups") {
+        return computeLayerGroupsLayout(view);
       }
       return computeDetailLayout(view);
     };
@@ -77,15 +94,19 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
     view,
     navigationLevel,
     activeLayerId,
+    activeSubGroupId,
     detailLevel,
     persona,
     filters,
+    showTests,
     expandedContainers,
     expandedContainersVersion,
     stage1Tick,
     focusNodeId,
     selectedNodeId,
     tourHighlightedNodeIds,
+    tourActive,
+    currentTourStep,
     searchResults,
     diffMode,
     changedNodeIds,
@@ -114,6 +135,8 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
           return acc;
         }, {}),
         health_score: null,
+        sub_groups: [],
+        display_order: Math.max(...merged.map((l) => l.display_order)),
       };
       displayLayers = [...kept, otherLayer];
     }
@@ -125,7 +148,9 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
       }
     }
 
-    const aggregated = aggregateEdges(currentView.edges, nodeToLayer);
+    const { visible: aggregated, hiddenCount } = capAggregatedEdges(
+      aggregateEdges(currentView.edges, nodeToLayer),
+    );
     const layerNodes = displayLayers.map((layer: ArchLayer) => ({
       id: layer.id,
       width: ARCH_NODE_SIZES.layerCluster.width,
@@ -138,15 +163,43 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
       target: agg.target,
     }));
 
-    const { positions, issues } = await computeStage1Layout(
+    // Curated artifacts carry a dependency-ordered display_order — re-rank
+    // the card slots so the stack reads top→bottom in that order (position =
+    // meaning). Uncurated views keep the edge-derived stacking untouched
+    // (P6): their display_order is just insertion order, not a claim.
+    const isCurated =
+      currentView.layers.some((l: ArchLayer) => l.sub_groups.length > 0) ||
+      currentView.entry_points.length > 0;
+
+    const { positions: rawPositions, issues } = await computeStage1Layout(
       [],
       layerNodes,
       [],
       layoutEdges,
       new Map(),
     );
+    const positions = isCurated
+      ? assignSlotsByRank(
+          rawPositions,
+          new Map(displayLayers.map((l: ArchLayer) => [l.id, l.display_order])),
+        )
+      : rawPositions;
 
     const searchHighlightIds = new Set<string>(searchResults.map((r) => r.nodeId));
+    // Dim-on-select (kg-ux plan B5): selecting a layer card fades unrelated
+    // cards and arrows — fade, never vanish.
+    const selectedLayerId =
+      selectedNodeId && displayLayers.some((l: ArchLayer) => l.id === selectedNodeId)
+        ? selectedNodeId
+        : null;
+    const connectedLayers = new Set<string>();
+    if (selectedLayerId) {
+      connectedLayers.add(selectedLayerId);
+      for (const agg of aggregated) {
+        if (agg.source === selectedLayerId) connectedLayers.add(agg.target);
+        if (agg.target === selectedLayerId) connectedLayers.add(agg.source);
+      }
+    }
     const nodes: Node[] = displayLayers.map((layer: ArchLayer) => {
       const pos = positions.get(layer.id) ?? { x: 0, y: 0, width: 0, height: 0 };
       const hasSearchHit = layer.node_ids.some((nid: string) => searchHighlightIds.has(nid));
@@ -157,6 +210,11 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
         data: {
           layer,
           searchHighlight: hasSearchHit,
+          // Tests mirror the code — demoted unless restored (decision 2).
+          demoted: layer.id === "layer:test" && !showTests,
+          dimmed:
+            (selectedLayerId ? !connectedLayers.has(layer.id) : false) ||
+            (searchHighlightIds.size > 0 && !hasSearchHit),
         },
         width: ARCH_NODE_SIZES.layerCluster.width,
         height: ARCH_NODE_SIZES.layerCluster.height,
@@ -172,16 +230,216 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
         type: MarkerType.ArrowClosed,
         width: 14,
         height: 14,
-        color: THEME.edge[agg.dominantType] ?? "#8b9dc3",
+        color: "var(--color-diagram-edge)",
       },
       data: {
         edge_type: agg.dominantType,
         count: agg.count,
         category: agg.dominantType,
+        dimmed: selectedLayerId
+          ? agg.source !== selectedLayerId && agg.target !== selectedLayerId
+          : false,
       },
     }));
 
-    return { nodes, edges, loading: false, issues };
+    return { nodes, edges, loading: false, issues, hiddenEdgeCount: hiddenCount };
+  }
+
+  /** Cards for one curated layer: its sub-groups plus a synthetic card for any
+   * files the curation pass left ungrouped, so every file keeps a home.
+   * Enforces the visible-box budget: the lowest-pagerank groups collapse into
+   * one "+N more groups" card before the tier ever exceeds the budget (P2).
+   * Deterministic, so the groups tier and detail tier always agree on
+   * membership. */
+  function subGroupCards(
+    layer: ArchLayer,
+    nodesById: Map<string, ArchNode>,
+  ): { id: string; name: string; node_ids: string[] }[] {
+    const grouped = new Set(layer.sub_groups.flatMap((g) => g.node_ids));
+    const leftovers = layer.node_ids.filter((id) => !grouped.has(id));
+    const cards = layer.sub_groups.map((g) => ({ id: g.id, name: g.name, node_ids: g.node_ids }));
+    if (leftovers.length > 0) {
+      cards.push({ id: `${layer.id}:__ungrouped`, name: "Other files", node_ids: leftovers });
+    }
+    if (cards.length <= MAX_VISIBLE_BOXES) {
+      return cards;
+    }
+    const score = (card: { node_ids: string[] }) =>
+      Math.max(...card.node_ids.map((id) => nodesById.get(id)?.pagerank ?? 0));
+    const ranked = [...cards].sort((a, b) => score(b) - score(a));
+    const kept = ranked.slice(0, MAX_VISIBLE_BOXES - 1);
+    const merged = ranked.slice(MAX_VISIBLE_BOXES - 1);
+    const keptSet = new Set(kept.map((c) => c.id));
+    return [
+      ...cards.filter((c) => keptSet.has(c.id)),
+      {
+        id: `${layer.id}:__more`,
+        name: `+${merged.length} more groups`,
+        node_ids: merged.flatMap((c) => c.node_ids),
+      },
+    ];
+  }
+
+  /** Shape a sub-group card as an ArchLayer so LayerClusterNode renders it
+   * (kind: "subGroup") — reuse, not a new node component. */
+  function synthesizeCardLayer(
+    card: { id: string; name: string; node_ids: string[] },
+    nodesById: Map<string, ArchNode>,
+  ): ArchLayer {
+    const dist: Record<string, number> = { simple: 0, moderate: 0, complex: 0 };
+    for (const id of card.node_ids) {
+      const c = nodesById.get(id)?.complexity ?? "simple";
+      dist[c] = (dist[c] ?? 0) + 1;
+    }
+    return {
+      id: card.id,
+      name: card.name,
+      description: "",
+      node_ids: card.node_ids,
+      file_count: card.node_ids.length,
+      complexity_distribution: dist,
+      health_score: null,
+      sub_groups: [],
+      display_order: 0,
+    };
+  }
+
+  // The intermediate "layer-groups" tier: only sub-group cards + aggregated
+  // arrows + cross-layer portals. Never renders file cards (budget P2).
+  async function computeLayerGroupsLayout(currentView: ArchitectureView): Promise<ArchitectureLayoutResult> {
+    const layer = currentView.layers.find((l: ArchLayer) => l.id === activeLayerId);
+    if (!layer) {
+      return { nodes: [], edges: [], loading: false, issues: [`Layer ${activeLayerId} not found`], hiddenEdgeCount: 0 };
+    }
+    if (layer.sub_groups.length === 0) {
+      // Layer lost its groups (e.g. filters) — degrade to the detail tier.
+      return computeDetailLayout(currentView);
+    }
+
+    const nodesById = new Map(currentView.nodes.map((n: ArchNode) => [n.id, n]));
+    const cards = subGroupCards(layer, nodesById);
+
+    const nodeToBox = new Map<string, string>();
+    for (const card of cards) {
+      for (const id of card.node_ids) {
+        nodeToBox.set(id, card.id);
+      }
+    }
+    const { visible: aggregated, hiddenCount } = capAggregatedEdges(
+      aggregateEdges(currentView.edges, nodeToBox),
+    );
+
+    const nodeIdToLayerId = useArchitectureStore.getState().nodeIdToLayerId;
+    const layerNodeIdSet = new Set(layer.node_ids);
+    const portalSpecs = buildPortalSpecs(
+      currentView.edges, layerNodeIdSet, layer, currentView.layers, nodeIdToLayerId,
+    );
+
+    const cardLayoutNodes = cards.map((card) => ({
+      id: card.id,
+      width: ARCH_NODE_SIZES.layerCluster.width,
+      height: ARCH_NODE_SIZES.layerCluster.height,
+    }));
+    const layoutEdges = aggregated.map((agg) => ({
+      id: agg.id,
+      source: agg.source,
+      target: agg.target,
+    }));
+
+    const { positions, issues } = await computeStage1Layout(
+      [],
+      cardLayoutNodes,
+      portalSpecs,
+      layoutEdges,
+      new Map(),
+    );
+
+    const searchHighlightIds = new Set<string>(searchResults.map((r) => r.nodeId));
+    // Dim-on-select (kg-ux plan B5) — card-level, same rule as overview.
+    const selectedCardId =
+      selectedNodeId && cards.some((c) => c.id === selectedNodeId) ? selectedNodeId : null;
+    const connectedCards = new Set<string>();
+    if (selectedCardId) {
+      connectedCards.add(selectedCardId);
+      for (const agg of aggregated) {
+        if (agg.source === selectedCardId) connectedCards.add(agg.target);
+        if (agg.target === selectedCardId) connectedCards.add(agg.source);
+      }
+    }
+    const nodes: Node[] = cards.map((card) => {
+      const pos = positions.get(card.id) ?? { x: 0, y: 0, width: 0, height: 0 };
+      return {
+        id: card.id,
+        type: "subGroupCluster",
+        position: { x: pos.x, y: pos.y },
+        data: {
+          layer: synthesizeCardLayer(card, nodesById),
+          kind: "subGroup",
+          searchHighlight: card.node_ids.some((nid) => searchHighlightIds.has(nid)),
+          dimmed:
+            (selectedCardId ? !connectedCards.has(card.id) : false) ||
+            (searchHighlightIds.size > 0 &&
+              !card.node_ids.some((nid) => searchHighlightIds.has(nid))),
+        },
+        width: ARCH_NODE_SIZES.layerCluster.width,
+        height: ARCH_NODE_SIZES.layerCluster.height,
+      };
+    });
+
+    // "You are here": dashed boundary around the drilled layer's cards.
+    const groupsFrame = buildScopeFrameNode(
+      `frame:${layer.id}`,
+      layer.name,
+      cards.map((card) => {
+        const pos = positions.get(card.id) ?? { x: 0, y: 0, width: 0, height: 0 };
+        return {
+          x: pos.x,
+          y: pos.y,
+          width: ARCH_NODE_SIZES.layerCluster.width,
+          height: ARCH_NODE_SIZES.layerCluster.height,
+        };
+      }),
+    );
+    if (groupsFrame) nodes.unshift(groupsFrame);
+
+    for (const portal of portalSpecs) {
+      const pos = positions.get(portal.id) ?? { x: 0, y: 0, width: 0, height: 0 };
+      nodes.push({
+        id: portal.id,
+        type: "portal",
+        position: { x: pos.x, y: pos.y },
+        data: {
+          targetLayerId: portal.targetLayerId,
+          targetLayerName: portal.targetLayerName,
+          edgeCount: portal.edgeCount,
+        },
+        width: ARCH_NODE_SIZES.portal.width,
+        height: ARCH_NODE_SIZES.portal.height,
+      });
+    }
+
+    const edges: Edge[] = aggregated.map((agg) => ({
+      id: agg.id,
+      source: agg.source,
+      target: agg.target,
+      type: "arch",
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        width: 14,
+        height: 14,
+        color: "var(--color-diagram-edge)",
+      },
+      data: {
+        edge_type: agg.dominantType,
+        count: agg.count,
+        category: agg.dominantType,
+        dimmed: selectedCardId
+          ? agg.source !== selectedCardId && agg.target !== selectedCardId
+          : false,
+      },
+    }));
+
+    return { nodes, edges, loading: false, issues, hiddenEdgeCount: hiddenCount };
   }
 
   async function computeDetailLayout(currentView: ArchitectureView): Promise<ArchitectureLayoutResult> {
@@ -189,10 +447,24 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
     const containerSizeMemory = useArchitectureStore.getState().containerSizeMemory;
     const layer = currentView.layers.find((l: ArchLayer) => l.id === activeLayerId);
     if (!layer) {
-      return { nodes: [], edges: [], loading: false, issues: [`Layer ${activeLayerId} not found`] };
+      return { nodes: [], edges: [], loading: false, issues: [`Layer ${activeLayerId} not found`], hiddenEdgeCount: 0 };
     }
 
-    const layerNodeIds = new Set(layer.node_ids);
+    const nodesById = new Map(currentView.nodes.map((n: ArchNode) => [n.id, n]));
+
+    // When a curated sub-group is active, file cards are scoped to it and the
+    // sibling groups stay collapsed cards (locked decision 1).
+    let scopeNodeIds = layer.node_ids;
+    let siblingCards: { id: string; name: string; node_ids: string[] }[] = [];
+    const activeCard = activeSubGroupId
+      ? subGroupCards(layer, nodesById).find((c) => c.id === activeSubGroupId)
+      : undefined;
+    if (activeSubGroupId && activeCard) {
+      scopeNodeIds = activeCard.node_ids;
+      siblingCards = subGroupCards(layer, nodesById).filter((c) => c.id !== activeSubGroupId);
+    }
+
+    const layerNodeIds = new Set(scopeNodeIds);
     let layerNodes = currentView.nodes.filter((n: ArchNode) => layerNodeIds.has(n.id));
 
     layerNodes = filterByPersona(layerNodes);
@@ -204,10 +476,23 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
     }
 
     const visibleNodeIds = new Set(layerNodes.map((n: ArchNode) => n.id));
-    const nodesById = new Map(currentView.nodes.map((n: ArchNode) => [n.id, n]));
 
-    const containers = buildContainers(layerNodes, currentView.edges, "auto");
-    const standaloneIds = getStandaloneNodeIds(layerNodes, containers);
+    // Curated sub-groups from the artifact drive grouping (P3); folder /
+    // community heuristics remain the fallback for uncurated layers (P6).
+    // Inside one sub-group the heuristics regroup its files.
+    const rawContainers = activeCard
+      ? buildContainers(layerNodes, currentView.edges, "auto")
+      : buildContainers(layerNodes, currentView.edges, "curated", layer.sub_groups);
+    const rawStandaloneIds = getStandaloneNodeIds(layerNodes, rawContainers);
+
+    // Hard visible-box budget (P2): sibling cards occupy slots too, so the
+    // file tier degrades into a "+N more" container before exceeding it.
+    const { containers, standaloneIds } = enforceBoxBudget(
+      rawContainers,
+      rawStandaloneIds,
+      (id) => nodesById.get(id)?.pagerank ?? 0,
+      Math.max(4, MAX_VISIBLE_BOXES - siblingCards.length),
+    );
 
     const nodeIdToLayerId = useArchitectureStore.getState().nodeIdToLayerId;
     const portalSpecs = buildPortalSpecs(currentView.edges, visibleNodeIds, layer, currentView.layers, nodeIdToLayerId);
@@ -221,8 +506,17 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
     for (const id of standaloneIds) {
       nodeToBox.set(id, id);
     }
+    // Sibling groups absorb their members so in-layer cross-group edges
+    // aggregate into one labelled arrow per visible card pair (P2).
+    for (const sibling of siblingCards) {
+      for (const id of sibling.node_ids) {
+        nodeToBox.set(id, sibling.id);
+      }
+    }
 
-    const aggregated = aggregateEdges(currentView.edges, nodeToBox);
+    const { visible: aggregated, hiddenCount } = capAggregatedEdges(
+      aggregateEdges(currentView.edges, nodeToBox),
+    );
 
     const standaloneLayoutNodes = standaloneIds.map((id) => {
       const node = nodesById.get(id);
@@ -230,6 +524,13 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
       const sizes = ARCH_NODE_SIZES[nodeType as keyof typeof ARCH_NODE_SIZES] ?? ARCH_NODE_SIZES.file;
       return { id, width: sizes.width, height: sizes.height };
     });
+    for (const sibling of siblingCards) {
+      standaloneLayoutNodes.push({
+        id: sibling.id,
+        width: ARCH_NODE_SIZES.layerCluster.width,
+        height: ARCH_NODE_SIZES.layerCluster.height,
+      });
+    }
 
     const stage1Edges = aggregated.map((agg) => ({
       id: agg.id,
@@ -243,6 +544,7 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
       portalSpecs,
       stage1Edges,
       containerSizeMemory,
+      expandedContainers,
     );
 
     const allNodes: Node[] = [];
@@ -257,12 +559,28 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
         if (e.source === selectedNodeId) selectedConnectedNodes.add(e.target);
         if (e.target === selectedNodeId) selectedConnectedNodes.add(e.source);
       }
+      // Selecting a folder/sibling card keeps its own members lit (B5).
+      const selectedContainer = containers.find((c) => c.id === selectedNodeId);
+      if (selectedContainer) {
+        for (const id of selectedContainer.childNodeIds) selectedConnectedNodes.add(id);
+      }
+      const selectedSibling = siblingCards.find((sb) => sb.id === selectedNodeId);
+      if (selectedSibling) {
+        for (const id of selectedSibling.node_ids) selectedConnectedNodes.add(id);
+      }
     }
+    // Box identity of the selection, for box-level dimming.
+    const selectedBox = selectedNodeId ? nodeToBox.get(selectedNodeId) ?? selectedNodeId : null;
+
+    // Scope members (containers + standalone files) collect their rects so
+    // the "you are here" frame can wrap them; siblings/portals stay outside.
+    const frameRects: { x: number; y: number; width: number; height: number }[] = [];
 
     for (const container of containers) {
       const pos = stage1Positions.get(container.id) ?? { x: 0, y: 0, width: 0, height: 0 };
       const isExpanded = expandedContainers.has(container.id);
       const searchHitCount = container.childNodeIds.filter((id) => searchHighlightIds.has(id)).length;
+      frameRects.push({ x: pos.x, y: pos.y, width: pos.width, height: pos.height });
 
       allNodes.push({
         id: container.id,
@@ -274,6 +592,12 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
           childCount: container.childNodeIds.length,
           expanded: isExpanded,
           searchHitCount,
+          dimmed:
+            (selectedBox
+              ? container.id !== selectedBox &&
+                !container.childNodeIds.some((id) => selectedConnectedNodes.has(id))
+              : false) ||
+            (searchHighlightIds.size > 0 && searchHitCount === 0),
         },
         width: pos.width,
         height: pos.height,
@@ -301,8 +625,14 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
             }));
 
           const stage2 = await computeStage2Layout(childLayoutNodes, internalEdges);
+          // Entry points anchor to the top of their group (plan C-3);
+          // demoted barrels never count as entries.
+          const hoisted = hoistPrioritySlots(stage2.positions, childLayoutNodes, (id) => {
+            const child = nodesById.get(id);
+            return Boolean(child?.is_entry_point) && !(child?.tags.includes("barrel") ?? false);
+          });
           const layoutResult = {
-            positions: stage2.positions,
+            positions: hoisted,
             size: stage2.actualSize,
           };
           store.setContainerLayout(container.id, layoutResult);
@@ -314,7 +644,7 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
             store.bumpStage1Tick();
           }
 
-          addChildNodes(allNodes, container, stage2.positions, pos, nodesById, searchHighlightIds, selectedConnectedNodes);
+          addChildNodes(allNodes, container, hoisted, pos, nodesById, searchHighlightIds, selectedConnectedNodes);
         }
       }
     }
@@ -324,6 +654,7 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
       if (!node) continue;
       const pos = stage1Positions.get(id) ?? { x: 0, y: 0, width: 0, height: 0 };
       const sizes = ARCH_NODE_SIZES[node.node_type as keyof typeof ARCH_NODE_SIZES] ?? ARCH_NODE_SIZES.file;
+      frameRects.push({ x: pos.x, y: pos.y, width: sizes.width, height: sizes.height });
       allNodes.push({
         id: node.id,
         type: "archFile",
@@ -331,6 +662,38 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
         data: buildArchFileData(node, searchHighlightIds, selectedConnectedNodes),
         width: sizes.width,
         height: sizes.height,
+      });
+    }
+
+    // "You are here": dashed boundary around the active scope's content.
+    const detailFrame = buildScopeFrameNode(
+      `frame:${activeSubGroupId ?? layer.id}`,
+      activeCard ? `${layer.name} › ${activeCard.name}` : layer.name,
+      frameRects,
+    );
+    if (detailFrame) allNodes.unshift(detailFrame);
+
+    for (const sibling of siblingCards) {
+      const pos = stage1Positions.get(sibling.id) ?? { x: 0, y: 0, width: 0, height: 0 };
+      allNodes.push({
+        id: sibling.id,
+        type: "subGroupCluster",
+        position: { x: pos.x, y: pos.y },
+        data: {
+          layer: synthesizeCardLayer(sibling, nodesById),
+          kind: "subGroup",
+          sibling: true,
+          searchHighlight: sibling.node_ids.some((nid) => searchHighlightIds.has(nid)),
+          dimmed:
+            (selectedBox
+              ? sibling.id !== selectedBox &&
+                !sibling.node_ids.some((id) => selectedConnectedNodes.has(id))
+              : false) ||
+            (searchHighlightIds.size > 0 &&
+              !sibling.node_ids.some((nid) => searchHighlightIds.has(nid))),
+        },
+        width: ARCH_NODE_SIZES.layerCluster.width,
+        height: ARCH_NODE_SIZES.layerCluster.height,
       });
     }
 
@@ -344,6 +707,15 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
           targetLayerId: portal.targetLayerId,
           targetLayerName: portal.targetLayerName,
           edgeCount: portal.edgeCount,
+          // Portals never appear in aggregated edges (nodeToBox has no portal
+          // mapping), so testing aggregated here dimmed every portal whenever
+          // anything was selected. A portal is related when the selection's
+          // neighbourhood reaches into its target layer.
+          dimmed: selectedBox
+            ? ![...selectedConnectedNodes].some(
+                (id) => nodeIdToLayerId.get(id) === portal.targetLayerId,
+              )
+            : false,
         },
         width: ARCH_NODE_SIZES.portal.width,
         height: ARCH_NODE_SIZES.portal.height,
@@ -352,7 +724,10 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
 
     for (const agg of aggregated) {
       const isDimmed = selectedNodeId
-        ? !selectedConnectedNodes.has(agg.source) && !selectedConnectedNodes.has(agg.target)
+        ? agg.source !== selectedBox &&
+          agg.target !== selectedBox &&
+          !selectedConnectedNodes.has(agg.source) &&
+          !selectedConnectedNodes.has(agg.target)
         : false;
       allEdges.push({
         id: agg.id,
@@ -363,7 +738,7 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
           type: MarkerType.ArrowClosed,
           width: 14,
           height: 14,
-          color: THEME.edge[agg.dominantType] ?? "#8b9dc3",
+          color: "var(--color-diagram-edge)",
         },
         data: {
           edge_type: agg.dominantType,
@@ -375,7 +750,7 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
       });
     }
 
-    return { nodes: allNodes, edges: allEdges, loading: false, issues };
+    return { nodes: allNodes, edges: allEdges, loading: false, issues, hiddenEdgeCount: hiddenCount };
   }
 
   function filterByPersona(nodes: ArchNode[]): ArchNode[] {
@@ -433,16 +808,58 @@ export function useArchitectureLayout(): ArchitectureLayoutResult {
       if (changedNodeIds.has(node.id)) diffState = "changed";
       else if (affectedNodeIds.has(node.id)) diffState = "affected";
     }
-    const dimmed = connectedNodes && selectedNodeId
+    const selectionDim = connectedNodes && selectedNodeId
       ? !connectedNodes.has(node.id)
       : false;
+    // Search recedes everything that doesn't match (kg-ux plan B6) —
+    // matches keep the accent highlight, the rest fades.
+    const searchDim = searchHighlightIds.size > 0 && !searchHighlightIds.has(node.id);
+    const dimmed = selectionDim || searchDim;
+    const isTourTarget = tourActive && tourHighlightedNodeIds.has(node.id);
     return {
       node,
       hasDocs: node.has_doc,
       searchHighlight: searchHighlightIds.has(node.id),
       tourHighlight: tourHighlightedNodeIds.has(node.id),
+      // Numbered step badge on the highlighted node (plan C-2).
+      tourStepNumber: isTourTarget ? currentTourStep + 1 : undefined,
       diffState,
       dimmed,
+    };
+  }
+
+  /** Dashed "you are here" boundary behind the drilled scope (kg-ux §2.4).
+   * Pure underlay: zIndex -1, non-interactive, sized to the members' bbox. */
+  function buildScopeFrameNode(
+    frameId: string,
+    label: string,
+    rects: { x: number; y: number; width: number; height: number }[],
+  ): Node | null {
+    if (rects.length === 0) return null;
+    const PAD = { top: 56, right: 40, bottom: 40, left: 40 };
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const r of rects) {
+      minX = Math.min(minX, r.x);
+      minY = Math.min(minY, r.y);
+      maxX = Math.max(maxX, r.x + r.width);
+      maxY = Math.max(maxY, r.y + r.height);
+    }
+    const width = maxX - minX + PAD.left + PAD.right;
+    const height = maxY - minY + PAD.top + PAD.bottom;
+    return {
+      id: frameId,
+      type: "scopeFrame",
+      position: { x: minX - PAD.left, y: minY - PAD.top },
+      data: { label, width, height },
+      width,
+      height,
+      zIndex: -1,
+      selectable: false,
+      draggable: false,
+      focusable: false,
     };
   }
 

--- a/packages/ui/src/c4/hooks/use-architecture-navigation.ts
+++ b/packages/ui/src/c4/hooks/use-architecture-navigation.ts
@@ -22,7 +22,13 @@ export function useArchitectureNavigation(): void {
             state.closeCodeViewer();
           } else if (state.selectedNodeId !== null) {
             state.selectNode(null);
-          } else if (state.navigationLevel === "layer-detail") {
+          } else if (state.expandedContainers.size > 0) {
+            // Grammar parity with the dependency graph's hub collapse:
+            // Esc peels the most recently expanded container before
+            // popping the tier (insertion-ordered Set).
+            const last = Array.from(state.expandedContainers).pop();
+            if (last) state.toggleContainer(last);
+          } else if (state.navigationLevel !== "overview") {
             state.drillOut();
           }
           break;

--- a/packages/ui/src/c4/index.ts
+++ b/packages/ui/src/c4/index.ts
@@ -73,6 +73,8 @@ export {
   FilterPanel,
   NodeTypeCategoryFilters,
   LearnPanel,
+  ArchBreadcrumb,
+  ArchLegend,
   PersonaSelector,
   CodeViewer,
   getLanguageFromPath,

--- a/packages/ui/src/c4/layout/containers.ts
+++ b/packages/ui/src/c4/layout/containers.ts
@@ -1,13 +1,22 @@
-import type { ArchNode, ArchEdge } from "../types";
+import type { ArchNode, ArchEdge, ArchSubGroup } from "../types";
 import type { ContainerAtom } from "./two-stage-layout";
+
+export type ContainerStrategy = "curated" | "folder" | "community" | "auto";
 
 export function buildContainers(
   nodes: ArchNode[],
   _edges: ArchEdge[],
-  strategy: "folder" | "community" | "auto",
+  strategy: ContainerStrategy,
+  subGroups?: ArchSubGroup[],
 ): ContainerAtom[] {
-  const resolved = resolveStrategy(strategy, nodes);
+  // Curated grouping comes from the artifact (P3); folder/community heuristics
+  // remain the fallback when curation is off or the layer has no sub-groups.
+  if (strategy === "curated" && subGroups && subGroups.length > 0) {
+    const curated = buildCuratedContainers(nodes, subGroups);
+    if (curated.length > 0) return curated;
+  }
 
+  const resolved = resolveStrategy(strategy, nodes);
   if (resolved === "folder") {
     return buildFolderContainers(nodes);
   }
@@ -15,13 +24,35 @@ export function buildContainers(
 }
 
 function resolveStrategy(
-  strategy: "folder" | "community" | "auto",
+  strategy: ContainerStrategy,
   nodes: ArchNode[],
 ): "folder" | "community" {
   if (strategy === "folder") return "folder";
   if (strategy === "community") return "community";
   const withPath = nodes.filter((n) => n.file_path !== null).length;
   return withPath / Math.max(nodes.length, 1) > 0.8 ? "folder" : "community";
+}
+
+function buildCuratedContainers(
+  nodes: ArchNode[],
+  subGroups: ArchSubGroup[],
+): ContainerAtom[] {
+  const visible = new Set(nodes.map((n) => n.id));
+
+  const containers: ContainerAtom[] = [];
+  for (const group of subGroups) {
+    // id/name verbatim from the artifact; members limited to visible nodes
+    // (persona / detail-level / user filters run upstream).
+    const childNodeIds = group.node_ids.filter((id) => visible.has(id));
+    if (childNodeIds.length <= 1) continue;
+    containers.push({
+      id: group.id,
+      label: group.name,
+      childNodeIds,
+    });
+  }
+
+  return containers;
 }
 
 function buildFolderContainers(nodes: ArchNode[]): ContainerAtom[] {
@@ -101,4 +132,68 @@ export function getStandaloneNodeIds(
     }
   }
   return nodes.filter((n) => !contained.has(n.id)).map((n) => n.id);
+}
+
+/** Hard budget for visible group boxes per viewport (viewer plan P2). */
+export const MAX_VISIBLE_BOXES = 12;
+
+export interface BudgetedBoxes {
+  containers: ContainerAtom[];
+  standaloneIds: string[];
+  /** Boxes folded into the "+N more" overflow container. */
+  collapsedCount: number;
+}
+
+/** Enforce the visible-box budget: when containers + standalone cards exceed
+ * *max*, the lowest-pagerank boxes collapse into one "+N more" container
+ * instead of ever exceeding the budget (degradation, not truncation). */
+export function enforceBoxBudget(
+  containers: ContainerAtom[],
+  standaloneIds: string[],
+  pagerankOf: (id: string) => number,
+  max: number = MAX_VISIBLE_BOXES,
+): BudgetedBoxes {
+  const total = containers.length + standaloneIds.length;
+  if (total <= max) {
+    return { containers, standaloneIds, collapsedCount: 0 };
+  }
+
+  type Box =
+    | { kind: "container"; score: number; container: ContainerAtom }
+    | { kind: "standalone"; score: number; id: string };
+
+  const boxes: Box[] = [
+    ...containers.map((c) => ({
+      kind: "container" as const,
+      score: Math.max(...c.childNodeIds.map(pagerankOf)),
+      container: c,
+    })),
+    ...standaloneIds.map((id) => ({
+      kind: "standalone" as const,
+      score: pagerankOf(id),
+      id,
+    })),
+  ].sort((a, b) => b.score - a.score);
+
+  // Keep the strongest max-1 boxes; everything else folds into the overflow.
+  const kept = boxes.slice(0, max - 1);
+  const merged = boxes.slice(max - 1);
+
+  const overflowChildren = merged.flatMap((b) =>
+    b.kind === "container" ? b.container.childNodeIds : [b.id],
+  );
+  const overflow: ContainerAtom = {
+    id: "container:__overflow",
+    label: `+${merged.length} more`,
+    childNodeIds: overflowChildren,
+  };
+
+  return {
+    containers: [
+      ...kept.filter((b) => b.kind === "container").map((b) => b.container),
+      overflow,
+    ],
+    standaloneIds: kept.filter((b) => b.kind === "standalone").map((b) => b.id),
+    collapsedCount: merged.length,
+  };
 }

--- a/packages/ui/src/c4/layout/edge-aggregation.ts
+++ b/packages/ui/src/c4/layout/edge-aggregation.ts
@@ -60,3 +60,24 @@ export function aggregateEdges(
   result.sort((a, b) => b.count - a.count);
   return result;
 }
+
+/** Hard budget for aggregated arrows per viewport (viewer plan P2). */
+export const MAX_VISIBLE_AGGREGATED_EDGES = 24;
+
+export interface CappedEdges {
+  visible: AggregatedEdge[];
+  /** Number of aggregated arrows dropped (the "+N weaker links" affordance). */
+  hiddenCount: number;
+}
+
+/** Keep only the heaviest aggregated arrows at the visible tier.
+ * Input is already sorted by weight (count) descending. */
+export function capAggregatedEdges(
+  edges: AggregatedEdge[],
+  max: number = MAX_VISIBLE_AGGREGATED_EDGES,
+): CappedEdges {
+  if (edges.length <= max) {
+    return { visible: edges, hiddenCount: 0 };
+  }
+  return { visible: edges.slice(0, max), hiddenCount: edges.length - max };
+}

--- a/packages/ui/src/c4/layout/two-stage-layout.ts
+++ b/packages/ui/src/c4/layout/two-stage-layout.ts
@@ -88,18 +88,56 @@ export function estimateContainerSize(childCount: number): { width: number; heig
   return { width, height };
 }
 
+/** Re-assign uniform card slots so reading order (top→bottom, left→right)
+ * follows the curated rank (position = meaning, viewer plan B-4).
+ *
+ * ELK's layered algorithm stacks by edge direction, which on real graphs can
+ * contradict the artifact's dependency order (and elkjs partitioning is
+ * unreliable once edges exist). Since the ranked cards are uniformly sized,
+ * permuting which card occupies which slot is safe and deterministic; edge
+ * paths follow automatically because the renderer draws from node positions.
+ * Unranked entries (portals, …) keep their slots. */
+export function assignSlotsByRank(
+  positions: Map<string, { x: number; y: number; width: number; height: number }>,
+  ranks: Map<string, number>,
+): Map<string, { x: number; y: number; width: number; height: number }> {
+  const rankedIds = [...positions.keys()].filter((id) => ranks.has(id));
+  if (rankedIds.length < 2) return positions;
+
+  const slots = rankedIds
+    .map((id) => positions.get(id)!)
+    .sort((a, b) => a.y - b.y || a.x - b.x);
+  const order = [...rankedIds].sort(
+    (a, b) => ranks.get(a)! - ranks.get(b)! || a.localeCompare(b),
+  );
+
+  const out = new Map(positions);
+  order.forEach((id, i) => out.set(id, slots[i]!));
+  return out;
+}
+
 export async function computeStage1Layout(
   containers: ContainerAtom[],
   standaloneNodes: { id: string; width: number; height: number }[],
   portalNodes: PortalSpec[],
   edges: { id: string; source: string; target: string }[],
   containerSizeMemory: Map<string, { width: number; height: number }>,
+  expandedContainerIds?: Set<string>,
 ): Promise<Stage1Result> {
   const allNodes: { id: string; width: number; height: number }[] = [];
 
   for (const container of containers) {
-    const memorized = containerSizeMemory.get(container.id);
-    const size = memorized ?? container.estimatedSize ?? estimateContainerSize(container.childNodeIds.length);
+    // A collapsed container renders as a small card; sizing it by its
+    // child-count estimate hands ELK an up-to-800×600 phantom box, which
+    // scatters the cards across acres of whitespace and anchors edge
+    // arrowheads at the phantom's midpoint — arrows pointing into empty
+    // canvas. Only an expanded container occupies its measured footprint.
+    const expanded = expandedContainerIds?.has(container.id) ?? false;
+    const size = expanded
+      ? containerSizeMemory.get(container.id)
+        ?? container.estimatedSize
+        ?? estimateContainerSize(container.childNodeIds.length)
+      : ARCH_NODE_SIZES.containerCollapsed;
     allNodes.push({ id: container.id, width: size.width, height: size.height });
   }
 
@@ -145,6 +183,45 @@ export async function computeStage1Layout(
   }
 
   return { positions, issues };
+}
+
+/** Bubble priority nodes (curated entry points) to the top-left slots of
+ * their group (viewer plan C-3). Permutes slots only among children of the
+ * same size so the layout stays overlap-free; non-priority nodes keep their
+ * relative order. */
+export function hoistPrioritySlots(
+  positions: Map<string, { x: number; y: number }>,
+  children: { id: string; width: number; height: number }[],
+  isPriority: (id: string) => boolean,
+): Map<string, { x: number; y: number }> {
+  const bySize = new Map<string, string[]>();
+  for (const child of children) {
+    if (!positions.has(child.id)) continue;
+    const key = `${child.width}x${child.height}`;
+    const group = bySize.get(key);
+    if (group) {
+      group.push(child.id);
+    } else {
+      bySize.set(key, [child.id]);
+    }
+  }
+
+  const out = new Map(positions);
+  for (const ids of bySize.values()) {
+    if (ids.length < 2 || !ids.some(isPriority)) continue;
+    const slotOrder = [...ids].sort((a, b) => {
+      const pa = positions.get(a)!;
+      const pb = positions.get(b)!;
+      return pa.y - pb.y || pa.x - pb.x;
+    });
+    const slots = slotOrder.map((id) => positions.get(id)!);
+    const order = [
+      ...slotOrder.filter(isPriority),
+      ...slotOrder.filter((id) => !isPriority(id)),
+    ];
+    order.forEach((id, i) => out.set(id, slots[i]!));
+  }
+  return out;
 }
 
 export async function computeStage2Layout(

--- a/packages/ui/src/c4/mobile/MobileBottomNav.tsx
+++ b/packages/ui/src/c4/mobile/MobileBottomNav.tsx
@@ -23,7 +23,7 @@ export function MobileBottomNav({ activeTab, onTabChange }: MobileBottomNavProps
       style={{
         display: "flex",
         height: 56,
-        borderTop: "1px solid var(--color-border-default, #334155)",
+        borderTop: "1px solid var(--color-border-default)",
         background: "var(--color-bg-elevated, rgba(17,24,39,0.96))",
         flexShrink: 0,
       }}
@@ -51,15 +51,15 @@ export function MobileBottomNav({ activeTab, onTabChange }: MobileBottomNavProps
               border: "none",
               cursor: "pointer",
               color: isActive
-                ? "var(--color-accent-primary, #f59520)"
-                : "var(--color-text-secondary, #94a3b8)",
+                ? "var(--color-accent-primary)"
+                : "var(--color-text-secondary)",
               fontSize: 10,
               fontWeight: 600,
               letterSpacing: 0.3,
               outline: "none",
             }}
             onFocus={(e) => {
-              e.currentTarget.style.outline = "2px solid var(--color-accent-primary, #f59520)";
+              e.currentTarget.style.outline = "2px solid var(--color-accent-primary)";
               e.currentTarget.style.outlineOffset = "-2px";
             }}
             onBlur={(e) => {

--- a/packages/ui/src/c4/mobile/MobileLayout.tsx
+++ b/packages/ui/src/c4/mobile/MobileLayout.tsx
@@ -43,7 +43,7 @@ export function MobileLayout({
         display: "flex",
         flexDirection: "column",
         overflow: "hidden",
-        background: "var(--color-bg-canvas, #0f172a)",
+        background: "var(--color-bg-canvas)",
       }}
     >
       <div
@@ -86,7 +86,7 @@ export function MobileLayout({
             pointerEvents: activeTab === "info" ? "auto" : "none",
             overflowY: "auto",
             background: "var(--color-bg-elevated, rgba(17,24,39,0.96))",
-            color: "var(--color-text-primary, #f1f5f9)",
+            color: "var(--color-text-primary)",
           }}
         >
           {infoContent}
@@ -101,7 +101,7 @@ export function MobileLayout({
             pointerEvents: activeTab === "files" ? "auto" : "none",
             overflowY: "auto",
             background: "var(--color-bg-elevated, rgba(17,24,39,0.96))",
-            color: "var(--color-text-primary, #f1f5f9)",
+            color: "var(--color-text-primary)",
           }}
         >
           {filesContent}

--- a/packages/ui/src/c4/nodes/ArchContainerNode.tsx
+++ b/packages/ui/src/c4/nodes/ArchContainerNode.tsx
@@ -5,6 +5,7 @@ import { ChevronRight, ChevronDown } from "lucide-react";
 import type { NodeProps } from "@xyflow/react";
 import { Handle, Position } from "@xyflow/react";
 import { useArchitectureStore } from "../store/use-architecture-store";
+import { THEME } from "../theme/theme-variables";
 
 export interface ArchContainerNodeProps {
   containerId: string;
@@ -12,42 +13,60 @@ export interface ArchContainerNodeProps {
   childCount: number;
   expanded: boolean;
   searchHitCount?: number | undefined;
+  /** Unrelated to the current selection — fade, never vanish (plan D). */
+  dimmed?: boolean | undefined;
 }
 
 function ArchContainerNodeImpl(props: NodeProps) {
   const { data, selected } = props as NodeProps & { data: ArchContainerNodeProps };
-  const { containerId, label, childCount, expanded, searchHitCount } = data;
+  const { containerId, label, childCount, expanded, searchHitCount, dimmed } = data;
   const [hovered, setHovered] = useState(false);
 
   const ChevronIcon = expanded ? ChevronDown : ChevronRight;
 
-  const handleClick = () => {
-    useArchitectureStore.getState().toggleContainer(containerId);
+  // Unified click grammar (kg-ux plan B5): single click selects (page-level
+  // handler); double-click expands/collapses (page-level too). Keyboard
+  // Enter/Space mirrors single-click selection.
+  const handleSelect = () => {
+    useArchitectureStore.getState().selectNode(containerId);
   };
 
+  // Diagram ink, not panel chrome: the panel border tokens sit at ~12% alpha
+  // and disappear into the paper canvas in light mode, leaving the (full-ink)
+  // edges pointing at boxes the eye can't see. Folder containers are
+  // supporting-cast boxes, so they take the faded-ink outline.
   const borderColor = selected
-    ? "#fbbf24"
-    : "rgba(96, 165, 250, 0.2)";
+    ? THEME.selection.ring
+    : "var(--color-kg-node-border-2)";
 
   return (
     <div
-      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      aria-label={`Inspect folder ${label}`}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleSelect();
+        }
+      }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
         cursor: "pointer",
         width: expanded ? 320 : 260,
         minHeight: expanded ? undefined : 56,
-        background: hovered ? "rgba(96, 165, 250, 0.07)" : "rgba(96, 165, 250, 0.04)",
+        background: hovered ? THEME.surface.washHover : THEME.surface.wash,
         border: `1.5px solid ${borderColor}`,
-        borderLeft: `3px solid ${selected ? "#fbbf24" : "rgba(96, 165, 250, 0.3)"}`,
+        borderLeft: `3px solid ${selected ? THEME.selection.ring : "var(--color-kg-node-border-2)"}`,
         borderRadius: 12,
         padding: "10px 14px",
         display: "flex",
         flexDirection: "column",
         gap: 2,
-        boxShadow: selected ? "0 0 0 2px rgba(251,191,36,0.3)" : "none",
-        transition: "background 0.15s ease",
+        boxShadow: selected ? `0 0 0 2px ${THEME.selection.ringAlpha}` : "none",
+        opacity: dimmed && !hovered ? 0.45 : 1,
+        transition: "background 0.15s ease, opacity 0.2s ease",
       }}
     >
       <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
@@ -55,7 +74,7 @@ function ArchContainerNodeImpl(props: NodeProps) {
         <span style={{
           fontSize: 13,
           fontWeight: 600,
-          color: "var(--color-text-primary, #f1f5f9)",
+          color: "var(--color-text-primary)",
           overflow: "hidden",
           textOverflow: "ellipsis",
           whiteSpace: "nowrap",
@@ -63,18 +82,18 @@ function ArchContainerNodeImpl(props: NodeProps) {
           {label}
         </span>
         <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-          <span style={{ fontSize: 11, color: "var(--color-text-secondary, #94a3b8)" }}>
+          <span style={{ fontSize: 11, color: "var(--color-text-secondary)" }}>
             {childCount}
           </span>
-          <ChevronIcon size={12} color="var(--color-text-secondary, #94a3b8)" aria-hidden />
+          <ChevronIcon size={12} color="var(--color-text-secondary)" aria-hidden />
         </div>
       </div>
       {searchHitCount != null && searchHitCount > 0 && (
         <span style={{
           fontSize: 10,
           fontFamily: "var(--font-mono, ui-monospace, monospace)",
-          color: "#f59520",
-          background: "rgba(245, 149, 32, 0.12)",
+          color: THEME.accent.primary,
+          background: THEME.accent.muted,
           padding: "1px 6px",
           borderRadius: 4,
           alignSelf: "flex-start",

--- a/packages/ui/src/c4/nodes/ArchFileNode.tsx
+++ b/packages/ui/src/c4/nodes/ArchFileNode.tsx
@@ -3,7 +3,9 @@
 import { memo } from "react";
 import { Flame, Skull, Play } from "lucide-react";
 import type { NodeProps } from "@xyflow/react";
-import { NodeShell } from "../../graph-primitives/node-shell";
+import { InkNodeShell, type InkRole } from "./ink-node-shell";
+import { getKindIcon } from "./kind-icons";
+import { EntityHoverCard } from "../../shared/entity";
 import { THEME } from "../theme/theme-variables";
 import type { ArchNode } from "../types";
 
@@ -12,33 +14,67 @@ export interface ArchFileNodeProps {
   hasDocs?: boolean | undefined;
   searchHighlight?: boolean | undefined;
   tourHighlight?: boolean | undefined;
+  /** 1-based step number shown while the guided tour highlights this node. */
+  tourStepNumber?: number | undefined;
   diffState?: "changed" | "affected" | "faded" | undefined;
   dimmed?: boolean | undefined;
 }
 
 function ArchFileNodeImpl(props: NodeProps) {
   const { data, selected } = props as NodeProps & { data: ArchFileNodeProps };
-  const { node, hasDocs, searchHighlight, tourHighlight, diffState, dimmed } = data;
-  const effectiveDiffState = dimmed && !diffState ? "faded" : diffState;
+  const { node, hasDocs, searchHighlight, tourHighlight, tourStepNumber, diffState, dimmed } = data;
 
-  const kindLabel = node.node_type;
+  // Re-export barrels are de-emphasized with their honest summary (plan C-3):
+  // faded card, no entry-point badge — they are shells, not destinations.
+  const isBarrel = node.tags.includes("barrel");
+  const barrelFaded = isBarrel && !selected && !searchHighlight && !tourHighlight;
 
-  const complexityColor = THEME.complexity[node.complexity] ?? "#94a3b8";
+  const kindLabel = isBarrel ? "barrel" : node.node_type;
+
+  // Role-based ink (plan §2.2): entry points are the orange "start here"
+  // blocks; barrels recede to secondary ink; everything else is primary.
+  const role: InkRole = node.is_entry_point && !isBarrel
+    ? "accent"
+    : isBarrel
+      ? "secondary"
+      : "primary";
+
+  const complexityColor = THEME.complexity[node.complexity] ?? THEME.text.muted;
 
   const badges = (
     <>
-      {node.is_entry_point && (
-        <span title="Entry point" aria-label="Entry point" style={{ display: "inline-flex", color: "#4ade80" }}>
+      {typeof tourStepNumber === "number" && (
+        <span
+          title={`Tour step ${tourStepNumber}`}
+          aria-label={`Tour step ${tourStepNumber}`}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 14,
+            height: 14,
+            borderRadius: "50%",
+            fontSize: 9,
+            fontWeight: 700,
+            color: "var(--color-text-on-accent)",
+            background: "var(--color-accent-fill)",
+          }}
+        >
+          {tourStepNumber}
+        </span>
+      )}
+      {node.is_entry_point && !isBarrel && (
+        <span title="Entry point" aria-label="Entry point" style={{ display: "inline-flex", color: "currentColor" }}>
           <Play size={10} aria-hidden />
         </span>
       )}
       {node.is_hotspot && (
-        <span title="Hotspot" aria-label="Hotspot" style={{ display: "inline-flex", color: "#fca5a5" }}>
+        <span title="Hotspot" aria-label="Hotspot" style={{ display: "inline-flex", color: THEME.status.hotspot }}>
           <Flame size={10} aria-hidden />
         </span>
       )}
       {node.is_dead && (
-        <span title="Dead code" aria-label="Dead code" style={{ display: "inline-flex", color: "#cbd5e1" }}>
+        <span title="Dead code" aria-label="Dead code" style={{ display: "inline-flex", color: THEME.status.dead }}>
           <Skull size={10} aria-hidden />
         </span>
       )}
@@ -62,21 +98,52 @@ function ArchFileNodeImpl(props: NodeProps) {
   );
 
   return (
-    <NodeShell
-      tone={node.node_type}
-      kindLabel={kindLabel}
-      title={node.name}
-      subtitle={node.summary}
-      footer={footer}
-      selected={selected}
-      searchHighlight={searchHighlight}
-      tourHighlight={tourHighlight}
-      diffState={effectiveDiffState}
-      hasDocs={hasDocs ?? node.has_doc}
-      badges={badges}
-      width={300}
-      height={140}
-    />
+    // Summary-rich hover (plan C-4): curated summary + tags + signals via the
+    // shared EntityHoverCard — no new card components.
+    <EntityHoverCard
+      entity={{ kind: "file", id: node.file_path ?? node.id }}
+      meta={{
+        kind: "file",
+        data: {
+          summary: node.summary,
+          tags: node.tags,
+          owner: node.primary_owner,
+          busFactor: node.bus_factor,
+          language: node.language,
+          hasDocs: hasDocs ?? node.has_doc,
+          hasDeadCode: node.is_dead,
+        },
+      }}
+    >
+      {/* Dimming discipline (plan D): unrelated cards fade, never vanish —
+          the diff overlay keeps its stronger "faded" treatment. */}
+      <div
+        style={
+          barrelFaded
+            ? { opacity: 0.55, transition: "opacity 0.2s ease" }
+            : dimmed && !diffState
+              ? { opacity: 0.45, transition: "opacity 0.2s ease" }
+              : { transition: "opacity 0.2s ease" }
+        }
+      >
+        <InkNodeShell
+          role={role}
+          icon={getKindIcon(node.node_type)}
+          kindLabel={kindLabel}
+          title={node.name}
+          subtitle={node.summary}
+          meta={footer}
+          selected={selected}
+          searchHighlight={searchHighlight}
+          tourHighlight={tourHighlight}
+          diffState={diffState}
+          hasDocs={hasDocs ?? node.has_doc}
+          badges={badges}
+          width={300}
+          height={140}
+        />
+      </div>
+    </EntityHoverCard>
   );
 }
 

--- a/packages/ui/src/c4/nodes/ContainerNode.tsx
+++ b/packages/ui/src/c4/nodes/ContainerNode.tsx
@@ -4,6 +4,7 @@ import { memo, type ReactNode } from "react";
 import { Files, Flame, Skull } from "lucide-react";
 import type { NodeProps } from "@xyflow/react";
 import { NodeShell } from "./node-shell";
+import { THEME } from "../theme/theme-variables";
 import type { C4Container } from "../types";
 
 export interface ContainerNodeProps {
@@ -21,14 +22,14 @@ function ContainerNodeImpl(props: NodeProps) {
   ];
   if (container.hotspot_count > 0) {
     chips.push(
-      <span key="hot" style={{ display: "inline-flex", alignItems: "center", gap: 3, color: "#fca5a5" }}>
+      <span key="hot" style={{ display: "inline-flex", alignItems: "center", gap: 3, color: THEME.status.hotspot }}>
         <Flame size={11} aria-hidden /> {container.hotspot_count}
       </span>,
     );
   }
   if (container.dead_count > 0) {
     chips.push(
-      <span key="dead" style={{ display: "inline-flex", alignItems: "center", gap: 3, color: "#cbd5e1" }}>
+      <span key="dead" style={{ display: "inline-flex", alignItems: "center", gap: 3, color: THEME.status.dead }}>
         <Skull size={11} aria-hidden /> {container.dead_count}
       </span>,
     );

--- a/packages/ui/src/c4/nodes/LayerClusterNode.tsx
+++ b/packages/ui/src/c4/nodes/LayerClusterNode.tsx
@@ -2,7 +2,8 @@
 
 import { memo, useState } from "react";
 import type { NodeProps } from "@xyflow/react";
-import { NodeShell } from "../../graph-primitives/node-shell";
+import { InkNodeShell, type InkRole } from "./ink-node-shell";
+import { getKindIcon } from "./kind-icons";
 import { useArchitectureStore } from "../store/use-architecture-store";
 import { THEME } from "../theme/theme-variables";
 import type { ArchLayer } from "../types";
@@ -10,15 +11,33 @@ import type { ArchLayer } from "../types";
 export interface LayerClusterNodeProps {
   layer: ArchLayer;
   searchHighlight?: boolean | undefined;
+  /** "layer" (default) drills into the layer; "subGroup" renders the same
+   * card as a curated sub-group and drills into it. Reuse, not a fork. */
+  kind?: "layer" | "subGroup" | undefined;
+  /** Visually de-emphasized (Test layer by default — decision 2). */
+  demoted?: boolean | undefined;
+  /** Collapsed sibling card in the detail tier — supporting cast, not the
+   * active scope, so it recedes to secondary ink (kg-ux plan §2.2). */
+  sibling?: boolean | undefined;
+  /** Unrelated to the current selection — fade, never vanish (plan D). */
+  dimmed?: boolean | undefined;
 }
 
 function LayerClusterNodeImpl(props: NodeProps) {
   const { data, selected } = props as NodeProps & { data: LayerClusterNodeProps };
-  const { layer, searchHighlight } = data;
+  const { layer, searchHighlight, demoted, sibling, dimmed } = data;
+  const kind = data.kind ?? "layer";
   const [hovered, setHovered] = useState(false);
 
-  const handleClick = () => {
-    useArchitectureStore.getState().drillIntoLayer(layer.id);
+  // Active-scope cards are primary ink; demoted (Test) and collapsed
+  // siblings recede to secondary ink.
+  const role: InkRole = demoted || sibling ? "secondary" : "primary";
+
+  // Unified click grammar (kg-ux plan B5): single click / Enter = select +
+  // inspect (the page-level onNodeClick handles mouse; keyboard mirrors it
+  // here). Drilling moved to double-click, owned by the page handler.
+  const handleSelect = () => {
+    useArchitectureStore.getState().selectNode(layer.id);
   };
 
   const dominantComplexity = (["complex", "moderate", "simple"] as const)
@@ -53,7 +72,7 @@ function LayerClusterNodeImpl(props: NodeProps) {
         style={{
           fontSize: 12,
           fontWeight: 600,
-          color: layer.health_score >= 80 ? "#4ade80" : layer.health_score >= 60 ? "#fbbf24" : "#f87171",
+          color: layer.health_score >= 80 ? THEME.health.good : layer.health_score >= 60 ? THEME.health.fair : THEME.health.poor,
         }}
       >
         {Math.round(layer.health_score)}
@@ -74,41 +93,52 @@ function LayerClusterNodeImpl(props: NodeProps) {
         style={{
           fontSize: 10,
           opacity: hovered ? 0.9 : 0,
-          color: "var(--color-accent-primary, #f59520)",
+          color: "currentColor",
           transition: "opacity 0.2s ease",
           textAlign: "right",
         }}
       >
-        Click to explore →
+        Double-click to open →
       </div>
     </div>
   );
 
   return (
     <div
-      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      aria-label={`${kind === "subGroup" ? "Inspect group" : "Inspect layer"} ${layer.name}`}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleSelect();
+        }
+      }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       style={{
         cursor: "pointer",
         boxShadow: hovered
-          ? "0 4px 16px rgba(0,0,0,0.4)"
+          ? "0 4px 16px rgba(0,0,0,0.25)"
           : "none",
-        borderRadius: 8,
-        transition: "box-shadow 0.2s ease",
+        borderRadius: 12,
+        opacity: (demoted || dimmed) && !hovered ? 0.45 : 1,
+        transition: "box-shadow 0.2s ease, opacity 0.2s ease",
       }}
     >
-      <NodeShell
-        tone="layerCluster"
-        kindLabel="LAYER"
+      <InkNodeShell
+        role={role}
+        icon={getKindIcon(kind === "subGroup" ? "subGroup" : "layer")}
+        heroIcon
+        kindLabel={kind === "subGroup" ? "GROUP" : "LAYER"}
         title={layer.name}
         subtitle={layer.description}
-        footer={footer}
+        meta={footer}
         selected={selected}
         searchHighlight={searchHighlight}
         width={360}
         height={220}
-        titleFontSize={18}
+        titleFontSize={16}
         subtitleLineClamp={2}
         badges={
           <span style={{

--- a/packages/ui/src/c4/nodes/PortalNode.tsx
+++ b/packages/ui/src/c4/nodes/PortalNode.tsx
@@ -5,6 +5,7 @@ import { ArrowRight } from "lucide-react";
 import type { NodeProps } from "@xyflow/react";
 import { Handle, Position } from "@xyflow/react";
 import { useArchitectureStore } from "../store/use-architecture-store";
+import { THEME } from "../theme/theme-variables";
 
 export interface PortalNodeProps {
   targetLayerId: string;
@@ -20,9 +21,10 @@ function PortalNodeImpl(props: NodeProps) {
     useArchitectureStore.getState().drillIntoLayer(targetLayerId);
   };
 
+  // Ghost ink: portals are pointers out of the scope, not members of it.
   const borderColor = selected
-    ? "#fbbf24"
-    : "rgba(148, 163, 184, 0.35)";
+    ? THEME.selection.ring
+    : "var(--color-diagram-cluster-border)";
 
   return (
     <div
@@ -30,14 +32,14 @@ function PortalNodeImpl(props: NodeProps) {
       style={{
         cursor: "pointer",
         width: 220,
-        background: "rgba(17, 24, 39, 0.6)",
+        background: THEME.surface.glass,
         border: `2px dashed ${borderColor}`,
         borderRadius: 8,
         padding: "8px 12px",
         display: "flex",
         flexDirection: "column",
         gap: 2,
-        boxShadow: selected ? "0 0 0 2px rgba(251,191,36,0.3)" : "0 2px 8px rgba(0,0,0,0.2)",
+        boxShadow: selected ? `0 0 0 2px ${THEME.selection.ringAlpha}` : "0 2px 8px rgba(0,0,0,0.2)",
       }}
     >
       <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
@@ -45,16 +47,16 @@ function PortalNodeImpl(props: NodeProps) {
         <span style={{
           fontSize: 13,
           fontWeight: 500,
-          color: "var(--color-text-primary, #f1f5f9)",
+          color: "var(--color-text-primary)",
           overflow: "hidden",
           textOverflow: "ellipsis",
           whiteSpace: "nowrap",
         }}>
           {targetLayerName}
         </span>
-        <ArrowRight size={12} color="var(--color-text-secondary, #94a3b8)" aria-hidden />
+        <ArrowRight size={12} color="var(--color-text-secondary)" aria-hidden />
       </div>
-      <span style={{ fontSize: 10, color: "var(--color-text-secondary, #94a3b8)" }}>
+      <span style={{ fontSize: 10, color: "var(--color-text-secondary)" }}>
         {edgeCount} connections
       </span>
       <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />

--- a/packages/ui/src/c4/nodes/ScopeFrameNode.tsx
+++ b/packages/ui/src/c4/nodes/ScopeFrameNode.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * "You are here" scope frame (kg-ux plan §2.4) — the dashed rounded
+ * boundary from the reference flowchart, drawn behind the drilled tier's
+ * nodes. Non-interactive underlay: clicks pass through to the pane, the
+ * name tab on the border says which scope you're inside.
+ */
+
+import { memo } from "react";
+import type { NodeProps } from "@xyflow/react";
+
+export interface ScopeFrameNodeProps {
+  label: string;
+  width: number;
+  height: number;
+}
+
+function ScopeFrameNodeImpl(props: NodeProps) {
+  const { data } = props as NodeProps & { data: ScopeFrameNodeProps };
+  const { label, width, height } = data;
+
+  return (
+    <div
+      aria-hidden
+      style={{
+        width,
+        height,
+        border: "1.5px dashed var(--color-diagram-cluster-border)",
+        borderRadius: 16,
+        pointerEvents: "none",
+        position: "relative",
+      }}
+    >
+      {/* Faint warm wash inside the boundary — garnish, sits behind cards. */}
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          borderRadius: 16,
+          backgroundImage: "var(--gradient-warm-wash)",
+          opacity: 0.4,
+        }}
+      />
+      {/* Name tab interrupting the dashed border */}
+      <span
+        style={{
+          position: "absolute",
+          top: -9,
+          left: 20,
+          padding: "1px 10px",
+          background: "var(--color-bg-canvas)",
+          border: "1px dashed var(--color-diagram-cluster-border)",
+          borderRadius: 6,
+          fontFamily: "var(--font-mono, ui-monospace, monospace)",
+          fontSize: 9,
+          fontWeight: 600,
+          letterSpacing: 1,
+          textTransform: "uppercase",
+          color: "var(--color-text-secondary)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export const ScopeFrameNode = memo(ScopeFrameNodeImpl);

--- a/packages/ui/src/c4/nodes/index.ts
+++ b/packages/ui/src/c4/nodes/index.ts
@@ -8,6 +8,7 @@ import { ArchFileNode } from "./ArchFileNode";
 import { ArchContainerNode } from "./ArchContainerNode";
 import { LayerClusterNode } from "./LayerClusterNode";
 import { PortalNode } from "./PortalNode";
+import { ScopeFrameNode } from "./ScopeFrameNode";
 
 export const c4NodeTypes: NodeTypes = {
   system: SystemNode,
@@ -22,8 +23,12 @@ export const archNodeTypes: NodeTypes = {
   archFile: ArchFileNode,
   archContainer: ArchContainerNode,
   layerCluster: LayerClusterNode,
+  // Curated sub-group card — same component, "subGroup" kind via data.
+  subGroupCluster: LayerClusterNode,
   portal: PortalNode,
+  // Dashed "you are here" boundary behind the drilled tier (kg-ux §2.4).
+  scopeFrame: ScopeFrameNode,
 };
 
 export { SystemNode, PersonNode, ExternalSystemNode, ContainerNode, ComponentNode };
-export { ArchFileNode, ArchContainerNode, LayerClusterNode, PortalNode };
+export { ArchFileNode, ArchContainerNode, LayerClusterNode, PortalNode, ScopeFrameNode };

--- a/packages/ui/src/c4/nodes/ink-node-shell.tsx
+++ b/packages/ui/src/c4/nodes/ink-node-shell.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+/**
+ * Blueprint ink node face (kg-ux plan §2.2) — the KG canvas card.
+ *
+ * Color encodes ROLE, not type (the kind icon carries type):
+ *   accent    — ember-gradient "start here" block (entry points, repo core,
+ *               current tour step); dark text per locked decision 1.
+ *   primary   — ink block: the nodes of the active scope.
+ *   secondary — recessed gray-plum ink: supporting cast (collapsed siblings,
+ *               barrels, demoted Test layer, "+N more").
+ *   ghost     — transparent face, dashed boundary (placeholders, portals).
+ */
+
+import * as React from "react";
+import { BookOpen, type LucideIcon } from "lucide-react";
+import { Handle, Position } from "@xyflow/react";
+
+export type InkRole = "accent" | "primary" | "secondary" | "ghost";
+
+export interface InkNodeShellProps {
+  role: InkRole;
+  kindLabel: string;
+  title: string;
+  /** Kind glyph (from getKindIcon) — renders beside the title, and as a
+   * large faint watermark when `heroIcon` is set (layer/group cards). */
+  icon?: LucideIcon | undefined;
+  subtitle?: string | undefined;
+  /** Bottom-right meta (degrees, complexity bars, counts). */
+  meta?: React.ReactNode | undefined;
+  /** Top-right signal glyphs (tour step, entry, hotspot, dead). */
+  badges?: React.ReactNode | undefined;
+  selected?: boolean | undefined;
+  focused?: boolean | undefined;
+  searchHighlight?: boolean | undefined;
+  tourHighlight?: boolean | undefined;
+  diffState?: "changed" | "affected" | "faded" | undefined;
+  width?: number | undefined;
+  height?: number | undefined;
+  hasDocs?: boolean | undefined;
+  titleFontSize?: number | undefined;
+  subtitleLineClamp?: number | undefined;
+  heroIcon?: boolean | undefined;
+}
+
+const FACES: Record<InkRole, { background: string; backgroundImage?: string; text: string; border: string }> = {
+  accent: {
+    background: "var(--color-accent-fill)",
+    backgroundImage: "var(--gradient-ember)",
+    text: "var(--color-text-on-accent)",
+    border: "transparent",
+  },
+  primary: {
+    background: "var(--color-kg-node-fill)",
+    // Ruled-paper texture in light mode (token resolves to none in dark).
+    backgroundImage: "var(--kg-card-texture)",
+    text: "var(--color-kg-node-text)",
+    border: "var(--color-kg-node-border)",
+  },
+  secondary: {
+    background: "var(--color-kg-node-fill-2)",
+    text: "var(--color-kg-node-text)",
+    border: "var(--color-kg-node-border-2)",
+  },
+  ghost: {
+    background: "transparent",
+    text: "var(--color-text-primary)",
+    border: "var(--color-diagram-cluster-border)",
+  },
+};
+
+function stateBorderColor(props: InkNodeShellProps, faceBorder: string): string {
+  if (props.selected) return "var(--color-viz-selection)";
+  if (props.diffState === "changed") return "var(--color-viz-diff-changed)";
+  if (props.diffState === "affected") return "var(--color-viz-diff-affected)";
+  if (props.tourHighlight) return "var(--color-accent-fill)";
+  if (props.searchHighlight) return "var(--color-accent-fill)";
+  if (props.focused) return "var(--color-accent-fill)";
+  return faceBorder;
+}
+
+function stateBoxShadow(props: InkNodeShellProps): string {
+  if (props.selected) {
+    return "0 0 0 2px color-mix(in srgb, var(--color-viz-selection) 35%, transparent)";
+  }
+  if (props.diffState === "changed") {
+    return "0 0 0 2px color-mix(in srgb, var(--color-viz-diff-changed) 40%, transparent)";
+  }
+  if (props.diffState === "affected") {
+    return "0 0 0 2px color-mix(in srgb, var(--color-viz-diff-affected) 35%, transparent)";
+  }
+  return "0 1px 2px rgba(0,0,0,0.15)";
+}
+
+export function InkNodeShell(props: InkNodeShellProps) {
+  const {
+    role,
+    kindLabel,
+    title,
+    icon: Icon,
+    subtitle,
+    meta,
+    badges,
+    selected,
+    searchHighlight,
+    tourHighlight,
+    diffState,
+    width,
+    height,
+    hasDocs,
+    titleFontSize = 12,
+    subtitleLineClamp = 2,
+    heroIcon,
+  } = props;
+
+  const face = FACES[role];
+  const opacity = diffState === "faded" ? 0.25 : 1;
+  const dashed = role === "ghost" || (searchHighlight && !selected);
+
+  return (
+    <div
+      data-ink-role={role}
+      style={{
+        width,
+        height,
+        background: face.background,
+        ...(face.backgroundImage
+          ? { backgroundImage: face.backgroundImage, backgroundSize: "cover", backgroundPosition: "center" }
+          : {}),
+        border: `1.5px ${dashed ? "dashed" : "solid"} ${stateBorderColor(props, face.border)}`,
+        borderRadius: 12,
+        color: face.text,
+        overflow: "hidden",
+        boxShadow: stateBoxShadow(props),
+        fontFamily: "var(--font-sans, system-ui, sans-serif)",
+        display: "flex",
+        flexDirection: "column",
+        padding: "10px 12px",
+        opacity,
+        animation: tourHighlight && !selected ? "accentPulse 2s ease-in-out infinite" : undefined,
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+
+      {/* Title row: kind glyph + mono name + signal badges */}
+      <div style={{ display: "flex", alignItems: "flex-start", gap: 6 }}>
+        {Icon && !heroIcon && (
+          <Icon size={14} strokeWidth={2} aria-hidden style={{ flexShrink: 0, marginTop: 1, opacity: 0.9 }} />
+        )}
+        <div
+          style={{
+            flex: 1,
+            minWidth: 0,
+            fontFamily: "var(--font-mono, ui-monospace, monospace)",
+            fontSize: titleFontSize,
+            fontWeight: 600,
+            lineHeight: 1.3,
+            wordBreak: "break-word",
+          }}
+        >
+          {title}
+        </div>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 4, flexShrink: 0 }}>
+          {badges}
+          {hasDocs && (
+            <span
+              title="Documentation available"
+              aria-label="Documentation available"
+              style={{ display: "inline-flex", alignItems: "center", opacity: 0.9 }}
+            >
+              <BookOpen size={11} aria-hidden />
+            </span>
+          )}
+        </span>
+      </div>
+
+      {subtitle && (
+        <div
+          style={{
+            marginTop: 3,
+            fontSize: 10.5,
+            opacity: 0.72,
+            lineHeight: 1.35,
+            wordBreak: "break-word",
+            display: "-webkit-box",
+            WebkitLineClamp: subtitleLineClamp,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
+          {subtitle}
+        </div>
+      )}
+
+      {/* Hero watermark glyph — layer/group cards have the room for it */}
+      {heroIcon && Icon && (
+        <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", minHeight: 0 }}>
+          <Icon size={36} strokeWidth={1.25} aria-hidden style={{ opacity: 0.2 }} />
+        </div>
+      )}
+
+      {/* Footer: kind label left, meta right */}
+      <div
+        style={{
+          marginTop: "auto",
+          paddingTop: 6,
+          display: "flex",
+          alignItems: "flex-end",
+          justifyContent: "space-between",
+          gap: 8,
+        }}
+      >
+        <span
+          style={{
+            fontFamily: "var(--font-mono, ui-monospace, monospace)",
+            fontSize: 8.5,
+            fontWeight: 600,
+            letterSpacing: 0.8,
+            textTransform: "uppercase",
+            opacity: 0.6,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {kindLabel}
+        </span>
+        {meta && <span style={{ fontSize: 10, opacity: 0.85 }}>{meta}</span>}
+      </div>
+
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+    </div>
+  );
+}

--- a/packages/ui/src/c4/nodes/kind-icons.ts
+++ b/packages/ui/src/c4/nodes/kind-icons.ts
@@ -1,0 +1,55 @@
+import {
+  ArrowRight,
+  Box,
+  Boxes,
+  Braces,
+  Cog,
+  Database,
+  ExternalLink,
+  FileCode,
+  FileJson,
+  FileText,
+  Folder,
+  Globe,
+  Layers,
+  Lightbulb,
+  Package,
+  Server,
+  Table,
+  User,
+  Workflow,
+  type LucideIcon,
+} from "lucide-react";
+
+/**
+ * Kind → glyph map for the blueprint ink nodes (kg-ux plan §2.2): with the
+ * tone-rainbow gone from card faces, the ICON carries the node's type.
+ * One map so cards, filters, and the legend can never disagree.
+ */
+const KIND_ICONS: Record<string, LucideIcon> = {
+  file: FileCode,
+  function: Braces,
+  class: Box,
+  module: Package,
+  config: Cog,
+  document: FileText,
+  concept: Lightbulb,
+  service: Server,
+  resource: Database,
+  pipeline: Workflow,
+  table: Table,
+  endpoint: Globe,
+  schema: FileJson,
+  system: Boxes,
+  person: User,
+  external: ExternalLink,
+  container: Folder,
+  component: Box,
+  layer: Layers,
+  subGroup: Folder,
+  portal: ArrowRight,
+};
+
+export function getKindIcon(kind: string): LucideIcon {
+  return KIND_ICONS[kind] ?? FileCode;
+}

--- a/packages/ui/src/c4/overlays/ExecutionFlowOverlay.tsx
+++ b/packages/ui/src/c4/overlays/ExecutionFlowOverlay.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Badge } from "../panels/panel-atoms";
+import { THEME } from "../theme/theme-variables";
 
 export interface ExecutionFlowEntry {
   id: string;
@@ -43,11 +44,11 @@ export function ExecutionFlowOverlay({ flows, visible }: ExecutionFlowOverlayPro
           width: 340,
           maxHeight: "70vh",
           overflowY: "auto",
-          background: "rgba(15, 23, 42, 0.95)",
-          border: "1px solid rgba(148, 163, 184, 0.2)",
+          background: THEME.surface.elevated,
+          border: `1px solid ${THEME.border.default}`,
           borderRadius: 8,
           padding: 16,
-          color: "#e2e8f0",
+          color: THEME.text.primary,
           fontSize: 13,
           zIndex: 500,
         }}
@@ -66,11 +67,11 @@ export function ExecutionFlowOverlay({ flows, visible }: ExecutionFlowOverlayPro
         width: 340,
         maxHeight: "70vh",
         overflowY: "auto",
-        background: "rgba(15, 23, 42, 0.95)",
-        border: "1px solid rgba(148, 163, 184, 0.2)",
+        background: THEME.surface.elevated,
+        border: `1px solid ${THEME.border.default}`,
         borderRadius: 8,
         padding: 16,
-        color: "#e2e8f0",
+        color: THEME.text.primary,
         fontSize: 13,
         zIndex: 500,
       }}
@@ -83,7 +84,7 @@ export function ExecutionFlowOverlay({ flows, visible }: ExecutionFlowOverlayPro
             key={flow.id}
             style={{
               padding: "8px 0",
-              borderBottom: "1px solid rgba(148, 163, 184, 0.12)",
+              borderBottom: `1px solid ${THEME.border.subtle}`,
             }}
           >
             <div
@@ -100,7 +101,7 @@ export function ExecutionFlowOverlay({ flows, visible }: ExecutionFlowOverlayPro
               <Badge label={flow.score.toFixed(2)} />
             </div>
             {flow.crosses_community && (
-              <div style={{ color: "#fbbf24", fontSize: 11, marginTop: 4, marginLeft: 20 }}>
+              <div style={{ color: "var(--color-warning)", fontSize: 11, marginTop: 4, marginLeft: 20 }}>
                 ⚠ Cross-boundary
               </div>
             )}
@@ -115,7 +116,7 @@ export function ExecutionFlowOverlay({ flows, visible }: ExecutionFlowOverlayPro
                       opacity: 0.85,
                     }}
                   >
-                    <span style={{ color: "#94a3b8", marginRight: 6 }}>{idx + 1}.</span>
+                    <span style={{ color: THEME.text.secondary, marginRight: 6 }}>{idx + 1}.</span>
                     {nodeId}
                   </div>
                 ))}

--- a/packages/ui/src/c4/panels/ArchBreadcrumb.tsx
+++ b/packages/ui/src/c4/panels/ArchBreadcrumb.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useArchitectureStore } from "../store/use-architecture-store";
+
+/** Tier breadcrumb for the architecture view: Overview → Layer → Group.
+ * Stays consistent whether or not a layer has a sub-group tier (decision 1).
+ */
+export function ArchBreadcrumb() {
+  const view = useArchitectureStore((s) => s.view);
+  const navigationLevel = useArchitectureStore((s) => s.navigationLevel);
+  const activeLayerId = useArchitectureStore((s) => s.activeLayerId);
+  const activeSubGroupId = useArchitectureStore((s) => s.activeSubGroupId);
+
+  if (!view || navigationLevel === "overview") return null;
+
+  const layer = view.layers.find((l) => l.id === activeLayerId);
+  const subGroup = layer?.sub_groups.find((g) => g.id === activeSubGroupId);
+
+  const crumbStyle: React.CSSProperties = {
+    background: "none",
+    border: "none",
+    padding: 0,
+    font: "inherit",
+    cursor: "pointer",
+    color: "var(--color-text-secondary)",
+  };
+  const sep = <span style={{ opacity: 0.5 }}>›</span>;
+  const current: React.CSSProperties = {
+    color: "var(--color-text-primary)",
+    fontWeight: 600,
+  };
+
+  const goOverview = () => {
+    const store = useArchitectureStore.getState();
+    // Two-stage drillOut: jump straight to the overview from any tier.
+    store.drillOut();
+    if (useArchitectureStore.getState().navigationLevel !== "overview") {
+      store.drillOut();
+    }
+  };
+
+  const goLayerGroups = () => {
+    if (activeLayerId) useArchitectureStore.getState().drillIntoLayer(activeLayerId);
+  };
+
+  return (
+    <nav
+      aria-label="Architecture navigation"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        fontSize: 12,
+      }}
+    >
+      <button type="button" style={crumbStyle} onClick={goOverview}>
+        Overview
+      </button>
+      {layer && (
+        <>
+          {sep}
+          {navigationLevel === "layer-detail" && activeSubGroupId ? (
+            <button type="button" style={crumbStyle} onClick={goLayerGroups}>
+              {layer.name}
+            </button>
+          ) : (
+            <span style={current}>{layer.name}</span>
+          )}
+        </>
+      )}
+      {activeSubGroupId && (
+        <>
+          {sep}
+          <span style={current}>
+            {subGroup?.name ?? activeSubGroupId.split(":").pop()}
+          </span>
+        </>
+      )}
+    </nav>
+  );
+}

--- a/packages/ui/src/c4/panels/ArchLegend.tsx
+++ b/packages/ui/src/c4/panels/ArchLegend.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * Decoder ring for the blueprint KG canvas (kg-ux plan B6) — what the ink
+ * weights, signal glyphs, edges, and gestures mean. Collapsible chip so it
+ * never competes with the canvas; rendered on every tier.
+ */
+
+import { useState } from "react";
+import { BookOpen, ChevronDown, ChevronUp, Flame, Play, Skull } from "lucide-react";
+
+const SWATCH_BASE: React.CSSProperties = {
+  width: 14,
+  height: 14,
+  borderRadius: 4,
+  flexShrink: 0,
+  display: "inline-block",
+};
+
+function Row({ swatch, children }: { swatch: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 10.5 }}>
+      {swatch}
+      <span style={{ color: "var(--color-text-secondary)" }}>{children}</span>
+    </div>
+  );
+}
+
+export function ArchLegend() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-start",
+        gap: 6,
+        fontFamily: "var(--font-sans, system-ui, sans-serif)",
+      }}
+    >
+      {open && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 7,
+            padding: "10px 12px",
+            borderRadius: 10,
+            background: "var(--color-bg-elevated)",
+            border: "1px solid var(--color-border-default)",
+            boxShadow: "0 6px 20px rgba(0,0,0,0.18)",
+            maxWidth: 240,
+          }}
+        >
+          <Row swatch={<span style={{ ...SWATCH_BASE, backgroundImage: "var(--gradient-ember)" }} />}>
+            Start here — entry points
+          </Row>
+          <Row swatch={<span style={{ ...SWATCH_BASE, background: "var(--color-kg-node-fill)", border: "1px solid var(--color-kg-node-border)" }} />}>
+            This scope
+          </Row>
+          <Row swatch={<span style={{ ...SWATCH_BASE, background: "var(--color-kg-node-fill-2)", border: "1px solid var(--color-kg-node-border-2)" }} />}>
+            Supporting — siblings, tests, barrels
+          </Row>
+          <Row swatch={<span style={{ ...SWATCH_BASE, background: "transparent", border: "1.5px dashed var(--color-diagram-cluster-border)" }} />}>
+            Boundary / pointer out of scope
+          </Row>
+
+          <div style={{ height: 1, background: "var(--color-border-subtle)", margin: "2px 0" }} />
+
+          <Row
+            swatch={
+              <span style={{ display: "inline-flex", gap: 3, color: "var(--color-text-secondary)" }}>
+                <Play size={11} aria-hidden />
+                <Flame size={11} aria-hidden />
+                <Skull size={11} aria-hidden />
+                <BookOpen size={11} aria-hidden />
+              </span>
+            }
+          >
+            Entry · hotspot · dead code · has docs
+          </Row>
+          <Row
+            swatch={
+              <svg width="22" height="8" aria-hidden style={{ flexShrink: 0 }}>
+                <line x1="0" y1="4" x2="22" y2="4" stroke="var(--color-diagram-edge)" strokeWidth="1.5" strokeDasharray="5 3" />
+              </svg>
+            }
+          >
+            Relation — the chip glyph tells the kind
+          </Row>
+
+          <div style={{ height: 1, background: "var(--color-border-subtle)", margin: "2px 0" }} />
+
+          <div
+            style={{
+              fontFamily: "var(--font-mono, ui-monospace, monospace)",
+              fontSize: 9.5,
+              color: "var(--color-text-secondary)",
+              lineHeight: 1.6,
+            }}
+          >
+            Click = inspect · 2×click = open
+            <br />
+            Esc = back · F = filters · / = search
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-label={open ? "Collapse legend" : "Expand legend"}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 5,
+          padding: "4px 10px",
+          borderRadius: 999,
+          fontSize: 10.5,
+          fontWeight: 600,
+          cursor: "pointer",
+          background: "var(--color-bg-elevated)",
+          border: "1px solid var(--color-border-default)",
+          color: "var(--color-text-secondary)",
+        }}
+      >
+        {open ? <ChevronDown size={11} aria-hidden /> : <ChevronUp size={11} aria-hidden />}
+        Legend
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/c4/panels/ArchNodeInfo.tsx
+++ b/packages/ui/src/c4/panels/ArchNodeInfo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { X, Code, MapPin, Layers, ExternalLink } from "lucide-react";
+import { X, Code, MapPin, Layers, ExternalLink, Folder, CornerDownRight } from "lucide-react";
 import { useArchitectureStore } from "../store/use-architecture-store";
 import { getTone } from "../../graph-primitives/tone-styles";
 import { THEME } from "../theme/theme-variables";
@@ -33,11 +33,101 @@ export function ArchNodeInfo(props: ArchNodeInfoProps) {
   const nodeIdToLayerId = useArchitectureStore((s) => s.nodeIdToLayerId);
   const selectNode = useArchitectureStore((s) => s.selectNode);
   const drillIntoLayer = useArchitectureStore((s) => s.drillIntoLayer);
+  const drillIntoSubGroup = useArchitectureStore((s) => s.drillIntoSubGroup);
   const openCodeViewer = useArchitectureStore((s) => s.openCodeViewer);
   const setFocusNode = useArchitectureStore((s) => s.setFocusNode);
   const view = useArchitectureStore((s) => s.view);
 
   const node = selectedNodeId ? nodesById.get(selectedNodeId) ?? null : null;
+
+  // Scope selection (kg-ux plan B5): single-clicking a layer/group card
+  // selects it — this panel is the "inspect" half of the grammar, with the
+  // explicit drill affordance ("Open on canvas") as the other half.
+  if (!node && selectedNodeId && view) {
+    const layerScope = view.layers.find((l) => l.id === selectedNodeId);
+    if (layerScope) {
+      return (
+        <ScopeInfo
+          kind="layer"
+          name={layerScope.name}
+          description={layerScope.description}
+          fileCount={layerScope.file_count}
+          groupCount={layerScope.sub_groups.length}
+          healthScore={layerScope.health_score}
+          onClose={() => selectNode(null)}
+          onOpen={() => drillIntoLayer(layerScope.id)}
+        />
+      );
+    }
+    for (const l of view.layers) {
+      const group = l.sub_groups.find((g) => g.id === selectedNodeId);
+      if (group) {
+        return (
+          <ScopeInfo
+            kind="group"
+            name={group.name}
+            description={`Sub-group of ${l.name}`}
+            fileCount={group.node_ids.length}
+            onClose={() => selectNode(null)}
+            onOpen={() => drillIntoSubGroup(group.id)}
+          />
+        );
+      }
+    }
+
+    // Folder containers (dir:<path>) — the boxes the detail canvas groups
+    // files into. They aren't ArchNodes, so without this branch selecting
+    // one left the inspector blank.
+    if (selectedNodeId.startsWith("dir:")) {
+      const path = selectedNodeId.slice(4);
+      const memberCount = view.nodes.filter((n) => n.id.startsWith(`${path}/`)).length;
+      return (
+        <ScopeInfo
+          kind="folder"
+          name={path.split("/").pop() ?? path}
+          description={path}
+          fileCount={memberCount}
+          onClose={() => selectNode(null)}
+          onOpen={() => useArchitectureStore.getState().toggleContainer(selectedNodeId)}
+        />
+      );
+    }
+
+    // The "+N more" card that absorbs files beyond the visible-box budget.
+    if (selectedNodeId === "container:__overflow") {
+      return (
+        <ScopeInfo
+          kind="folder"
+          name="More files"
+          description="Files beyond the visible-box budget for this scope. Expand the card to lay them out."
+          onClose={() => selectNode(null)}
+          onOpen={() => useArchitectureStore.getState().toggleContainer(selectedNodeId)}
+        />
+      );
+    }
+
+    // Portal chips (portal:layer:A→layer:B) — wayfinding to a neighbouring
+    // layer this scope exchanges imports with.
+    if (selectedNodeId.startsWith("portal:")) {
+      const targetLayerId = selectedNodeId.split("→")[1];
+      const targetLayer = targetLayerId
+        ? view.layers.find((l) => l.id === targetLayerId)
+        : undefined;
+      if (targetLayer) {
+        return (
+          <ScopeInfo
+            kind="portal"
+            name={targetLayer.name}
+            description={`Files in this scope exchange imports with the ${targetLayer.name} layer. Open it to follow them.`}
+            fileCount={targetLayer.file_count}
+            onClose={() => selectNode(null)}
+            onOpen={() => drillIntoLayer(targetLayer.id)}
+          />
+        );
+      }
+    }
+  }
+
   if (!node) return null;
 
   const tone = getTone(node.node_type);
@@ -90,7 +180,7 @@ export function ArchNodeInfo(props: ArchNodeInfoProps) {
 
       {props.docContent && props.renderDoc ? (
         <Section title="Wiki">
-          <div style={{ fontSize: 12, lineHeight: 1.45, color: "var(--color-text-secondary, #cbd5e1)" }}>
+          <div style={{ fontSize: 12, lineHeight: 1.45, color: "var(--color-text-secondary)" }}>
             {props.renderDoc(props.docContent)}
           </div>
           {props.onOpenDoc && (
@@ -103,7 +193,7 @@ export function ArchNodeInfo(props: ArchNodeInfoProps) {
         </Section>
       ) : (
         <Section title="Wiki">
-          <div style={{ fontSize: 11, color: "var(--color-text-secondary, #94a3b8)", opacity: 0.7 }}>
+          <div style={{ fontSize: 11, color: "var(--color-text-secondary)", opacity: 0.7 }}>
             Wiki not generated yet. Run docs generation to populate this section.
           </div>
         </Section>
@@ -132,7 +222,7 @@ export function ArchNodeInfo(props: ArchNodeInfoProps) {
                   display: "flex",
                   justifyContent: "space-between",
                   padding: "3px 0",
-                  borderTop: "1px solid rgba(148,163,184,0.12)",
+                  borderTop: "1px solid var(--color-border-subtle)",
                   fontSize: 11,
                 }}
               >
@@ -187,7 +277,7 @@ function HeaderSection({
   tone: { band: string; text: string };
   onClose: () => void;
 }) {
-  const dotColor = THEME.complexity[node.complexity] ?? "#94a3b8";
+  const dotColor = THEME.complexity[node.complexity] ?? "var(--color-text-muted)";
 
   return (
     <header
@@ -196,7 +286,7 @@ function HeaderSection({
         alignItems: "center",
         justifyContent: "space-between",
         padding: "10px 12px",
-        borderBottom: "1px solid var(--color-border-default, #334155)",
+        borderBottom: "1px solid var(--color-border-default)",
         gap: 8,
       }}
     >
@@ -249,7 +339,7 @@ function HealthSection({
         />
       </div>
       {health.is_silo && (
-        <div style={{ marginTop: 6, fontSize: 10, color: "#fbbf24", fontWeight: 600 }}>
+        <div style={{ marginTop: 6, fontSize: 10, color: "var(--color-warning)", fontWeight: 600 }}>
           ⚠ Knowledge silo detected
         </div>
       )}
@@ -355,11 +445,11 @@ function ConnectionList({
               border: "none",
               borderRadius: 4,
               cursor: "pointer",
-              color: "var(--color-text-primary, #f1f5f9)",
+              color: "var(--color-text-primary)",
               fontSize: 11,
               textAlign: "left",
             }}
-            onMouseEnter={(e) => { (e.currentTarget.style.background = "rgba(148,163,184,0.1)"); }}
+            onMouseEnter={(e) => { (e.currentTarget.style.background = "var(--color-bg-wash-hover)"); }}
             onMouseLeave={(e) => { (e.currentTarget.style.background = "none"); }}
           >
             <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
@@ -373,5 +463,94 @@ function ConnectionList({
         <Sub style={{ paddingLeft: 6 }}>+{remaining} more</Sub>
       )}
     </div>
+  );
+}
+
+/** Inspect card for a selected layer / sub-group (kg-ux plan B5): summary +
+ * stats + the explicit drill button mirroring double-click on the canvas. */
+function ScopeInfo({
+  kind,
+  name,
+  description,
+  fileCount,
+  groupCount,
+  healthScore,
+  onClose,
+  onOpen,
+}: {
+  kind: "layer" | "group" | "folder" | "portal";
+  name: string;
+  description?: string | undefined;
+  fileCount?: number | undefined;
+  groupCount?: number | undefined;
+  healthScore?: number | null | undefined;
+  onClose: () => void;
+  onOpen: () => void;
+}) {
+  const Icon = kind === "layer" ? Layers : kind === "portal" ? ExternalLink : Folder;
+  const rows: [string, string][] = fileCount != null ? [["Files", String(fileCount)]] : [];
+  if (kind === "layer" && groupCount && groupCount > 0) {
+    rows.push(["Groups", String(groupCount)]);
+  }
+  if (healthScore !== null && healthScore !== undefined) {
+    rows.push(["Health", String(Math.round(healthScore))]);
+  }
+
+  return (
+    <>
+      <Section>
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 8 }}>
+          <Icon size={16} style={{ flexShrink: 0, marginTop: 2, color: "var(--color-accent-primary)" }} aria-hidden />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <Title>{name}</Title>
+            <Sub style={{ marginTop: 2 }}>
+              {kind === "layer"
+                ? "Layer"
+                : kind === "folder"
+                  ? "Folder"
+                  : kind === "portal"
+                    ? "Connected layer"
+                    : "Group"}
+            </Sub>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close inspector"
+            style={{
+              background: "none",
+              border: "none",
+              color: "var(--color-text-secondary)",
+              cursor: "pointer",
+              padding: 2,
+            }}
+          >
+            <X size={14} aria-hidden />
+          </button>
+        </div>
+        {description && <Sub style={{ marginTop: 6 }}>{description}</Sub>}
+      </Section>
+
+      {rows.length > 0 && (
+        <Section>
+          <KVList rows={rows} />
+        </Section>
+      )}
+
+      <Section>
+        <ActionRow>
+          <ActionButton onClick={onOpen} icon={CornerDownRight} variant="primary">
+            {kind === "layer" || kind === "portal"
+              ? "Open layer"
+              : kind === "folder"
+                ? "Expand on canvas"
+                : "Open group"}
+          </ActionButton>
+        </ActionRow>
+        <Sub style={{ marginTop: 6, fontSize: 10 }}>
+          Double-clicking the card does the same. Esc deselects.
+        </Sub>
+      </Section>
+    </>
   );
 }

--- a/packages/ui/src/c4/panels/C4Breadcrumb.tsx
+++ b/packages/ui/src/c4/panels/C4Breadcrumb.tsx
@@ -45,8 +45,8 @@ export function C4Breadcrumb({
               padding: 0,
               cursor: seg.current ? "default" : "pointer",
               color: seg.current
-                ? "var(--color-text-primary, #f1f5f9)"
-                : "var(--color-text-secondary, #94a3b8)",
+                ? "var(--color-text-primary)"
+                : "var(--color-text-secondary)",
               fontWeight: seg.current ? 600 : 500,
             }}
           >

--- a/packages/ui/src/c4/panels/C4DetailPanel.tsx
+++ b/packages/ui/src/c4/panels/C4DetailPanel.tsx
@@ -70,9 +70,9 @@ export function C4DetailPanel(props: C4DetailPanelProps) {
         overflow: "auto",
         padding: 0,
         background: "var(--color-bg-elevated, rgba(17,24,39,0.96))",
-        border: "1px solid var(--color-border-default, #334155)",
+        border: "1px solid var(--color-border-default)",
         borderRadius: 8,
-        color: "var(--color-text-primary, #f1f5f9)",
+        color: "var(--color-text-primary)",
         fontSize: 12,
         zIndex: 5,
         display: "flex",
@@ -94,7 +94,7 @@ function Header({ data, onClose }: { data: C4NodeData; onClose: () => void }) {
         alignItems: "center",
         justifyContent: "space-between",
         padding: "10px 12px",
-        borderBottom: "1px solid var(--color-border-default, #334155)",
+        borderBottom: "1px solid var(--color-border-default)",
       }}
     >
       <span style={{ textTransform: "uppercase", fontSize: 10, letterSpacing: 0.6, opacity: 0.65, fontWeight: 600 }}>
@@ -193,7 +193,7 @@ function ContainerOrComponentBody(props: C4DetailPanelProps) {
               Primary owner: <strong>{health.primary_owner}</strong>{" "}
               ({Math.round(health.primary_owner_pct * 100)}%)
               {health.is_silo && (
-                <span style={{ marginLeft: 6, color: "#fbbf24" }}>· silo</span>
+                <span style={{ marginLeft: 6, color: "var(--color-warning)" }}>· silo</span>
               )}
             </Sub>
           )}
@@ -210,7 +210,7 @@ function ContainerOrComponentBody(props: C4DetailPanelProps) {
                   display: "flex",
                   justifyContent: "space-between",
                   padding: "3px 0",
-                  borderTop: "1px solid rgba(148,163,184,0.12)",
+                  borderTop: "1px solid var(--color-border-subtle)",
                   fontSize: 11,
                 }}
               >
@@ -229,7 +229,7 @@ function ContainerOrComponentBody(props: C4DetailPanelProps) {
         <Section title="Documentation">
           <Title style={{ fontSize: 12 }}>{doc.title}</Title>
           {docContent && renderDoc ? (
-            <div style={{ marginTop: 6, fontSize: 12, lineHeight: 1.45, color: "var(--color-text-secondary, #cbd5e1)" }}>
+            <div style={{ marginTop: 6, fontSize: 12, lineHeight: 1.45, color: "var(--color-text-secondary)" }}>
               {renderDoc(docContent)}
             </div>
           ) : (
@@ -256,7 +256,7 @@ function ContainerOrComponentBody(props: C4DetailPanelProps) {
 
 function Section({ title, children }: { title?: string; children: ReactNode }) {
   return (
-    <div style={{ padding: "10px 12px", borderBottom: "1px solid rgba(148,163,184,0.12)" }}>
+    <div style={{ padding: "10px 12px", borderBottom: "1px solid var(--color-border-subtle)" }}>
       {title && (
         <div
           style={{
@@ -294,7 +294,7 @@ function KVList({ rows }: { rows: [string, string][] }) {
             display: "flex",
             justifyContent: "space-between",
             padding: "3px 0",
-            borderTop: "1px solid rgba(148,163,184,0.12)",
+            borderTop: "1px solid var(--color-border-subtle)",
             fontSize: 11,
           }}
         >
@@ -330,9 +330,9 @@ function ActionButton({
         padding: "5px 10px",
         background: primary ? "var(--color-accent-muted, rgba(245,149,32,0.2))" : "transparent",
         color: primary
-          ? "var(--color-accent-primary, #f59520)"
-          : "var(--color-text-secondary, #cbd5e1)",
-        border: `1px solid ${primary ? "var(--color-accent-primary, #f59520)" : "var(--color-border-default, #334155)"}`,
+          ? "var(--color-accent-primary)"
+          : "var(--color-text-secondary)",
+        border: `1px solid ${primary ? "var(--color-accent-primary)" : "var(--color-border-default)"}`,
         borderRadius: 4,
         cursor: "pointer",
         fontSize: 11,

--- a/packages/ui/src/c4/panels/C4Legend.tsx
+++ b/packages/ui/src/c4/panels/C4Legend.tsx
@@ -1,11 +1,15 @@
 "use client";
 
+import { getTone } from "../../graph-primitives/tone-styles";
+
+// Swatches come from the same tone palette the nodes render with, so the
+// legend can never drift from the canvas.
 const ITEMS: { label: string; color: string }[] = [
-  { label: "System",    color: "#1f3a8a" },
-  { label: "Person",    color: "#374151" },
-  { label: "Container", color: "#0f3a5f" },
-  { label: "Component", color: "#0d2a47" },
-  { label: "External",  color: "#1f2937" },
+  { label: "System",    color: getTone("system").band },
+  { label: "Person",    color: getTone("person").band },
+  { label: "Container", color: getTone("container").band },
+  { label: "Component", color: getTone("component").band },
+  { label: "External",  color: getTone("external").band },
 ];
 
 export function C4Legend() {
@@ -17,9 +21,9 @@ export function C4Legend() {
         gap: 10,
         padding: "6px 10px",
         fontSize: 11,
-        color: "var(--color-text-secondary, #94a3b8)",
+        color: "var(--color-text-secondary)",
         background: "var(--color-bg-surface, rgba(15,23,42,0.7))",
-        border: "1px solid var(--color-border-default, #334155)",
+        border: "1px solid var(--color-border-default)",
         borderRadius: 6,
       }}
     >
@@ -32,7 +36,7 @@ export function C4Legend() {
               height: 10,
               borderRadius: 2,
               background: it.color,
-              border: "1px solid rgba(148,163,184,0.4)",
+              border: "1px solid var(--color-border-default)",
             }}
           />
           {it.label}

--- a/packages/ui/src/c4/panels/C4LevelTabs.tsx
+++ b/packages/ui/src/c4/panels/C4LevelTabs.tsx
@@ -40,13 +40,13 @@ export function C4LevelTabs({ level, onLevelChange, l3Enabled }: C4LevelTabsProp
               fontSize: 12,
               fontWeight: 500,
               borderRadius: 6,
-              border: "1px solid var(--color-border-default, #334155)",
+              border: "1px solid var(--color-border-default)",
               background: active
                 ? "var(--color-accent-muted, rgba(245,149,32,0.15))"
                 : "transparent",
               color: active
-                ? "var(--color-accent-primary, #f59520)"
-                : "var(--color-text-secondary, #94a3b8)",
+                ? "var(--color-accent-primary)"
+                : "var(--color-text-secondary)",
               cursor: disabled ? "not-allowed" : "pointer",
               opacity: disabled ? 0.4 : 1,
             }}

--- a/packages/ui/src/c4/panels/C4NodeInspector.tsx
+++ b/packages/ui/src/c4/panels/C4NodeInspector.tsx
@@ -23,9 +23,9 @@ export function C4NodeInspector({ data, onClose, onDrillIn }: C4NodeInspectorPro
         overflow: "auto",
         padding: 12,
         background: "var(--color-bg-elevated, rgba(17,24,39,0.95))",
-        border: "1px solid var(--color-border-default, #334155)",
+        border: "1px solid var(--color-border-default)",
         borderRadius: 8,
-        color: "var(--color-text-primary, #f1f5f9)",
+        color: "var(--color-text-primary)",
         fontSize: 12,
         zIndex: 5,
       }}
@@ -96,8 +96,8 @@ function InspectorBody({
                 marginTop: 10,
                 padding: "5px 10px",
                 background: "var(--color-accent-muted, rgba(245,149,32,0.2))",
-                color: "var(--color-accent-primary, #f59520)",
-                border: "1px solid var(--color-accent-primary, #f59520)",
+                color: "var(--color-accent-primary)",
+                border: "1px solid var(--color-accent-primary)",
                 borderRadius: 4,
                 cursor: "pointer",
                 fontSize: 11,
@@ -135,7 +135,7 @@ function Row({ title, sub }: { title: string; sub?: string }) {
 
 function KV({ k, v }: { k: string; v: string }) {
   return (
-    <div style={{ display: "flex", justifyContent: "space-between", padding: "3px 0", borderTop: "1px solid rgba(148,163,184,0.15)" }}>
+    <div style={{ display: "flex", justifyContent: "space-between", padding: "3px 0", borderTop: "1px solid var(--color-bg-wash-hover)" }}>
       <span style={{ opacity: 0.6 }}>{k}</span>
       <span style={{ fontFamily: "var(--font-mono, ui-monospace, monospace)" }}>{v}</span>
     </div>

--- a/packages/ui/src/c4/panels/CodeViewer.tsx
+++ b/packages/ui/src/c4/panels/CodeViewer.tsx
@@ -101,7 +101,7 @@ export function CodeViewer({ fetchContent }: CodeViewerProps): React.ReactElemen
     background: "none",
     border: "none",
     cursor: "pointer",
-    color: "var(--color-text-secondary, #cbd5e1)",
+    color: "var(--color-text-secondary)",
     padding: 4,
     display: "inline-flex",
     alignItems: "center",
@@ -115,7 +115,7 @@ export function CodeViewer({ fetchContent }: CodeViewerProps): React.ReactElemen
         alignItems: "center",
         justifyContent: "space-between",
         padding: "8px 12px",
-        borderBottom: "1px solid var(--color-border-default, #334155)",
+        borderBottom: "1px solid var(--color-border-default)",
         flexShrink: 0,
         gap: 8,
       }}
@@ -127,7 +127,7 @@ export function CodeViewer({ fetchContent }: CodeViewerProps): React.ReactElemen
               width: 40,
               height: 4,
               borderRadius: 2,
-              background: "var(--color-text-secondary, #94a3b8)",
+              background: "var(--color-text-secondary)",
               opacity: 0.4,
               marginRight: 8,
             }}
@@ -179,7 +179,7 @@ export function CodeViewer({ fetchContent }: CodeViewerProps): React.ReactElemen
           style={{
             height: 14,
             borderRadius: 4,
-            background: "rgba(148,163,184,0.15)",
+            background: "var(--color-bg-wash-hover)",
             width: `${60 + (i % 4) * 10}%`,
             animation: "pulse 1.5s ease-in-out infinite",
           }}
@@ -199,16 +199,16 @@ export function CodeViewer({ fetchContent }: CodeViewerProps): React.ReactElemen
         flex: 1,
       }}
     >
-      <AlertCircle size={32} style={{ color: "#ef4444" }} />
-      <div style={{ fontSize: 13, color: "var(--color-text-secondary, #cbd5e1)" }}>{error}</div>
+      <AlertCircle size={32} style={{ color: "var(--color-error)" }} />
+      <div style={{ fontSize: 13, color: "var(--color-text-secondary)" }}>{error}</div>
       <button
         type="button"
         onClick={doFetch}
         style={{
           padding: "6px 14px",
           background: "var(--color-accent-muted, rgba(245,149,32,0.2))",
-          color: "var(--color-accent-primary, #f59520)",
-          border: "1px solid var(--color-accent-primary, #f59520)",
+          color: "var(--color-accent-primary)",
+          border: "1px solid var(--color-accent-primary)",
           borderRadius: 4,
           cursor: "pointer",
           fontSize: 12,
@@ -248,7 +248,7 @@ export function CodeViewer({ fetchContent }: CodeViewerProps): React.ReactElemen
                   display: "flex",
                   background: inRange ? "rgba(245,149,32,0.1)" : "transparent",
                   borderLeft: inRange
-                    ? "3px solid var(--color-accent-primary, #f59520)"
+                    ? "3px solid var(--color-accent-primary)"
                     : "3px solid transparent",
                 }}
               >
@@ -258,7 +258,7 @@ export function CodeViewer({ fetchContent }: CodeViewerProps): React.ReactElemen
                     width: 50,
                     textAlign: "right",
                     paddingRight: 12,
-                    color: "var(--color-text-secondary, #94a3b8)",
+                    color: "var(--color-text-secondary)",
                     opacity: 0.5,
                     userSelect: "none",
                     flexShrink: 0,
@@ -305,10 +305,10 @@ export function CodeViewer({ fetchContent }: CodeViewerProps): React.ReactElemen
             display: "flex",
             flexDirection: "column",
             background: "var(--color-bg-elevated, rgba(17,24,39,0.98))",
-            border: "1px solid var(--color-border-default, #334155)",
+            border: "1px solid var(--color-border-default)",
             borderRadius: 8,
             boxShadow: "0 25px 50px rgba(0,0,0,0.5)",
-            color: "var(--color-text-primary, #f1f5f9)",
+            color: "var(--color-text-primary)",
             fontFamily: "var(--font-sans, system-ui, sans-serif)",
             overflow: "hidden",
           }}
@@ -331,9 +331,9 @@ export function CodeViewer({ fetchContent }: CodeViewerProps): React.ReactElemen
         display: "flex",
         flexDirection: "column",
         background: "var(--color-bg-elevated, rgba(17,24,39,0.98))",
-        borderTop: "1px solid var(--color-border-default, #334155)",
+        borderTop: "1px solid var(--color-border-default)",
         boxShadow: "0 -10px 30px rgba(0,0,0,0.3)",
-        color: "var(--color-text-primary, #f1f5f9)",
+        color: "var(--color-text-primary)",
         fontFamily: "var(--font-sans, system-ui, sans-serif)",
       }}
     >

--- a/packages/ui/src/c4/panels/FileExplorer.tsx
+++ b/packages/ui/src/c4/panels/FileExplorer.tsx
@@ -136,11 +136,11 @@ function TreeNodeRow({
             background: "none",
             border: "none",
             cursor: "pointer",
-            color: "var(--color-text-primary, #f1f5f9)",
+            color: "var(--color-text-primary)",
             fontSize: 11,
             textAlign: "left",
           }}
-          onMouseEnter={(e) => { (e.currentTarget.style.background = "rgba(148,163,184,0.08)"); }}
+          onMouseEnter={(e) => { (e.currentTarget.style.background = "var(--color-bg-wash)"); }}
           onMouseLeave={(e) => { (e.currentTarget.style.background = "none"); }}
         >
           {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
@@ -179,13 +179,13 @@ function TreeNodeRow({
         border: "none",
         cursor: "pointer",
         color: isSelected
-          ? "var(--color-accent-primary, #f59520)"
-          : "var(--color-text-primary, #f1f5f9)",
+          ? "var(--color-accent-primary)"
+          : "var(--color-text-primary)",
         fontSize: 11,
         textAlign: "left",
       }}
       onMouseEnter={(e) => {
-        if (!isSelected) e.currentTarget.style.background = "rgba(148,163,184,0.08)";
+        if (!isSelected) e.currentTarget.style.background = "var(--color-bg-wash)";
       }}
       onMouseLeave={(e) => {
         if (!isSelected) e.currentTarget.style.background = "none";

--- a/packages/ui/src/c4/panels/FilterPanel.tsx
+++ b/packages/ui/src/c4/panels/FilterPanel.tsx
@@ -23,14 +23,14 @@ function CheckboxRow({
         padding: "4px 0",
         fontSize: 11,
         cursor: "pointer",
-        color: "var(--color-text-primary, #f1f5f9)",
+        color: "var(--color-text-primary)",
       }}
     >
       <input
         type="checkbox"
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
-        style={{ accentColor: "var(--color-accent-primary, #f59520)" }}
+        style={{ accentColor: "var(--color-accent-primary)" }}
       />
       {label}
     </label>
@@ -47,6 +47,11 @@ export function FilterPanel() {
   const setEdgeCategoryFilter = useArchitectureStore((s) => s.setEdgeCategoryFilter);
   const resetFilters = useArchitectureStore((s) => s.resetFilters);
   const setFilterPanelOpen = useArchitectureStore((s) => s.setFilterPanelOpen);
+  const showTests = useArchitectureStore((s) => s.showTests);
+  const setShowTests = useArchitectureStore((s) => s.setShowTests);
+  const hasTestLayer = useArchitectureStore(
+    (s) => s.view?.layers.some((l) => l.id === "layer:test") ?? false,
+  );
 
   const nodeTypes = useMemo(() => {
     if (!view) return [];
@@ -76,7 +81,7 @@ export function FilterPanel() {
         left: 12,
         width: 280,
         background: "var(--color-bg-elevated, rgba(17,24,39,0.96))",
-        border: "1px solid var(--color-border-default, #334155)",
+        border: "1px solid var(--color-border-default)",
         borderRadius: 8,
         boxShadow: "0 8px 24px rgba(0,0,0,0.4)",
         zIndex: 8,
@@ -90,10 +95,10 @@ export function FilterPanel() {
           alignItems: "center",
           justifyContent: "space-between",
           padding: "10px 12px",
-          borderBottom: "1px solid rgba(148,163,184,0.12)",
+          borderBottom: "1px solid var(--color-border-subtle)",
         }}
       >
-        <span style={{ fontSize: 12, fontWeight: 600, color: "var(--color-text-primary, #f1f5f9)" }}>
+        <span style={{ fontSize: 12, fontWeight: 600, color: "var(--color-text-primary)" }}>
           Filters
         </span>
         <button
@@ -103,7 +108,7 @@ export function FilterPanel() {
             background: "transparent",
             border: "none",
             cursor: "pointer",
-            color: "var(--color-text-secondary, #94a3b8)",
+            color: "var(--color-text-secondary)",
             padding: 2,
           }}
         >
@@ -132,6 +137,17 @@ export function FilterPanel() {
           />
         ))}
       </Section>
+
+      {hasTestLayer && (
+        <Section title="Display">
+          {/* Tests mirror the code — demoted by default (decision 2). */}
+          <CheckboxRow
+            label="Show tests"
+            checked={showTests}
+            onChange={setShowTests}
+          />
+        </Section>
+      )}
 
       <Section title="Layers">
         {view.layers.map((layer) => (

--- a/packages/ui/src/c4/panels/LearnPanel.tsx
+++ b/packages/ui/src/c4/panels/LearnPanel.tsx
@@ -1,8 +1,18 @@
 "use client";
 
-import { Compass } from "lucide-react";
+import { BookOpen, Compass, FileCode, Server } from "lucide-react";
 import { useArchitectureStore } from "../store/use-architecture-store";
+import type { ArchTourStepKind } from "../types";
 import { Section, ActionButton, Pill } from "./panel-atoms";
+
+/** Iconography per curated step kind (viewer plan C-2). */
+function KindIcon({ kind }: { kind: ArchTourStepKind }) {
+  const style = { flexShrink: 0, opacity: 0.8 } as const;
+  if (kind === "overview") return <BookOpen size={13} style={style} aria-label="Overview step" />;
+  if (kind === "infra") return <Server size={13} style={style} aria-label="Infrastructure step" />;
+  if (kind === "code") return <FileCode size={13} style={style} aria-label="Code step" />;
+  return null;
+}
 
 export function LearnPanel() {
   const view = useArchitectureStore((s) => s.view);
@@ -70,12 +80,13 @@ export function LearnPanel() {
                     justifyContent: "center",
                     fontSize: 9,
                     fontWeight: 600,
-                    background: "rgba(148,163,184,0.15)",
+                    background: "var(--color-bg-wash-hover)",
                     flexShrink: 0,
                   }}
                 >
                   {i + 1}
                 </span>
+                <KindIcon kind={step.kind} />
                 <span>{step.title}</span>
               </div>
             ))}
@@ -87,6 +98,12 @@ export function LearnPanel() {
 
   const step = tour[currentTourStep];
   const progress = ((currentTourStep + 1) / tour.length) * 100;
+  // Curated steps carry the "why this stop" prose in `reason` (plan C-2);
+  // legacy LLM tours keep their description.
+  const stepBody = step?.reason || step?.description || "";
+  const stepLayer = step?.layer_id
+    ? view?.layers.find((l) => l.id === step.layer_id)
+    : undefined;
 
   return (
     <Section>
@@ -96,7 +113,7 @@ export function LearnPanel() {
           style={{
             height: 3,
             borderRadius: 2,
-            background: "rgba(148,163,184,0.15)",
+            background: "var(--color-bg-wash-hover)",
             marginBottom: 12,
             overflow: "hidden",
           }}
@@ -105,21 +122,29 @@ export function LearnPanel() {
             style={{
               width: `${progress}%`,
               height: "100%",
-              background: "var(--color-accent-primary, #f59520)",
+              background: "var(--color-accent-primary)",
               borderRadius: 2,
               transition: "width 0.3s ease",
             }}
           />
         </div>
 
-        {/* Step title */}
-        <div style={{ fontWeight: 600, fontSize: 14, marginBottom: 4 }}>
-          {step?.title}
+        {/* Step title + kind icon */}
+        <div style={{ display: "flex", alignItems: "center", gap: 6, fontWeight: 600, fontSize: 14, marginBottom: 4 }}>
+          {step && <KindIcon kind={step.kind} />}
+          <span>{step?.title}</span>
         </div>
 
-        {/* Step description */}
+        {/* Layer the step belongs to (the canvas follows it) */}
+        {stepLayer && (
+          <div style={{ marginBottom: 6 }}>
+            <Pill label={stepLayer.name} />
+          </div>
+        )}
+
+        {/* Step body: curated reason, or legacy description */}
         <div style={{ fontSize: 12, opacity: 0.8, lineHeight: 1.5, marginBottom: 10 }}>
-          {step?.description}
+          {stepBody}
         </div>
 
         {/* Referenced nodes */}
@@ -172,8 +197,8 @@ export function LearnPanel() {
                 borderRadius: "50%",
                 background:
                   i === currentTourStep
-                    ? "var(--color-accent-primary, #f59520)"
-                    : "rgba(148,163,184,0.3)",
+                    ? "var(--color-accent-primary)"
+                    : "var(--color-border-default)",
                 border: "none",
                 cursor: "pointer",
                 padding: 0,

--- a/packages/ui/src/c4/panels/NodeTooltip.tsx
+++ b/packages/ui/src/c4/panels/NodeTooltip.tsx
@@ -17,7 +17,7 @@ export function NodeTooltip({ node, position }: NodeTooltipProps) {
   if (!node || !position) return null;
 
   const tone = getTone(node.node_type);
-  const dotColor = THEME.complexity[node.complexity] ?? "#94a3b8";
+  const dotColor = THEME.complexity[node.complexity] ?? THEME.text.muted;
 
   const truncatedSummary =
     node.summary.length > MAX_SUMMARY_LEN
@@ -40,9 +40,9 @@ export function NodeTooltip({ node, position }: NodeTooltipProps) {
         background: "var(--color-bg-glass, rgba(17,24,39,0.75))",
         backdropFilter: "blur(8px)",
         WebkitBackdropFilter: "blur(8px)",
-        border: "1px solid var(--color-border-default, #334155)",
+        border: "1px solid var(--color-border-default)",
         borderRadius: 8,
-        color: "var(--color-text-primary, #f1f5f9)",
+        color: "var(--color-text-primary)",
         fontSize: 11,
         fontFamily: "var(--font-sans, system-ui, sans-serif)",
         boxShadow: "0 8px 24px rgba(0,0,0,0.4)",
@@ -104,9 +104,9 @@ export function NodeTooltip({ node, position }: NodeTooltipProps) {
                 borderRadius: 10,
                 fontSize: 10,
                 fontWeight: 500,
-                background: "rgba(148,163,184,0.15)",
-                color: "var(--color-text-secondary, #94a3b8)",
-                border: "1px solid rgba(148,163,184,0.2)",
+                background: "var(--color-bg-wash-hover)",
+                color: "var(--color-text-secondary)",
+                border: "1px solid var(--color-border-default)",
               }}
             >
               {tag}

--- a/packages/ui/src/c4/panels/NodeTypeCategoryFilters.tsx
+++ b/packages/ui/src/c4/panels/NodeTypeCategoryFilters.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react";
 import { useArchitectureStore } from "../store/use-architecture-store";
+import { getKindIcon } from "../nodes/kind-icons";
 import type { ArchNodeType } from "../types";
 
 const CATEGORY_NODE_TYPES: Record<string, ArchNodeType[]> = {
@@ -12,12 +13,14 @@ const CATEGORY_NODE_TYPES: Record<string, ArchNodeType[]> = {
   data: ["table", "endpoint", "schema"],
 };
 
-const CATEGORY_COLORS: Record<string, string> = {
-  code: "#3b82f6",
-  config: "#f59e0b",
-  docs: "#67e8f9",
-  infra: "#a78bfa",
-  data: "#2dd4bf",
+// Each category pill carries its representative kind glyph (ink system —
+// icons encode type, not color; kg-ux plan §2.2).
+const CATEGORY_ICON_KIND: Record<string, string> = {
+  code: "file",
+  config: "config",
+  docs: "document",
+  infra: "service",
+  data: "table",
 };
 
 export function NodeTypeCategoryFilters() {
@@ -49,27 +52,32 @@ export function NodeTypeCategoryFilters() {
     <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
       {Object.keys(CATEGORY_NODE_TYPES).map((category) => {
         const active = nodeTypeFilters[category] !== false;
-        const color = CATEGORY_COLORS[category] ?? "#94a3b8";
+        const Icon = getKindIcon(CATEGORY_ICON_KIND[category] ?? "file");
         return (
           <button
             key={category}
             type="button"
             onClick={() => handleToggle(category)}
             style={{
-              display: "inline-block",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
               padding: "3px 10px",
               borderRadius: 12,
               fontSize: 10,
               fontWeight: 600,
               cursor: "pointer",
-              border: `1px solid ${color}`,
-              color: color,
-              background: "transparent",
-              opacity: active ? 1 : 0.35,
+              border: active
+                ? "1px solid var(--color-accent-primary)"
+                : "1px solid var(--color-border-default)",
+              color: active ? "var(--color-accent-primary)" : "var(--color-text-secondary)",
+              background: active ? "var(--color-accent-muted)" : "transparent",
+              opacity: active ? 1 : 0.55,
               textDecoration: active ? "none" : "line-through",
               transition: "opacity 0.15s",
             }}
           >
+            <Icon size={11} aria-hidden />
             {category}
           </button>
         );

--- a/packages/ui/src/c4/panels/PathFinderModal.tsx
+++ b/packages/ui/src/c4/panels/PathFinderModal.tsx
@@ -40,9 +40,9 @@ export function PathFinderModal() {
   const selectStyle: React.CSSProperties = {
     width: "100%",
     padding: "8px 12px",
-    background: "#1e293b",
-    color: "#e2e8f0",
-    border: "1px solid rgba(148,163,184,0.3)",
+    background: "var(--color-bg-surface)",
+    color: "var(--color-text-primary)",
+    border: "1px solid var(--color-border-default)",
     borderRadius: 6,
     fontSize: 13,
   };
@@ -67,11 +67,11 @@ export function PathFinderModal() {
           width: 500,
           maxHeight: "80vh",
           overflowY: "auto",
-          background: "#0f172a",
-          border: "1px solid rgba(148, 163, 184, 0.2)",
+          background: "var(--color-bg-elevated)",
+          border: "1px solid var(--color-border-default)",
           borderRadius: 12,
           padding: 24,
-          color: "#e2e8f0",
+          color: "var(--color-text-primary)",
         }}
       >
         <div
@@ -90,7 +90,7 @@ export function PathFinderModal() {
             style={{
               background: "none",
               border: "none",
-              color: "#94a3b8",
+              color: "var(--color-text-secondary)",
               cursor: "pointer",
               fontSize: 18,
               padding: 4,
@@ -145,8 +145,8 @@ export function PathFinderModal() {
           style={{
             width: "100%",
             padding: "10px 0",
-            background: fromId && toId ? "#f59520" : "rgba(148,163,184,0.2)",
-            color: fromId && toId ? "#0f172a" : "#94a3b8",
+            background: fromId && toId ? "var(--color-accent-fill)" : "var(--color-bg-wash-hover)",
+            color: fromId && toId ? "var(--color-text-on-accent)" : "var(--color-text-secondary)",
             border: "none",
             borderRadius: 6,
             fontSize: 13,
@@ -180,10 +180,10 @@ export function PathFinderModal() {
                         padding: "8px 10px",
                         borderRadius: 6,
                         cursor: "pointer",
-                        borderBottom: "1px solid rgba(148,163,184,0.12)",
+                        borderBottom: "1px solid var(--color-border-subtle)",
                       }}
                     >
-                      <span style={{ fontSize: 12, color: "#94a3b8", minWidth: 20 }}>
+                      <span style={{ fontSize: 12, color: "var(--color-text-secondary)", minWidth: 20 }}>
                         {idx + 1}.
                       </span>
                       <span style={{ flex: 1, fontSize: 13 }}>

--- a/packages/ui/src/c4/panels/PersonaSelector.tsx
+++ b/packages/ui/src/c4/panels/PersonaSelector.tsx
@@ -13,11 +13,11 @@ export function PersonaSelector() {
       onChange={(e) => setPersona(e.target.value as Persona)}
       style={{
         background: "transparent",
-        border: "1px solid var(--color-border-default, #334155)",
+        border: "1px solid var(--color-border-default)",
         borderRadius: 4,
         padding: "4px 8px",
         fontSize: 11,
-        color: "var(--color-text-primary, #f1f5f9)",
+        color: "var(--color-text-primary)",
         cursor: "pointer",
         outline: "none",
       }}

--- a/packages/ui/src/c4/panels/ProjectOverview.tsx
+++ b/packages/ui/src/c4/panels/ProjectOverview.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useMemo } from "react";
-import { Compass } from "lucide-react";
+import { Compass, LogIn } from "lucide-react";
 import { useArchitectureStore } from "../store/use-architecture-store";
 import { getTone } from "../../graph-primitives/tone-styles";
+import { THEME } from "../theme/theme-variables";
 import { Section, Title, Sub, Pill, ActionButton } from "./panel-atoms";
 
 export function ProjectOverview() {
@@ -11,6 +12,12 @@ export function ProjectOverview() {
   const tourActive = useArchitectureStore((s) => s.tourActive);
   const startTour = useArchitectureStore((s) => s.startTour);
   const selectNode = useArchitectureStore((s) => s.selectNode);
+  const drillIntoLayer = useArchitectureStore((s) => s.drillIntoLayer);
+
+  const orderedLayers = useMemo(() => {
+    if (!view) return [];
+    return [...view.layers].sort((a, b) => a.display_order - b.display_order);
+  }, [view]);
 
   const nodeTypeCounts = useMemo(() => {
     if (!view) return [];
@@ -49,10 +56,97 @@ export function ProjectOverview() {
 
   return (
     <>
+      {/* Orientation first (viewer plan C-1): summary, tour CTA, entry
+          points, layer stack. Stats demoted below the fold. */}
       <Section>
         <Title style={{ fontSize: 15 }}>{view.project_name}</Title>
         <Sub style={{ marginTop: 4 }}>{view.project_description}</Sub>
       </Section>
+
+      {view.tour.length > 0 && !tourActive && (
+        <Section>
+          <ActionButton onClick={startTour} icon={Compass} variant="primary">
+            Start tour ({view.tour.length} steps)
+          </ActionButton>
+        </Section>
+      )}
+
+      {view.entry_points.length > 0 && (
+        <Section title="Entry points">
+          <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            {view.entry_points.slice(0, 8).map((path) => {
+              const name = path.split("/").pop() ?? path;
+              const dir = path.slice(0, path.length - name.length);
+              return (
+                <button
+                  key={path}
+                  type="button"
+                  aria-label={`Open entry point ${path}`}
+                  onClick={() => selectNode(path)}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    padding: "4px 6px",
+                    background: "none",
+                    border: "none",
+                    borderRadius: 4,
+                    cursor: "pointer",
+                    color: "var(--color-text-primary)",
+                    fontSize: 11,
+                    textAlign: "left",
+                  }}
+                  onMouseEnter={(e) => { (e.currentTarget.style.background = "var(--color-bg-wash-hover)"); }}
+                  onMouseLeave={(e) => { (e.currentTarget.style.background = "none"); }}
+                >
+                  <LogIn size={11} style={{ flexShrink: 0, color: "var(--color-accent-primary)" }} />
+                  <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    <span style={{ opacity: 0.5 }}>{dir}</span>
+                    <span style={{ fontWeight: 600 }}>{name}</span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </Section>
+      )}
+
+      {orderedLayers.length > 0 && (
+        <Section title="Layer stack">
+          <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+            {orderedLayers.map((layer) => (
+              <button
+                key={layer.id}
+                type="button"
+                aria-label={`Explore layer ${layer.name}`}
+                onClick={() => drillIntoLayer(layer.id)}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  padding: "5px 8px",
+                  background: "var(--color-bg-wash)",
+                  border: "1px solid var(--color-border-subtle)",
+                  borderRadius: 4,
+                  cursor: "pointer",
+                  color: "var(--color-text-primary)",
+                  fontSize: 11,
+                  textAlign: "left",
+                }}
+                onMouseEnter={(e) => { (e.currentTarget.style.background = "var(--color-bg-wash-hover)"); }}
+                onMouseLeave={(e) => { (e.currentTarget.style.background = "var(--color-bg-wash)"); }}
+              >
+                <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {layer.name}
+                </span>
+                <span style={{ fontFamily: "var(--font-mono, ui-monospace, monospace)", opacity: 0.55, flexShrink: 0, marginLeft: 8 }}>
+                  {layer.file_count}
+                </span>
+              </button>
+            ))}
+          </div>
+        </Section>
+      )}
 
       <Section title="Stats">
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
@@ -92,7 +186,7 @@ export function ProjectOverview() {
               return (
                 <div key={type} style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 11 }}>
                   <span style={{ width: 60, opacity: 0.7, flexShrink: 0 }}>{type}</span>
-                  <div style={{ flex: 1, height: 6, borderRadius: 3, background: "rgba(148,163,184,0.1)" }}>
+                  <div style={{ flex: 1, height: 6, borderRadius: 3, background: "var(--color-bg-wash-hover)" }}>
                     <div style={{ width: `${pct}%`, height: "100%", borderRadius: 3, background: tone.band }} />
                   </div>
                   <span style={{ width: 28, textAlign: "right", fontFamily: "var(--font-mono, ui-monospace, monospace)", opacity: 0.7 }}>{count}</span>
@@ -109,19 +203,19 @@ export function ProjectOverview() {
             {complexityCounts.simple > 0 && (
               <div
                 aria-label={`${complexityCounts.simple} simple`}
-                style={{ flex: complexityCounts.simple, background: "#22c55e" }}
+                style={{ flex: complexityCounts.simple, background: THEME.complexity.simple }}
               />
             )}
             {complexityCounts.moderate > 0 && (
               <div
                 aria-label={`${complexityCounts.moderate} moderate`}
-                style={{ flex: complexityCounts.moderate, background: "#f59e0b" }}
+                style={{ flex: complexityCounts.moderate, background: THEME.complexity.moderate }}
               />
             )}
             {complexityCounts.complex > 0 && (
               <div
                 aria-label={`${complexityCounts.complex} complex`}
-                style={{ flex: complexityCounts.complex, background: "#ef4444" }}
+                style={{ flex: complexityCounts.complex, background: THEME.complexity.complex }}
               />
             )}
           </div>
@@ -151,11 +245,11 @@ export function ProjectOverview() {
                   border: "none",
                   borderRadius: 4,
                   cursor: "pointer",
-                  color: "var(--color-text-primary, #f1f5f9)",
+                  color: "var(--color-text-primary)",
                   fontSize: 11,
                   textAlign: "left",
                 }}
-                onMouseEnter={(e) => { (e.currentTarget.style.background = "rgba(148,163,184,0.1)"); }}
+                onMouseEnter={(e) => { (e.currentTarget.style.background = "var(--color-bg-wash-hover)"); }}
                 onMouseLeave={(e) => { (e.currentTarget.style.background = "none"); }}
               >
                 <span>{n.name}</span>
@@ -166,13 +260,6 @@ export function ProjectOverview() {
         </Section>
       )}
 
-      {view.tour.length > 0 && !tourActive && (
-        <Section>
-          <ActionButton onClick={startTour} icon={Compass}>
-            Start Guided Tour ({view.tour.length} steps)
-          </ActionButton>
-        </Section>
-      )}
     </>
   );
 }
@@ -182,7 +269,7 @@ function StatCell({ label, value }: { label: string; value: string }) {
     <div
       style={{
         padding: "8px 10px",
-        border: "1px solid rgba(148,163,184,0.12)",
+        border: "1px solid var(--color-border-subtle)",
         borderRadius: 6,
         textAlign: "center",
       }}

--- a/packages/ui/src/c4/panels/SearchBar.tsx
+++ b/packages/ui/src/c4/panels/SearchBar.tsx
@@ -70,7 +70,7 @@ export function SearchBar() {
           alignItems: "center",
           gap: 8,
           padding: "8px 12px",
-          borderBottom: "1px solid var(--color-border-default, #334155)",
+          borderBottom: "1px solid var(--color-border-default)",
         }}
       >
         <Search size={14} style={{ opacity: 0.5, flexShrink: 0 }} />
@@ -86,7 +86,7 @@ export function SearchBar() {
             background: "transparent",
             border: "none",
             outline: "none",
-            color: "var(--color-text-primary, #f1f5f9)",
+            color: "var(--color-text-primary)",
             fontSize: 12,
             fontFamily: "inherit",
           }}
@@ -100,7 +100,7 @@ export function SearchBar() {
             left: 0,
             right: 0,
             background: "var(--color-bg-elevated, rgba(17,24,39,0.96))",
-            border: "1px solid var(--color-border-default, #334155)",
+            border: "1px solid var(--color-border-default)",
             borderRadius: 6,
             maxHeight: 240,
             overflowY: "auto",
@@ -123,10 +123,10 @@ export function SearchBar() {
                   padding: "8px 12px",
                   background: "transparent",
                   border: "none",
-                  borderBottom: "1px solid rgba(148,163,184,0.08)",
+                  borderBottom: "1px solid var(--color-bg-wash)",
                   cursor: "pointer",
                   textAlign: "left",
-                  color: "var(--color-text-primary, #f1f5f9)",
+                  color: "var(--color-text-primary)",
                 }}
               >
                 <Badge label={result.node_type} color={tone.text} bg={tone.bg} />
@@ -136,7 +136,7 @@ export function SearchBar() {
                     width: 40,
                     height: 4,
                     borderRadius: 2,
-                    background: "rgba(148,163,184,0.2)",
+                    background: "var(--color-border-default)",
                     overflow: "hidden",
                   }}
                 >
@@ -144,7 +144,7 @@ export function SearchBar() {
                     style={{
                       width: `${result.score * 100}%`,
                       height: "100%",
-                      background: "var(--color-accent-primary, #f59520)",
+                      background: "var(--color-accent-primary)",
                       borderRadius: 2,
                     }}
                   />

--- a/packages/ui/src/c4/panels/Sidebar.tsx
+++ b/packages/ui/src/c4/panels/Sidebar.tsx
@@ -37,13 +37,13 @@ const TAB_STYLE_BASE: React.CSSProperties = {
   borderBottomWidth: 2,
   borderBottomStyle: "solid",
   borderBottomColor: "transparent",
-  color: "var(--color-text-secondary, #94a3b8)",
+  color: "var(--color-text-secondary)",
 };
 
 const TAB_STYLE_ACTIVE: React.CSSProperties = {
   ...TAB_STYLE_BASE,
-  color: "var(--color-accent-primary, #f59520)",
-  borderBottomColor: "var(--color-accent-primary, #f59520)",
+  color: "var(--color-accent-primary)",
+  borderBottomColor: "var(--color-accent-primary)",
 };
 
 export function Sidebar(props: SidebarProps) {
@@ -64,9 +64,9 @@ export function Sidebar(props: SidebarProps) {
         width: 320,
         maxHeight: "calc(100% - 24px)",
         background: "var(--color-bg-elevated, rgba(17,24,39,0.96))",
-        border: "1px solid var(--color-border-default, #334155)",
+        border: "1px solid var(--color-border-default)",
         borderRadius: 8,
-        color: "var(--color-text-primary, #f1f5f9)",
+        color: "var(--color-text-primary)",
         fontSize: 12,
         zIndex: 5,
         display: "flex",
@@ -79,7 +79,7 @@ export function Sidebar(props: SidebarProps) {
         aria-label="Sidebar tabs"
         style={{
           display: "flex",
-          borderBottom: "1px solid var(--color-border-default, #334155)",
+          borderBottom: "1px solid var(--color-border-default)",
           flexShrink: 0,
         }}
       >

--- a/packages/ui/src/c4/panels/index.ts
+++ b/packages/ui/src/c4/panels/index.ts
@@ -16,6 +16,8 @@ export { Sidebar } from "./Sidebar";
 export type { SidebarProps } from "./Sidebar";
 export { ProjectOverview } from "./ProjectOverview";
 export { ArchNodeInfo } from "./ArchNodeInfo";
+export { ArchBreadcrumb } from "./ArchBreadcrumb";
+export { ArchLegend } from "./ArchLegend";
 export type { ArchNodeInfoProps, ArchNodeHealth } from "./ArchNodeInfo";
 export { FileExplorer } from "./FileExplorer";
 export { SearchBar } from "./SearchBar";

--- a/packages/ui/src/c4/panels/panel-atoms.tsx
+++ b/packages/ui/src/c4/panels/panel-atoms.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 
 export function Section({ title, children }: { title?: string; children: ReactNode }) {
   return (
-    <div style={{ padding: "10px 12px", borderBottom: "1px solid rgba(148,163,184,0.12)" }}>
+    <div style={{ padding: "10px 12px", borderBottom: "1px solid var(--color-border-subtle)" }}>
       {title && (
         <div
           style={{
@@ -43,7 +43,7 @@ export function KVList({ rows }: { rows: [string, string][] }) {
             justifyContent: "space-between",
             gap: 8,
             padding: "3px 0",
-            borderTop: "1px solid rgba(148,163,184,0.12)",
+            borderTop: "1px solid var(--color-border-subtle)",
             fontSize: 11,
           }}
         >
@@ -79,9 +79,9 @@ export function ActionButton({
         padding: "5px 10px",
         background: primary ? "var(--color-accent-muted, rgba(245,149,32,0.2))" : "transparent",
         color: primary
-          ? "var(--color-accent-primary, #f59520)"
-          : "var(--color-text-secondary, #cbd5e1)",
-        border: `1px solid ${primary ? "var(--color-accent-primary, #f59520)" : "var(--color-border-default, #334155)"}`,
+          ? "var(--color-accent-primary)"
+          : "var(--color-text-secondary)",
+        border: `1px solid ${primary ? "var(--color-accent-primary)" : "var(--color-border-default)"}`,
         borderRadius: 4,
         cursor: "pointer",
         fontSize: 11,
@@ -115,8 +115,8 @@ export function Badge({
         fontSize: 10,
         fontWeight: 600,
         letterSpacing: 0.4,
-        color: color ?? "#ffffff",
-        background: bg ?? "rgba(148,163,184,0.2)",
+        color: color ?? "var(--color-text-primary)",
+        background: bg ?? "var(--color-border-default)",
         textTransform: "uppercase",
       }}
     >
@@ -134,9 +134,9 @@ export function Pill({ label }: { label: string }) {
         borderRadius: 10,
         fontSize: 10,
         fontWeight: 500,
-        background: "rgba(148,163,184,0.15)",
-        color: "var(--color-text-secondary, #94a3b8)",
-        border: "1px solid rgba(148,163,184,0.2)",
+        background: "var(--color-bg-wash-hover)",
+        color: "var(--color-text-secondary)",
+        border: "1px solid var(--color-border-default)",
       }}
     >
       {label}

--- a/packages/ui/src/c4/store/use-architecture-store.ts
+++ b/packages/ui/src/c4/store/use-architecture-store.ts
@@ -22,9 +22,11 @@ interface ArchitectureStoreState {
   edgesBySource: Map<string, ArchEdge[]>;
   edgesByTarget: Map<string, ArchEdge[]>;
   nodeIdToLayerId: Map<string, string>;
+  nodeIdToSubGroupId: Map<string, string>;
 
   navigationLevel: NavigationLevel;
   activeLayerId: string | null;
+  activeSubGroupId: string | null;
   selectedNodeId: string | null;
 
   expandedContainers: Set<string>;
@@ -41,6 +43,8 @@ interface ArchitectureStoreState {
   filters: ArchFilters;
   nodeTypeFilters: Record<string, boolean>;
   filterPanelOpen: boolean;
+  /** Test layer is demoted by default (locked decision 2); this restores it. */
+  showTests: boolean;
 
   tourActive: boolean;
   currentTourStep: number;
@@ -65,6 +69,7 @@ interface ArchitectureStoreActions {
   clearView: () => void;
 
   drillIntoLayer: (layerId: string) => void;
+  drillIntoSubGroup: (subGroupId: string) => void;
   drillOut: () => void;
 
   selectNode: (nodeId: string | null) => void;
@@ -87,6 +92,7 @@ interface ArchitectureStoreActions {
   setEdgeCategoryFilter: (category: string, visible: boolean) => void;
   resetFilters: () => void;
   setFilterPanelOpen: (open: boolean) => void;
+  setShowTests: (show: boolean) => void;
 
   startTour: () => void;
   endTour: () => void;
@@ -135,6 +141,7 @@ function buildIndexes(view: ArchitectureView) {
   const edgesBySource = new Map<string, ArchEdge[]>();
   const edgesByTarget = new Map<string, ArchEdge[]>();
   const nodeIdToLayerId = new Map<string, string>();
+  const nodeIdToSubGroupId = new Map<string, string>();
 
   for (const node of view.nodes) {
     nodesById.set(node.id, node);
@@ -159,9 +166,96 @@ function buildIndexes(view: ArchitectureView) {
     for (const nodeId of layer.node_ids) {
       nodeIdToLayerId.set(nodeId, layer.id);
     }
+    for (const group of layer.sub_groups) {
+      for (const nodeId of group.node_ids) {
+        nodeIdToSubGroupId.set(nodeId, group.id);
+      }
+    }
   }
 
-  return { nodesById, edgesBySource, edgesByTarget, nodeIdToLayerId };
+  return { nodesById, edgesBySource, edgesByTarget, nodeIdToLayerId, nodeIdToSubGroupId };
+}
+
+/** Tolerate older / uncurated backend payloads (kg-ux hardening): the API
+ * response may predate the curated-KG schema (no sub_groups / entry_points /
+ * tour — e.g. a server running pre-curation code), and JSON from the wire is
+ * never as trustworthy as the TS types claim. Every field the viewer
+ * iterates gets a safe default so a stale backend degrades to the uncurated
+ * experience instead of crashing the page. */
+function normalizeView(view: ArchitectureView): ArchitectureView {
+  return {
+    ...view,
+    layers: (view.layers ?? []).map((l, i) => ({
+      ...l,
+      node_ids: l.node_ids ?? [],
+      sub_groups: l.sub_groups ?? [],
+      display_order: l.display_order ?? i,
+      health_score: l.health_score ?? null,
+      complexity_distribution: l.complexity_distribution ?? {},
+    })),
+    nodes: (view.nodes ?? []).map((n) => ({ ...n, tags: n.tags ?? [] })),
+    edges: view.edges ?? [],
+    tour: view.tour ?? [],
+    languages: view.languages ?? [],
+    frameworks: view.frameworks ?? [],
+    external_systems: view.external_systems ?? [],
+    entry_points: view.entry_points ?? [],
+    entry_candidates: view.entry_candidates ?? [],
+  };
+}
+
+/** Drill state that lands on *nodeId*'s file card: its layer, and — when the
+ * layer is curated into sub-groups — the sub-group that contains it.
+ * Returns {} when the node's layer is unknown or already active. */
+function drillStateForNode(
+  state: ArchitectureStoreState,
+  nodeId: string | null,
+): Partial<ArchitectureStoreState> {
+  if (!nodeId) return {};
+  const layerId = state.nodeIdToLayerId.get(nodeId) ?? null;
+  if (!layerId) return {};
+  const subGroupId = state.nodeIdToSubGroupId.get(nodeId) ?? null;
+  if (
+    state.navigationLevel === "layer-detail" &&
+    layerId === state.activeLayerId &&
+    subGroupId === state.activeSubGroupId
+  ) {
+    return {};
+  }
+  return {
+    navigationLevel: "layer-detail" as NavigationLevel,
+    activeLayerId: layerId,
+    activeSubGroupId: subGroupId,
+    expandedContainers: new Set<string>(),
+    containerLayoutCache: new Map<string, ContainerLayoutResult>(),
+  };
+}
+
+/** Drill state for a tour step: follow the step's node when it's in the
+ * graph, else fall back to the step's curated layer_id so the canvas still
+ * follows the walk (viewer plan C-2). */
+function drillStateForStep(
+  state: ArchitectureStoreState,
+  nodeId: string | null,
+  layerId: string | null | undefined,
+): Partial<ArchitectureStoreState> {
+  if (nodeId && state.nodeIdToLayerId.has(nodeId)) {
+    return drillStateForNode(state, nodeId);
+  }
+  if (
+    layerId &&
+    layerId !== state.activeLayerId &&
+    state.view?.layers.some((l: ArchLayer) => l.id === layerId)
+  ) {
+    return {
+      navigationLevel: "layer-detail" as NavigationLevel,
+      activeLayerId: layerId,
+      activeSubGroupId: null,
+      expandedContainers: new Set<string>(),
+      containerLayoutCache: new Map<string, ContainerLayoutResult>(),
+    };
+  }
+  return {};
 }
 
 const INITIAL_STATE: ArchitectureStoreState = {
@@ -170,9 +264,11 @@ const INITIAL_STATE: ArchitectureStoreState = {
   edgesBySource: new Map(),
   edgesByTarget: new Map(),
   nodeIdToLayerId: new Map(),
+  nodeIdToSubGroupId: new Map(),
 
   navigationLevel: "overview",
   activeLayerId: null,
+  activeSubGroupId: null,
   selectedNodeId: null,
 
   expandedContainers: new Set(),
@@ -194,6 +290,7 @@ const INITIAL_STATE: ArchitectureStoreState = {
   },
   nodeTypeFilters: { ...DEFAULT_NODE_TYPE_FILTERS },
   filterPanelOpen: false,
+  showTests: false,
 
   tourActive: false,
   currentTourStep: 0,
@@ -218,8 +315,10 @@ export const useArchitectureStore = create<ArchitectureStore>()(
     (set, get) => ({
       ...INITIAL_STATE,
 
-      setView: (view: ArchitectureView) => {
-        const { nodesById, edgesBySource, edgesByTarget, nodeIdToLayerId } = buildIndexes(view);
+      setView: (rawView: ArchitectureView) => {
+        const view = normalizeView(rawView);
+        const { nodesById, edgesBySource, edgesByTarget, nodeIdToLayerId, nodeIdToSubGroupId } =
+          buildIndexes(view);
         const filters = buildFiltersFromView(view);
         set({
           view,
@@ -227,9 +326,11 @@ export const useArchitectureStore = create<ArchitectureStore>()(
           edgesBySource,
           edgesByTarget,
           nodeIdToLayerId,
+          nodeIdToSubGroupId,
           filters,
           navigationLevel: "overview",
           activeLayerId: null,
+          activeSubGroupId: null,
           selectedNodeId: null,
           expandedContainers: new Set(),
           containerLayoutCache: new Map(),
@@ -247,9 +348,26 @@ export const useArchitectureStore = create<ArchitectureStore>()(
       },
 
       drillIntoLayer: (layerId: string) => {
+        // Layers curated into sub-groups land on the intermediate
+        // "layer-groups" tier; small/uncurated layers drill straight to
+        // file cards (locked decision 1 — never synthesize a one-group tier).
+        const layer = get().view?.layers.find((l: ArchLayer) => l.id === layerId);
+        const hasSubGroups = (layer?.sub_groups.length ?? 0) > 0;
+        set({
+          navigationLevel: hasSubGroups ? "layer-groups" : "layer-detail",
+          activeLayerId: layerId,
+          activeSubGroupId: null,
+          selectedNodeId: null,
+          focusNodeId: null,
+          expandedContainers: new Set(),
+          containerLayoutCache: new Map(),
+        });
+      },
+
+      drillIntoSubGroup: (subGroupId: string) => {
         set({
           navigationLevel: "layer-detail",
-          activeLayerId: layerId,
+          activeSubGroupId: subGroupId,
           selectedNodeId: null,
           focusNodeId: null,
           expandedContainers: new Set(),
@@ -258,9 +376,24 @@ export const useArchitectureStore = create<ArchitectureStore>()(
       },
 
       drillOut: () => {
+        const state = get();
+        // layer-detail inside a sub-group steps back up to the groups tier;
+        // everything else returns to the overview.
+        if (state.navigationLevel === "layer-detail" && state.activeSubGroupId) {
+          set({
+            navigationLevel: "layer-groups",
+            activeSubGroupId: null,
+            selectedNodeId: null,
+            focusNodeId: null,
+            expandedContainers: new Set(),
+            containerLayoutCache: new Map(),
+          });
+          return;
+        }
         set({
           navigationLevel: "overview",
           activeLayerId: null,
+          activeSubGroupId: null,
           selectedNodeId: null,
           focusNodeId: null,
           expandedContainers: new Set(),
@@ -270,23 +403,11 @@ export const useArchitectureStore = create<ArchitectureStore>()(
 
       selectNode: (nodeId: string | null) => {
         const state = get();
-
-        if (nodeId !== null) {
-          const nodeLayerId = state.nodeIdToLayerId.get(nodeId);
-          if (nodeLayerId && nodeLayerId !== state.activeLayerId) {
-            set({
-              navigationLevel: "layer-detail",
-              activeLayerId: nodeLayerId,
-              selectedNodeId: nodeId,
-              focusNodeId: null,
-              expandedContainers: new Set(),
-              containerLayoutCache: new Map(),
-            });
-            return;
-          }
-        }
-
-        set({ selectedNodeId: nodeId, focusNodeId: null });
+        set({
+          ...drillStateForNode(state, nodeId),
+          selectedNodeId: nodeId,
+          focusNodeId: null,
+        });
       },
 
       toggleContainer: (containerId: string) => {
@@ -418,6 +539,10 @@ export const useArchitectureStore = create<ArchitectureStore>()(
         set({ filterPanelOpen: open });
       },
 
+      setShowTests: (show: boolean) => {
+        set({ showTests: show });
+      },
+
       startTour: () => {
         const state = get();
         const tour = state.view?.tour;
@@ -425,19 +550,13 @@ export const useArchitectureStore = create<ArchitectureStore>()(
         const firstStep = tour[0];
         const nodeIds = firstStep?.node_ids ?? [];
         const firstNodeId = nodeIds[0] ?? null;
-        const layerId = firstNodeId ? state.nodeIdToLayerId.get(firstNodeId) ?? null : null;
         set({
           tourActive: true,
           currentTourStep: 0,
           tourHighlightedNodeIds: new Set(nodeIds),
           selectedNodeId: firstNodeId,
           focusNodeId: null,
-          ...(layerId ? {
-            navigationLevel: "layer-detail" as NavigationLevel,
-            activeLayerId: layerId,
-            expandedContainers: new Set<string>(),
-            containerLayoutCache: new Map<string, ContainerLayoutResult>(),
-          } : {}),
+          ...drillStateForStep(state, firstNodeId, firstStep?.layer_id),
         });
       },
 
@@ -455,23 +574,7 @@ export const useArchitectureStore = create<ArchitectureStore>()(
         if (!tour || tour.length === 0) return;
         const maxStep = tour.length - 1;
         if (state.currentTourStep >= maxStep) return;
-        const nextIdx = state.currentTourStep + 1;
-        const step = tour[nextIdx];
-        const nodeIds = step?.node_ids ?? [];
-        const firstNodeId = nodeIds[0] ?? null;
-        const layerId = firstNodeId ? state.nodeIdToLayerId.get(firstNodeId) ?? null : null;
-        set({
-          currentTourStep: nextIdx,
-          tourHighlightedNodeIds: new Set(nodeIds),
-          selectedNodeId: firstNodeId,
-          focusNodeId: null,
-          ...(layerId && layerId !== state.activeLayerId ? {
-            navigationLevel: "layer-detail" as NavigationLevel,
-            activeLayerId: layerId,
-            expandedContainers: new Set<string>(),
-            containerLayoutCache: new Map<string, ContainerLayoutResult>(),
-          } : {}),
-        });
+        get().goToTourStep(state.currentTourStep + 1);
       },
 
       prevTourStep: () => {
@@ -479,23 +582,7 @@ export const useArchitectureStore = create<ArchitectureStore>()(
         const tour = state.view?.tour;
         if (!tour || tour.length === 0) return;
         if (state.currentTourStep <= 0) return;
-        const prevIdx = state.currentTourStep - 1;
-        const step = tour[prevIdx];
-        const nodeIds = step?.node_ids ?? [];
-        const firstNodeId = nodeIds[0] ?? null;
-        const layerId = firstNodeId ? state.nodeIdToLayerId.get(firstNodeId) ?? null : null;
-        set({
-          currentTourStep: prevIdx,
-          tourHighlightedNodeIds: new Set(nodeIds),
-          selectedNodeId: firstNodeId,
-          focusNodeId: null,
-          ...(layerId && layerId !== state.activeLayerId ? {
-            navigationLevel: "layer-detail" as NavigationLevel,
-            activeLayerId: layerId,
-            expandedContainers: new Set<string>(),
-            containerLayoutCache: new Map<string, ContainerLayoutResult>(),
-          } : {}),
-        });
+        get().goToTourStep(state.currentTourStep - 1);
       },
 
       goToTourStep: (step: number) => {
@@ -506,18 +593,12 @@ export const useArchitectureStore = create<ArchitectureStore>()(
         const tourStep = tour[clamped];
         const nodeIds = tourStep?.node_ids ?? [];
         const firstNodeId = nodeIds[0] ?? null;
-        const layerId = firstNodeId ? state.nodeIdToLayerId.get(firstNodeId) ?? null : null;
         set({
           currentTourStep: clamped,
           tourHighlightedNodeIds: new Set(nodeIds),
           selectedNodeId: firstNodeId,
           focusNodeId: null,
-          ...(layerId && layerId !== state.activeLayerId ? {
-            navigationLevel: "layer-detail" as NavigationLevel,
-            activeLayerId: layerId,
-            expandedContainers: new Set<string>(),
-            containerLayoutCache: new Map<string, ContainerLayoutResult>(),
-          } : {}),
+          ...drillStateForStep(state, firstNodeId, tourStep?.layer_id),
         });
       },
 

--- a/packages/ui/src/c4/theme/theme-variables.ts
+++ b/packages/ui/src/c4/theme/theme-variables.ts
@@ -1,6 +1,6 @@
 export const THEME = {
   canvas: {
-    bg: "var(--color-bg-canvas, #0f172a)",
+    bg: "var(--color-bg-canvas)",
     dot: "var(--color-canvas-dot, rgba(148,163,184,0.08))",
   },
 
@@ -9,48 +9,64 @@ export const THEME = {
     overlay: "var(--color-bg-overlay, rgba(15,23,42,0.92))",
     glass: "var(--color-bg-glass, rgba(17,24,39,0.75))",
     glassBlur: "blur(8px)",
+    wash: "var(--color-bg-wash)",
+    washHover: "var(--color-bg-wash-hover)",
   },
 
   border: {
-    default: "var(--color-border-default, #334155)",
+    default: "var(--color-border-default)",
     subtle: "var(--color-border-subtle, rgba(148,163,184,0.12))",
   },
 
   text: {
-    primary: "var(--color-text-primary, #f1f5f9)",
-    secondary: "var(--color-text-secondary, #94a3b8)",
-    muted: "var(--color-text-muted, #64748b)",
+    primary: "var(--color-text-primary)",
+    secondary: "var(--color-text-secondary)",
+    muted: "var(--color-text-muted)",
   },
 
   accent: {
-    primary: "var(--color-accent-primary, #f59520)",
+    primary: "var(--color-accent-primary)",
     muted: "var(--color-accent-muted, rgba(245,149,32,0.2))",
     hover: "var(--color-accent-hover, rgba(245,149,32,0.35))",
   },
 
   selection: {
-    ring: "#fbbf24",
-    ringAlpha: "rgba(251,191,36,0.4)",
+    ring: "var(--color-viz-selection)",
+    ringAlpha: "var(--color-accent-muted, rgba(245,149,32,0.16))",
   },
 
   complexity: {
-    simple: "#22c55e",
-    moderate: "#f59e0b",
-    complex: "#ef4444",
+    simple: "var(--color-success)",
+    moderate: "var(--color-warning)",
+    complex: "var(--color-error)",
   } as Record<string, string>,
 
+  /** Status badge glyphs (entry / hotspot / dead) — semantic tokens, both themes. */
+  status: {
+    entry: "var(--color-success)",
+    hotspot: "var(--color-error)",
+    dead: "var(--color-text-muted)",
+  },
+
+  /** Health-score buckets (≥80 / ≥60 / below). */
+  health: {
+    good: "var(--color-success)",
+    fair: "var(--color-warning)",
+    poor: "var(--color-error)",
+  },
+
   edge: {
-    imports: "#d4a754",
-    depends_on: "#e8976b",
-    contains: "#a78bfa",
-    tested_by: "#6ee7b7",
-    default: "#8b9dc3",
+    imports: "var(--color-edge-imports)",
+    depends_on: "var(--color-warning)",
+    contains: "var(--color-accent-secondary)",
+    tested_by: "var(--color-success)",
+    default: "var(--color-text-tertiary)",
   } as Record<string, string>,
 
   diff: {
-    changed: "#fca5a5",
+    changed: "var(--color-viz-diff-changed)",
     changedAlpha: "rgba(252,165,165,0.4)",
-    affected: "#fbbf24",
+    affected: "var(--color-viz-diff-affected)",
     affectedAlpha: "rgba(251,191,36,0.3)",
   },
 
@@ -70,6 +86,11 @@ export const THEME = {
     tooltip: "0 8px 24px rgba(0,0,0,0.4)",
   },
 } as const;
+
+/** Edge color for a relation type, falling back to the muted default. */
+export function edgeColor(edgeType: string): string {
+  return THEME.edge[edgeType] ?? "var(--color-text-tertiary)";
+}
 
 export const KEYFRAMES = {
   accentPulse: `

--- a/packages/ui/src/c4/types.ts
+++ b/packages/ui/src/c4/types.ts
@@ -133,6 +133,12 @@ export interface ArchEdge {
   confidence: number;
 }
 
+export interface ArchSubGroup {
+  id: string;
+  name: string;
+  node_ids: string[];
+}
+
 export interface ArchLayer {
   id: string;
   name: string;
@@ -141,13 +147,26 @@ export interface ArchLayer {
   file_count: number;
   complexity_distribution: Record<string, number>;
   health_score: number | null;
+  /** Curated drill-down groups within the layer (empty when uncurated). */
+  sub_groups: ArchSubGroup[];
+  /** Dependency-ordered stacking position (0 = top of the stack). */
+  display_order: number;
 }
+
+export type ArchTourStepKind = "overview" | "code" | "infra" | "";
 
 export interface ArchTourStep {
   order: number;
   title: string;
   description: string;
   node_ids: string[];
+  /** Curated, layer-aware fields (null/empty for legacy LLM tours). */
+  target_path: string | null;
+  layer_id: string | null;
+  reason: string;
+  depth: number | null;
+  kind: ArchTourStepKind;
+  page_type: string | null;
 }
 
 export interface ArchitectureView {
@@ -163,13 +182,16 @@ export interface ArchitectureView {
   languages: string[];
   frameworks: string[];
   external_systems: C4ExternalSystem[];
+  /** Curated, ranked entry points (repo-relative paths; empty when uncurated). */
+  entry_points: string[];
+  entry_candidates: string[];
 }
 
 // ---------------------------------------------------------------------------
 // Architecture store types
 // ---------------------------------------------------------------------------
 
-export type NavigationLevel = "overview" | "layer-detail";
+export type NavigationLevel = "overview" | "layer-groups" | "layer-detail";
 export type Persona = "overview" | "learn" | "deep-dive";
 export type DetailLevel = "file" | "class" | "symbol";
 export type SearchMode = "fuzzy" | "semantic";

--- a/packages/ui/src/graph-primitives/edge-renderer.tsx
+++ b/packages/ui/src/graph-primitives/edge-renderer.tsx
@@ -4,9 +4,10 @@ import { memo } from "react";
 import {
   BaseEdge,
   EdgeLabelRenderer,
-  getBezierPath,
+  getSmoothStepPath,
   type EdgeProps,
 } from "@xyflow/react";
+import { ArrowRight, Check, Folder, Link2, Zap, type LucideIcon } from "lucide-react";
 import { THEME } from "../c4/theme/theme-variables";
 
 export interface ArchEdgeData {
@@ -18,24 +19,39 @@ export interface ArchEdgeData {
 }
 
 export const EDGE_CATEGORY_COLORS: Record<string, string> = {
-  structural: "#60a5fa",
-  behavioral: "#4ade80",
-  "data-flow": "#c084fc",
-  dependencies: "#fb923c",
-  semantic: "#94a3b8",
+  structural: "var(--color-accent-secondary)",
+  behavioral: "var(--color-success)",
+  "data-flow": "var(--color-edge-co-change)",
+  dependencies: "var(--color-accent-fill)",
+  semantic: "var(--color-text-tertiary)",
 };
 
-const EDGE_DEFAULT_COLOR = "#8b9dc3";
+const EDGE_DEFAULT_COLOR = "var(--color-text-tertiary)";
 
+/** Semantic tint — carried by the chip glyph, not the stroke (kg-ux §2.3). */
 function getEdgeColor(edgeType: string | undefined): string {
   if (!edgeType) return EDGE_DEFAULT_COLOR;
   return THEME.edge[edgeType] ?? EDGE_CATEGORY_COLORS[edgeType] ?? EDGE_DEFAULT_COLOR;
 }
 
+const EDGE_TYPE_ICONS: Record<string, LucideIcon> = {
+  imports: ArrowRight,
+  calls: Zap,
+  contains: Folder,
+  tested_by: Check,
+  depends_on: Link2,
+};
+
 export function computeEdgeStrokeWidth(count: number): number {
-  return Math.min(1.5 + Math.log2(count + 1), 5);
+  return Math.min(1 + Math.log2(count + 1) * 0.5, 2.5);
 }
 
+/**
+ * Blueprint edge (kg-ux plan §2.3): orthogonal smooth-step path, thin dashed
+ * ink stroke (--color-diagram-edge), with a small paper CHIP riding the edge
+ * — relation glyph (semantic tint) + label in mono. Selected = solid orange
+ * with marching ants; everything else is calm and static.
+ */
 function ArchEdgeRendererImpl(props: EdgeProps) {
   const {
     id,
@@ -56,22 +72,24 @@ function ArchEdgeRendererImpl(props: EdgeProps) {
   const isPortal = edgeData?.isPortalEdge ?? false;
   const dimmed = edgeData?.dimmed ?? false;
 
-  const [edgePath, labelX, labelY] = getBezierPath({
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
     sourceX,
     sourceY,
     sourcePosition,
     targetX,
     targetY,
     targetPosition,
+    borderRadius: 8,
   });
 
-  const baseColor = getEdgeColor(edgeType);
-  const stroke = selected ? "#fbbf24" : baseColor;
-  const strokeWidth = dimmed ? 1 : computeEdgeStrokeWidth(count);
-  const strokeOpacity = selected ? 1.0 : dimmed ? 0.06 : 0.75;
+  const stroke = selected ? "var(--color-viz-selection)" : "var(--color-diagram-edge)";
+  const strokeWidth = dimmed ? 1 : selected ? 2 : computeEdgeStrokeWidth(count);
+  const strokeOpacity = selected ? 1.0 : dimmed ? 0.06 : 0.9;
 
   const typeLabel = (edgeType ?? "").replace(/_/g, " ");
-  const label = dimmed ? "" : count > 3 ? `${typeLabel} (${count})` : typeLabel || "";
+  const label = dimmed ? "" : count > 1 ? `${typeLabel} ×${count}` : typeLabel || "";
+  const ChipIcon = (edgeType && EDGE_TYPE_ICONS[edgeType]) || ArrowRight;
+  const chipTint = getEdgeColor(edgeType);
 
   return (
     <>
@@ -82,8 +100,8 @@ function ArchEdgeRendererImpl(props: EdgeProps) {
         style={{
           stroke,
           strokeWidth,
-          strokeDasharray: isPortal ? "6 3" : "8 4",
-          animation: dimmed ? "none" : "edgeFlow 1.5s linear infinite",
+          strokeDasharray: selected ? "none" : isPortal ? "4 3" : "6 4",
+          animation: selected ? "edgeFlow 1.5s linear infinite" : "none",
           opacity: strokeOpacity,
         }}
       />
@@ -93,20 +111,28 @@ function ArchEdgeRendererImpl(props: EdgeProps) {
             style={{
               position: "absolute",
               transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
-              background: "rgba(15, 23, 42, 0.88)",
-              color: stroke,
-              padding: "2px 6px",
-              borderRadius: 4,
-              fontSize: 10,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              background: "var(--color-bg-surface)",
+              color: "var(--color-text-secondary)",
+              padding: "2px 7px",
+              borderRadius: 6,
+              fontFamily: "var(--font-mono, ui-monospace, monospace)",
+              fontSize: 9.5,
               fontWeight: 500,
               letterSpacing: 0.3,
               pointerEvents: "none",
-              border: `1px solid ${stroke}33`,
+              border: selected
+                ? "1px solid var(--color-viz-selection)"
+                : "1px solid var(--color-border-default)",
+              boxShadow: "0 1px 2px rgba(0,0,0,0.08)",
               whiteSpace: "nowrap",
-              opacity: selected ? 1 : 0.85,
+              opacity: selected ? 1 : 0.92,
             }}
             className="nodrag nopan"
           >
+            <ChipIcon size={10} aria-hidden style={{ color: chipTint, flexShrink: 0 }} />
             {label}
           </div>
         </EdgeLabelRenderer>

--- a/packages/ui/src/graph-primitives/node-shell.tsx
+++ b/packages/ui/src/graph-primitives/node-shell.tsx
@@ -26,19 +26,19 @@ export interface NodeShellProps {
 }
 
 function getBorderColor(props: NodeShellProps, fallbackBorder: string): string {
-  if (props.selected) return "#fbbf24";
-  if (props.diffState === "changed") return "#fca5a5";
-  if (props.diffState === "affected") return "#fbbf24";
-  if (props.tourHighlight) return "#f59520";
-  if (props.searchHighlight) return "#f59520";
-  if (props.focused) return "#f59520";
+  if (props.selected) return "var(--color-viz-selection)";
+  if (props.diffState === "changed") return "var(--color-viz-diff-changed)";
+  if (props.diffState === "affected") return "var(--color-viz-diff-affected)";
+  if (props.tourHighlight) return "var(--color-accent-fill)";
+  if (props.searchHighlight) return "var(--color-accent-fill)";
+  if (props.focused) return "var(--color-accent-fill)";
   return fallbackBorder;
 }
 
 function getBoxShadow(props: NodeShellProps): string {
-  if (props.selected) return "0 0 0 2px rgba(251,191,36,0.4)";
-  if (props.diffState === "changed") return "0 0 0 2px rgba(252,165,165,0.4)";
-  if (props.diffState === "affected") return "0 0 0 2px rgba(251,191,36,0.3)";
+  if (props.selected) return "0 0 0 2px color-mix(in srgb, var(--color-viz-selection) 40%, transparent)";
+  if (props.diffState === "changed") return "0 0 0 2px color-mix(in srgb, var(--color-viz-diff-changed) 40%, transparent)";
+  if (props.diffState === "affected") return "0 0 0 2px color-mix(in srgb, var(--color-viz-diff-affected) 35%, transparent)";
   return "0 1px 2px rgba(0,0,0,0.2)";
 }
 
@@ -77,7 +77,7 @@ export function NodeShell(props: NodeShellProps) {
         height,
         background: s.bg,
         border: `1.5px ${getBorderStyle(props)} ${getBorderColor(props, s.border)}`,
-        borderLeft: `3px solid ${selected ? "#fbbf24" : s.band}`,
+        borderLeft: `3px solid ${selected ? "var(--color-viz-selection)" : s.band}`,
         borderRadius: 8,
         color: s.text,
         overflow: "hidden",

--- a/packages/ui/src/graph-primitives/tone-styles.ts
+++ b/packages/ui/src/graph-primitives/tone-styles.ts
@@ -1,24 +1,33 @@
+/*
+ * Categorical node-tone palette (C4 / arch diagrams). These are
+ * the data-viz counterpart to LANGUAGE_COLORS — literal hex because they feed
+ * the static SVG exporter where a CSS var() string can't resolve. Retuned from
+ * the old cool navy/teal/purple set to the warm/plum families (mirrors the
+ * --color-community-* / --color-accent-secondary spine). Dark plum-tinted
+ * fills carry the C4 node body; the hub hue lines the border + kind band. Each
+ * pairing keeps light text >= AA on its fill.
+ */
 export const TONE_STYLES = {
-  system:       { bg: "#1f3a8a", border: "#1e40af", band: "#1e40af", text: "#ffffff" },
-  person:       { bg: "#374151", border: "#4b5563", band: "#4b5563", text: "#ffffff" },
-  external:     { bg: "#1f2937", border: "#374151", band: "#374151", text: "#e5e7eb" },
-  container:    { bg: "#0f3a5f", border: "#1d4ed8", band: "#1d4ed8", text: "#ffffff" },
-  component:    { bg: "#0d2a47", border: "#1e3a8a", band: "#1e3a8a", text: "#e5e7eb" },
-  file:         { bg: "#0f3a5f", border: "#1a6b8a", band: "#1a6b8a", text: "#ffffff" },
-  function:     { bg: "#1a3d2e", border: "#2d7d5a", band: "#2d7d5a", text: "#ffffff" },
-  class:        { bg: "#2d1f4a", border: "#6b4fa0", band: "#6b4fa0", text: "#ffffff" },
-  config:       { bg: "#3d2f0a", border: "#8a6b1a", band: "#8a6b1a", text: "#ffffff" },
-  document:     { bg: "#1a3a5a", border: "#4a8ab0", band: "#4a8ab0", text: "#ffffff" },
-  service:      { bg: "#3d1a2f", border: "#8a4a6b", band: "#8a4a6b", text: "#ffffff" },
-  pipeline:     { bg: "#2d1f3d", border: "#6b5a8a", band: "#6b5a8a", text: "#ffffff" },
-  module:       { bg: "#1f2d1a", border: "#5a7a4a", band: "#5a7a4a", text: "#ffffff" },
-  layerCluster: { bg: "#0d1a2d", border: "#1a3a5a", band: "#1a3a5a", text: "#f1f5f9" },
-  portal:       { bg: "transparent", border: "#475569", band: "#475569", text: "#94a3b8" },
-  concept:      { bg: "#1f2937", border: "#374151", band: "#374151", text: "#e5e7eb" },
-  table:        { bg: "#1a2d3d", border: "#3d6b8a", band: "#3d6b8a", text: "#ffffff" },
-  endpoint:     { bg: "#2d3d1a", border: "#6b8a3d", band: "#6b8a3d", text: "#ffffff" },
-  schema:       { bg: "#1a2d3d", border: "#3d6b8a", band: "#3d6b8a", text: "#ffffff" },
-  resource:     { bg: "#2d1f3d", border: "#6b5a8a", band: "#6b5a8a", text: "#ffffff" },
+  system:       { bg: "#3a2417", border: "#f59520", band: "#f59520", text: "#ffffff" }, // brand orange
+  person:       { bg: "#2c2530", border: "#84778a", band: "#84778a", text: "#ffffff" }, // charcoal mauve
+  external:     { bg: "#251f2c", border: "#5e5360", band: "#5e5360", text: "#e7e1f0" }, // muted plum-gray
+  container:    { bg: "#3a2417", border: "#d9825f", band: "#d9825f", text: "#ffffff" }, // peach
+  component:    { bg: "#2d1f1a", border: "#cf6a55", band: "#cf6a55", text: "#f1ece9" }, // terracotta
+  file:         { bg: "#2a1c33", border: "#826aa0", band: "#826aa0", text: "#ffffff" }, // plum
+  function:     { bg: "#1f2a18", border: "#6b7a3d", band: "#6b7a3d", text: "#ffffff" }, // olive/sage
+  class:        { bg: "#2a1c33", border: "#a98fc4", band: "#a98fc4", text: "#ffffff" }, // plum-300
+  config:       { bg: "#33280a", border: "#a8821f", band: "#a8821f", text: "#ffffff" }, // gold
+  document:     { bg: "#1a2c2a", border: "#558f89", band: "#558f89", text: "#ffffff" }, // deep teal
+  service:      { bg: "#2d1620", border: "#9e5570", band: "#9e5570", text: "#ffffff" }, // wine
+  pipeline:     { bg: "#251f2c", border: "#7d659c", band: "#7d659c", text: "#ffffff" }, // plum-soft
+  module:       { bg: "#1f2a18", border: "#90a05e", band: "#90a05e", text: "#ffffff" }, // sage-soft
+  layerCluster: { bg: "#1a1320", border: "#58436c", band: "#58436c", text: "#f4f1f8" }, // deep plum
+  portal:       { bg: "transparent", border: "#8c7f88", band: "#8c7f88", text: "#a79db3" }, // neutral
+  concept:      { bg: "#251f2c", border: "#5e5360", band: "#5e5360", text: "#e7e1f0" }, // charcoal mauve
+  table:        { bg: "#2d1f1c", border: "#b06a86", band: "#b06a86", text: "#ffffff" }, // dusty rose
+  endpoint:     { bg: "#2a2417", border: "#c9a544", band: "#c9a544", text: "#ffffff" }, // gold-soft
+  schema:       { bg: "#2d1f1c", border: "#cf93ab", band: "#cf93ab", text: "#ffffff" }, // dusty rose-soft
+  resource:     { bg: "#251f2c", border: "#7d659c", band: "#7d659c", text: "#ffffff" }, // plum-soft
 } as const;
 
 export type ToneName = keyof typeof TONE_STYLES;
@@ -44,4 +53,6 @@ export const ARCH_NODE_SIZES = {
   endpoint:     { width: 260, height: 110 },
   schema:       { width: 260, height: 110 },
   resource:     { width: 260, height: 110 },
+  /** Collapsed folder container card (ArchContainerNode, chevron closed). */
+  containerCollapsed: { width: 260, height: 64 },
 } as const;


### PR DESCRIPTION
## What

Blueprint redesign of the C4/architecture canvas (`packages/ui/src/c4/`):

- **Node/edge system**: graph-paper canvas, ink-outline paper cards (light) and ruled-paper dark cards, kind icons, smooth-step dashed ink edges with paper chips; edges anchor to collapsed container cards instead of phantom estimated positions.
- **Navigation**: unified click grammar (single = inspect, double = drill, dim-on-select), dashed "you are here" scope frame behind drilled tiers (`ScopeFrameNode`), breadcrumb + legend panels (`ArchBreadcrumb`, `ArchLegend`), inspector cards for folder/overflow/portal selections with portal dimming.
- **Curated KG awareness**: layer-group tiers from curated layers; `setView` tolerates pre-curation backend payloads (no hard dependency on a migrated server).
- **Export**: SVG export samples the live theme's ink palette.
- **Onboarding**: legend decoder ring, loading states, search dim; single orientation panel.
- **Mobile**: bottom-nav and layout updates to match.

Includes the `graph-primitives/` node/edge/tone primitives shared with the architecture canvas (their assertions live in this slice's tests). Stacks on the theme-token PR; the c4 directory is token-pure (it's covered by the no-raw-hex gate).

## Why

The C4 canvas was the most visually inconsistent surface after the token migration and the place where curated layers/tiers pay off most. The blueprint language gives architecture views a coherent visual identity in both themes, and the click-grammar unification removes the inspect-vs-drill ambiguity users hit constantly.

## How it was tested

- `npm run type-check` and `npx vitest run` green in `packages/ui` — updated/new suites: `arch-nodes`, `layer-groups-tier`, `project-overview`, `learn-panel-tour`, `search-filter-tour`, `sidebar`, `theme-mobile`, `two-stage-layout`, `edge-aggregation`, `containers`, `export`, `graph-primitives`, `architecture-store`.
- Renders against both current and pre-curation API payloads (fixture-covered).
