### PR TITLE
fix(mcp): use shared database engine factory

### DIFF
--- a/packages/core/src/repowise/core/workspace/registry.py
+++ b/packages/core/src/repowise/core/workspace/registry.py
@@ -160,11 +160,9 @@ class RepoRegistry:
         from sqlalchemy.ext.asyncio import (
             async_sessionmaker as _async_sessionmaker,
         )
-        from sqlalchemy.ext.asyncio import (
-            create_async_engine,
-        )
 
         from repowise.core.persistence.database import (
+            create_engine,
             get_db_url,
             init_db,
         )
@@ -174,10 +172,7 @@ class RepoRegistry:
 
         db_url = get_db_url(f"sqlite:///{db_path.as_posix()}")
 
-        engine = create_async_engine(
-            db_url,
-            connect_args={"check_same_thread": False},
-        )
+        engine = create_engine(db_url)
         await init_db(engine)
 
         session_factory = _async_sessionmaker(

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -9,9 +9,10 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from repowise.core.persistence.database import (
+    create_engine,
     get_configured_db_url,
     get_repo_db_path,
     init_db,
@@ -334,12 +335,8 @@ async def _lifespan(server: FastMCP):
 
     db_url = resolve_db_url(_state._repo_path)
 
-    connect_args: dict = {}
-    if db_url.startswith("sqlite"):
-        connect_args["check_same_thread"] = False
-
     _log.info("repowise MCP: initialising database…")
-    engine = create_async_engine(db_url, connect_args=connect_args)
+    engine = create_engine(db_url)
     await init_db(engine)
 
     _state._session_factory = async_sessionmaker(

--- a/tests/unit/server/mcp/test_config.py
+++ b/tests/unit/server/mcp/test_config.py
@@ -75,13 +75,13 @@ async def test_mcp_lifespan_uses_cli_database_env_var(monkeypatch):
     async def fake_load_vector_stores(repo_path: str | None) -> None:
         return None
 
-    def fake_create_async_engine(url: str, connect_args: dict | None = None) -> DummyEngine:
+    def fake_create_engine(url: str) -> DummyEngine:
         captured["url"] = url
         return DummyEngine()
 
     monkeypatch.setenv("REPOWISE_DB_URL", "sqlite+aiosqlite:///tmp/from-cli.db")
     monkeypatch.delenv("REPOWISE_DATABASE_URL", raising=False)
-    monkeypatch.setattr(mcp_server, "create_async_engine", fake_create_async_engine)
+    monkeypatch.setattr(mcp_server, "create_engine", fake_create_engine)
     monkeypatch.setattr(mcp_server, "init_db", fake_init_db)
     monkeypatch.setattr(mcp_server, "FullTextSearch", DummyFts)
     monkeypatch.setattr(mcp_server, "InMemoryVectorStore", DummyVectorStore)

--- a/tests/unit/server/test_mcp_database_pragmas.py
+++ b/tests/unit/server/test_mcp_database_pragmas.py
@@ -1,0 +1,67 @@
+"""MCP database engines must use the shared persistence factory.
+
+The core factory installs SQLite WAL and busy_timeout pragmas. Issue #88
+called out that MCP startup paths were bypassing that factory with raw
+``create_async_engine`` calls, so these tests exercise the MCP-specific paths
+and inspect the live connection pragmas.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import text
+
+from repowise.core.workspace.config import RepoEntry, WorkspaceConfig
+from repowise.core.workspace.registry import RepoRegistry
+
+
+async def _read_pragma(session_factory: Any, pragma: str) -> str:
+    async with session_factory() as session:
+        result = await session.execute(text(f"PRAGMA {pragma}"))
+        row = result.fetchone()
+        return str(row[0]) if row is not None else ""
+
+
+@pytest.mark.asyncio
+async def test_single_repo_mcp_engine_uses_sqlite_pragmas(tmp_path: Path) -> None:
+    from repowise.server.mcp_server import _server, _state
+
+    repo_path = tmp_path / "repo"
+    (repo_path / ".repowise").mkdir(parents=True)
+
+    _state._repo_path = str(repo_path)
+    try:
+        async with _server._lifespan(_server.mcp):
+            assert _state._session_factory is not None
+            assert (await _read_pragma(_state._session_factory, "journal_mode")).lower() == "wal"
+            assert int(await _read_pragma(_state._session_factory, "busy_timeout")) >= 1000
+    finally:
+        _state._repo_path = None
+        _state._session_factory = None
+        _state._fts = None
+        _state._vector_store = None
+        _state._decision_store = None
+        _state._vector_store_ready = None
+
+
+@pytest.mark.asyncio
+async def test_workspace_registry_engine_uses_sqlite_pragmas(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    repo_path = workspace_root / "api"
+    (repo_path / ".repowise").mkdir(parents=True)
+
+    ws_config = WorkspaceConfig(
+        repos=[RepoEntry(path="api", alias="api", is_primary=True)],
+        default_repo="api",
+    )
+    registry = RepoRegistry(workspace_root=workspace_root, ws_config=ws_config)
+
+    try:
+        ctx = await registry.get("api")
+        assert (await _read_pragma(ctx.session_factory, "journal_mode")).lower() == "wal"
+        assert int(await _read_pragma(ctx.session_factory, "busy_timeout")) >= 1000
+    finally:
+        await registry.close()


### PR DESCRIPTION
## Summary
- route single-repo MCP startup through the shared persistence create_engine() factory
- route workspace RepoRegistry per-repo contexts through the same factory
- add MCP-specific regression tests that verify SQLite WAL and usy_timeout pragmas are active

## Context
Issue #88 called out that MCP DB setup bypassed the shared engine factory, so MCP paths could miss the SQLite WAL / usy_timeout behavior used elsewhere in Repowise.

## Verification
- uv run pytest tests/unit/server/test_mcp_database_pragmas.py tests/unit/persistence/test_database_pragmas.py tests/unit/server/test_mcp_workspace.py
- uv run ruff check packages/server/src/repowise/server/mcp_server/_server.py packages/core/src/repowise/core/workspace/registry.py tests/unit/server/test_mcp_database_pragmas.py --ignore SIM105

Note: plain Ruff still reports a pre-existing unrelated SIM105 in egistry.py; this PR leaves it untouched.