### PR TITLE
feat(mcp): improve workspace HTTP discovery

### DIFF
--- a/packages/cli/src/repowise/cli/commands/mcp_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/mcp_cmd.py
@@ -8,6 +8,63 @@ import click
 
 from repowise.cli.helpers import console, find_repowise_repo_root, resolve_repo_path
 from repowise.cli.ui import load_dotenv
+from repowise.core.workspace.config import WorkspaceConfig, find_workspace_root
+
+
+def _workspace_summary(path: Path) -> dict[str, object] | None:
+    workspace_root = find_workspace_root(path)
+    if workspace_root is None:
+        return None
+
+    try:
+        ws_config = WorkspaceConfig.load(workspace_root)
+    except Exception:
+        return None
+
+    aliases = ws_config.repo_aliases()
+    default = ws_config.get_primary()
+    default_alias = default.alias if default else (aliases[0] if aliases else None)
+    resolved_path = path.resolve()
+
+    for entry in ws_config.repos:
+        entry_path = (workspace_root / entry.path).resolve()
+        try:
+            resolved_path.relative_to(entry_path)
+        except ValueError:
+            continue
+        default_alias = entry.alias
+        break
+
+    return {
+        "workspace_root": workspace_root,
+        "default_repo": default_alias,
+        "aliases": aliases,
+    }
+
+
+def _print_network_startup(
+    transport: str,
+    repo_path: Path,
+    port: int,
+    workspace: dict[str, object] | None,
+) -> None:
+    label = "streamable HTTP" if transport == "streamable-http" else "SSE"
+    endpoint = "mcp" if transport == "streamable-http" else "sse"
+    console.print(
+        f"[bold green]Starting repowise MCP server ({label})[/bold green]\n"
+        f"URL: http://127.0.0.1:{port}/{endpoint}"
+    )
+
+    if workspace is not None:
+        aliases = workspace["aliases"]
+        repo_list = ", ".join(aliases) if isinstance(aliases, list) else ""
+        console.print(
+            f"Workspace: {workspace['workspace_root']}\n"
+            f"Default repo: {workspace['default_repo'] or 'none'}\n"
+            f"Repos: {repo_list or 'none'}"
+        )
+    else:
+        console.print(f"Repo: {repo_path}")
 
 
 @click.command("mcp")
@@ -30,7 +87,7 @@ from repowise.cli.ui import load_dotenv
 def mcp_command(path: str | None, transport: str, port: int) -> None:
     """Start the MCP server for editor integration.
 
-    Exposes 16 tools for querying the repowise wiki via the MCP protocol.
+    Exposes 17 tools for querying the repowise wiki via the MCP protocol.
     Supports stdio (for Claude Code, Codex, Cursor, Cline), streamable HTTP,
     and legacy SSE transports.
 
@@ -51,22 +108,16 @@ def mcp_command(path: str | None, transport: str, port: int) -> None:
         repo_path = resolve_repo_path(path)
     load_dotenv(repo_path)
 
+    workspace = _workspace_summary(repo_path)
     repowise_dir = repo_path / ".repowise"
-    if not repowise_dir.exists():
+    if workspace is None and not repowise_dir.exists():
         console.print(
             f"[yellow]Warning: No .repowise directory found at {repo_path}.[/yellow]\n"
             "Run 'repowise init' first to generate documentation."
         )
 
-    if transport == "sse":
-        console.print(
-            f"[bold green]Starting repowise MCP server (SSE) on port {port}...[/bold green]"
-        )
-    elif transport == "streamable-http":
-        console.print(
-            "[bold green]Starting repowise MCP server (streamable HTTP) "
-            f"at http://127.0.0.1:{port}/mcp...[/bold green]"
-        )
+    if transport in {"sse", "streamable-http"}:
+        _print_network_startup(transport, repo_path, port, workspace)
     else:
         # stdio mode — no console output (it would corrupt the protocol)
         pass

--- a/packages/core/src/repowise/core/workspace/registry.py
+++ b/packages/core/src/repowise/core/workspace/registry.py
@@ -160,11 +160,9 @@ class RepoRegistry:
         from sqlalchemy.ext.asyncio import (
             async_sessionmaker as _async_sessionmaker,
         )
-        from sqlalchemy.ext.asyncio import (
-            create_async_engine,
-        )
 
         from repowise.core.persistence.database import (
+            create_engine,
             get_db_url,
             init_db,
         )
@@ -174,10 +172,7 @@ class RepoRegistry:
 
         db_url = get_db_url(f"sqlite:///{db_path.as_posix()}")
 
-        engine = create_async_engine(
-            db_url,
-            connect_args={"check_same_thread": False},
-        )
+        engine = create_engine(db_url)
         await init_db(engine)
 
         session_factory = _async_sessionmaker(

--- a/packages/server/src/repowise/server/mcp_server/__init__.py
+++ b/packages/server/src/repowise/server/mcp_server/__init__.py
@@ -1,4 +1,4 @@
-"""repowise MCP Server — 9 tools for AI coding assistants.
+"""repowise MCP Server — 17 tools for AI coding assistants.
 
 Exposes the full repowise wiki as queryable tools via the MCP protocol.
 Supports stdio transport (Claude Code, Cursor, Cline), streamable HTTP, and
@@ -42,6 +42,7 @@ from repowise.server.mcp_server.tool_context import get_context
 from repowise.server.mcp_server.tool_dead_code import get_dead_code
 from repowise.server.mcp_server.tool_health import get_health
 from repowise.server.mcp_server.tool_overview import get_overview
+from repowise.server.mcp_server.tool_repos import list_repos
 from repowise.server.mcp_server.tool_risk import get_risk
 from repowise.server.mcp_server.tool_search import search_codebase
 from repowise.server.mcp_server.tool_symbol import get_symbol
@@ -114,6 +115,7 @@ __all__ = [
     "get_risk",
     "get_symbol",
     "get_why",
+    "list_repos",
     "mcp",
     "run_mcp",
     "search_codebase",

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -9,9 +9,10 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from repowise.core.persistence.database import (
+    create_engine,
     get_configured_db_url,
     get_repo_db_path,
     init_db,
@@ -334,12 +335,8 @@ async def _lifespan(server: FastMCP):
 
     db_url = resolve_db_url(_state._repo_path)
 
-    connect_args: dict = {}
-    if db_url.startswith("sqlite"):
-        connect_args["check_same_thread"] = False
-
     _log.info("repowise MCP: initialising database…")
-    engine = create_async_engine(db_url, connect_args=connect_args)
+    engine = create_engine(db_url)
     await init_db(engine)
 
     _state._session_factory = async_sessionmaker(

--- a/packages/server/src/repowise/server/mcp_server/tool_repos.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_repos.py
@@ -1,0 +1,78 @@
+"""MCP tool: list_repos - discover repos served by this MCP server."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from repowise.core.registry import mcp_tool_registry as mcp
+from repowise.server.mcp_server import _state
+from repowise.server.mcp_server._meta import build_meta as _build_meta
+
+
+def _workspace_repos(registry: Any) -> list[dict[str, Any]]:
+    ws_config = getattr(registry, "ws_config", None)
+    default_alias = registry.get_default_alias()
+
+    if ws_config is None:
+        return [
+            {
+                "alias": alias,
+                "path": None,
+                "absolute_path": None,
+                "is_default": alias == default_alias,
+            }
+            for alias in registry.get_all_aliases()
+        ]
+
+    repos: list[dict[str, Any]] = []
+    for entry in ws_config.repos:
+        absolute_path = (registry.workspace_root / entry.path).resolve()
+        repos.append(
+            {
+                "alias": entry.alias,
+                "path": entry.path,
+                "absolute_path": absolute_path.as_posix(),
+                "is_default": entry.alias == default_alias,
+                "indexed_at": entry.indexed_at,
+                "last_commit_at_index": entry.last_commit_at_index,
+            }
+        )
+    return repos
+
+
+@mcp.tool()
+async def list_repos() -> dict[str, Any]:
+    """List repos available through this MCP server.
+
+    In workspace mode this returns every configured workspace repo alias. Use
+    those aliases as the ``repo`` parameter on workspace-aware tools.
+    """
+    registry = _state._registry
+    if registry is not None:
+        return {
+            "workspace": True,
+            "workspace_root": registry.workspace_root.as_posix(),
+            "default_repo": registry.get_default_alias(),
+            "repos": _workspace_repos(registry),
+            "hint": "Use repo='<alias>' on tools that accept a repo parameter.",
+            "_meta": _build_meta(),
+        }
+
+    return {
+        "workspace": False,
+        "workspace_root": None,
+        "default_repo": "default",
+        "repos": [
+            {
+                "alias": "default",
+                "path": str(_state._repo_path) if _state._repo_path else None,
+                "absolute_path": str(_state._repo_path) if _state._repo_path else None,
+                "is_default": True,
+            }
+        ],
+        "hint": "This MCP server is serving a single repo; omit repo unless a tool asks for it.",
+        "_meta": _build_meta(),
+    }
+
+
+__all__ = ["list_repos"]

--- a/tests/unit/cli/test_mcp_transport.py
+++ b/tests/unit/cli/test_mcp_transport.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from repowise.cli.main import cli
+from repowise.core.workspace.config import RepoEntry, WorkspaceConfig
 
 
 def test_mcp_help_lists_streamable_http_transport() -> None:
@@ -47,6 +48,56 @@ def test_mcp_cli_accepts_streamable_http_transport(
         "transport": "streamable-http",
         "repo_path": str(tmp_path.resolve()),
         "port": 7339,
+    }
+
+
+def test_mcp_cli_streamable_http_prints_workspace_summary(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    api = workspace / "services" / "api"
+    web = workspace / "apps" / "web"
+    api.mkdir(parents=True)
+    web.mkdir(parents=True)
+    WorkspaceConfig(
+        repos=[
+            RepoEntry(path="services/api", alias="api", is_primary=True),
+            RepoEntry(path="apps/web", alias="web"),
+        ],
+        default_repo="api",
+    ).save(workspace)
+
+    captured: dict[str, object] = {}
+
+    def fake_run_mcp(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("repowise.server.mcp_server.run_mcp", fake_run_mcp)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "mcp",
+            str(workspace),
+            "--transport",
+            "streamable-http",
+            "--port",
+            "7341",
+        ],
+    )
+
+    assert result.exit_code == 0
+    output = result.output.replace("\n", "")
+    assert "URL: http://127.0.0.1:7341/mcp" in result.output
+    assert f"Workspace: {workspace.resolve()}" in output
+    assert "Default repo: api" in result.output
+    assert "Repos: api, web" in result.output
+    assert "Warning: No .repowise directory" not in result.output
+    assert captured == {
+        "transport": "streamable-http",
+        "repo_path": str(workspace.resolve()),
+        "port": 7341,
     }
 
 

--- a/tests/unit/server/mcp/test_config.py
+++ b/tests/unit/server/mcp/test_config.py
@@ -75,13 +75,13 @@ async def test_mcp_lifespan_uses_cli_database_env_var(monkeypatch):
     async def fake_load_vector_stores(repo_path: str | None) -> None:
         return None
 
-    def fake_create_async_engine(url: str, connect_args: dict | None = None) -> DummyEngine:
+    def fake_create_engine(url: str) -> DummyEngine:
         captured["url"] = url
         return DummyEngine()
 
     monkeypatch.setenv("REPOWISE_DB_URL", "sqlite+aiosqlite:///tmp/from-cli.db")
     monkeypatch.delenv("REPOWISE_DATABASE_URL", raising=False)
-    monkeypatch.setattr(mcp_server, "create_async_engine", fake_create_async_engine)
+    monkeypatch.setattr(mcp_server, "create_engine", fake_create_engine)
     monkeypatch.setattr(mcp_server, "init_db", fake_init_db)
     monkeypatch.setattr(mcp_server, "FullTextSearch", DummyFts)
     monkeypatch.setattr(mcp_server, "InMemoryVectorStore", DummyVectorStore)

--- a/tests/unit/server/test_mcp_database_pragmas.py
+++ b/tests/unit/server/test_mcp_database_pragmas.py
@@ -1,0 +1,67 @@
+"""MCP database engines must use the shared persistence factory.
+
+The core factory installs SQLite WAL and busy_timeout pragmas. Issue #88
+called out that MCP startup paths were bypassing that factory with raw
+``create_async_engine`` calls, so these tests exercise the MCP-specific paths
+and inspect the live connection pragmas.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import text
+
+from repowise.core.workspace.config import RepoEntry, WorkspaceConfig
+from repowise.core.workspace.registry import RepoRegistry
+
+
+async def _read_pragma(session_factory: Any, pragma: str) -> str:
+    async with session_factory() as session:
+        result = await session.execute(text(f"PRAGMA {pragma}"))
+        row = result.fetchone()
+        return str(row[0]) if row is not None else ""
+
+
+@pytest.mark.asyncio
+async def test_single_repo_mcp_engine_uses_sqlite_pragmas(tmp_path: Path) -> None:
+    from repowise.server.mcp_server import _server, _state
+
+    repo_path = tmp_path / "repo"
+    (repo_path / ".repowise").mkdir(parents=True)
+
+    _state._repo_path = str(repo_path)
+    try:
+        async with _server._lifespan(_server.mcp):
+            assert _state._session_factory is not None
+            assert (await _read_pragma(_state._session_factory, "journal_mode")).lower() == "wal"
+            assert int(await _read_pragma(_state._session_factory, "busy_timeout")) >= 1000
+    finally:
+        _state._repo_path = None
+        _state._session_factory = None
+        _state._fts = None
+        _state._vector_store = None
+        _state._decision_store = None
+        _state._vector_store_ready = None
+
+
+@pytest.mark.asyncio
+async def test_workspace_registry_engine_uses_sqlite_pragmas(tmp_path: Path) -> None:
+    workspace_root = tmp_path / "workspace"
+    repo_path = workspace_root / "api"
+    (repo_path / ".repowise").mkdir(parents=True)
+
+    ws_config = WorkspaceConfig(
+        repos=[RepoEntry(path="api", alias="api", is_primary=True)],
+        default_repo="api",
+    )
+    registry = RepoRegistry(workspace_root=workspace_root, ws_config=ws_config)
+
+    try:
+        ctx = await registry.get("api")
+        assert (await _read_pragma(ctx.session_factory, "journal_mode")).lower() == "wal"
+        assert int(await _read_pragma(ctx.session_factory, "busy_timeout")) >= 1000
+    finally:
+        await registry.close()

--- a/tests/unit/server/test_mcp_workspace.py
+++ b/tests/unit/server/test_mcp_workspace.py
@@ -25,7 +25,7 @@ from repowise.core.persistence.models import (
 from repowise.core.persistence.search import FullTextSearch
 from repowise.core.persistence.vector_store import InMemoryVectorStore
 from repowise.core.providers.embedding.base import MockEmbedder
-from repowise.core.workspace.registry import RepoContext, RepoRegistry
+from repowise.core.workspace.registry import RepoContext
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -601,3 +601,45 @@ async def test_overview_all_includes_cross_repo_topology(workspace_mcp_with_enri
     result = await get_overview(repo="all")
     assert "cross_repo_topology" in result
     assert result["cross_repo_topology"]["co_change_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_list_repos_discovers_workspace_aliases(workspace_mcp):
+    from repowise.server.mcp_server import list_repos
+
+    result = await list_repos()
+
+    assert result["workspace"] is True
+    assert result["workspace_root"] == "/tmp/workspace"
+    assert result["default_repo"] == "backend"
+    assert [repo["alias"] for repo in result["repos"]] == ["backend", "frontend"]
+    assert result["repos"][0]["is_default"] is True
+    assert "repo='<alias>'" in result["hint"]
+
+
+@pytest.mark.asyncio
+async def test_list_repos_single_repo_mode():
+    import repowise.server.mcp_server as mcp_mod
+    from repowise.server.mcp_server import list_repos
+
+    original_registry = mcp_mod._registry
+    original_repo_path = mcp_mod._repo_path
+    mcp_mod._registry = None
+    mcp_mod._repo_path = "/tmp/solo"
+
+    try:
+        result = await list_repos()
+    finally:
+        mcp_mod._registry = original_registry
+        mcp_mod._repo_path = original_repo_path
+
+    assert result["workspace"] is False
+    assert result["default_repo"] == "default"
+    assert result["repos"] == [
+        {
+            "alias": "default",
+            "path": "/tmp/solo",
+            "absolute_path": "/tmp/solo",
+            "is_default": True,
+        }
+    ]


### PR DESCRIPTION
## Summary
- print workspace-aware startup details for streamable HTTP/SSE MCP servers, including URL, workspace root, default repo, and repo aliases
- add a list_repos MCP tool so Claude/Codex can discover workspace repo aliases before calling repo-aware tools
- keep stdio quiet and preserve existing transport dispatch behavior

## Context
Refs #88.

This is intended as the next UX layer on top of the merged streamable HTTP transport work (#444). The branch currently includes the PR #443 database engine commits because that PR is expected to merge soon; I can rebase this branch after #443 lands.

## Verification
- uv run ruff check packages/cli/src/repowise/cli/commands/mcp_cmd.py packages/server/src/repowise/server/mcp_server/__init__.py packages/server/src/repowise/server/mcp_server/tool_repos.py tests/unit/cli/test_mcp_transport.py tests/unit/server/test_mcp_workspace.py
- uv run pytest tests/unit/cli/test_mcp_transport.py tests/unit/server/test_mcp_workspace.py tests/unit/server/mcp/test_config.py tests/unit/server/test_mcp_database_pragmas.py

## Callout
@RaghavChamadiya one thing I found while reviewing this: when MCP is started from a workspace root, the existing CLI behavior loads only <workspace>/.repowise/.env, not the default/child repo's .repowise/.env. This branch does not change that behavior, but the HTTP workspace flow makes it more visible for LLM-backed tools. Should I open a separate PR to resolve per-workspace/default-repo env loading?