### PR TITLE
feat(distill): default the init rewrite-hook prompt to yes

### DIFF
--- a/docs/DISTILL.md
+++ b/docs/DISTILL.md
@@ -71,10 +71,11 @@ MCP clients without a shell can resolve the same refs through
 
 ### 3. The command-rewrite hook (Claude Code + Codex)
 
-Opt-in. A PreToolUse hook rewrites noisy agent commands —
+A PreToolUse hook rewrites noisy agent commands —
 `pytest -x` → `repowise distill pytest -x` — **pending your approval**: the
 default posture is `ask`, so Claude Code shows you the modified command before
-running it. Install:
+running it. `repowise init` offers to install it (default: yes); install
+manually with:
 
 ```bash
 repowise hook rewrite install      # or opt in during `repowise init`

--- a/packages/cli/src/repowise/cli/commands/init_cmd/_interactive.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/_interactive.py
@@ -19,8 +19,8 @@ def offer_distill_rewrite_hook(
     ``flag`` is the resolved ``--distill-hook/--no-distill-hook`` value:
     True installs without prompting, False skips AND gates the repos off in
     config (so a hook installed globally from another repo stays inert
-    there), None prompts when interactive and does nothing otherwise —
-    strictly opt-in.
+    there), None prompts when interactive (defaulting to yes) and does
+    nothing otherwise.
 
     The hook itself is user-level (one install covers every repo), but the
     verdict is recorded per repo as ``distill.commands.enabled`` in each
@@ -60,7 +60,7 @@ def offer_distill_rewrite_hook(
             f"  [dim]{scope}Each rewrite is shown for approval; raw output stays "
             "recoverable via `repowise expand`.[/dim]"
         )
-        flag = click.confirm("  Install the Claude Code rewrite hook?", default=False)
+        flag = click.confirm("  Install the Claude Code rewrite hook?", default=True)
 
     if flag:
         path = adapter.install_rewrite_hook()


### PR DESCRIPTION
## Summary
- `repowise init`'s prompt to install the Claude Code command-rewrite hook now defaults to **yes** — pressing Enter installs it (was: skip).
- Updated the `offer_distill_rewrite_hook` docstring and `docs/DISTILL.md` to match.

## What does NOT change
- The hook posture stays `ask` — every rewrite is still shown for approval before running.
- `--no-distill-hook` and declining the prompt still gate the repo off via `distill.commands.enabled: false`.
- Non-interactive runs still do nothing (no silent install).

## Test plan
- [x] `pytest tests/unit/distill/test_init_optin.py` — 11 passed