### PR TITLE
fix(web): clarify health trend score changes

### DIFF
--- a/packages/web/src/app/repos/[id]/health/trend/page.tsx
+++ b/packages/web/src/app/repos/[id]/health/trend/page.tsx
@@ -94,7 +94,7 @@ export default function HealthTrendPage() {
 
           <section className="space-y-2">
             <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
-              Files that moved most since last index
+              Largest score changes since last index
             </h2>
             {data.file_deltas.length === 0 ? (
               <p className="text-sm text-[var(--color-text-tertiary)]">


### PR DESCRIPTION
## Summary

- rename the health trend file-delta section from a move/rename-oriented label to a score-change label
- keep the underlying trend data, table columns, sorting, and API contract unchanged

Fixes #452.

## Why

The trend page section listed files whose health scores changed most between the latest snapshots, but the heading said "Files that moved most since last index." That read like file moves or renames, which is not what the table represents.

The new heading, "Largest score changes since last index," matches the data shown in the table: before score, after score, and delta.

## Scope

This is a copy-only web UI change:

- no API changes
- no schema changes
- no scoring or trend calculation changes
- no layout changes beyond the replacement text

## Verification

- `npm.cmd ci`
- `npm.cmd run type-check --workspace packages/web`
- `git diff --check`
