### PR TITLE
fix(init): health progress-bar UX, cost-gate default yes, concurrency 10, resume hint

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -228,7 +228,7 @@ def _run_generation_phase(
 @click.option(
     "--force", is_flag=True, default=False, help="Regenerate all pages, ignoring existing."
 )
-@click.option("--concurrency", type=int, default=5, help="Max concurrent LLM calls.")
+@click.option("--concurrency", type=int, default=10, help="Max concurrent LLM calls.")
 @click.option(
     "--reasoning",
     type=click.Choice(REASONING_MODES),

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -250,6 +250,12 @@ def run_repo_generation(
     cost_tracker = build_cost_tracker(repo_path, result.repo_name)
     provider._cost_tracker = cost_tracker
 
+    if verbose:
+        console.print(
+            "  [dim](each generated page is saved as it completes — safe to Ctrl-C, "
+            "then run 'repowise init --resume' to pick up where it stopped)[/dim]"
+        )
+
     with Progress(
         SpinnerColumn(spinner_name=OWL_SPINNER, style=BRAND_STYLE),
         TextColumn("[progress.description]{task.description}"),

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -46,18 +46,23 @@ class CostGateDeclined(Exception):  # noqa: N818 — a control-flow signal, not 
 
 
 def confirm_cost_gate(message: str) -> bool:
-    """Render the cost-gate ``[y/N]`` prompt with visual padding.
+    """Render the cost-gate ``[Y/n]`` prompt with visual padding.
 
     Click's plain ``confirm`` interleaves with the trailing line of any
     prior Rich output (progress-bar frames, status spinners), making the
-    ``[y/N]`` glyphs hard to spot — users have walked past it and approved
+    confirm glyphs hard to spot — users have walked past it and approved
     a $14 bill thinking they were still in cost-estimate territory. A
     blank line + horizontal rule cleanly separates the prompt from
     whatever was printed above it.
+
+    Default is Yes: the user just picked a coverage tier with the cost
+    range printed next to it, so Enter-through should continue the run
+    they configured — the gate exists to make the spend visible, not to
+    interrupt it.
     """
     console.line()
     console.rule(style="yellow")
-    return click.confirm(message, default=False)
+    return click.confirm(message, default=True)
 
 
 def cost_gate_declined(est: Any, *, yes: bool, message: str) -> bool:

--- a/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
@@ -400,7 +400,7 @@ def _workspace_init(
     index_only: bool = False,
     skip_tests: bool = False,
     skip_infra: bool = False,
-    concurrency: int = 5,
+    concurrency: int = 10,
     test_run: bool = False,
     reasoning: str | None = None,
     yes: bool = False,

--- a/packages/cli/src/repowise/cli/commands/update_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd.py
@@ -634,7 +634,7 @@ def _run_full_health_rescore(
 @click.option("--provider", "provider_name", default=None, help="LLM provider name.")
 @click.option("--model", default=None, help="Model identifier override.")
 @click.option("--since", default=None, help="Base git ref to diff from (overrides state).")
-@click.option("--concurrency", type=int, default=5, help="Max concurrent LLM calls.")
+@click.option("--concurrency", type=int, default=10, help="Max concurrent LLM calls.")
 @click.option(
     "--reasoning",
     type=click.Choice(REASONING_MODES),
@@ -739,7 +739,7 @@ def update_command(
     docs_flag: bool | None = None,
     full: bool = False,
     agents_md: bool | None = None,
-    concurrency: int = 5,
+    concurrency: int = 10,
     no_cost_tracking: bool = False,
 ) -> None:
     """Incrementally update wiki pages for files changed since last sync.

--- a/packages/cli/src/repowise/cli/commands/workspace_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/workspace_cmd.py
@@ -236,7 +236,7 @@ def _format_relative_time(iso_timestamp: str | None) -> str:
 )
 @click.option("--provider", "provider_name", default=None, help="LLM provider name (overrides primary's).")
 @click.option("--model", default=None, help="Model identifier (overrides primary's).")
-@click.option("--concurrency", type=int, default=5, help="Max concurrent LLM calls during doc generation.")
+@click.option("--concurrency", type=int, default=10, help="Max concurrent LLM calls during doc generation.")
 def workspace_add(
     path: str,
     alias: str | None,
@@ -453,7 +453,7 @@ def _run_index_for_repo(
     generate_docs: bool = False,
     provider_name: str | None = None,
     model: str | None = None,
-    concurrency: int = 5,
+    concurrency: int = 10,
     docs_skip_reason: str | None = None,
 ) -> None:
     """Run the ingestion pipeline on a single repo, optionally with LLM docs.

--- a/packages/cli/src/repowise/cli/ui/mode_selection.py
+++ b/packages/cli/src/repowise/cli/ui/mode_selection.py
@@ -241,11 +241,11 @@ def _prompt_generation(
     console.print()
 
     # Smart concurrency default
-    default_concurrency = 5
+    default_concurrency = 10
     if scan and scan.total_files < 200:
-        default_concurrency = 8
+        default_concurrency = 12
     elif scan and scan.total_files > 5000:
-        default_concurrency = 3
+        default_concurrency = 5
 
     result["concurrency"] = click.prompt(
         "  Max concurrent LLM calls",

--- a/packages/core/src/repowise/core/analysis/health/engine.py
+++ b/packages/core/src/repowise/core/analysis/health/engine.py
@@ -340,6 +340,10 @@ class HealthAnalyzer:
                 log.debug("health_walk_failed", path=pf.file_info.path, error=str(exc))
                 fcx = FileComplexity(functions=[], classes=[])
             walked.append((pf, fcx))
+            # Walk tick — the phase total counts each file twice (walk +
+            # evaluate); see analyze_async.
+            if on_step:
+                on_step(pf.file_info.path)
 
         repo_fn_mod_p80 = _compute_repo_function_mod_p80(walked, self.git_meta_map)
         repo_dependents_p80 = _compute_repo_dependents_p80(self.parsed_files, self.graph)
@@ -422,20 +426,20 @@ class HealthAnalyzer:
         repo_commit_counts = _build_repo_commit_counts(self.git_meta_map)
         graph_view: HasEdge | None = _ImportEdgeView(self.graph) if self.graph is not None else None
 
-        if "dry_violation" in disabled:
-            dup_report = DuplicationReport()
-        else:
-            try:
-                dup_report = await asyncio.to_thread(
+        # Duplication is only consumed by the biomarker stage, so it can
+        # overlap with the pre-walk instead of blocking it — on large
+        # repos the scan takes seconds during which the progress bar
+        # would otherwise sit at zero.
+        dup_task: asyncio.Task | None = None
+        if "dry_violation" not in disabled:
+            dup_task = asyncio.ensure_future(
+                asyncio.to_thread(
                     detect_clones,
                     self.parsed_files,
                     self.git_meta_map,
                     cache_dir=self.duplication_cache_dir,
                 )
-                _log_duplication_diagnostics(dup_report)
-            except Exception as exc:
-                log.debug("health_duplication_failed", error=str(exc))
-                dup_report = DuplicationReport()
+            )
 
         target_files = [
             pf
@@ -443,6 +447,8 @@ class HealthAnalyzer:
             if changed_set is None or pf.file_info.path in changed_set
         ]
         if not target_files:
+            if dup_task is not None:
+                dup_task.cancel()
             return HealthReport(
                 repo_id="",
                 analyzed_at=datetime.now(UTC),
@@ -464,9 +470,23 @@ class HealthAnalyzer:
                 except Exception as exc:
                     log.debug("health_walk_failed", path=pf.file_info.path, error=str(exc))
                     fcx = FileComplexity(functions=[], classes=[])
+            # Walk tick — the phase total counts each file twice (walk +
+            # evaluate) so the bar moves from the very first completed walk.
+            if on_step:
+                on_step(pf.file_info.path)
             return pf, fcx
 
         walked = await asyncio.gather(*[_one(pf) for pf in target_files])
+
+        if dup_task is None:
+            dup_report = DuplicationReport()
+        else:
+            try:
+                dup_report = await dup_task
+                _log_duplication_diagnostics(dup_report)
+            except Exception as exc:
+                log.debug("health_duplication_failed", error=str(exc))
+                dup_report = DuplicationReport()
         repo_fn_mod_p80 = _compute_repo_function_mod_p80(list(walked), self.git_meta_map)
         repo_dependents_p80 = _compute_repo_dependents_p80(self.parsed_files, self.graph)
         repo_active_contributors = _compute_repo_active_contributors(self.git_meta_map)

--- a/packages/core/src/repowise/core/pipeline/phases/analysis.py
+++ b/packages/core/src/repowise/core/pipeline/phases/analysis.py
@@ -82,8 +82,11 @@ async def _run_health_analysis(
         from repowise.core.analysis.health.config import HealthConfig
 
         if progress:
-            # Per-file determinate progress: one tick per parsed file.
-            progress.on_phase_start("health", len(parsed_files))
+            # Two ticks per parsed file: one when its AST walk completes,
+            # one when its biomarker evaluation completes. Without the
+            # walk tick the bar sits at 0 through the duplication scan and
+            # the entire pre-walk — most of the phase's wall-clock.
+            progress.on_phase_start("health", 2 * len(parsed_files))
 
         # Build a {file_path → community label} map so per-file metrics
         # carry a real module name, not None. Community detection is


### PR DESCRIPTION
## Problem

During `repowise init`, the health phase progress bar sits at `0/N` for several seconds (14s+ on a ~2,000-file repo) before the first tick, then races to full. Two heavy stages ran before any `on_step` fired:

1. The `detect_clones` duplication scan was awaited up-front, blocking everything.
2. The entire pre-walk `asyncio.gather` of AST walks completed before the sequential biomarker loop — the only stage that ticked.

Separately, a few init-flow ergonomics: the `$2` LLM cost gate prompted with `[y/N]` so Enter-through *aborted* the run the user had just configured; the default LLM concurrency of 5 left throughput on the table; and nothing told users that page generation is safely interruptible.

## Changes

### Health progress bar
- **Two ticks per file**: the phase total is now `2 * len(parsed_files)` — one tick when a file's AST walk completes, one when its biomarker evaluation completes. The bar moves from the first completed walk and progresses steadily through the whole phase. Applied to both the async (≥500 files) and sync paths.
- **Duplication overlaps the pre-walk** (`analyze_async`): only the biomarker stage consumes the clone report, so the scan now runs concurrently with the walk instead of blocking it. Same exception fallback to an empty `DuplicationReport`; the empty-target early return cancels the in-flight task.

### Init-flow ergonomics
- **Cost gate defaults to yes**: `confirm_cost_gate` renders `[Y/n]`. The gate exists to make the spend visible, not to interrupt the run the user just configured. `--yes` and an explicit `n` behave exactly as before. Covers both call sites (single-repo and per-repo workspace gates).
- **Default LLM concurrency 5 → 10** across `init`, `update`, and `workspace add`, plus the interactive advanced-config ladder (tiny repos <200 files: 8 → 12; huge repos >5000 files: 3 → 5). The core engine default was already 12; the CLI was the bottleneck.
- **Resumability hint at generation start**: pages persist incrementally (`run_generation_with_persistence` upserts each page as it lands), so the generation phase now prints the same kind of "safe to Ctrl-C, resume with `repowise init --resume`" hint that Phase 1 already shows for the graph build.

## Testing

- `tests/unit/health`, `tests/unit/pipeline`, `tests/integration/test_health_coverage_integration.py` — 325 passed.
- Smoke-tested the `analyze_async` empty-target early return (dup task cancellation path).
- `ruff check` on touched files: no new findings (9 pre-existing, none on changed lines).
