### PR TITLE
release: v0.19.0 (wiki styles, hybrid MCP, web UX overhaul, health self-validation)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,8 +11,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.19.0] — 2026-06-13
+
 ### Added
-- **OpenCode CLI provider.** A new local OpenCode LLM provider runs documentation generation through the local OpenCode CLI via `opencode run --format json`. Uses `asyncio.create_subprocess_exec` (no shell), parses JSONL output, validates model names against a safe character set, and treats `opencode/*` cost as `$0.00`. No API keys are stored — OpenCode manages its own auth and model selection through its provider system. Interactive selection detects the OpenCode CLI on `PATH` and shows helpful install/setup instructions when it's missing.
+- **Wiki styles: selectable documentation voice.** Generated pages can now be produced in one of four styles: `comprehensive` (the default, unchanged), `caveman` (token-condensed, AI-first), `reference` (API-manual), or `tutorial` (beginner-friendly), plus user-defined custom styles. Styles change only the prose voice and density, not the document structure: headings, sections, table of contents, search, and cross-links are unaffected. (#468)
+- **OpenCode CLI provider.** A new local OpenCode LLM provider runs documentation generation through the local OpenCode CLI via `opencode run --format json`. Uses `asyncio.create_subprocess_exec` (no shell), parses JSONL output, validates model names against a safe character set, and treats `opencode/*` cost as `$0.00`. No API keys are stored; OpenCode manages its own auth and model selection through its provider system. Interactive selection detects the OpenCode CLI on `PATH` and shows helpful install/setup instructions when it's missing. (#436)
+- **Health score self-validation.** The code-health surface now validates the score against each repo's own bug history: it ranks files by health, takes the 20 lowest, and reports how many were touched by a `fix:` commit in the trailing ~6 months versus the repo-wide baseline rate (the lift), e.g. "16/20 lowest-health files had a bug fix in the last 6 months, 3.3x the 24% baseline". Stays silent when there is too little history to be honest. (#438)
+- **Error-handling maintainability biomarker.** A new biomarker surfaces swallowed-exception and unsafe-unwrap anti-patterns as a bounded maintainability finding: empty or trivial `catch`/`except` bodies across Python, JS/TS, Java, Kotlin, C#, and C++, plus Python catch-all `except:` / `except Exception:` / `except BaseException:`. (#453)
+- **MCP streamable HTTP transport.** The MCP server can now serve over a streamable HTTP transport in addition to stdio. (#444)
+- **`REPOWISE_PORT` env var.** `repowise serve` now honours the `REPOWISE_PORT` environment variable for the server port. (#455)
+
+### Changed
+- **Web dashboard UX overhaul.** End-to-end rework of the web UI: a slimmer six-group sidebar (Overview, Docs, Architecture, Code Health, People and History, Chat) shared across desktop and mobile, Overview as the repo landing page, canonical entity pages, a single unified architecture destination, and surfacing of git/agent provenance data that was already persisted but previously invisible. Theme unchanged; design tokens were only added, never renamed. Retired pages (hotspots, ownership, dead-code, blast-radius) and stub routes redirect into their new homes, so every old URL still resolves. (#466)
+- **Hybrid MCP improvements.** A batch of MCP server improvements centered on making a tool response trustworthy enough that the agent never re-reads the source it just paid for: a verified trust contract, an honest savings ledger, indexing of module-level constants, and trimmed per-call token overhead. Net additive to the tool surface, with no breaking changes to existing tool contracts. (#467)
+- **Change-risk clarity.** Change-risk now prioritises repo-relative signals and uses honest driver labels instead of misleading absolute framing. (#465, #469)
+- **Dead-code framing.** Findings are now framed as cleanup candidates rather than safe-to-delete, reflecting that static reachability can't prove a symbol is unused. (#433)
+
+### Fixed
+- **Co-change strength display.** Co-change strength now shows the raw score instead of a misleading percentage. (#439)
+- **Health scoring of module-level JS callbacks.** Module-level JavaScript callbacks are now scored correctly. (#456)
+- **Health trend wording.** Clarified how health-trend score changes are presented in the web UI. (#457)
+- **CLI model selection.** The CLI now honours the `config.yaml` model when a provider is set via env var or flag. (#442)
+- **Chat config inheritance.** Chat now inherits the per-repo provider, model, and key from the init config. (#434)
+
+### Performance
+- **XL-repo indexing pass.** Faster indexing on very large repos via cpp hint regex tuning, git deep-walk improvements, and XAML index reuse. (#459)
+- **Large-repo indexing pass.** Indexing and update-path improvements covering type references, health, dynamic hints, and dead-code analysis. (#450)
+- **Incremental duplication splice.** Update runs now splice duplication pairs incrementally instead of recomputing them wholesale. (#460)
+
+### Documentation
+- Plugin: version bump to 0.19.0 (no command/skill/hook/MCP-surface changes).
 
 ---
 

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.18.0"
+__version__ = "0.19.0"

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -241,7 +241,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.18.0</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.19.0</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -323,7 +323,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
         <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
           <ThemeToggle className="w-full justify-between" />
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.18.0
+            repowise v0.19.0
           </p>
         </div>
       )}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.19.0
+
+Version bump to track the repowise 0.19.0 release. No changes to the plugin's
+commands, skills, hooks, or MCP tool surface this cycle.
+
 ## 0.18.0
 
 Version bump to track the repowise 0.18.0 release. No changes to the plugin's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.18.0"
+version = "0.19.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Cuts repowise v0.19.0. Branch contains only the version bump, lockfile sync, and changelog.

## What ships

**Added**
- Wiki styles: selectable documentation voice (comprehensive / caveman / reference / tutorial + custom) (#468)
- OpenCode CLI provider (#436)
- Code-health score self-validation against each repo's own bug history (#438)
- Error-handling maintainability biomarker (#453)
- MCP streamable HTTP transport (#444)
- `REPOWISE_PORT` env var support in `serve` (#455)

**Changed**
- Web dashboard UX overhaul: consolidated IA, entity pages, unified architecture, provenance surfacing (#466)
- Hybrid MCP improvements: verified trust contract, honest savings, constant indexing (#467)
- Change-risk clarity: repo-relative priority + honest driver labels (#465, #469)
- Dead-code findings framed as cleanup candidates (#433)

**Fixed**
- Co-change strength shown as raw score, not percentage (#439)
- Health scoring of module-level JS callbacks (#456); health-trend wording (#457)
- CLI honours `config.yaml` model when provider set via env/flag (#442)
- Chat inherits per-repo provider/model/key from init config (#434)

**Performance**
- XL-repo (#459) and large-repo (#450) indexing passes; incremental duplication splice on update runs (#460)

Plugin bumped to 0.19.0 (no command/skill/hook/MCP-surface changes).

## Version bump
- `pyproject.toml`, `cli/core/server __init__.py`, both plugin manifests, web sidebar + mobile-nav footers, `uv.lock` self-entry. Grep confirms no `0.18.0` stragglers.

## Test plan
- [x] `uv build --wheel` clean: `repowise-0.19.0-py3-none-any.whl` (36 command entries, `serve_cmd.py` present, `.scm`/`.j2` data files bundled)
- [x] `uv.lock` self-entry regenerated to 0.19.0
- [x] Plugin MCP-tool parity grep: only exposed tools referenced, no `get_dependency_path` / `get_architecture_diagram` leak
- [ ] Local `npm run build --workspace packages/web` not validated on this Windows machine (environmental `.js`->`.ts` workspace-resolution quirk under the symlinked monorepo). CI builds the web tarball on Linux and is green on `main` for this exact code; v0.18.0 shipped the identical import pattern.
- [ ] Post-merge: tag merge commit on `main`, push tag, watch `publish.yml`

## Merge convention
Use a **regular merge commit** (not squash) so the tag points at a real merge of the bump-only diff and artifact provenance stays traceable.
