### PR TITLE
perf: large-repo indexing pass (type refs, health, dynamic hints, dead code) + update-path fixes

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -795,6 +795,15 @@ def init_command(
     )
     register_editor_clients(console, repo_path)
 
+    # Inherit the workspace's distill rewrite-hook verdict NOW, before the
+    # config fingerprint below is computed. `repowise update` runs the same
+    # backfill at its start; if init leaves the verdict unwritten, the first
+    # update writes it, sees a fingerprint mismatch, and silently replaces
+    # the incremental path with a full health re-score of every file.
+    from repowise.cli.commands.workspace_cmd import inherit_workspace_distill_verdict
+
+    inherit_workspace_distill_verdict(repo_path)
+
     # ---- State (always) ----
     # Even in index-only mode we persist `last_sync_commit` so that a
     # subsequent `repowise update` (e.g. fired by the post-commit hook) has

--- a/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
@@ -339,6 +339,19 @@ def _never_flag_regex(patterns: tuple[str, ...]) -> re.Pattern[str]:
     return re.compile("|".join(fnmatch.translate(os.path.normcase(p)) for p in patterns))
 
 
+@lru_cache(maxsize=131072)
+def _never_flag_regex_match(path: str) -> bool:
+    """Memoized ``_never_flag_regex`` match for the default pattern set.
+
+    The alternation has ~540 branches, so one match costs tens of
+    microseconds, and the detector passes ask about the same node ids
+    repeatedly (every graph node is checked by both the unreachable-files
+    and unused-exports passes). Pure function of *path*: the pattern set is
+    a module constant, so process-wide memoization is sound.
+    """
+    return _never_flag_regex(_NEVER_FLAG_PATTERNS).match(os.path.normcase(path)) is not None
+
+
 class DeadCodeAnalyzer:
     """Detects unreachable files, unused exports, unused internals, and
     zombie packages using the dependency graph and git metadata.
@@ -1186,7 +1199,7 @@ class DeadCodeAnalyzer:
         """Return True if path should never be flagged as dead."""
         if path in whitelist:
             return True
-        if _never_flag_regex(_NEVER_FLAG_PATTERNS).match(os.path.normcase(path)):
+        if _never_flag_regex_match(path):
             return True
         # Workspace-driven never-flag — set by language warmups that read
         # the build manifest (Gradle non-``main`` source sets, Cargo

--- a/packages/core/src/repowise/core/analysis/health/engine.py
+++ b/packages/core/src/repowise/core/analysis/health/engine.py
@@ -219,11 +219,24 @@ def _build_repo_commit_counts(git_meta_map: dict[str, dict]) -> dict[str, int]:
     return out
 
 
-def _has_paired_test_file(rel_path: str, all_paths: set[str]) -> bool:
+def _path_basenames(all_paths: set[str]) -> set[str]:
+    """Final path components of *all_paths*, split on ``/`` only.
+
+    A path matches ``other.endswith("/" + c) or other == c`` for a
+    slash-free candidate filename ``c`` exactly when its ``/``-basename
+    equals ``c``, so one precomputed basename set answers every
+    ``_has_paired_test_file`` lookup. Splitting on ``/`` only (not ``\\``)
+    preserves that equivalence for any non-POSIX path that slips in.
+    """
+    return {p.rsplit("/", 1)[-1] for p in all_paths}
+
+
+def _has_paired_test_file(rel_path: str, path_basenames: set[str]) -> bool:
     """Heuristic: does any other file look like a test for *rel_path*?
 
     Cheap and conservative — looks for common test-file naming
-    conventions paired with the same basename.
+    conventions paired with the same basename. *path_basenames* is the
+    precomputed ``_path_basenames`` set for the analyzed file list.
     """
     p = Path(rel_path)
     stem = p.stem
@@ -241,9 +254,7 @@ def _has_paired_test_file(rel_path: str, all_paths: set[str]) -> bool:
         f"{stem}.spec.cts",
         f"{stem}_test.go",
     }
-    return any(
-        any(other.endswith("/" + c) or other == c for c in candidates) for other in all_paths
-    )
+    return not candidates.isdisjoint(path_basenames)
 
 
 class HealthAnalyzer:
@@ -301,7 +312,7 @@ class HealthAnalyzer:
         # PageRank is optional — graph_builder.symbol_pagerank exists but
         # is symbol-level; we use file-level in-degree as the dependents
         # signal (cheap, deterministic, conservative).
-        all_paths = {pf.file_info.path for pf in self.parsed_files}
+        path_basenames = _path_basenames({pf.file_info.path for pf in self.parsed_files})
         repo_commit_counts = _build_repo_commit_counts(self.git_meta_map)
         graph_view: HasEdge | None = _ImportEdgeView(self.graph) if self.graph is not None else None
 
@@ -364,7 +375,7 @@ class HealthAnalyzer:
             file_metric, file_findings = self._evaluate_file(
                 pf,
                 fcx,
-                all_paths,
+                path_basenames,
                 disabled=file_disabled,
                 dup_report=dup_report,
                 graph_view=graph_view,
@@ -422,7 +433,7 @@ class HealthAnalyzer:
         per_file_disabled: dict[str, set[str]] = cfg.get("per_file_disabled", {}) or {}
         changed_set: set[str] | None = set(changed_files) if changed_files is not None else None
 
-        all_paths = {pf.file_info.path for pf in self.parsed_files}
+        path_basenames = _path_basenames({pf.file_info.path for pf in self.parsed_files})
         repo_commit_counts = _build_repo_commit_counts(self.git_meta_map)
         graph_view: HasEdge | None = _ImportEdgeView(self.graph) if self.graph is not None else None
 
@@ -504,7 +515,7 @@ class HealthAnalyzer:
             file_metric, file_findings = self._evaluate_file(
                 pf,
                 fcx,
-                all_paths,
+                path_basenames,
                 disabled=file_disabled,
                 dup_report=dup_report,
                 graph_view=graph_view,
@@ -581,7 +592,7 @@ class HealthAnalyzer:
         self,
         pf: Any,
         fcx: FileComplexity,
-        all_paths: set[str],
+        path_basenames: set[str],
         *,
         disabled: list[str],
         dup_report: DuplicationReport,
@@ -627,7 +638,7 @@ class HealthAnalyzer:
             file_path=file_path,
             language=pf.file_info.language,
             nloc=nloc,
-            has_test_file=_has_paired_test_file(file_path, all_paths)
+            has_test_file=_has_paired_test_file(file_path, path_basenames)
             or _is_test_file(file_path)
             or _coverage_is_test_file(file_path),
             module=module,

--- a/packages/core/src/repowise/core/fs_walk.py
+++ b/packages/core/src/repowise/core/fs_walk.py
@@ -41,7 +41,7 @@ import structlog
 
 log = structlog.get_logger(__name__)
 
-__all__ = ["PRUNED_DIRS", "PRUNED_DIRS_DERIVED", "iter_glob", "walk_repo"]
+__all__ = ["PRUNED_DIRS", "PRUNED_DIRS_DERIVED", "WalkSnapshot", "iter_glob", "walk_repo"]
 
 # Directory basenames that can NEVER hold first-party source or manifests:
 # VCS metadata, package/venv caches, and tool caches. Pruned at every level
@@ -194,6 +194,83 @@ def _matches(rel_posix: str, basename: str, pattern: str) -> bool:
     if "/" not in pattern:
         return fnmatch.fnmatch(basename, pattern)
     return fnmatch.fnmatch(rel_posix, pattern) or fnmatch.fnmatch(rel_posix, "*/" + pattern)
+
+
+class WalkSnapshot:
+    """One pruned walk, replayed for many :func:`iter_glob`-style queries.
+
+    Callers that issue several ``iter_glob`` queries against the same tree
+    (the dynamic-hint extractors run ~40 of them) pay one filesystem walk
+    here and answer every query from memory. Replay preserves
+    :func:`iter_glob` semantics and yield order exactly: entries are stored
+    in walk order, files before directories per directory, and ``/``-tail
+    patterns match against paths relative to the *query* root.
+
+    Queries rooted below the snapshot root are served from the snapshot's
+    subtree (os.walk pre-order keeps a subtree's entries in the same
+    relative order a direct walk of that subtree would produce). A query
+    root outside the snapshot tree falls back to a live walk.
+    """
+
+    __slots__ = ("_entries", "_prune_dirs", "_prune_nested_git", "root")
+
+    def __init__(
+        self,
+        root: Path | str,
+        *,
+        prune_dirs: frozenset[str] = PRUNED_DIRS,
+        prune_nested_git: bool = True,
+    ) -> None:
+        self.root = Path(root)
+        self._prune_dirs = prune_dirs
+        self._prune_nested_git = prune_nested_git
+        # (dirpath, root-relative posix dir ('' for the root), dirnames, filenames)
+        self._entries: list[tuple[Path, str, list[str], list[str]]] = []
+        for dirpath, dirnames, filenames in walk_repo(
+            self.root, prune_dirs=prune_dirs, prune_nested_git=prune_nested_git
+        ):
+            rel = dirpath.relative_to(self.root).as_posix()
+            self._entries.append(
+                (dirpath, "" if rel == "." else rel, list(dirnames), list(filenames))
+            )
+
+    def iter_glob(self, root: Path | str, patterns: str | Iterable[str]) -> Iterator[Path]:
+        """Replay of ``iter_glob(root, patterns)`` against the snapshot."""
+        query_root = Path(root)
+        pats = (patterns,) if isinstance(patterns, str) else tuple(patterns)
+
+        sub_rel: str | None
+        if query_root == self.root:
+            sub_rel = None
+        else:
+            try:
+                sub_rel = query_root.relative_to(self.root).as_posix()
+            except ValueError:
+                # Outside the snapshot tree: serve live with the same pruning.
+                yield from iter_glob(
+                    query_root,
+                    pats,
+                    prune_dirs=self._prune_dirs,
+                    prune_nested_git=self._prune_nested_git,
+                )
+                return
+
+        for dirpath, rel_dir, dirnames, filenames in self._entries:
+            if sub_rel is None:
+                q_rel = rel_dir
+            elif rel_dir == sub_rel:
+                q_rel = ""
+            elif rel_dir.startswith(sub_rel + "/"):
+                q_rel = rel_dir[len(sub_rel) + 1 :]
+            else:
+                continue
+            prefix = "" if q_rel == "" else q_rel + "/"
+            for name in filenames:
+                if any(_matches(prefix + name, name, p) for p in pats):
+                    yield dirpath / name
+            for name in dirnames:
+                if any(_matches(prefix + name, name, p) for p in pats):
+                    yield dirpath / name
 
 
 def iter_glob(

--- a/packages/core/src/repowise/core/ingestion/dynamic_hints/base.py
+++ b/packages/core/src/repowise/core/ingestion/dynamic_hints/base.py
@@ -20,15 +20,24 @@ class DynamicEdge:
 class DynamicHintExtractor(ABC):
     name: str
 
+    # Shared walk snapshot, attached by HintRegistry.extract_all so the ~40
+    # _rglob queries the extractor fleet issues replay ONE filesystem walk
+    # instead of each walking the tree again. None -> live walk (direct
+    # extractor use in tests keeps working unchanged).
+    _walk_snapshot = None
+
     @abstractmethod
     def extract(self, repo_root: Path) -> list[DynamicEdge]: ...
 
-    @staticmethod
-    def _rglob(root: Path, pattern: str) -> Iterator[Path]:
+    def _rglob(self, root: Path, pattern: str) -> Iterator[Path]:
         """Pruned replacement for :py:meth:`pathlib.Path.rglob`.
 
         Skips ``node_modules``, ``.venv``, ``.next``, etc. so large
         polyrepos don't tank the dynamic-hints phase. See
-        :mod:`dynamic_hints._walk` for the full prune list.
+        :mod:`dynamic_hints._walk` for the full prune list. Served from
+        the registry's shared :class:`~repowise.core.fs_walk.WalkSnapshot`
+        when one is attached.
         """
+        if self._walk_snapshot is not None:
+            return self._walk_snapshot.iter_glob(root, pattern)
         return iter_glob(root, pattern)

--- a/packages/core/src/repowise/core/ingestion/dynamic_hints/registry.py
+++ b/packages/core/src/repowise/core/ingestion/dynamic_hints/registry.py
@@ -89,17 +89,38 @@ class HintRegistry:
         if not self._extractors:
             return edges
 
-        with ThreadPoolExecutor(max_workers=self._max_workers) as pool:
-            futures = {pool.submit(self._run_one, ex, repo_root): ex for ex in self._extractors}
-            for future in as_completed(futures):
-                ex = futures[future]
-                try:
-                    got = future.result()
-                except Exception as e:
-                    log.warning("dynamic_hints_failed", extractor=ex.name, error=str(e))
-                    continue
-                edges.extend(got)
-                log.debug("dynamic_hints", extractor=ex.name, count=len(got))
+        # One pruned walk shared by every extractor: the fleet issues ~40
+        # _rglob queries, and each used to re-walk the tree. Snapshot
+        # construction failure falls back to per-extractor live walks.
+        snapshot = None
+        try:
+            from repowise.core.fs_walk import WalkSnapshot
+
+            from ._walk import PRUNED_DIRS
+
+            snapshot = WalkSnapshot(repo_root, prune_dirs=PRUNED_DIRS)
+        except Exception as e:  # pragma: no cover - snapshot is best-effort
+            log.warning("dynamic_hints_snapshot_failed", error=str(e))
+        for ex in self._extractors:
+            ex._walk_snapshot = snapshot
+
+        try:
+            with ThreadPoolExecutor(max_workers=self._max_workers) as pool:
+                futures = {
+                    pool.submit(self._run_one, ex, repo_root): ex for ex in self._extractors
+                }
+                for future in as_completed(futures):
+                    ex = futures[future]
+                    try:
+                        got = future.result()
+                    except Exception as e:
+                        log.warning("dynamic_hints_failed", extractor=ex.name, error=str(e))
+                        continue
+                    edges.extend(got)
+                    log.debug("dynamic_hints", extractor=ex.name, count=len(got))
+        finally:
+            for ex in self._extractors:
+                ex._walk_snapshot = None
         # Thread-completion order varies run-to-run; sort so downstream graph
         # construction (and therefore the exported KG) stays deterministic.
         edges.sort(key=lambda e: (e.source, e.target, e.edge_type, e.hint_source, e.weight))

--- a/packages/core/src/repowise/core/ingestion/dynamic_hints/xaml.py
+++ b/packages/core/src/repowise/core/ingestion/dynamic_hints/xaml.py
@@ -95,7 +95,7 @@ class XamlDynamicHints(DynamicHintExtractor):
 
     def extract(self, repo_root: Path) -> list[DynamicEdge]:
         # Cheap pre-flight: any XAML in the tree at all?
-        xaml_files = list(_iter_xaml_files(repo_root))
+        xaml_files = list(_iter_xaml_files(repo_root, rglob=self._rglob))
         if not xaml_files:
             return []
 
@@ -172,10 +172,13 @@ class XamlDynamicHints(DynamicHintExtractor):
 # Helpers (module-level so they're easy to unit-test in isolation)
 # ---------------------------------------------------------------------------
 
-def _iter_xaml_files(repo_root: Path):
-    from ._walk import iter_glob as _iter_glob
+def _iter_xaml_files(repo_root: Path, rglob=None):
+    if rglob is None:
+        from ._walk import iter_glob as _iter_glob
+
+        rglob = _iter_glob
     for ext in _XAML_EXTS:
-        for path in _iter_glob(repo_root, f"*{ext}"):
+        for path in rglob(repo_root, f"*{ext}"):
             try:
                 rel = path.resolve().relative_to(repo_root.resolve())
             except ValueError:

--- a/packages/core/src/repowise/core/ingestion/git_indexer/file_history.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/file_history.py
@@ -30,8 +30,12 @@ from ._constants import (
     _PR_NUMBER_RE,
     HOTSPOT_HALFLIFE_DAYS,
 )
-from .enrich import detect_original_path, get_blame_ownership, is_significant_commit
-from .function_blame import build_blame_index, ownership_from_blame
+from .enrich import detect_original_path, is_significant_commit
+from .function_blame import (
+    _MIN_COMMITS_FOR_BLAME,
+    build_blame_index,
+    ownership_from_blame,
+)
 from .records import (
     _LOG_FORMAT,
     _RECORD_SEP,
@@ -384,6 +388,14 @@ def index_file(
         # primary-owner signal and the in-memory ``BlameIndex`` consumed by
         # ``function_hotspot`` / ``code_age_volatility``. Skipped for large
         # files — git blame is O(lines) and can block the executor thread.
+        #
+        # Files below the function-blame commit floor used to take a second
+        # blame pass through gitpython's ``repo.blame`` just for ownership.
+        # That object-building parse is pure Python, holds the GIL across the
+        # 20-way thread fan-out, and on a large repo MOST files sit below the
+        # floor, so it dominated the FULL git phase. The porcelain parse now
+        # serves ownership for every file; the floor only gates whether the
+        # BlameIndex is retained for the function biomarkers, as before.
         if include_blame:
             try:
                 file_size = (repo_path / file_path).stat().st_size
@@ -392,21 +404,11 @@ def index_file(
                         repo,
                         file_path,
                         repo_path=repo_path,
-                        commit_count_total=meta["commit_count_total"],
                     )
                     if blame_idx.lines:
-                        meta["blame_index"] = blame_idx
+                        if meta["commit_count_total"] >= _MIN_COMMITS_FOR_BLAME:
+                            meta["blame_index"] = blame_idx
                         blame_name, blame_email, blame_pct = ownership_from_blame(blame_idx)
-                        if blame_name:
-                            meta["primary_owner_name"] = blame_name
-                            meta["primary_owner_email"] = blame_email
-                            meta["primary_owner_commit_pct"] = blame_pct
-                    else:
-                        # Below the in-blame commit-count floor — fall back
-                        # to the legacy gitpython ownership computation so we
-                        # don't lose owner data on small files that the
-                        # function biomarkers don't need anyway.
-                        blame_name, blame_email, blame_pct = get_blame_ownership(repo, file_path)
                         if blame_name:
                             meta["primary_owner_name"] = blame_name
                             meta["primary_owner_email"] = blame_email

--- a/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
@@ -286,7 +286,10 @@ class GitIndexer:
         return summary, results
 
     async def index_changed_files(
-        self, changed_file_paths: list[str], all_files: set[str] | None = None
+        self,
+        changed_file_paths: list[str],
+        all_files: set[str] | None = None,
+        co_change_sink: dict[str, list[dict]] | None = None,
     ) -> list[dict]:
         """Incremental update: re-index only changed files.
 
@@ -301,6 +304,12 @@ class GitIndexer:
         re-runs so the changed files' partners stay fresh — without it,
         ``index_file``'s empty defaults overwrite the init-computed partners
         on every update, blanking exactly the files that change most.
+
+        ``co_change_sink``, when provided, receives the FULL per-file partner
+        map that walk produces (every tracked file, not just the changed
+        ones). The update path uses it to rebuild the graph's ``co_changes``
+        edges for the whole repo so the update-built graph converges with the
+        init-built one.
         """
         repo = self._get_repo()
         if repo is None:
@@ -408,6 +417,8 @@ class GitIndexer:
                         meta["co_change_partners_json"] = json.dumps(co_changes[fp])
                     if fp in change_entropy:
                         meta["change_entropy"] = change_entropy[fp]
+                if co_change_sink is not None:
+                    co_change_sink.update(co_changes)
             except Exception as exc:
                 logger.debug("co_change_pass_failed", error=str(exc))
 

--- a/packages/core/src/repowise/core/ingestion/type_ref_resolution.py
+++ b/packages/core/src/repowise/core/ingestion/type_ref_resolution.py
@@ -64,6 +64,37 @@ log = structlog.get_logger(__name__)
 # only matters for downstream weighting (PageRank, blast-radius).
 _TYPE_USE_CONFIDENCE = 0.8
 
+_EMPTY_NAMES: frozenset[str] = frozenset()
+
+
+def _build_defined_name_index(graph: nx.DiGraph) -> dict[str, set[str]]:
+    """Map each node to the set of symbol names among its direct successors.
+
+    Replaces the per-candidate ``graph.successors`` scans the find helpers
+    below used to run for every type reference, which cost O(refs x
+    candidates x symbols_per_file) on package-fan-out languages like Go.
+    Built once per ``resolve_type_refs`` pass.
+
+    Building it upfront is equivalent to scanning live: strategies only add
+    file -> file ``type_use`` edges and the ``local_type_uses`` node
+    attribute while they run, never symbol nodes or edges to symbols, so a
+    candidate's symbol-successor set cannot change mid-pass. Falsy symbol
+    names are excluded, matching the callers, which all skip falsy type
+    names before lookup.
+    """
+    sym_name: dict[str, str] = {}
+    for node, data in graph.nodes(data=True):
+        if data.get("node_type") == "symbol":
+            name = data.get("name")
+            if name:
+                sym_name[node] = name
+    index: dict[str, set[str]] = {}
+    for src, dst in graph.edges():
+        name = sym_name.get(dst)
+        if name is not None:
+            index.setdefault(src, set()).add(name)
+    return index
+
 
 # ---------------------------------------------------------------------------
 # Strategy: C# / .NET
@@ -73,6 +104,7 @@ def _resolve_csharp_type_refs(
     parsed: ParsedFile,
     ctx: "ResolverContext",
     graph: "nx.DiGraph",
+    defined_names: dict[str, set[str]],
 ) -> int:
     """Resolve C# ``@param.type`` captures via ``DotNetProjectIndex``.
 
@@ -143,6 +175,7 @@ def _resolve_rust_type_refs(
     parsed: ParsedFile,
     ctx: "ResolverContext",
     graph: "nx.DiGraph",
+    defined_names: dict[str, set[str]],
 ) -> int:
     """Resolve Rust ``@param.type`` captures via stem map + import graph."""
     if not parsed.type_refs:
@@ -155,6 +188,8 @@ def _resolve_rust_type_refs(
     for imp in parsed.imports:
         if imp.resolved_file and not imp.resolved_file.startswith("external:"):
             import_targets.add(imp.resolved_file)
+    # Sorted once: import_targets is a set; first-match must be deterministic.
+    sorted_imports = sorted(import_targets)
 
     for ref in parsed.type_refs:
         type_name = ref.type_name
@@ -164,7 +199,9 @@ def _resolve_rust_type_refs(
         if bare in _RUST_BUILTIN_TYPES:
             continue
 
-        target = _find_rust_type_file(bare, from_path, import_targets, ctx, graph)
+        target = _find_rust_type_file(
+            bare, from_path, sorted_imports, ctx, graph, defined_names
+        )
         if target is None:
             continue
         _add_or_merge_type_use_edge(graph, src=from_path, dst=target,
@@ -176,19 +213,15 @@ def _resolve_rust_type_refs(
 def _find_rust_type_file(
     type_name: str,
     from_path: str,
-    import_targets: set[str],
+    sorted_imports: list[str],
     ctx: "ResolverContext",
     graph: "nx.DiGraph",
+    defined_names: dict[str, set[str]],
 ) -> str | None:
     """Find the file defining *type_name*, preferring imported files."""
-    # Sorted: import_targets is a set; first-match must be deterministic.
-    for imp_file in sorted(import_targets):
-        if not graph.has_node(imp_file):
-            continue
-        for succ in graph.successors(imp_file):
-            nd = graph.nodes.get(succ, {})
-            if nd.get("node_type") == "symbol" and nd.get("name") == type_name:
-                return imp_file
+    for imp_file in sorted_imports:
+        if type_name in defined_names.get(imp_file, _EMPTY_NAMES):
+            return imp_file
 
     candidates = ctx.stem_map.get(type_name.lower(), [])
     if len(candidates) == 1 and candidates[0] != from_path:
@@ -206,6 +239,7 @@ def _resolve_go_type_refs(
     parsed: ParsedFile,
     ctx: "ResolverContext",
     graph: "nx.DiGraph",
+    defined_names: dict[str, set[str]],
 ) -> int:
     """Resolve Go ``@param.type`` captures via the Go package index.
 
@@ -242,6 +276,8 @@ def _resolve_go_type_refs(
     candidates.discard(from_path)
     if not candidates:
         return 0
+    # Sorted once: set iteration; first-match must be deterministic.
+    sorted_candidates = sorted(candidates)
 
     emitted = 0
     seen_targets: set[tuple[str, str]] = set()
@@ -249,7 +285,7 @@ def _resolve_go_type_refs(
         name = ref.type_name
         if not name or name in _GO_BUILTIN_TYPES:
             continue
-        target = _find_go_type_file(name, candidates, graph)
+        target = _find_go_type_file(name, sorted_candidates, defined_names)
         if target is None or target == from_path:
             continue
         if (name, target) in seen_targets:
@@ -263,18 +299,13 @@ def _resolve_go_type_refs(
 
 def _find_go_type_file(
     type_name: str,
-    candidate_files: set[str],
-    graph: "nx.DiGraph",
+    sorted_candidates: list[str],
+    defined_names: dict[str, set[str]],
 ) -> str | None:
-    """Return a candidate file that defines a type named *type_name*."""
-    # Sorted: set iteration; first-match must be deterministic.
-    for cand in sorted(candidate_files):
-        if not graph.has_node(cand):
-            continue
-        for succ in graph.successors(cand):
-            nd = graph.nodes.get(succ, {})
-            if nd.get("node_type") == "symbol" and nd.get("name") == type_name:
-                return cand
+    """Return the first sorted candidate file defining a type named *type_name*."""
+    for cand in sorted_candidates:
+        if type_name in defined_names.get(cand, _EMPTY_NAMES):
+            return cand
     return None
 
 
@@ -313,6 +344,7 @@ def _resolve_c_type_refs(
     parsed: ParsedFile,
     ctx: "ResolverContext",
     graph: "nx.DiGraph",
+    defined_names: dict[str, set[str]],
 ) -> int:
     """Resolve C / C++ ``@param.type`` captures via ``#include`` + stem map.
 
@@ -360,6 +392,10 @@ def _resolve_c_type_refs(
         except Exception:
             sibling_files = set()
 
+    # Sorted once: set iteration; first-match must be deterministic.
+    sorted_imports = sorted(import_targets)
+    sorted_siblings = sorted(sibling_files)
+
     emitted = 0
     seen_targets: set[tuple[str, str]] = set()
     for ref in parsed.type_refs:
@@ -369,7 +405,8 @@ def _resolve_c_type_refs(
         if is_cpp and name in _CPP_STL_HEAD_NAMES:
             continue
         target = _find_c_type_file(
-            name, from_path, import_targets, sibling_files, ctx, graph
+            name, from_path, sorted_imports, sorted_siblings, ctx, graph,
+            defined_names,
         )
         if target is None or target == from_path:
             continue
@@ -385,34 +422,27 @@ def _resolve_c_type_refs(
 def _find_c_type_file(
     type_name: str,
     from_path: str,
-    import_targets: set[str],
-    sibling_files: set[str],
+    sorted_imports: list[str],
+    sorted_siblings: list[str],
     ctx: "ResolverContext",
     graph: "nx.DiGraph",
+    defined_names: dict[str, set[str]],
 ) -> str | None:
     """Find the file defining *type_name*, preferring ``#include``d headers.
 
-    Falls back to *sibling_files* (same workspace target — usually a
+    Falls back to *sorted_siblings* (same workspace target, usually a
     sibling ``.cc`` declaring an internal class that another ``.cc`` in
     the same target uses by value), then the global stem map.
     """
-    # Sorted: import_targets is a set; first-match must be deterministic.
-    for imp_file in sorted(import_targets):
-        if not graph.has_node(imp_file):
-            continue
-        for succ in graph.successors(imp_file):
-            nd = graph.nodes.get(succ, {})
-            if nd.get("node_type") == "symbol" and nd.get("name") == type_name:
-                return imp_file
+    for imp_file in sorted_imports:
+        if type_name in defined_names.get(imp_file, _EMPTY_NAMES):
+            return imp_file
 
-    # Sorted: set iteration; first-match must be deterministic.
-    for sib in sorted(sibling_files):
-        if sib == from_path or not graph.has_node(sib):
+    for sib in sorted_siblings:
+        if sib == from_path:
             continue
-        for succ in graph.successors(sib):
-            nd = graph.nodes.get(succ, {})
-            if nd.get("node_type") == "symbol" and nd.get("name") == type_name:
-                return sib
+        if type_name in defined_names.get(sib, _EMPTY_NAMES):
+            return sib
 
     candidates = ctx.stem_map.get(type_name.lower(), [])
     if len(candidates) == 1 and candidates[0] != from_path:
@@ -430,6 +460,7 @@ def _resolve_ts_type_refs(
     parsed: ParsedFile,
     ctx: "ResolverContext",
     graph: "nx.DiGraph",
+    defined_names: dict[str, set[str]],
 ) -> int:
     """Resolve TS/JS ``@param.type`` captures via import bindings + stem map.
 
@@ -494,7 +525,9 @@ def _resolve_ts_type_refs(
             continue
         target = name_to_source.get(name) or namespace_to_source.get(name)
         if target is None:
-            target = _find_ts_type_in_stem_map(name, from_path, ctx, graph)
+            target = _find_ts_type_in_stem_map(
+                name, from_path, ctx, graph, defined_names
+            )
         if target is None or target == from_path:
             continue
         if (name, target) in seen:
@@ -522,6 +555,7 @@ def _find_ts_type_in_stem_map(
     from_path: str,
     ctx: "ResolverContext",
     graph: "nx.DiGraph",
+    defined_names: dict[str, set[str]],
 ) -> str | None:
     """Locate ``type_name`` via the global stem map.
 
@@ -535,14 +569,12 @@ def _find_ts_type_in_stem_map(
     if len(candidates) != 1:
         return None
     candidate = candidates[0]
-    if candidate == from_path or not graph.has_node(candidate):
+    if candidate == from_path:
         return None
     # Verify the candidate file actually exports a symbol matching name —
     # avoids accidentally matching ``utils.ts`` to a type called ``Utils``.
-    for succ in graph.successors(candidate):
-        nd = graph.nodes.get(succ, {})
-        if nd.get("node_type") == "symbol" and nd.get("name") == type_name:
-            return candidate
+    if type_name in defined_names.get(candidate, _EMPTY_NAMES):
+        return candidate
     return None
 
 
@@ -554,6 +586,7 @@ def _resolve_jvm_type_refs(
     parsed: ParsedFile,
     ctx: "ResolverContext",
     graph: "nx.DiGraph",
+    defined_names: dict[str, set[str]],
 ) -> int:
     """Resolve Java / Kotlin ``@param.type`` captures via ``JvmWorkspaceIndex``.
 
@@ -596,6 +629,8 @@ def _resolve_jvm_type_refs(
     candidates.discard(from_path)
     if not candidates:
         return 0
+    # Sorted once: set iteration; first-match must be deterministic.
+    sorted_candidates = sorted(candidates)
 
     emitted = 0
     seen_targets: set[tuple[str, str]] = set()
@@ -603,7 +638,7 @@ def _resolve_jvm_type_refs(
         name = ref.type_name
         if not name:
             continue
-        target = _find_jvm_type_file(name, candidates, graph)
+        target = _find_jvm_type_file(name, sorted_candidates, defined_names)
         if target is None or target == from_path:
             continue
         if (name, target) in seen_targets:
@@ -620,18 +655,13 @@ def _resolve_jvm_type_refs(
 
 def _find_jvm_type_file(
     type_name: str,
-    candidate_files: set[str],
-    graph: "nx.DiGraph",
+    sorted_candidates: list[str],
+    defined_names: dict[str, set[str]],
 ) -> str | None:
-    """Return a candidate file that defines a top-level type named *type_name*."""
-    # Sorted: set iteration; first-match must be deterministic.
-    for cand in sorted(candidate_files):
-        if not graph.has_node(cand):
-            continue
-        for succ in graph.successors(cand):
-            nd = graph.nodes.get(succ, {})
-            if nd.get("node_type") == "symbol" and nd.get("name") == type_name:
-                return cand
+    """Return the first sorted candidate file defining a top-level type named *type_name*."""
+    for cand in sorted_candidates:
+        if type_name in defined_names.get(cand, _EMPTY_NAMES):
+            return cand
     return None
 
 
@@ -639,7 +669,9 @@ def _find_jvm_type_file(
 # Strategy registry
 # ---------------------------------------------------------------------------
 
-Strategy = Callable[[ParsedFile, "ResolverContext", "nx.DiGraph"], int]
+Strategy = Callable[
+    [ParsedFile, "ResolverContext", "nx.DiGraph", dict[str, set[str]]], int
+]
 
 # Add new languages here — see module docstring. Keep the entries
 # tightly scoped: each strategy must only touch its own language's
@@ -667,12 +699,13 @@ def resolve_type_refs(
     Returns a per-language emitted-edge count for logging.
     """
     counts: dict[str, int] = {}
+    defined_names = _build_defined_name_index(graph)
     for parsed in parsed_files.values():
         lang = parsed.file_info.language
         strategy = _STRATEGIES.get(lang)
         if strategy is None:
             continue
-        emitted = strategy(parsed, ctx, graph)
+        emitted = strategy(parsed, ctx, graph, defined_names)
         if emitted:
             counts[lang] = counts.get(lang, 0) + emitted
     if counts:

--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -137,6 +137,20 @@ def build_repo_graph(
     except Exception:
         pass  # framework edge detection is best-effort
 
+    # Add dynamic-hint edges, mirroring the init pipeline's ingestion phase.
+    # Without this the update-built graph was missing every dynamic edge the
+    # init graph had: metrics computed on update diverged from init's, and
+    # the first post-init update could never hit the centrality cache.
+    try:
+        from repowise.core.ingestion.dynamic_hints import HintRegistry
+
+        dynamic_edges = HintRegistry().extract_all(Path(repo_path))
+        graph_builder.add_dynamic_edges(dynamic_edges)
+        if dynamic_edges:
+            log(f"Dynamic hint edges added: [cyan]{len(dynamic_edges)}[/cyan]")
+    except Exception:
+        pass  # dynamic hints are best-effort, same as the init phase
+
     return parsed_files, source_map, graph_builder, repo_structure, len(file_infos)
 
 
@@ -201,11 +215,26 @@ async def rebuild_graph_and_git(
         changed_paths = build_filtered_changed_paths(file_diffs, exclude_patterns)
         # The full tracked-file set lets the indexer re-run the repo-wide
         # co-change walk so partners aren't wiped to "[]" for changed files.
+        # The sink captures that walk's FULL per-file partner map: the graph
+        # was just rebuilt from scratch, so co_changes edges must be re-added
+        # for every file (not only the changed ones) or the update graph
+        # diverges from the init graph and the centrality cache can't hit.
+        co_change_full: dict[str, list[dict]] = {}
         updated_meta = await git_indexer.index_changed_files(
-            changed_paths, all_files=set(source_map.keys())
+            changed_paths,
+            all_files=set(source_map.keys()),
+            co_change_sink=co_change_full,
         )
         git_meta_map = {m["file_path"]: m for m in updated_meta}
-        graph_builder.update_co_change_edges(git_meta_map)
+        if co_change_full:
+            graph_builder.update_co_change_edges(
+                {
+                    fp: {"co_change_partners_json": partners}
+                    for fp, partners in co_change_full.items()
+                }
+            )
+        else:
+            graph_builder.update_co_change_edges(git_meta_map)
     except Exception as exc:
         log(f"[yellow]Git re-index skipped: {exc}[/yellow]")
 

--- a/tests/unit/cli/test_distill_verdict_fingerprint.py
+++ b/tests/unit/cli/test_distill_verdict_fingerprint.py
@@ -1,0 +1,82 @@
+"""Regression: the inherited distill verdict must not read as a config change.
+
+``repowise update`` backfills a workspace member's ``distill.commands.enabled``
+verdict into ``.repowise/config.yaml`` at the start of every run. When init
+left the verdict unwritten, the first update's backfill changed the config
+fingerprint computed at init time, and the update silently replaced the
+incremental path with a full health re-score of every file (47s instead of
+the partial update on an ~900-file Go repo). Init now runs the same backfill
+before fingerprinting, so the update-time backfill is a no-op.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from repowise.cli.commands.workspace_cmd import inherit_workspace_distill_verdict
+from repowise.cli.helpers import config_fingerprint
+from repowise.core.workspace.config import RepoEntry, WorkspaceConfig
+
+
+def _make_workspace(tmp_path: Path, *, primary_verdict: bool | None) -> Path:
+    """Workspace root with a primary repo and a member repo; returns member."""
+    primary = tmp_path / "primary"
+    member = tmp_path / "member"
+    (primary / ".repowise").mkdir(parents=True)
+    (member / ".repowise").mkdir(parents=True)
+    if primary_verdict is not None:
+        (primary / ".repowise" / "config.yaml").write_text(
+            yaml.dump({"distill": {"commands": {"enabled": primary_verdict}}}),
+            encoding="utf-8",
+        )
+    WorkspaceConfig(
+        repos=[
+            RepoEntry(path="primary", alias="primary", is_primary=True),
+            RepoEntry(path="member", alias="member"),
+        ],
+        default_repo="primary",
+    ).save(tmp_path)
+    return member
+
+
+class TestDistillVerdictFingerprint:
+    def test_inherit_is_idempotent_for_fingerprint(self, tmp_path: Path) -> None:
+        """Once the verdict is written (as init now does), re-running the
+        update-time backfill leaves the config fingerprint unchanged."""
+        member = _make_workspace(tmp_path, primary_verdict=True)
+
+        # Init-time backfill, then fingerprint (the new init ordering).
+        inherit_workspace_distill_verdict(member)
+        fp_at_init = config_fingerprint(member)
+
+        # Update-time backfill must be a no-op.
+        inherit_workspace_distill_verdict(member)
+        assert config_fingerprint(member) == fp_at_init
+
+        cfg = yaml.safe_load((member / ".repowise" / "config.yaml").read_text())
+        assert cfg["distill"]["commands"]["enabled"] is True
+
+    def test_unwritten_verdict_changed_the_fingerprint(self, tmp_path: Path) -> None:
+        """The bug shape: fingerprint taken before the backfill differs from
+        the fingerprint after it, which is what made the first update of
+        every workspace member take the full-rescore path."""
+        member = _make_workspace(tmp_path, primary_verdict=True)
+        fp_without_verdict = config_fingerprint(member)
+        inherit_workspace_distill_verdict(member)
+        assert config_fingerprint(member) != fp_without_verdict
+
+    def test_no_primary_verdict_is_noop(self, tmp_path: Path) -> None:
+        member = _make_workspace(tmp_path, primary_verdict=None)
+        fp_before = config_fingerprint(member)
+        inherit_workspace_distill_verdict(member)
+        assert config_fingerprint(member) == fp_before
+        assert not (member / ".repowise" / "config.yaml").exists()
+
+    def test_outside_workspace_is_noop(self, tmp_path: Path) -> None:
+        lone = tmp_path / "lone"
+        (lone / ".repowise").mkdir(parents=True)
+        fp_before = config_fingerprint(lone)
+        inherit_workspace_distill_verdict(lone)
+        assert config_fingerprint(lone) == fp_before

--- a/tests/unit/cli/test_update_git_tier.py
+++ b/tests/unit/cli/test_update_git_tier.py
@@ -79,11 +79,10 @@ async def test_essential_tier_update_never_blames(tmp_path, monkeypatch):
         calls.append("blame")
         raise AssertionError("blame must not run on ESSENTIAL updates")
 
+    # build_blame_index is the single blame entry point now (ownership
+    # derives from its porcelain parse; the gitpython fallback is gone).
     monkeypatch.setattr(
         "repowise.core.ingestion.git_indexer.file_history.build_blame_index", _no_blame
-    )
-    monkeypatch.setattr(
-        "repowise.core.ingestion.git_indexer.file_history.get_blame_ownership", _no_blame
     )
 
     indexer = GitIndexer(tmp_path, tier=GitIndexTier.ESSENTIAL)

--- a/tests/unit/dead_code/test_never_flag_regex.py
+++ b/tests/unit/dead_code/test_never_flag_regex.py
@@ -73,6 +73,24 @@ class TestRegexEquivalence:
             assert bool(regex.match(os.path.normcase(concrete))) == _fnmatch_any(concrete), pat
 
 
+class TestMemoizedMatch:
+    """The lru_cached match wrapper must equal the direct regex match,
+    including for symbol-node ids (``path::Name``), which the detector
+    passes feed it alongside file paths."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [*_PROBE_PATHS, "pkg/a.go::Handler", "cmd/main_test.go::TestX", "app/page.tsx::Page"],
+    )
+    def test_memoized_equals_direct(self, path):
+        from repowise.core.analysis.dead_code.analyzer import _never_flag_regex_match
+
+        direct = bool(_never_flag_regex(_NEVER_FLAG_PATTERNS).match(os.path.normcase(path)))
+        assert _never_flag_regex_match(path) == direct, path
+        # Second call exercises the cached branch.
+        assert _never_flag_regex_match(path) == direct, path
+
+
 class TestShouldNeverFlag:
     def _analyzer(self) -> DeadCodeAnalyzer:
         return DeadCodeAnalyzer(nx.DiGraph(), {})

--- a/tests/unit/health/test_file_nloc.py
+++ b/tests/unit/health/test_file_nloc.py
@@ -88,7 +88,7 @@ def test_health_metric_nloc_uses_file_nloc():
     metric, _ = HealthAnalyzer(graph=None)._evaluate_file(
         pf,
         fcx,
-        all_paths={"src/route.js"},
+        path_basenames={"route.js"},
         disabled=[],
         dup_report=DuplicationReport(),
     )

--- a/tests/unit/health/test_mts_cts_test_classification.py
+++ b/tests/unit/health/test_mts_cts_test_classification.py
@@ -11,6 +11,9 @@ from repowise.core.analysis.health.biomarkers.hidden_coupling import (
 from repowise.core.analysis.health.coverage import is_test_file, paired_test_file
 from repowise.core.analysis.health.engine import (
     _has_paired_test_file,
+    _path_basenames,
+)
+from repowise.core.analysis.health.engine import (
     _is_test_file as _engine_is_test_file,
 )
 
@@ -41,5 +44,9 @@ def test_paired_test_file_finds_mts_cts() -> None:
 
 
 def test_engine_has_paired_test_file_for_mts_source() -> None:
-    assert _has_paired_test_file("src/foo.mts", {"src/foo.mts", "src/foo.test.mts"})
-    assert _has_paired_test_file("src/bar.cts", {"src/bar.cts", "src/bar.spec.cts"})
+    assert _has_paired_test_file(
+        "src/foo.mts", _path_basenames({"src/foo.mts", "src/foo.test.mts"})
+    )
+    assert _has_paired_test_file(
+        "src/bar.cts", _path_basenames({"src/bar.cts", "src/bar.spec.cts"})
+    )

--- a/tests/unit/health/test_paired_test_basenames.py
+++ b/tests/unit/health/test_paired_test_basenames.py
@@ -1,0 +1,104 @@
+"""Equivalence tests for the precomputed test-pair basename set.
+
+``_has_paired_test_file`` used to scan every analyzed path for every
+evaluated file (O(files x paths x candidates) string suffix checks; 16s
+isolated on an ~2,000-file repo). It now answers from one precomputed
+``_path_basenames`` set. These tests pin the new formulation to a verbatim
+copy of the old scan over a corpus of tricky paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repowise.core.analysis.health.engine import (
+    _has_paired_test_file,
+    _path_basenames,
+)
+
+
+def _reference_has_paired_test_file(rel_path: str, all_paths: set[str]) -> bool:
+    """The pre-index implementation, kept verbatim as the oracle."""
+    p = Path(rel_path)
+    stem = p.stem
+    candidates = {
+        f"test_{stem}.py",
+        f"{stem}_test.py",
+        f"{stem}.test.ts",
+        f"{stem}.test.tsx",
+        f"{stem}.test.js",
+        f"{stem}.test.mts",
+        f"{stem}.test.cts",
+        f"{stem}.spec.ts",
+        f"{stem}.spec.js",
+        f"{stem}.spec.mts",
+        f"{stem}.spec.cts",
+        f"{stem}_test.go",
+    }
+    return any(
+        any(other.endswith("/" + c) or other == c for c in candidates)
+        for other in all_paths
+    )
+
+
+CORPUS: set[str] = {
+    # root-level pair (the `other == c` branch)
+    "test_root.py",
+    "root.py",
+    # nested pairs (the `endswith("/" + c)` branch)
+    "pkg/sub/test_mod.py",
+    "pkg/sub/mod.py",
+    "src/widget.ts",
+    "src/widget.spec.ts",
+    "cmd/server.go",
+    "cmd/server_test.go",
+    # near-misses that must NOT match: prefix without separator
+    "pkg/xtest_near.py",
+    "near.py",
+    "src/footest_other.go",
+    "other.go",
+    # test-suffix file with no source pair
+    "orphan.test.js",
+    # backslash path: the old scan only recognised "/" separators, so
+    # this must NOT read as a pair for windowsy.py
+    "dir\\test_windowsy.py",
+    "windowsy.py",
+    # deep nesting + dotted stem
+    "a/b/c/d/e/data.test.tsx",
+    "a/b/c/d/e/data.tsx",
+    "lib/parser.config.ts",
+}
+
+
+class TestPairedTestBasenames:
+    def test_matches_reference_over_corpus(self) -> None:
+        basenames = _path_basenames(CORPUS)
+        for rel_path in sorted(CORPUS):
+            expected = _reference_has_paired_test_file(rel_path, CORPUS)
+            assert _has_paired_test_file(rel_path, basenames) == expected, rel_path
+
+    def test_positive_and_negative_anchors(self) -> None:
+        basenames = _path_basenames(CORPUS)
+        # Anchors so the corpus comparison cannot silently pass on all-False.
+        assert _has_paired_test_file("root.py", basenames)
+        assert _has_paired_test_file("pkg/sub/mod.py", basenames)
+        assert _has_paired_test_file("src/widget.ts", basenames)
+        assert _has_paired_test_file("cmd/server.go", basenames)
+        assert _has_paired_test_file("a/b/c/d/e/data.tsx", basenames)
+        assert not _has_paired_test_file("near.py", basenames)
+        assert not _has_paired_test_file("other.go", basenames)
+        assert not _has_paired_test_file("lib/parser.config.ts", basenames)
+        # Backslash separator was never recognised by the old scan.
+        assert not _has_paired_test_file("windowsy.py", basenames)
+
+    def test_basenames_split_on_forward_slash_only(self) -> None:
+        assert _path_basenames({"a/b.py", "c.py", "d\\e.py", "x/y/z.go"}) == {
+            "b.py",
+            "c.py",
+            "d\\e.py",
+            "z.go",
+        }
+
+    def test_empty_paths(self) -> None:
+        assert _path_basenames(set()) == set()
+        assert not _has_paired_test_file("anything.py", set())

--- a/tests/unit/ingestion/test_blame_ownership_single_pass.py
+++ b/tests/unit/ingestion/test_blame_ownership_single_pass.py
@@ -1,0 +1,95 @@
+"""Blame ownership must survive the removal of the second blame pass.
+
+``index_file`` used to run ``git blame`` twice for files below the
+function-blame commit floor: the porcelain pass (returning an empty index)
+and gitpython's ``repo.blame`` object parse, just for ownership. Ownership
+now derives from the single porcelain pass for every file; the commit floor
+only gates whether the BlameIndex is retained. These tests pin the derived
+ownership to the legacy gitpython computation and the floor semantics.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from repowise.core.ingestion.git_indexer.enrich import get_blame_ownership
+from repowise.core.ingestion.git_indexer.file_history import index_file
+from repowise.core.ingestion.git_indexer.function_blame import (
+    build_blame_index,
+    ownership_from_blame,
+)
+
+
+@pytest.fixture
+def repo(tmp_path: Path):
+    import git as gitpython
+
+    r = gitpython.Repo.init(tmp_path)
+    alice = gitpython.Actor("Alice", "alice@example.com")
+    bob = gitpython.Actor("Bob", "bob@example.com")
+
+    # sparse.py: 2 commits (below the 5-commit floor), alice owns 3/4 lines.
+    (tmp_path / "sparse.py").write_text("a1\na2\na3\n")
+    r.index.add(["sparse.py"])
+    r.index.commit("feat: alice writes sparse", author=alice, committer=alice)
+    (tmp_path / "sparse.py").write_text("a1\na2\na3\nb1\n")
+    r.index.add(["sparse.py"])
+    r.index.commit("feat: bob appends one line", author=bob, committer=bob)
+
+    # hot.py: 5 commits (meets the floor), alternating authors.
+    (tmp_path / "hot.py").write_text("l1\n")
+    r.index.add(["hot.py"])
+    r.index.commit("feat: line 1", author=alice, committer=alice)
+    for i, author in enumerate((bob, alice, bob, alice), start=2):
+        content = "".join(f"l{j}\n" for j in range(1, i + 1))
+        (tmp_path / "hot.py").write_text(content)
+        r.index.add(["hot.py"])
+        r.index.commit(f"feat: line {i}", author=author, committer=author)
+
+    yield r, tmp_path
+    r.close()
+
+
+class TestSingleBlamePassOwnership:
+    def test_porcelain_ownership_matches_legacy_gitpython(self, repo) -> None:
+        r, root = repo
+        for path in ("sparse.py", "hot.py"):
+            legacy = get_blame_ownership(r, path)
+            idx = build_blame_index(r, path, repo_path=root)
+            derived = ownership_from_blame(idx)
+            assert derived[0] == legacy[0], path          # name
+            assert derived[1] == legacy[1], path          # email
+            assert derived[2] == pytest.approx(legacy[2]), path  # share
+
+    def test_sparse_file_gets_ownership_but_no_blame_index(self, repo) -> None:
+        r, root = repo
+        meta = index_file(
+            r, "sparse.py", repo_path=root, commit_limit=500,
+            follow_renames=False, include_blame=True,
+        )
+        assert meta["primary_owner_name"] == "Alice"
+        assert meta["primary_owner_email"] == "alice@example.com"
+        assert meta["primary_owner_commit_pct"] == pytest.approx(0.75)
+        assert "blame_index" not in meta
+
+    def test_hot_file_retains_blame_index(self, repo) -> None:
+        r, root = repo
+        meta = index_file(
+            r, "hot.py", repo_path=root, commit_limit=500,
+            follow_renames=False, include_blame=True,
+        )
+        assert "blame_index" in meta
+        assert meta["blame_index"].lines
+        assert meta["primary_owner_name"] == "Alice"  # 3 of 5 lines
+
+    def test_essential_tier_skips_blame_entirely(self, repo) -> None:
+        r, root = repo
+        meta = index_file(
+            r, "sparse.py", repo_path=root, commit_limit=500,
+            follow_renames=False, include_blame=False,
+        )
+        assert "blame_index" not in meta
+        # Commit-author fallback ownership still present (2 commits: alice, bob).
+        assert meta["primary_owner_name"] in ("Alice", "Bob")

--- a/tests/unit/ingestion/test_git_indexer_tiers.py
+++ b/tests/unit/ingestion/test_git_indexer_tiers.py
@@ -77,12 +77,29 @@ def test_index_file_essential_skips_blame(tmp_path) -> None:
 
 
 def test_index_file_full_consults_blame(tmp_path) -> None:
-    """With include_blame=True, blame ownership overrides the commit author."""
+    """With include_blame=True, blame ownership overrides the commit author.
+
+    Ownership derives from the single ``git blame --line-porcelain``
+    invocation (``repo.git.blame``); gitpython's ``repo.blame`` object parse
+    is never consulted anymore, even for files below the commit floor.
+    """
     repo = MagicMock()
-    blame_commit = MagicMock()
-    blame_commit.author.name = "Carol"
-    blame_commit.author.email = "c@x.io"
-    repo.blame.return_value = [(blame_commit, ["line1", "line2", "line3"])]
+    sha = "c" * 40
+
+    def _porcelain_block(line_no: int) -> str:
+        return (
+            f"{sha} {line_no} {line_no} 1\n"
+            "author Carol\n"
+            "author-mail <c@x.io>\n"
+            "author-time 1700000000\n"
+            "author-tz +0000\n"
+            "summary feat: carol wrote this\n"
+            "filename a.py\n"
+            f"\tline{line_no}\n"
+        )
+
+    repo.git.blame.return_value = "".join(_porcelain_block(i) for i in (1, 2, 3))
+    repo.blame.side_effect = AssertionError("gitpython repo.blame must not run")
     (tmp_path / "a.py").write_text("x = 1\n")
 
     meta = index_file(
@@ -95,7 +112,9 @@ def test_index_file_full_consults_blame(tmp_path) -> None:
         precomputed_commits=_commits(),
     )
     assert meta["primary_owner_name"] == "Carol"  # blame wins
-    repo.blame.assert_called_once()
+    assert meta["primary_owner_email"] == "c@x.io"
+    repo.git.blame.assert_called_once()
+    repo.blame.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/ingestion/test_type_ref_defined_name_index.py
+++ b/tests/unit/ingestion/test_type_ref_defined_name_index.py
@@ -1,0 +1,149 @@
+"""Equivalence tests for the type-ref defined-name index.
+
+``resolve_type_refs`` used to locate a type's defining file by scanning
+``graph.successors(candidate)`` for every (type reference, candidate file)
+pair. It now precomputes one ``node -> {symbol names among successors}``
+map per pass and answers lookups by set membership. These tests pin the
+two formulations to each other:
+
+* the index itself matches a per-node successor scan on graphs mixing
+  file nodes, symbol nodes, symbol->symbol edges, and unnamed symbols;
+* the find helpers return the same first-sorted-candidate answer as a
+  reference implementation of the old scan loop;
+* adding the kind of edges strategies emit mid-pass (file -> file
+  ``type_use``) changes neither formulation, which is the invariant that
+  makes the upfront build equivalent to live scanning.
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+
+from repowise.core.ingestion.type_ref_resolution import (
+    _build_defined_name_index,
+    _find_go_type_file,
+    _find_jvm_type_file,
+)
+
+
+def _reference_scan(type_name: str, candidates, graph: nx.DiGraph) -> str | None:
+    """The pre-index lookup loop, kept verbatim as the behavioral oracle."""
+    for cand in sorted(candidates):
+        if not graph.has_node(cand):
+            continue
+        for succ in graph.successors(cand):
+            nd = graph.nodes.get(succ, {})
+            if nd.get("node_type") == "symbol" and nd.get("name") == type_name:
+                return cand
+    return None
+
+
+def _make_graph() -> nx.DiGraph:
+    g = nx.DiGraph()
+    # Files
+    for f in ("a.go", "b.go", "pkg/c.go", "pkg/d.go", "no_symbols.go"):
+        g.add_node(f, node_type="file", name=f)
+    # Symbols (file -> symbol "defines" edges)
+    defs = {
+        "a.go": [("a.go::Writer", "Writer"), ("a.go::Reader", "Reader")],
+        "b.go": [("b.go::Writer", "Writer"), ("b.go::Helper", "Helper")],
+        "pkg/c.go": [("pkg/c.go::Config", "Config")],
+        "pkg/d.go": [("pkg/d.go::unnamed", ""), ("pkg/d.go::Config", "Config")],
+    }
+    for f, symbols in defs.items():
+        for sid, name in symbols:
+            g.add_node(sid, node_type="symbol", name=name)
+            g.add_edge(f, sid, edge_type="defines")
+    # file -> file imports edge: target file node has a name attr but is
+    # not a symbol; must never satisfy a lookup.
+    g.add_edge("a.go", "pkg/c.go", edge_type="imports", imported_names=["Config"])
+    # symbol -> symbol edge (has_method style); the method symbol must not
+    # appear under the *file* keys it is not a direct successor of.
+    g.add_node("a.go::Writer.Write", node_type="symbol", name="Write")
+    g.add_edge("a.go::Writer", "a.go::Writer.Write", edge_type="has_method")
+    return g
+
+
+class TestIndexEquivalence:
+    def test_index_matches_successor_scan_per_node(self) -> None:
+        g = _make_graph()
+        index = _build_defined_name_index(g)
+        for node in g.nodes:
+            expected = {
+                d.get("name")
+                for s in g.successors(node)
+                if (d := g.nodes[s]).get("node_type") == "symbol" and d.get("name")
+            }
+            assert index.get(node, set()) == expected, node
+
+    def test_unnamed_symbols_and_file_successors_excluded(self) -> None:
+        g = _make_graph()
+        index = _build_defined_name_index(g)
+        # pkg/d.go defines an unnamed symbol and Config: only Config lands.
+        assert index["pkg/d.go"] == {"Config"}
+        # a.go's successors include the file node pkg/c.go (named "pkg/c.go")
+        # via the imports edge; file successors never contribute.
+        assert "pkg/c.go" not in index["a.go"]
+        assert index["a.go"] == {"Writer", "Reader"}
+        # A file defining nothing has no entry; lookups treat that as empty.
+        assert "no_symbols.go" not in index
+
+    def test_find_matches_reference_for_all_names_and_candidate_sets(self) -> None:
+        g = _make_graph()
+        index = _build_defined_name_index(g)
+        candidate_sets = [
+            {"a.go", "b.go"},
+            {"b.go", "a.go", "pkg/c.go"},
+            {"pkg/c.go", "pkg/d.go"},
+            {"no_symbols.go", "b.go"},
+            {"missing.go", "a.go"},  # candidate not in the graph
+            set(),
+        ]
+        # Falsy names are outside the lookup domain: every strategy skips
+        # them before calling a find helper (``if not name: continue``), so
+        # the index drops unnamed symbols rather than matching "" the way a
+        # raw attribute comparison would.
+        names = ["Writer", "Reader", "Helper", "Config", "Write", "Nope"]
+        for cands in candidate_sets:
+            sorted_cands = sorted(cands)
+            for name in names:
+                expected = _reference_scan(name, cands, g)
+                assert _find_go_type_file(name, sorted_cands, index) == expected, (
+                    name,
+                    cands,
+                )
+                assert _find_jvm_type_file(name, sorted_cands, index) == expected, (
+                    name,
+                    cands,
+                )
+
+    def test_first_sorted_candidate_wins_on_shadowed_name(self) -> None:
+        g = _make_graph()
+        index = _build_defined_name_index(g)
+        # Writer is defined in both a.go and b.go: sorted order picks a.go,
+        # exactly as the reference scan does.
+        assert _find_go_type_file("Writer", sorted({"b.go", "a.go"}), index) == "a.go"
+        assert _reference_scan("Writer", {"b.go", "a.go"}, g) == "a.go"
+
+    def test_mid_pass_type_use_edges_do_not_invalidate_index(self) -> None:
+        """Strategies only add file -> file ``type_use`` edges while running;
+        neither formulation's answers change, so building the index upfront
+        is equivalent to scanning live."""
+        g = _make_graph()
+        index = _build_defined_name_index(g)
+        before = {
+            name: _reference_scan(name, {"a.go", "b.go", "pkg/c.go"}, g)
+            for name in ("Writer", "Config", "Helper")
+        }
+        g.add_edge(
+            "b.go",
+            "pkg/c.go",
+            edge_type="type_use",
+            confidence=0.8,
+            type_uses=["Config"],
+            imported_names=["Config"],
+        )
+        sorted_cands = sorted({"a.go", "b.go", "pkg/c.go"})
+        for name, expected in before.items():
+            assert _reference_scan(name, {"a.go", "b.go", "pkg/c.go"}, g) == expected
+            assert _find_go_type_file(name, sorted_cands, index) == expected

--- a/tests/unit/ingestion/test_walk_snapshot.py
+++ b/tests/unit/ingestion/test_walk_snapshot.py
@@ -1,0 +1,107 @@
+"""Equivalence tests for WalkSnapshot vs live iter_glob.
+
+The dynamic-hint extractor fleet issues ~40 ``iter_glob`` queries per
+``extract_all``; each used to walk the tree from disk. ``WalkSnapshot``
+replays one walk for all of them, and these tests pin the replay to the
+live walk: same files, same directories, same order, for basename
+patterns, ``/``-tail patterns, directory-name matches, and query roots
+below the snapshot root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from repowise.core.fs_walk import PRUNED_DIRS_DERIVED, WalkSnapshot, iter_glob
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    """A tree exercising pruning, nesting, dir matches, and a nested repo."""
+    files = [
+        "main.go",
+        "go.mod",
+        "settings.py",
+        "pkg/a.go",
+        "pkg/settings/local.py",
+        "pkg/sub/deep/b.go",
+        "tests/conftest.py",
+        "tests/test_a.py",
+        "tests/sub/test_b.py",
+        "node_modules/dep/index.js",          # pruned dir
+        "build/gen.go",                       # pruned (derived set)
+        "vendored/.git/HEAD",                 # nested git repo
+        "vendored/inner.go",
+        "META-INF/services/com.example.Impl",
+    ]
+    for rel in files:
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x", encoding="utf-8")
+    # A directory named "settings" (django matches directories by name).
+    (tmp_path / "app" / "settings").mkdir(parents=True)
+    (tmp_path / "app" / "settings" / "base.py").write_text("x", encoding="utf-8")
+    return tmp_path
+
+
+QUERIES = [
+    "*.go",
+    "*.py",
+    "settings.py",
+    "settings",            # directory-name match
+    "conftest.py",
+    "go.mod",
+    "tsconfig*.json",      # no matches
+    "META-INF/services",   # /-tail pattern
+    ("*.go", "*.py"),      # multi-pattern, one walk
+]
+
+
+class TestWalkSnapshotEquivalence:
+    def test_matches_live_iter_glob_at_root(self, tree: Path) -> None:
+        snap = WalkSnapshot(tree, prune_dirs=PRUNED_DIRS_DERIVED)
+        for pattern in QUERIES:
+            live = list(iter_glob(tree, pattern, prune_dirs=PRUNED_DIRS_DERIVED))
+            replay = list(snap.iter_glob(tree, pattern))
+            assert replay == live, pattern
+
+    def test_matches_live_iter_glob_at_subroot(self, tree: Path) -> None:
+        snap = WalkSnapshot(tree, prune_dirs=PRUNED_DIRS_DERIVED)
+        for sub in ("tests", "pkg", "pkg/sub", "app"):
+            sub_root = tree / sub
+            for pattern in ("*.py", "*.go", "test_*.py", "settings"):
+                live = list(iter_glob(sub_root, pattern, prune_dirs=PRUNED_DIRS_DERIVED))
+                replay = list(snap.iter_glob(sub_root, pattern))
+                assert replay == live, (sub, pattern)
+
+    def test_pruned_and_nested_git_excluded(self, tree: Path) -> None:
+        snap = WalkSnapshot(tree, prune_dirs=PRUNED_DIRS_DERIVED)
+        hits = {p.name for p in snap.iter_glob(tree, ("*.go", "*.js"))}
+        assert "index.js" not in hits   # node_modules pruned
+        assert "gen.go" not in hits     # build pruned (derived set)
+        assert "inner.go" not in hits   # nested git repo pruned
+
+    def test_out_of_tree_root_falls_back_to_live_walk(self, tree: Path, tmp_path_factory) -> None:
+        other = tmp_path_factory.mktemp("elsewhere")
+        (other / "lone.go").write_text("x", encoding="utf-8")
+        snap = WalkSnapshot(tree, prune_dirs=PRUNED_DIRS_DERIVED)
+        assert [p.name for p in snap.iter_glob(other, "*.go")] == ["lone.go"]
+
+    def test_extractor_rglob_uses_attached_snapshot(self, tree: Path) -> None:
+        from repowise.core.ingestion.dynamic_hints.base import DynamicHintExtractor
+
+        class _Probe(DynamicHintExtractor):
+            name = "probe"
+
+            def extract(self, repo_root: Path):  # pragma: no cover - unused
+                return []
+
+        probe = _Probe()
+        live = list(probe._rglob(tree, "*.go"))
+        probe._walk_snapshot = WalkSnapshot(tree, prune_dirs=PRUNED_DIRS_DERIVED)
+        try:
+            assert list(probe._rglob(tree, "*.go")) == live
+        finally:
+            probe._walk_snapshot = None

--- a/tests/unit/pipeline/test_update_graph_convergence.py
+++ b/tests/unit/pipeline/test_update_graph_convergence.py
@@ -1,0 +1,111 @@
+"""The update path must build the same graph as the init path.
+
+The incremental rebuild used to skip two edge passes the init pipeline runs:
+dynamic hints (never executed on update) and the repo-wide ``co_changes``
+edges (re-added only for the changed files, on a graph rebuilt from scratch).
+The update-built graph therefore structurally diverged from the init-built
+one: metrics persisted by an update disagreed with init's for identical code,
+and the first post-init update could never hit the centrality cache.
+
+These tests build both graph shapes over the same small git repo and assert
+node/edge convergence plus equality of the centrality-cache signatures (the
+exact keys the cache hits on).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
+from repowise.core.ingestion.git_indexer import GitIndexer
+from repowise.core.ingestion.git_indexer.tiers import GitIndexTier
+from repowise.core.ingestion.graph._centrality_cache import subgraph_signature
+from repowise.core.pipeline.incremental import rebuild_graph_and_git
+
+
+def _build_git_repo(tmp_path: Path) -> None:
+    """Two python files co-committed 3x so co_changes edges exist (min_count=3)."""
+    import git as gitpython
+
+    repo = gitpython.Repo.init(tmp_path)
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", "Alice")
+        cw.set_value("user", "email", "alice@example.com")
+
+    # a.py and b.py are co-committed but unrelated statically: co_changes
+    # edges are only added between files with no existing import edge.
+    # c.py imports a.py so the graph also carries a real import edge.
+    (tmp_path / "a.py").write_text("x = 1\n")
+    (tmp_path / "b.py").write_text("y = 2\n")
+    (tmp_path / "c.py").write_text("from a import x\nz = x + 1\n")
+    repo.index.add(["a.py", "b.py", "c.py"])
+    repo.index.commit("feat: add modules a, b and c")
+
+    for i in range(2, 5):
+        (tmp_path / "a.py").write_text(f"x = {i}\n")
+        (tmp_path / "b.py").write_text(f"y = {i}\n")
+        repo.index.add(["a.py", "b.py"])
+        repo.index.commit(f"chore: co-change a and b, round {i}")
+    repo.close()
+
+
+def _build_init_shaped_graph(tmp_path: Path, git_meta_map: dict) -> GraphBuilder:
+    """Replicate the init pipeline's graph construction (ingestion phase +
+    co-change augmentation), independent of the update-path helpers."""
+    from repowise.core.ingestion.dynamic_hints import HintRegistry
+
+    traverser = FileTraverser(tmp_path)
+    parser = ASTParser()
+    gb = GraphBuilder(tmp_path)
+    for fi in traverser.traverse():
+        gb.add_file(parser.parse_file(fi, Path(fi.abs_path).read_bytes()))
+    gb.build()
+    # Framework edges: tech-stack detection on a bare two-file repo adds
+    # nothing, but run it anyway to mirror the phase order.
+    try:
+        from repowise.core.generation.editor_files.tech_stack import detect_tech_stack
+
+        gb.add_framework_edges([item.name for item in detect_tech_stack(tmp_path)])
+    except Exception:
+        pass
+    gb.add_dynamic_edges(HintRegistry().extract_all(tmp_path))
+    gb.add_co_change_edges(git_meta_map)
+    return gb
+
+
+def _edge_set(gb: GraphBuilder) -> set[tuple[str, str, str]]:
+    g = gb.graph()
+    return {(u, v, d.get("edge_type", "")) for u, v, d in g.edges(data=True)}
+
+
+async def test_update_graph_converges_with_init_graph(tmp_path: Path) -> None:
+    _build_git_repo(tmp_path)
+
+    # Init shape: full git index feeds co-change edges for every file.
+    init_indexer = GitIndexer(tmp_path, tier=GitIndexTier.FULL)
+    _summary, init_meta = await init_indexer.index_repo("repo1")
+    init_meta_map = {m["file_path"]: m for m in init_meta}
+    init_gb = _build_init_shaped_graph(tmp_path, init_meta_map)
+
+    # Sanity: the fixture actually produces a co_changes edge, otherwise
+    # this test cannot detect the divergence it exists to prevent.
+    assert any(t == "co_changes" for _, _, t in _edge_set(init_gb))
+
+    # Update shape: one changed file, graph rebuilt by the update path.
+    file_diffs = [SimpleNamespace(path="a.py", status="modified")]
+    (_pf, _src, upd_gb, _structure, _count, _meta) = await rebuild_graph_and_git(
+        tmp_path, file_diffs, cfg={}, exclude_patterns=[], git_tier="full"
+    )
+
+    assert set(init_gb.graph().nodes()) == set(upd_gb.graph().nodes())
+    assert _edge_set(init_gb) == _edge_set(upd_gb)
+
+    # The exact property the centrality cache keys on: identical file and
+    # symbol subgraph signatures, so a first post-init update can hit.
+    assert subgraph_signature(init_gb.file_subgraph()) == subgraph_signature(
+        upd_gb.file_subgraph()
+    )
+    assert subgraph_signature(init_gb.symbol_subgraph()) == subgraph_signature(
+        upd_gb.symbol_subgraph()
+    )


### PR DESCRIPTION
Indexing-layer performance pass focused on large repos, benchmarked on hugo (896 Go files, 2,014 parsed files, 2,216 commits). Init wall drops from 86s to ~70-76s and update from 47.5s to ~31-39s, with two correctness fixes along the way. Every change is behavior-preserving and ships with an equivalence or regression test.

## Performance

- **Type-ref resolution: graph build 10.75s -> 2.74s (isolated).** `_find_go_type_file` (and its JVM/C/Rust/TS siblings) scanned `graph.successors()` of every candidate file for every type reference: 185M function calls on hugo. One `node -> {defined symbol names}` map is now built per resolve pass and lookups become set membership; per-file candidate sorts are hoisted out of the per-ref loop. Full hugo graph snapshot is bit-identical under a fixed hash seed.
- **Health: full analysis 18.3s -> 12.9s (isolated, warm cache).** `_has_paired_test_file` ran O(files x paths x candidates) string suffix checks (44M `endswith` calls on hugo). A path matches `endswith(/ + c)` or equals `c` exactly when its basename equals `c`, so one precomputed basename set answers every lookup.
- **Dynamic hints: 2.93s -> 0.83s (isolated).** The 18 extractors issued ~40 `iter_glob` queries and each walked the tree from disk. `WalkSnapshot` replays one pruned walk for all of them, preserving `iter_glob` semantics, order, and subtree-rooted queries. Edge list is bit-identical on hugo.
- **Dead code: 3.12s -> 1.78s (isolated).** The ~540-glob never-flag alternation costs tens of microseconds per match and both node-scanning passes re-match the same ~15k node ids. The match is a pure function of the path, so it is now memoized. Findings identical.
- **Blame: single porcelain pass.** Files below the function-blame commit floor took a second blame pass through gitpython's `repo.blame` object parse just for ownership. Ownership now derives from the one `git blame --line-porcelain` invocation for every file; the floor only gates BlameIndex retention. Wall-neutral (blame cost is the subprocess), but ownership is bit-identical across all 938 hugo files, the GIL-holding parse no longer competes with concurrent ingestion, and the duplicate code path is gone.

## Correctness fixes the profiling surfaced

- **First update after init silently ran a full health re-score for every workspace member.** `repowise update` backfills the workspace distill verdict into the member's `config.yaml` at the start of the run; init never wrote it, so the stored config fingerprint mismatched and the update took the config-rescore branch instead of the incremental path (47s vs partial update on hugo). Init now runs the same backfill before fingerprinting.
- **The update-built graph diverged from the init-built graph.** Updates never ran dynamic hints and re-added `co_changes` edges only for changed files on a graph rebuilt from scratch, so metrics persisted by an update disagreed with init for identical code and the first post-init update could never hit the centrality cache. The update path now runs the hint registry and re-adds co-change edges for every file from the repo-wide walk it already performs; a test asserts node/edge-set equality and centrality-cache signature equality between both build shapes.

## Validation

- Unit suite green: 4,902 tests (10 new equivalence/regression tests across the six changes).
- Hugo graph snapshots (15,108 nodes / 53,702 edges, all attributes) compared bit-for-bit before/after the resolution changes; git ownership metadata diffed across all 938 files with zero differences.
- Bench protocol: single run per config on hugo + microdot via the existing harness.