### PR TITLE
fix(web): prevent workspace redirect loop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14736,7 +14736,8 @@
         "eslint": "^9",
         "eslint-config-next": "^15.2.4",
         "tailwindcss": "^4.0.0",
-        "typescript": "^5.7"
+        "typescript": "^5.7",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start --port 3000",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.4",
@@ -43,7 +44,8 @@
     "eslint": "^9",
     "eslint-config-next": "^15.2.4",
     "tailwindcss": "^4.0.0",
-    "typescript": "^5.7"
+    "typescript": "^5.7",
+    "vitest": "^4.1.5"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -32,7 +32,7 @@ export default async function DashboardPage() {
   const [repos, jobs, ws] = await Promise.allSettled([
     listRepos(),
     listJobs({ limit: 10 }),
-    getWorkspace(),
+    getWorkspace({ cache: "no-store" }),
   ]);
 
   const repoList = repos.status === "fulfilled" ? repos.value : [];

--- a/packages/web/src/app/workspace/layout.tsx
+++ b/packages/web/src/app/workspace/layout.tsx
@@ -1,20 +1,21 @@
 import { redirect } from "next/navigation";
 import { getWorkspace } from "@/lib/api/workspace";
+import { shouldRedirectFromWorkspace } from "@/lib/workspace-mode";
 
 export default async function WorkspaceLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  let isWorkspace = false;
+  let isWorkspace: boolean | null = null;
   try {
-    const ws = await getWorkspace();
+    const ws = await getWorkspace({ cache: "no-store" });
     isWorkspace = ws.is_workspace;
   } catch {
     // API unavailable
   }
 
-  if (!isWorkspace) {
+  if (shouldRedirectFromWorkspace(isWorkspace)) {
     redirect("/");
   }
 

--- a/packages/web/src/lib/api/workspace.ts
+++ b/packages/web/src/lib/api/workspace.ts
@@ -7,8 +7,10 @@ import type {
   WorkspaceSyncResponse,
 } from "./types";
 
-export async function getWorkspace(): Promise<WorkspaceResponse> {
-  return apiGet<WorkspaceResponse>("/api/workspace");
+export async function getWorkspace(
+  fetchOptions?: RequestInit,
+): Promise<WorkspaceResponse> {
+  return apiGet<WorkspaceResponse>("/api/workspace", undefined, fetchOptions);
 }
 
 export async function getWorkspaceContracts(opts?: {

--- a/packages/web/src/lib/workspace-mode.test.ts
+++ b/packages/web/src/lib/workspace-mode.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { shouldRedirectFromWorkspace } from "./workspace-mode";
+
+describe("shouldRedirectFromWorkspace", () => {
+  it("redirects only when workspace mode is explicitly false", () => {
+    expect(shouldRedirectFromWorkspace(false)).toBe(true);
+    expect(shouldRedirectFromWorkspace(true)).toBe(false);
+    expect(shouldRedirectFromWorkspace(null)).toBe(false);
+  });
+});

--- a/packages/web/src/lib/workspace-mode.ts
+++ b/packages/web/src/lib/workspace-mode.ts
@@ -1,0 +1,3 @@
+export function shouldRedirectFromWorkspace(isWorkspace: boolean | null): boolean {
+  return isWorkspace === false;
+}

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
## Summary
- prevent workspace subroutes from redirecting away when the workspace API is temporarily unavailable
- use uncached workspace mode checks for the root and workspace layout redirect decisions
- add web Vitest coverage so the redirect behavior is pinned in future runs

Fixes #431

## Testing
- npm run test --workspace packages/web
- npm test
- npm run lint
- npm run type-check
- git diff --check

## Notes
- uv run pytest tests/unit/ was attempted, but the full unit suite timed out locally after the uv environment was created.