### PR TITLE
release: v0.19.1 (fix web UI build resolution + harden publish pipeline)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,7 +116,9 @@ jobs:
   # ---------------------------------------------------------------------------
   publish:
     name: Publish to PyPI
-    needs: build-python
+    # Gate PyPI publish on BOTH builds so a web-build failure can never leave a
+    # half-shipped release (wheel on PyPI but no GitHub release / web tarball).
+    needs: [build-web, build-python]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.19.1] — 2026-06-13
+
+### Fixed
+- **`repowise serve` web UI failed to build for the release tarball.** The bundled web dashboard could not be compiled once a workspace-package barrel entry was imported as a value (introduced by the wiki-styles constants), because Webpack could not resolve the ESM `.js` re-export specifiers in `@repowise-dev/types` / `@repowise-dev/ui` back to their `.ts` sources. Added an extension alias to the Next.js build so `.js` specifiers map to `.ts`/`.tsx`. This affected only the published `repowise-web.tar.gz`; the Python wheel was unaffected. (#471)
+
+---
+
 ## [0.19.0] — 2026-06-13
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -6,6 +6,20 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: ["lucide-react", "recharts"],
   },
+  // The workspace packages (@repowise-dev/types, @repowise-dev/ui) are ESM
+  // ("type": "module") and their barrel files re-export with explicit ".js"
+  // specifiers (e.g. export * from "./graph.js") that point at ".ts" sources.
+  // Webpack needs an extension alias to map those ".js" specifiers back to the
+  // real ".ts"/".tsx" files when it transpiles these packages inline; without
+  // it, any value import of a barrel entry fails to resolve at build time.
+  webpack(config) {
+    config.resolve.extensionAlias = {
+      ...config.resolve.extensionAlias,
+      ".js": [".ts", ".tsx", ".js", ".jsx"],
+      ".jsx": [".tsx", ".jsx"],
+    };
+    return config;
+  },
   images: {
     unoptimized: true,
   },

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -241,7 +241,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.19.0</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.19.1</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -323,7 +323,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
         <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
           <ThemeToggle className="w-full justify-between" />
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.19.0
+            repowise v0.19.1
           </p>
         </div>
       )}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.19.1
+
+Version bump to track the repowise 0.19.1 release. No changes to the plugin's
+commands, skills, hooks, or MCP tool surface this cycle.
+
 ## 0.19.0
 
 Version bump to track the repowise 0.19.0 release. No changes to the plugin's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.19.0"
+version = "0.19.1"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Patch release. Recovers the v0.19.0 release, whose `build-web` job failed in `publish.yml` (the wheel published to PyPI, but no GitHub release / web tarball was created).

## Root cause
`@repowise-dev/types` and `@repowise-dev/ui` are ESM packages whose barrel files re-export with explicit `.js` specifiers pointing at `.ts` sources (`export * from "./graph.js"`). Until now every web import of these packages used either subpath imports (which map directly to `.ts` via the `exports` map) or `import type` (erased before bundling), so the barrel `index.ts` was never compiled. The wiki-styles work (#468) added the first **value** imports of the bare entry (`WIKI_STYLES`, `DEFAULT_WIKI_STYLE`), forcing Webpack to compile `index.ts` and resolve its `.js` re-exports, which it could not map back to `.ts`. The web build failed identically locally and in CI.

## Fixes
- **Web build resolution.** Added a Webpack `extensionAlias` to `packages/web/next.config.ts` so `.js` specifiers resolve to `.ts`/`.tsx`. Verified: `npm run build --workspace packages/web` compiles cleanly and emits the standalone `server.js` with workspace code bundled.
- **Pipeline hardening.** `publish.yml` now gates the PyPI publish job on `build-web` succeeding (previously `needs: build-python` only), so a web-build failure can never again leave a half-shipped release.

## Version bump
- `pyproject.toml`, `cli/core/server __init__.py`, both plugin manifests, web footers, `uv.lock`. Grep confirms no `0.19.0` stragglers.

## Test plan
- [x] `npm run build --workspace packages/web` succeeds; standalone `server.js` present; workspace chunks bundled
- [x] `uv build --wheel` clean: `repowise-0.19.1-py3-none-any.whl`; `uv.lock` self-entry regenerated
- [ ] Post-merge: tag `v0.19.1` on `main`, push tag, watch `publish.yml` (expect web tarball + GitHub release this time)

## Note
The v0.19.0 wheel is already on PyPI (immutable). After this lands, `pip install -U repowise` gets a working 0.19.1; users pinned to 0.19.0 would hit a 404 on the web tarball at `serve` time.
