### PR TITLE
release: v0.18.0 — curated KG serving blocks, MCP savings, compact init banner

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.18.0] — 2026-06-08
 
 ### Added
 - **MCP counterfactual token savings.** Every MCP tool call now records what its
@@ -30,6 +30,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on-machine), falling back to a default rate when undetectable — because saved
   tokens are input the agent never had to read. Missed savings now read as an
   "unlock more" prompt rather than a footnote.
+
+### Changed
+- **`repowise init` always renders the compact banner.** The init splash now
+  uses the compact owl variant (~60% of the old full-art width) on every
+  terminal, so narrow shells no longer wrap it. (#423)
+
+### Internal
+- Shared UI/server building blocks consolidated so the web UI and downstream
+  consumers stop duplicating code: `OwlLoader` and the design-token gate
+  scripts move into the `@repowise-dev/ui` package, a dependency-free
+  `@repowise-dev/ui/brand` constants export is added, and the community/
+  architecture view builders are extracted from the server routers into
+  FastAPI-free `services/` functions. No change to the install/serve UX or any
+  endpoint's response shape. (#423)
 
 ---
 

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.17.1"
+__version__ = "0.18.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.17.1"
+__version__ = "0.18.0"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.17.1"
+__version__ = "0.18.0"

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -272,7 +272,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.17.1</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.18.0</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -357,7 +357,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
         <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
           <ThemeToggle className="w-full justify-between" />
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.17.1
+            repowise v0.18.0
           </p>
         </div>
       )}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.18.0
+
+Version bump to track the repowise 0.18.0 release. No changes to the plugin's
+commands, skills, hooks, or MCP tool surface this cycle.
+
 ## 0.17.0
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.17.1"
+version = "0.18.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.17.1"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## release: v0.18.0

Cuts repowise **0.18.0** from current `main`. Bump-only branch (version + lockfile
+ changelogs) per the release runbook.

### What ships in 0.18.0

- **MCP counterfactual token savings** — every MCP tool call records what raw
  exploration its curated answer replaced, into the unified savings ledger.
- **Costs page savings hero** — leads with tokens + dollars saved (distill +
  MCP), priced at the agent's actual model.
- **`repowise init` always renders the compact banner.**
- **Internal:** shared UI/server building blocks consolidated (OwlLoader +
  design gates → `@repowise-dev/ui`, dependency-free `@repowise-dev/ui/brand`
  export, server view-builders extracted to FastAPI-free services). No
  install/serve UX change; no endpoint response-shape change.

### Version bump (0.17.1 → 0.18.0)

`pyproject.toml`, the three package `__init__.py` files, both web footers, both
Claude Code plugin manifests, and `uv.lock`. Changelog `[Unreleased]` dated as
`[0.18.0]`; plugin CHANGELOG entry added (no plugin-surface change this cycle).

### Build validation (done locally)

- [x] `uv build --wheel` → `repowise-0.18.0-py3-none-any.whl` clean (34 command
      modules, 36 `.scm`/`.j2` package-data files, `serve_cmd.py` present)
- [x] `uv lock` self-entry bumped to 0.18.0
- [x] Plugin MCP-tool parity: only the 9 exposed tools appear in skills/commands

### After merge (post-merge steps)

- [ ] Tag `v0.18.0` on the squash commit on `main` and push → `publish.yml`
      builds the wheel + web tarball and publishes to PyPI + the GitHub release
- [ ] Verify the GitHub release has all 3 assets and PyPI shows 0.18.0

Merge convention: squash (repo is squash-only); I'll tag the squash commit.
