### PR TITLE
release: v0.17.1 — MCP Registry listing + post-0.17.0 fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- mcp-name: dev.repowise/repowise -->
+
 <div align="center">
 
 <a href="https://www.repowise.dev"><img src=".github/assets/banner.png" alt="repowise — the codebase intelligence layer for your AI coding agent" width="100%" /></a>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.17.1] — 2026-06-07
+
+### Added
+- **Official MCP Registry listing.** repowise is published to the
+  [MCP Registry](https://registry.modelcontextprotocol.io) as
+  `dev.repowise/repowise` (PyPI package, stdio transport), so MCP clients can
+  discover and install the server from the registry directly.
+- **Distill: stat-only diff filter.** `git diff --stat` output gets its own
+  filter — the roll-up line plus the top-20 rows by churn — instead of
+  slipping past the hunk-based diff filter raw (#414).
+
+### Changed
+- **Skeleton is the default context card for files.** `get_context` on file
+  targets above ~80 lines now returns the smart skeleton (every signature,
+  central bodies inlined) instead of the bare symbol list — measured strictly
+  better per token. `compact=False` opts out; a `mostly_full` flag marks small
+  files where a direct `Read` costs little more (#414).
+- **`repowise init` defaults tuned.** LLM concurrency defaults to 10 (tiny
+  repos 12, huge repos 5) across `init`, `update`, and `workspace add`; the
+  LLM cost-gate confirm defaults to yes (the cost was already shown beside the
+  coverage tier); page generation prints a hint that runs are resumable with
+  `init --resume` (#412).
+
+### Fixed
+- **Semantic search lost embeddings on mid-size repos.** A whole generation
+  level was embedded in one API request; file pages routinely blew the
+  provider's per-request token cap, failed 400, and the failure was swallowed
+  at debug level — fresh inits silently lost all file-page embeddings.
+  `embed_batch` now chunks requests with failure isolation per chunk, and the
+  loss (if any) surfaces as a warning with a `repowise reindex` repair hint
+  (#414).
+- **`repowise update` evicted pages from semantic search.** Regenerated pages
+  were persisted to SQLite but never re-embedded, so every update drifted the
+  vector corpus away from file pages. Updates now embed regenerated pages into
+  the vector store; existing repos repair with `repowise reindex` (#414).
+- **`search_codebase` ranking.** Decision records (short title-statements)
+  no longer dominate design-noun queries — they're down-weighted unless the
+  query is why-shaped; retrieval over-fetches before re-ranking; the `kind`
+  filter runs before the limit cut so `kind="implementation"` can't return an
+  empty list; pages without a backing file classify as `"doc"` (#413, #414).
+- **`get_risk` calibration.** The 0–10 score no longer pins at 10.0 from
+  transitive-dependent breadth alone (exponential file term + capped breadth
+  term); co-change partners survive incremental updates instead of being
+  wiped; files excluded via `.git/info/exclude` no longer leak into
+  `will_break`; `directive.missing_tests` is scoped to the PR's changed files
+  (#413, #414).
+- **`get_context` contract.** Docs + freshness defaults are always returned —
+  `include=["skeleton"]` no longer drops the summary and freshness card;
+  signatures collapse onto one line (no leaked `\r\n` from CRLF files); module
+  cards describe child files with their indexed summaries (#413).
+- **Generated CLAUDE.md quality.** Word-boundary truncation in tables (no more
+  mid-word chops), prose-only sentence extraction (list items and table rows
+  no longer jam onto the architecture paragraph), guided-tour steps carry file
+  paths again, the Owner column drops when no module has owner data, and tech
+  stack detection ignores test fixtures / vendored repos and finds
+  `tsconfig.json` in workspace packages (#413).
+- **`repowise init` health-phase progress bar** moved from the first completed
+  AST walk instead of sitting at 0/N through the pre-walk, and the duplication
+  scan overlaps the pre-walk (#412).
+- **Distill on Windows:** `cmd /c` wrappers are stripped during command
+  normalization so native listings route to the file-listing filter, which now
+  also accepts absolute Windows paths (#413).
+
 ## [0.17.0] — 2026-06-06
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.17.0"
+__version__ = "0.17.1"

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -272,7 +272,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.17.0</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.17.1</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -357,7 +357,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
         <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
           <ThemeToggle className="w-full justify-between" />
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.17.0
+            repowise v0.17.1
           </p>
         </div>
       )}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.17.0"
+version = "0.17.1"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "dev.repowise/repowise",
+  "title": "Repowise",
+  "description": "Codebase intelligence for AI coding agents — graph, git history, docs, decisions, code health.",
+  "repository": {
+    "url": "https://github.com/repowise-dev/repowise",
+    "source": "github"
+  },
+  "websiteUrl": "https://www.repowise.dev",
+  "version": "0.17.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "repowise",
+      "version": "0.17.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp",
+          "description": "The repowise CLI subcommand that starts the MCP server"
+        },
+        {
+          "type": "positional",
+          "valueHint": "repo_path",
+          "description": "Absolute path to the repository to serve (must be indexed first with `repowise init`)",
+          "isRequired": true,
+          "format": "filepath"
+        },
+        {
+          "type": "named",
+          "name": "--transport",
+          "value": "stdio",
+          "description": "Transport protocol"
+        }
+      ]
+    }
+  ]
+}

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.17.0"
+version = "0.17.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
Patch release. Ships the official MCP Registry listing for the OSS server and rolls up the fixes merged since v0.17.0 (#412, #413, #414).

- **MCP Registry:** `server.json` at the repo root registers `dev.repowise/repowise` (PyPI package, stdio transport, `repowise mcp <repo_path> --transport stdio`); the README gains the hidden `mcp-name` marker the registry uses to verify PyPI package ownership — this is why a release is needed (the marker must be in the README published to PyPI).
- **Version bump** 0.17.0 → 0.17.1 in pyproject, the three package `__init__`s, web footer (sidebar + mobile nav), both plugin manifests, and `uv.lock`.
- **Changelog** entry for 0.17.1 covering the semantic-search embedding-pipeline fixes, `search_codebase` ranking, `get_risk` calibration, `get_context` skeleton default + contract fixes, generated-CLAUDE.md quality, init UX/concurrency defaults, and the distill stat-diff/Windows fixes.

## Test plan
- [x] `uv build --wheel` — `repowise-0.17.1-py3-none-any.whl` builds cleanly; CLI commands, `.scm` queries, and `.j2` templates present
- [x] `npm run build --workspace packages/web` — standalone output at the expected path, workspace-package code compiled into chunks
- [x] `mcp-publisher validate` passes on `server.json`
- [x] Plugin tool-surface grep guard — only the nine exposed tools referenced
- [ ] Post-merge: tag `v0.17.1` on `main` → `publish.yml` (wheel → PyPI, web tarball → GitHub release)
- [ ] Post-publish: `pip install --upgrade repowise && repowise --version` → 0.17.1
- [ ] Post-publish: `mcp-publisher publish` for `dev.repowise/repowise`

> **Merge convention:** regular merge commit, **not squash** — the tag must point at a real merge of the bump-only commits.