### PR TITLE
feat(mcp): add streamable HTTP transport

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -574,12 +574,13 @@ If `PATH` is omitted, `repowise mcp` first walks upward from the current directo
 
 | Flag | Description |
 |------|-------------|
-| `--transport` | `stdio` (default, for editors) or `sse` (for web clients) |
-| `--port` | Port for SSE transport (default: 7338) |
+| `--transport` | `stdio` (default, for editors), `streamable-http` (for HTTP clients), or `sse` (legacy) |
+| `--port` | Port for HTTP/SSE transports (default: 7338) |
 
 ```bash
 repowise mcp --transport stdio           # for Claude Code, Codex, Cursor, etc.
-repowise mcp --transport sse --port 7338 # for web clients
+repowise mcp --transport streamable-http # for HTTP clients
+repowise mcp --transport sse --port 7338 # legacy SSE
 ```
 
 See [MCP Tools](MCP_TOOLS.md) for all 9 exposed tools.

--- a/docs/COMPUTED_GLOSSARY.md
+++ b/docs/COMPUTED_GLOSSARY.md
@@ -353,7 +353,7 @@ workspace overlays, MCP responses, and CLI output.
 | `repowise generate-claude-md` | Editor-file data and rendered `.claude/CLAUDE.md`. | `hotspots`, `key_modules`, `decisions` in markdown |
 | `repowise augment` | Hook-time graph/search enrichment for AI tool calls. | Related files, symbols, importers, dependencies |
 | `repowise distill` / `expand` / `saved` | Compact errors-first command output with reversible omission markers, marker restoration, and the savings ledger rollup ([DISTILL.md](DISTILL.md)). | `[repowise#a1b2c3d4e5f6: 230 lines omitted (~6.1k tokens); ...]` |
-| `repowise mcp` | FastMCP server exposing the computed graph/wiki/risk tools below. | stdio or SSE transport |
+| `repowise mcp` | FastMCP server exposing the computed graph/wiki/risk tools below. | stdio, streamable HTTP, or SSE transport |
 
 ## MCP And API-Visible Computed Payloads
 

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -6,7 +6,8 @@ repowise exposes 9 tools via the [Model Context Protocol](https://modelcontextpr
 
 ```bash
 repowise mcp --transport stdio           # for Claude Code, Codex, Cursor, etc.
-repowise mcp --transport sse --port 7338 # for web clients
+repowise mcp --transport streamable-http # for HTTP clients on port 7338
+repowise mcp --transport sse --port 7338 # legacy SSE transport
 ```
 
 **Auto-setup:** `repowise init` automatically registers the MCP server and installs proactive hooks for Claude Code. `repowise init --codex` writes project-local Codex MCP config and hooks.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -372,8 +372,8 @@ This is how you connect repowise to Claude Code, Cursor, Cline, Windsurf, and ot
 
 | Flag | Description |
 |------|-------------|
-| `--transport` | Protocol: `stdio` (default, for editors) or `sse` (for web clients) |
-| `--port` | Port for SSE transport (default: 7338) |
+| `--transport` | Protocol: `stdio` (default, for editors), `streamable-http` (for HTTP clients), or `sse` (legacy) |
+| `--port` | Port for HTTP/SSE transports (default: 7338) |
 
 **MCP tools exposed (9 tools):**
 
@@ -846,13 +846,13 @@ Add an MCP server entry pointing to:
 }
 ```
 
-### Web-based MCP clients
+### HTTP MCP clients
 
 ```bash
-repowise mcp /path/to/your-repo --transport sse --port 7338
+repowise mcp /path/to/your-repo --transport streamable-http --port 7338
 ```
 
-Connect to `http://localhost:7338/sse`.
+Connect to `http://localhost:7338/mcp`.
 
 ### What AI editors can do with MCP
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -322,8 +322,8 @@ repowise mcp [PATH] [OPTIONS]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--transport` | `stdio` | Transport protocol: `stdio` (editors) or `sse` (web clients) |
-| `--port` | `7338` | Port for SSE transport |
+| `--transport` | `stdio` | Transport protocol: `stdio` (editors), `streamable-http` (HTTP clients), or `sse` (legacy) |
+| `--port` | `7338` | Port for HTTP/SSE transports |
 
 ```bash
 # stdio transport, current directory (typical editor integration)
@@ -332,7 +332,10 @@ repowise mcp
 # Specific repository path
 repowise mcp /path/to/repo
 
-# SSE transport for web clients
+# Streamable HTTP transport for HTTP clients
+repowise mcp --transport streamable-http
+
+# Legacy SSE transport
 repowise mcp --transport sse
 ```
 

--- a/packages/cli/src/repowise/cli/commands/mcp_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/mcp_cmd.py
@@ -14,21 +14,25 @@ from repowise.cli.ui import load_dotenv
 @click.argument("path", required=False, default=None)
 @click.option(
     "--transport",
-    type=click.Choice(["stdio", "sse"]),
+    type=click.Choice(["stdio", "sse", "streamable-http"]),
     default="stdio",
-    help="Transport protocol: stdio (Claude Code/Codex/Cursor) or sse (web clients).",
+    help=(
+        "Transport protocol: stdio (Claude Code/Codex/Cursor), "
+        "streamable-http (HTTP clients), or sse (legacy web clients)."
+    ),
 )
 @click.option(
     "--port",
     type=int,
     default=7338,
-    help="Port for SSE transport (default: 7338).",
+    help="Port for HTTP/SSE transports (default: 7338).",
 )
 def mcp_command(path: str | None, transport: str, port: int) -> None:
     """Start the MCP server for editor integration.
 
     Exposes 16 tools for querying the repowise wiki via the MCP protocol.
-    Supports both stdio (for Claude Code, Codex, Cursor, Cline) and SSE transports.
+    Supports stdio (for Claude Code, Codex, Cursor, Cline), streamable HTTP,
+    and legacy SSE transports.
 
     Loads ``<repo>/.repowise/.env`` into the environment before starting so
     that MCP tools (e.g. ``get_answer``) can resolve the configured LLM
@@ -38,6 +42,7 @@ def mcp_command(path: str | None, transport: str, port: int) -> None:
 
         repowise mcp                     # stdio, current directory
         repowise mcp /path/to/repo       # stdio, specific repo
+        repowise mcp --transport streamable-http  # HTTP on port 7338
         repowise mcp --transport sse     # SSE on port 7338
     """
     if path is None:
@@ -56,6 +61,11 @@ def mcp_command(path: str | None, transport: str, port: int) -> None:
     if transport == "sse":
         console.print(
             f"[bold green]Starting repowise MCP server (SSE) on port {port}...[/bold green]"
+        )
+    elif transport == "streamable-http":
+        console.print(
+            "[bold green]Starting repowise MCP server (streamable HTTP) "
+            f"at http://127.0.0.1:{port}/mcp...[/bold green]"
         )
     else:
         # stdio mode — no console output (it would corrupt the protocol)

--- a/packages/cli/src/repowise/cli/mcp_config.py
+++ b/packages/cli/src/repowise/cli/mcp_config.py
@@ -465,6 +465,7 @@ Cline (cline_mcp_settings.json):
 
 Or run directly:
   repowise mcp {abs_path}
+  repowise mcp {abs_path} --transport streamable-http --port 7338
   repowise mcp {abs_path} --transport sse --port 7338
 
 Config saved to: {repo_path / ".repowise" / "mcp.json"}

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -236,7 +236,8 @@ repowise exposes 16 MCP tools for AI coding assistants. Start the MCP server via
 
 ```bash
 repowise mcp                          # stdio transport (Claude Code, Cursor, Cline)
-repowise mcp --transport sse          # SSE transport on port 7338
+repowise mcp --transport streamable-http  # HTTP transport on port 7338
+repowise mcp --transport sse          # legacy SSE transport on port 7338
 ```
 
 | Tool | What It Answers | When to Call |

--- a/packages/server/src/repowise/server/mcp_server/__init__.py
+++ b/packages/server/src/repowise/server/mcp_server/__init__.py
@@ -1,12 +1,13 @@
 """repowise MCP Server — 9 tools for AI coding assistants.
 
 Exposes the full repowise wiki as queryable tools via the MCP protocol.
-Supports both stdio transport (Claude Code, Cursor, Cline) and SSE transport
-(web-based MCP clients).
+Supports stdio transport (Claude Code, Cursor, Cline), streamable HTTP, and
+legacy SSE transport.
 
 Usage:
     repowise mcp --transport stdio  # for Claude Code / Cursor / Cline
-    repowise mcp --transport sse    # for web-based clients
+    repowise mcp --transport streamable-http  # for HTTP clients
+    repowise mcp --transport sse    # for legacy SSE clients
 """
 
 from __future__ import annotations

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -411,6 +411,9 @@ def run_mcp(
     if transport == "sse":
         mcp.settings.port = port
         mcp.run(transport="sse")
+    elif transport == "streamable-http":
+        mcp.settings.port = port
+        mcp.run(transport="streamable-http")
     else:
         # stdio servers are spawned per-session by the MCP client; when the
         # client dies abnormally the stdio loop doesn't exit (and Windows

--- a/tests/unit/cli/test_mcp_transport.py
+++ b/tests/unit/cli/test_mcp_transport.py
@@ -1,0 +1,102 @@
+"""MCP transport CLI and server dispatch tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from repowise.cli.main import cli
+
+
+def test_mcp_help_lists_streamable_http_transport() -> None:
+    result = CliRunner().invoke(cli, ["mcp", "--help"])
+
+    assert result.exit_code == 0
+    assert "streamable-http" in result.output
+    assert "HTTP/SSE" in result.output
+
+
+def test_mcp_cli_accepts_streamable_http_transport(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".repowise").mkdir()
+    captured: dict[str, object] = {}
+
+    def fake_run_mcp(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("repowise.server.mcp_server.run_mcp", fake_run_mcp)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "mcp",
+            str(tmp_path),
+            "--transport",
+            "streamable-http",
+            "--port",
+            "7339",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "streamable HTTP" in result.output
+    assert captured == {
+        "transport": "streamable-http",
+        "repo_path": str(tmp_path.resolve()),
+        "port": 7339,
+    }
+
+
+def test_run_mcp_dispatches_streamable_http(monkeypatch) -> None:
+    from repowise.server.mcp_server import _server
+
+    calls: list[dict[str, str]] = []
+    watchdog_started = False
+
+    def fake_run(**kwargs):
+        calls.append(kwargs)
+
+    def fake_watchdog():
+        nonlocal watchdog_started
+        watchdog_started = True
+
+    monkeypatch.setattr(_server.mcp, "run", fake_run)
+    monkeypatch.setattr(
+        "repowise.server.mcp_server._watchdog.start_parent_watchdog",
+        fake_watchdog,
+    )
+
+    _server.run_mcp(transport="streamable-http", repo_path="/tmp/repo", port=7340)
+
+    assert _server.mcp.settings.port == 7340
+    assert calls == [{"transport": "streamable-http"}]
+    assert watchdog_started is False
+
+
+def test_run_mcp_keeps_existing_stdio_and_sse_dispatch(monkeypatch) -> None:
+    from repowise.server.mcp_server import _server
+
+    calls: list[dict[str, str]] = []
+    watchdog_calls = 0
+
+    def fake_run(**kwargs):
+        calls.append(kwargs)
+
+    def fake_watchdog():
+        nonlocal watchdog_calls
+        watchdog_calls += 1
+
+    monkeypatch.setattr(_server.mcp, "run", fake_run)
+    monkeypatch.setattr(
+        "repowise.server.mcp_server._watchdog.start_parent_watchdog",
+        fake_watchdog,
+    )
+
+    _server.run_mcp(transport="sse", port=7338)
+    _server.run_mcp(transport="stdio", port=9999)
+
+    assert calls == [{"transport": "sse"}, {"transport": "stdio"}]
+    assert watchdog_calls == 1

--- a/website/cli-reference.md
+++ b/website/cli-reference.md
@@ -186,14 +186,15 @@ repowise mcp [PATH] [OPTIONS]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--transport` | choice | stdio | `stdio` (for editors) or `sse` (for web clients) |
-| `--port` | int | 7338 | Port for SSE transport |
+| `--transport` | choice | stdio | `stdio` (for editors), `streamable-http` (for HTTP clients), or `sse` (legacy) |
+| `--port` | int | 7338 | Port for HTTP/SSE transports |
 
 ### Examples
 
 ```bash
 repowise mcp                              # stdio (Claude Code, Cursor, Cline)
-repowise mcp --transport sse --port 7338  # SSE for web clients
+repowise mcp --transport streamable-http  # HTTP on port 7338
+repowise mcp --transport sse --port 7338  # legacy SSE
 ```
 
 See [MCP Server →](mcp-server) for editor-specific configuration.

--- a/website/mcp-server.md
+++ b/website/mcp-server.md
@@ -146,16 +146,27 @@ repowise mcp /path/to/repo           # stdio, specific repo
 repowise mcp --transport stdio       # explicit
 ```
 
-### SSE (Server-Sent Events)
+### Streamable HTTP
 
-For web-based MCP clients or headless setups where a persistent HTTP server is preferable.
+For HTTP-based MCP clients or headless setups where a persistent local server is preferable.
+
+```bash
+repowise mcp --transport streamable-http              # HTTP on port 7338
+repowise mcp --transport streamable-http --port 8080  # Custom port
+```
+
+Clients connect to `http://localhost:7338/mcp`.
+
+### SSE (Server-Sent Events, legacy)
+
+For clients that still require the older SSE transport.
 
 ```bash
 repowise mcp --transport sse              # SSE on port 7338
 repowise mcp --transport sse --port 8080  # Custom port
 ```
 
-Clients connect to `http://localhost:7338/sse` and receive server-sent events. Configure with `REPOWISE_MCP_PORT` env var or `mcp.settings.port` in `.repowise/mcp.json`.
+Clients connect to `http://localhost:7338/sse` and receive server-sent events.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `streamable-http` as a supported `repowise mcp --transport` value
- dispatch streamable HTTP through FastMCP and apply `--port` to the HTTP server
- keep stdio as the default and retain SSE as a legacy transport
- update MCP docs/help text and generated setup guidance

## Context
Issue #88 called out moving away from SSE toward HTTP as a focused contribution separate from the larger multi-tenant MCP architecture work.

FastMCP in the pinned SDK supports `streamable-http` directly, so this PR does not require an SDK version bump.

## Verification
- `uv run pytest tests/unit/cli/test_mcp_transport.py tests/unit/cli/test_mcp_config.py tests/unit/cli/test_commands.py::TestStubs::test_mcp_help`
- `uv run ruff check packages/cli/src/repowise/cli/commands/mcp_cmd.py packages/server/src/repowise/server/mcp_server/_server.py packages/server/src/repowise/server/mcp_server/__init__.py packages/cli/src/repowise/cli/mcp_config.py tests/unit/cli/test_mcp_transport.py`