### PR TITLE
release: v0.17.0 — Distill, multi-language import resolution, light-default theme

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.17.0] — 2026-06-06
 
 ### Added
 - **Distill — index-aware output distillation.** A new capability that
@@ -47,6 +47,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overrides, disabled filters, omission-store TTL/size). `repowise doctor`
   validates the block, reports omission-store size against its cap, and shows
   rewrite-hook install state.
+- **Distill on Codex CLI.** The rewrite hook now supports Codex CLI alongside
+  Claude Code, with repowise-command corrections (#391). A lint filter joins
+  the filter set, `repowise saved` discovers missed savings, and the ledger
+  tags savings per surface (#390).
+- **Multi-language import resolution.** Lightweight per-language import
+  resolvers with same-scope linking and spec metadata sharpen the dependency
+  graph across the language registry (#392).
+- **Light-default design-token theme system.** The web UI moves to a
+  design-token theme with light as the default and a dual-theme component
+  sweep (#405).
+- **Owl mascot init banner.** `repowise init` opens with the owl mascot and a
+  repo-seeded heatmap wordmark (#364), plus a clearer mode panel and
+  searchable model selection (#379).
+- **Agent-provenance layer in the git indexer.** Commit indexing records a
+  deterministic agent-provenance layer (#366).
+- **Claude Code plugin.** A `repowise` Claude Code plugin and root
+  marketplace, refreshed to the current command/skill/MCP surface (#356).
+
+### Changed
+- **`repowise init` defaults the distill rewrite-hook prompt to yes** (#409),
+  and every init flow records the verdict (#382).
+- **Indexing and incremental updates scale with change size.** Parsing and
+  betweenness results are cached across incremental updates (#369, #368),
+  workspace indexing routes already-indexed repos through the incremental
+  path (#384), and filesystem walks prune nested repos and junk trees (#380).
+
+### Fixed
+- **`get_context` hardened** — segment-boundary partial matching, git-file
+  fall-through, and batch isolation (#401).
+- **Distill correctness:** Grep-rescue fixes, PowerShell hook coverage, a
+  nudge floor, and allowlist seeding (#389).
+- **Health scoring:** `duplication_pct` computed from the union of clone
+  ranges (#388), whole-file NLOC for file metrics instead of function-body
+  sums (#387), and hotspot/ownership signals calibrated for small teams and
+  quiet repos (#363).
+- **Submodules:** persisted include-submodules flags are honored in health,
+  dead-code, incremental updates, and upgrades (#383, #381).
+- **Dead code:** local Express route middleware rescued from unused-export
+  detection (#386); explicit relative JS imports resolve (#376).
+- **Process hygiene:** MCP orphan watchdog, live-PID update locks, and
+  PATH-hijack-proof registration (#385).
+- **Generation:** never-started page coroutines are closed on cancellation
+  (#365).
+- **Server:** jobs honor `exclude_patterns` and prune stale rows (#354);
+  breadcrumb path labels are decoded in the web UI (#359).
+
+### Dependencies
+- starlette 0.52.1 → 1.0.1 (#367).
 
 ---
 

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -272,7 +272,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.16.0</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.17.0</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -357,7 +357,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
         <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
           <ThemeToggle className="w-full justify-between" />
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.16.0
+            repowise v0.17.0
           </p>
         </div>
       )}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.17.0
+
+### Changed
+- Widened the bundled `PostToolUse` hook matcher to include `PowerShell`
+  (the Windows Claude Code shell tool), matching the CLI-installed augment
+  hook.
+
 ## 0.16.0
 
 First release distributed through the marketplace at the repo root

--- a/plugins/claude-code/hooks/hooks.json
+++ b/plugins/claude-code/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PostToolUse": [
       {
-        "matcher": "Bash|Grep|Glob|Read|Edit|Write",
+        "matcher": "Bash|PowerShell|Grep|Glob|Read|Edit|Write",
         "hooks": [
           {
             "type": "command",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.16.0"
+version = "0.17.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Cuts **v0.17.0** from latest `main` (`91336a7`). Headline changes since v0.16.0:

- **Distill** — index-aware output distillation (`distill` / `expand` / `saved`), opt-in Claude Code rewrite hook (now default-yes in `init`), Codex CLI support, savings ledger + dashboard card
- **Multi-language import resolution** — lightweight resolvers, same-scope linking, spec metadata (#392)
- **Light-default design-token theme system** for the web UI (#405)
- Owl mascot init banner (#364) + clearer init mode panel (#379)
- Claude Code plugin + root marketplace (#356); plugin hook matcher synced to include `PowerShell`
- `get_context` hardening (#401), health-scoring fixes (#388, #387, #363), incremental-update performance (#368, #369, #384, #380), process hygiene (#385)
- starlette 0.52.1 → 1.0.1 (#367)

Full details in `docs/CHANGELOG.md` under `[0.17.0] — 2026-06-06`.

## Release contents

- Version bump to 0.17.0 in `pyproject.toml`, the three `__init__.py` files, web UI footer (sidebar + mobile nav), and both plugin manifests
- `uv.lock` regenerated (repowise self-entry 0.16.0 → 0.17.0)
- OSS changelog section for 0.17.0; plugin `CHANGELOG.md` entry
- Plugin sync: `hooks.json` matcher widened to `Bash|PowerShell|Grep|Glob|Read|Edit|Write` to match the CLI-installed augment hook

## Test plan

- [x] `uv build --wheel` — clean build, 34 command files, `.scm` queries + `.j2` templates present, no stale files in wheel
- [x] Fresh-venv smoke test — `repowise --version` → 0.17.0, `repowise.cli`/`core`/`server` all import
- [x] `npm ci && npm run build --workspace packages/web` — all routes built, standalone `server.js` produced, workspace-package code compiled into bundle
- [x] Drift grep — no `0.16.0` remnants in bump locations (only the unrelated `h11` dep in `uv.lock`)
- [x] Plugin parity — live MCP tool set matches the 9 exposed tools; no unexposed tool referenced in skills/commands
- [ ] Post-merge: tag `v0.17.0` on the merge commit, push tag, watch `publish.yml`
- [ ] Post-publish: PyPI version check, release assets check, tarball structure check
- [ ] End-user smoke test (`pip install --upgrade repowise && repowise serve` in a fresh dir)

> **Merge convention:** use a **regular merge commit** (not squash) — the tag must point at a real merge of the bump-only commits for artifact provenance.