### PR TITLE
docs(readme): lead the agent-efficiency benchmark with token reduction, not cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,18 @@ repositories (same model, same harness, with vs without repowise's MCP tools):
 
 <div align="center">
 
-**−70% tool calls&nbsp;&nbsp;·&nbsp;&nbsp;−89% file reads&nbsp;&nbsp;·&nbsp;&nbsp;−36% cost per query&nbsp;&nbsp;·&nbsp;&nbsp;answer quality at parity**
+**up to −96% tokens to load context&nbsp;&nbsp;·&nbsp;&nbsp;−89% file reads&nbsp;&nbsp;·&nbsp;&nbsp;−70% fewer tool calls&nbsp;&nbsp;·&nbsp;&nbsp;answer quality at parity**
 
 </div>
 
-Best case shown; across the two benchmarks the range is −49% to −70% tool calls,
-−69% to −89% file reads, and −29% to −36% cost. Bonus: feeding an agent a commit
-via `get_context` costs **2,391 tokens vs 64,039** for the raw changed files —
-**~27× fewer**. Reports: [flask48](https://github.com/repowise-dev/repowise-bench/blob/master/BENCHMARK_REPORT_FLASK48.md) · [sklearn48](https://github.com/repowise-dev/repowise-bench/blob/master/BENCHMARK_REPORT_SKLEARN48.md)
+The win is *context*: repowise hands the agent a curated answer instead of a
+pile of files to read. Loading a commit's context via `get_context` costs
+**2,391 tokens vs 64,039** raw — **~27× fewer (−96%)**. Across the two
+benchmarks, agents read **−69% to −89% fewer files** and make **−49% to −70%
+fewer tool calls** at answer quality on par with raw exploration; on a long,
+multi-step investigation that compounds to **−41% of the context re-read across
+the whole session**. Saved tokens are tokens you don't pay for — dollar cost
+drops too, though agent-side prompt caching now mutes the cost delta. Reports: [flask48](https://github.com/repowise-dev/repowise-bench/blob/master/BENCHMARK_REPORT_FLASK48.md) · [flask v3](https://github.com/repowise-dev/repowise-bench/blob/master/BENCHMARK_REPORT_FLASK_V3.md) · [sklearn48](https://github.com/repowise-dev/repowise-bench/blob/master/BENCHMARK_REPORT_SKLEARN48.md)
 
 ### 2 · Distill — index-aware output distillation
 


### PR DESCRIPTION
Reframes the **Benchmarks → §1 Agent efficiency** block to lead with the metric that actually reproduces and impresses — **token/context reduction** — instead of the dollar-cost figure, which modern agent-side prompt caching now mutes (re-reading cached context is ~0.1×, so the file reads repowise eliminates are already cheap in dollars).

**What changes (README only, no code):**
- Hero line now: *up to −96% tokens to load context · −89% file reads · −70% fewer tool calls · answer quality at parity* (drops the `−36% cost per query`).
- Supporting paragraph leads with the `get_context` commit example (**2,391 vs 64,039 tokens, ~27× / −96%**), keeps the published file-read/tool-call ranges, adds the long-session figure (**−41% of context re-read across a whole multi-step investigation**), and folds cost into one honest clause.
- Adds the **flask v3** report link (now on `repowise-bench` master).

All numbers are reproducible and link to committed reports. The deterministic per-operation token cuts (−96% via `get_context`, −86%/−89% via `distill`) are the strongest, most defensible claims; cost is demoted because it's caching-dependent.