### PR TITLE
fix(mcp): register all server tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center"><em>The codebase intelligence layer for the AI era. Context your AI agent can use, and the health, risk, and ownership signals your team can trust.</em></p>
 
-<p align="center"><strong>Five intelligence layers · Nine MCP tools · 15 languages · Multi-repo workspaces · One <code>pip install</code></strong></p>
+<p align="center"><strong>Five intelligence layers · 18 MCP tools · 15 languages · Multi-repo workspaces · One <code>pip install</code></strong></p>
 
 <p align="center">
   <a href="https://www.repowise.dev"><img src="https://img.shields.io/badge/LIVE_DEMO-repowise.dev-F59520?style=for-the-badge&labelColor=0A0A0A" alt="Live demo — repowise.dev" /></a>
@@ -34,7 +34,7 @@
   <a href="#benchmarks">Benchmarks</a> ·
   <a href="#supported-languages">Languages</a> ·
   <a href="#quickstart">Quickstart</a> ·
-  <a href="#nine-mcp-tools">MCP tools</a> ·
+  <a href="#18-mcp-tools">MCP tools</a> ·
   <a href="#how-it-compares">Comparison</a> ·
   <a href="#for-teams--enterprises">Hosted</a>
 </sub></p>
@@ -54,7 +54,7 @@ source code and no memory of how the codebase got there.
 repowise fixes that. It indexes your codebase into **five intelligence layers** —
 dependency graph, git history, auto-generated docs, architectural decisions, and
 code health — and exposes them to Claude Code, Codex, and any MCP-compatible agent
-through **nine task-shaped tools**. The result: your agent answers *"why does
+through **18 task-shaped tools**. The result: your agent answers *"why does
 auth work this way?"* instead of *"here is what `auth.ts` contains"* — with
 **fewer tool calls, fewer file reads, and lower cost per query, at comparable
 answer quality** ([benchmarks ↓](#benchmarks)).
@@ -358,7 +358,7 @@ To add the MCP server to another editor manually:
 
 ---
 
-## Nine MCP tools
+## 18 MCP tools
 
 Most tools are designed around data entities — one module, one file, one symbol —
 forcing agents into long chains of sequential calls. repowise tools are designed
@@ -373,11 +373,20 @@ diverges from live `.git/HEAD`.
 | `get_answer(question)` | Hybrid retrieval (FTS + vector via RRF) + PageRank bias + 1-hop graph expansion → a cited answer with calibrated `retrieval_quality`. Returns structured `best_guesses` on low confidence. Collapses search → read → reason into one round-trip. |
 | `get_context(targets, include?)` | Triage card for files / modules / symbols: title, summary, signatures, `hotspot` bit, `governing_decisions`, and `symbol_id`s. `include` opens callers/callees, ownership, metrics, decisions, full_doc. Batch many targets. |
 | `get_symbol("file.py::Name")` | Raw source bytes for one indexed symbol with exact line bounds — cheaper and safer than `Read` + offset math. |
+| `get_callers_callees(symbol_id)` | Direct caller/callee and class-hierarchy neighborhood for a symbol. |
+| `get_graph_metrics(target)` | PageRank, centrality, community, entry-point score, and percentile context for a file or symbol. |
+| `get_community(target)` | Community membership, cohesion, neighboring communities, and important members. |
+| `get_execution_flows(...)` | Top entry points and call-path traces through the dependency graph. |
 | `search_codebase(query, kind?)` | Semantic search over the wiki, filterable by `kind` (implementation / test / config / doc), tagging each result's `search_method`. |
 | `get_risk(targets, changed_files?)` | Hotspot scores, dependents, co-change partners, ownership, test gaps, security signals. Pass `changed_files` for PR mode → a `directive` block (`will_break`, `missing_cochanges`, `missing_tests`, `governance_risk`). |
 | `get_why(query?, targets?)` | Architectural decision records, status, evidence spans, and the supersession **lineage chain**. Falls back to git archaeology when no ADRs exist. |
+| `update_decision_records(action, ...)` | Create, update, list, get, delete, and change status for architectural decision records. |
+| `get_dependency_path(source, target)` | Shortest dependency path or bridge context between two files/modules/symbols. |
+| `get_architecture_diagram(...)` | Mermaid architecture diagram for the repo, module, or file scope. |
 | `get_dead_code(...)` | Unreachable code by confidence tier with cleanup-impact estimates; cross-repo consumer detection in workspace mode. |
 | `get_health(targets?, include?)` | 25-biomarker scores per file. Dashboard mode → KPIs + lowest-scoring files + module rollup; targeted mode → per-file findings. `include`: coverage, refactoring, trend. |
+| `annotate_file(target, notes)` | Persistent human notes on a wiki page that survive regeneration. |
+| `list_repos()` | Workspace repository aliases and default repo metadata. |
 
 Worked example (*"Add rate limiting to all API endpoints"* in 5 calls instead of
 ~30 greps+reads) and the full reference: **[docs/MCP_TOOLS.md →](docs/MCP_TOOLS.md)**

--- a/docs/COMMERCIAL.md
+++ b/docs/COMMERCIAL.md
@@ -19,7 +19,7 @@ models. Specific pricing figures are provided in a separate proposal.
 ## 1. Who the commercial license is for
 
 The open-source distribution covers the full developer-experience surface — the five
-intelligence layers, the nine MCP tools, multi-repo workspaces, the local dashboard,
+intelligence layers, the 18 MCP tools, multi-repo workspaces, the local dashboard,
 auto-sync, and auto-generated `CLAUDE.md`. That is everything an engineer or a team
 needs to make their AI coding agents codebase-aware.
 
@@ -113,7 +113,7 @@ the items that matter most to you can be prioritized.
 | Capability | Open Source (AGPL) | Commercial License |
 |------------|:------------------:|:------------------:|
 | Five intelligence layers | ✅ | ✅ |
-| Nine MCP tools | ✅ | ✅ |
+| 18 MCP tools | ✅ | ✅ |
 | Multi-repo workspaces | ✅ | ✅ |
 | Full-tier language support (incl. C# / .NET) | ✅ | ✅ |
 | Local dashboard (incl. local security pattern scan) | ✅ | ✅ |

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-repowise exposes 9 tools via the [Model Context Protocol](https://modelcontextprotocol.io) (MCP). These tools give AI coding assistants (Claude Code, Codex, Cursor, Cline, Windsurf) structured access to your codebase intelligence — dependency graph, git history, documentation, and architectural decisions.
+repowise exposes 18 tools via the [Model Context Protocol](https://modelcontextprotocol.io) (MCP). These tools give AI coding assistants (Claude Code, Codex, Cursor, Cline, Windsurf) structured access to your codebase intelligence — dependency graph, git history, documentation, and architectural decisions.
 
 **Start the MCP server:**
 
@@ -22,11 +22,20 @@ repowise mcp --transport sse --port 7338 # legacy SSE transport
 | `get_answer` | One-call RAG Q&A | First call on any code question |
 | `get_context` | Rich context for targets | Before reading or modifying code |
 | `get_symbol` | Raw source bytes for one symbol | When you need one function/class body |
+| `get_callers_callees` | Direct symbol neighborhood | When tracing who calls what |
+| `get_graph_metrics` | Centrality and community metrics | When judging importance or risk |
+| `get_community` | Architectural cluster details | When exploring module boundaries |
+| `get_execution_flows` | Entry-point call traces | When following runtime paths |
 | `search_codebase` | Semantic search | Discovering code by topic |
 | `get_risk` | Modification risk | Before changing hotspot files |
 | `get_why` | Architectural decisions | Before structural changes |
+| `update_decision_records` | Decision-record CRUD | After making architectural decisions |
+| `get_dependency_path` | Graph path between targets | When connecting two modules/files |
+| `get_architecture_diagram` | Mermaid diagram output | When a visual map helps |
 | `get_dead_code` | Unreachable code | Cleanup tasks |
 | `get_health` | Code-health biomarker scores | Before refactoring — find the worst files |
+| `annotate_file` | Persistent human notes | When preserving context across regeneration |
+| `list_repos` | Workspace repo list | When choosing a repo alias |
 
 ---
 
@@ -50,8 +59,8 @@ envelope lists how to get it back:
 Truncated skeleton blocks are replaced in place by a `[repowise#<ref>: ...]`
 marker; everything else is captured into one combined document per response.
 Resolve refs with `repowise expand <ref>` from a shell, or
-`get_symbol("repowise#<ref>")` from any MCP client — the tool count stays at
-nine. See [DISTILL.md](DISTILL.md) for the full reversibility model.
+`get_symbol("repowise#<ref>")` from any MCP client. See [DISTILL.md](DISTILL.md)
+for the full reversibility model.
 
 ---
 
@@ -172,6 +181,80 @@ get_symbol(symbol_id="repowise#a1b2c3d4e5f6", query="FAILED")
 
 ---
 
+## `get_callers_callees`
+
+Find who calls a symbol and what it calls. Also works for class-hierarchy
+queries with `edge_types=["extends", "implements"]`.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `symbol_id` | string | Yes | Canonical symbol ID, usually from `get_context` |
+| `direction` | string | No | `"callers"`, `"callees"`, or `"both"` |
+| `edge_types` | list[string] | No | Edge types to include; defaults to `["calls"]` |
+| `limit` | int | No | Max results per direction |
+| `repo` | string | No | *(workspace only)* Target repo alias |
+
+**When to use:** When a change depends on direct call relationships or class
+hierarchy rather than broad file-level context.
+
+---
+
+## `get_graph_metrics`
+
+Return PageRank, betweenness, community, entry-point score, degree counts, and
+percentile context for a file or symbol.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `target` | string | Yes | File path or symbol ID |
+| `repo` | string | No | *(workspace only)* Target repo alias |
+
+**When to use:** When deciding whether a target is central, peripheral, or a
+high-leverage entry point.
+
+---
+
+## `get_community`
+
+Show the architectural community/cluster a file belongs to, including cohesion,
+members, and neighboring communities.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `target` | string | Yes | File path or community ID |
+| `include_members` | boolean | No | Include member files; default true |
+| `member_limit` | int | No | Max members to return |
+| `repo` | string | No | *(workspace only)* Target repo alias |
+
+**When to use:** When exploring module boundaries or planning refactors that
+could cross architectural clusters.
+
+---
+
+## `get_execution_flows`
+
+Show top entry points and BFS call-path traces through the dependency graph.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `top_n` | int | No | Number of entry points to trace |
+| `max_depth` | int | No | Max trace depth per flow |
+| `entry_point` | string | No | Specific symbol to trace from |
+| `repo` | string | No | *(workspace only)* Target repo alias |
+
+**When to use:** When following runtime paths from route handlers, commands, or
+other entry points.
+
+---
+
 ## `search_codebase`
 
 Semantic search over the full wiki. Natural language queries.
@@ -253,6 +336,66 @@ get_why()
 
 ---
 
+## `update_decision_records`
+
+Create, update, list, get, delete, or change status for architectural decision
+records.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | string | Yes | `create`, `update`, `update_status`, `delete`, `list`, or `get` |
+| `decision_id` | string | Action-dependent | Required for update/get/delete/status changes |
+| `title` | string | No | Decision title for create/update |
+| `status` | string | No | Decision status, such as `proposed`, `accepted`, or `superseded` |
+| `context`, `decision`, `rationale` | string | No | Decision content fields |
+| `affected_files`, `affected_modules`, `tags` | list[string] | No | Scope and classification metadata |
+| `repo` | string | No | *(workspace only)* Target repo alias |
+
+**When to use:** After architectural changes, or when maintaining decision
+records that guide future work.
+
+---
+
+## `get_dependency_path`
+
+Find how two files, modules, or symbols are connected in the dependency graph.
+If no direct path exists, returns bridge context such as shared neighbors and
+community analysis.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `source` | string | Yes | Source file, module, or symbol |
+| `target` | string | Yes | Target file, module, or symbol |
+| `repo` | string | No | *(workspace only)* Target repo alias |
+
+**When to use:** When you need to understand why two areas are coupled or how a
+change could flow through the graph.
+
+---
+
+## `get_architecture_diagram`
+
+Return a Mermaid diagram for the repository or a specific module/file scope.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `scope` | string | No | `"repo"`, `"module"`, or `"file"` |
+| `path` | string | Scope-dependent | Module or file path for scoped diagrams |
+| `diagram_type` | string | No | `"auto"`, `"flowchart"`, `"class"`, or `"sequence"` |
+| `show_heat` | boolean | No | Annotate nodes with churn heat colors |
+| `repo` | string | No | *(workspace only)* Target repo alias |
+
+**When to use:** When a visual map is useful for documentation, review, or
+explaining structure.
+
+---
+
 ## `get_dead_code`
 
 Unreachable code sorted by confidence tier with cleanup impact estimates.
@@ -311,9 +454,38 @@ get_health(targets=["module:src.api"], include=["trend"])
 
 ---
 
+## `annotate_file`
+
+Attach human-authored notes to a file or module wiki page. Notes survive
+LLM-driven regeneration and are returned with context.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `target` | string | Yes | File or module path |
+| `notes` | string | Yes | Note text; pass an empty string to clear notes |
+| `repo` | string | No | *(workspace only)* Target repo alias |
+
+**When to use:** When preserving rationale, known issues, or local context that
+generated docs should not overwrite.
+
+---
+
+## `list_repos`
+
+List repositories known to the current workspace and identify the default repo.
+
+**Parameters:** None.
+
+**When to use:** In workspace mode, before passing a `repo` alias to other MCP
+tools.
+
+---
+
 ## Workspace Mode
 
-In workspace mode (initialized with `repowise init .`), all tools accept an optional `repo` parameter:
+In workspace mode (initialized with `repowise init .`), repo-scoped tools accept an optional `repo` parameter:
 
 - **Omit `repo`** — queries the default (primary) repo
 - **`repo="backend"`** — targets a specific repo by alias
@@ -328,7 +500,7 @@ The MCP server automatically enriches responses with cross-repo intelligence:
 
 ## Proactive Hooks (Complementary)
 
-In addition to the 9 MCP tools, `repowise init` installs AI-agent hooks (Claude Code and Codex) that provide **passive, automatic** context enrichment:
+In addition to the 18 MCP tools, `repowise init` installs AI-agent hooks (Claude Code and Codex) that provide **passive, automatic** context enrichment:
 
 - **Claude Code PostToolUse** — broad or zero-result `Grep`/`Glob` calls can be enriched with graph context, and git operations can trigger stale-wiki notices.
 - **Codex SessionStart/UserPromptSubmit** — Codex receives concise Repowise MCP workflow guidance when a session or prompt starts.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -226,7 +226,7 @@ REPOWISE_API_URL=http://localhost:7337 npm run dev --workspace packages/web
 
 - **[User Guide](USER_GUIDE.md)** — full CLI reference, web UI features, MCP setup, common workflows, and troubleshooting
 - **[CLI Reference](CLI_REFERENCE.md)** — every command with every flag
-- **[MCP Tools](MCP_TOOLS.md)** — all 9 MCP tools with parameters and examples
+- **[MCP Tools](MCP_TOOLS.md)** — all 18 MCP tools with parameters and examples
 - **[Workspaces](WORKSPACES.md)** — multi-repo workspace setup and cross-repo intelligence
 - **[Auto-Sync](AUTO_SYNC.md)** — hooks, file watcher, webhooks, polling
 - **[Architecture](architecture/ARCHITECTURE.md)** — how repowise is built internally

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -376,7 +376,7 @@ This is how you connect repowise to Claude Code, Cursor, Cline, Windsurf, and ot
 | `--transport` | Protocol: `stdio` (default, for editors), `streamable-http` (for HTTP clients), or `sse` (legacy) |
 | `--port` | Port for HTTP/SSE transports (default: 7338) |
 
-**MCP tools exposed (9 tools):**
+**MCP tools exposed (18 tools):**
 
 | Tool | What it does |
 |------|-------------|
@@ -384,11 +384,20 @@ This is how you connect repowise to Claude Code, Cursor, Cline, Windsurf, and ot
 | `get_answer` | One-call RAG: confidence-gated synthesis over the wiki, with cited 2–5 sentence answers and a per-repository question cache |
 | `get_context` | Complete context for files/modules/symbols — docs, ownership, decisions, freshness, community membership. Defaults to `compact=True`; pass `compact=False` for the full structure block and importer list. In workspace mode, accepts `repo` parameter. |
 | `get_symbol` | Raw source bytes for one indexed symbol with exact line bounds (cheaper/safer than `Read` + offset math) |
+| `get_callers_callees` | Direct caller/callee and class-hierarchy neighborhood for a symbol |
+| `get_graph_metrics` | PageRank, centrality, community, entry-point score, and percentile context for a file or symbol |
+| `get_community` | Architectural community details, members, cohesion, and neighboring communities |
+| `get_execution_flows` | Top entry points and call-path traces through the dependency graph |
 | `search_codebase` | Semantic search over wiki with git freshness boosting. In workspace mode, searches across all repos. |
 | `get_risk` | Modification risk assessment — hotspot score, dependents, co-change partners, bus factor, blast radius, test gaps, 0–10 risk score |
 | `get_why` | Why code is structured the way it is — architectural decisions, git archaeology. Three modes: NL search, path-based, health dashboard. |
+| `update_decision_records` | Create, update, list, get, delete, and change status for architectural decision records |
+| `get_dependency_path` | Dependency path or bridge context between two files, modules, or symbols |
+| `get_architecture_diagram` | Mermaid architecture diagram for repository, module, or file scope |
 | `get_dead_code` | Tiered dead code report grouped by confidence with cleanup impact estimates |
 | `get_health` | 25-biomarker code-health scores — dashboard KPIs + lowest-scoring files, or per-file findings; `include` for refactoring suggestions and trend alerts |
+| `annotate_file` | Persistent human notes on a wiki page that survive regeneration |
+| `list_repos` | Workspace repository aliases and default repo metadata |
 
 In workspace mode, tools are workspace-aware — pass `repo="backend"` to target a specific repo or `repo="all"` to query across the entire workspace. The default repo is used when `repo` is omitted.
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -16,7 +16,7 @@ For per-package detail (installation, full API reference, all CLI flags, file ma
 |---------|--------|----------------|
 | `packages/core` | [`packages/core/README.md`](../packages/core/README.md) | Ingestion, generation, persistence, providers — all key classes with code examples |
 | `packages/cli` | [`packages/cli/README.md`](../packages/cli/README.md) | All 10 CLI commands with every flag documented |
-| `packages/server` | [`packages/server/README.md`](../packages/server/README.md) | All REST API endpoints, 11 MCP tools, webhook setup, scheduler jobs |
+| `packages/server` | [`packages/server/README.md`](../packages/server/README.md) | All REST API endpoints, 18 MCP tools, webhook setup, scheduler jobs |
 | `packages/web` | [`packages/web/README.md`](../packages/web/README.md) | Every frontend file with purpose — API client, hooks, components, pages |
 
 ---
@@ -1048,12 +1048,16 @@ and supports two transports:
 - **stdio** — for Claude Code, Cursor, Cline (add to their MCP config)
 - **SSE** — for web-based MCP clients (served on port 7338)
 
-### Tools (11 total)
+### Tools (18 total)
 
 | Tool | What it answers | When to call |
 |------|----------------|-------------|
 | `get_overview` | Architecture summary, module map, entry points. | First call when exploring an unfamiliar codebase. |
 | `get_context(targets, include?)` | Docs, ownership, history, decisions, freshness for files/modules/symbols. Pass multiple targets in one call. | When you need to understand specific code before reading or modifying it. |
+| `get_callers_callees(symbol_id)` | Direct caller/callee and class-hierarchy neighborhood for a symbol. | When tracing symbol-level impact. |
+| `get_graph_metrics(target)` | PageRank, centrality, community, entry-point score, and percentiles. | When judging graph importance. |
+| `get_community(target)` | Community membership, cohesion, important members, and neighboring clusters. | When exploring module boundaries. |
+| `get_execution_flows(...)` | Entry-point traces through call edges. | When following runtime paths. |
 | `get_risk(targets)` | Hotspot score, dependents, co-change partners, risk summary per target. Also returns top 5 global hotspots. | Before modifying files — assess what could break. |
 | `get_why(query?)` | Three modes: NL search over decisions, path-based decisions for a file, no-arg health dashboard. | Before making architectural changes — understand existing intent. |
 | `update_decision_records(action, ...)` | Full CRUD on decision records: create, update, update_status, delete, list, get. | After every coding task — record new decisions and keep existing ones current. |
@@ -1064,6 +1068,8 @@ and supports two transports:
 | `get_answer` | One-call RAG: confidence-gated synthesis with cited answers and question cache. | First call on any code question — collapses search → read → reason. |
 | `get_symbol` | Resolve a qualified symbol id to source body, signature, and docstring. | When the question names a specific class, function, or method. |
 | `annotate_file` | Attach human-authored notes to a wiki page — survives re-indexing. | Adding rationale, known issues, or context the LLM shouldn't overwrite. |
+| `get_health` | Code-health biomarker scores and dashboard rollups. | Before refactoring or prioritizing cleanup. |
+| `list_repos` | Workspace repository aliases and default repo metadata. | When selecting a repo alias in workspace mode. |
 
 ### Auto-generated Config
 
@@ -1155,7 +1161,7 @@ file, tokens used, estimated cost, estimated time remaining).
 repowise includes an interactive chat interface that lets users ask questions about
 their codebase and receive answers grounded in the wiki, dependency graph, git
 history, and architectural decisions. The chat agent uses whichever LLM provider
-the user has configured and has access to all 11 MCP tools.
+the user has configured and has access to all 18 MCP tools.
 
 See [`docs/CHAT.md`](CHAT.md) for the full technical reference covering the
 backend agentic loop, SSE streaming protocol, provider abstraction extensions,
@@ -1166,7 +1172,7 @@ database schema, frontend component architecture, and artifact rendering system.
 - **Provider-agnostic** — the chat agent goes through the same provider abstraction
   as documentation generation. A `ChatProvider` protocol extends `BaseProvider` with
   `stream_chat()` for streaming + tool use without breaking existing callers.
-- **Tool reuse** — the 11 MCP tools are called directly as Python functions (no
+- **Tool reuse** — the 18 MCP tools are called directly as Python functions (no
   subprocess round-trip). Tool schemas are defined once in `chat_tools.py` and
   fed to both the LLM and the executor.
 - **SSE streaming** — `POST /api/repos/{repo_id}/chat/messages` runs the agentic

--- a/docs/architecture/pluggable-storage.md
+++ b/docs/architecture/pluggable-storage.md
@@ -216,7 +216,7 @@ broken plugin cannot derail the pipeline.
 The seams add a layer of indirection but no behavior change for users
 of the OSS defaults: `repowise init` still writes to
 `.repowise/wiki.db`, the in-process graph still owns ingestion, the
-nine MCP tools still expose the same surface, and `repowise --help`
+18 MCP tools still expose the same surface, and `repowise --help`
 lists the same commands in the same order. Plugins extend the
 defaults; they don't replace them unless an integration explicitly
 swaps an implementation in.

--- a/docs/internals/chat.md
+++ b/docs/internals/chat.md
@@ -2,7 +2,7 @@
 
 The codebase chat feature lets users have an interactive conversation with their
 codebase. The agent uses whichever LLM provider the user has configured, has
-access to all 10 MCP tools, and streams responses back to the browser in real time
+access to all 18 MCP tools, and streams responses back to the browser in real time
 showing tool calls as they happen and rendering results in an artifact panel.
 
 ---

--- a/packages/server/src/repowise/server/mcp_server/__init__.py
+++ b/packages/server/src/repowise/server/mcp_server/__init__.py
@@ -1,4 +1,4 @@
-"""repowise MCP Server — 17 tools for AI coding assistants.
+"""repowise MCP Server — 18 tools for AI coding assistants.
 
 Exposes the full repowise wiki as queryable tools via the MCP protocol.
 Supports stdio transport (Claude Code, Cursor, Cline), streamable HTTP, and
@@ -37,10 +37,18 @@ from repowise.server.mcp_server._server import (
     mcp,
     run_mcp,
 )
+from repowise.server.mcp_server.tool_annotate import annotate_file
 from repowise.server.mcp_server.tool_answer import get_answer
+from repowise.server.mcp_server.tool_callers import get_callers_callees
+from repowise.server.mcp_server.tool_community import get_community
 from repowise.server.mcp_server.tool_context import get_context
 from repowise.server.mcp_server.tool_dead_code import get_dead_code
+from repowise.server.mcp_server.tool_decision_records import update_decision_records
+from repowise.server.mcp_server.tool_dependency import get_dependency_path
+from repowise.server.mcp_server.tool_diagram import get_architecture_diagram
+from repowise.server.mcp_server.tool_flows import get_execution_flows
 from repowise.server.mcp_server.tool_health import get_health
+from repowise.server.mcp_server.tool_metrics import get_graph_metrics
 from repowise.server.mcp_server.tool_overview import get_overview
 from repowise.server.mcp_server.tool_repos import list_repos
 from repowise.server.mcp_server.tool_risk import get_risk
@@ -106,10 +114,17 @@ __all__ = [
     "_compute_alignment",
     "_get_repo",
     "_is_path",
+    "annotate_file",
     "create_mcp_server",
     "get_answer",
+    "get_architecture_diagram",
+    "get_callers_callees",
+    "get_community",
     "get_context",
     "get_dead_code",
+    "get_dependency_path",
+    "get_execution_flows",
+    "get_graph_metrics",
     "get_health",
     "get_overview",
     "get_risk",
@@ -119,4 +134,5 @@ __all__ = [
     "mcp",
     "run_mcp",
     "search_codebase",
+    "update_decision_records",
 ]

--- a/tests/unit/server/mcp/test_tool_registration.py
+++ b/tests/unit/server/mcp/test_tool_registration.py
@@ -1,0 +1,46 @@
+"""MCP server tool registration."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import repowise.server.mcp_server as mcp_server
+from repowise.core.registry import mcp_tool_registry
+from repowise.server.mcp_server import create_mcp_server
+
+
+def _is_tool_decorator(decorator: ast.expr) -> bool:
+    if isinstance(decorator, ast.Call):
+        decorator = decorator.func
+    return isinstance(decorator, ast.Attribute) and decorator.attr == "tool"
+
+
+def _declared_tool_names() -> set[str]:
+    base = Path(mcp_server.__file__).parent
+    names: set[str] = set()
+
+    for path in base.rglob("*.py"):
+        if not any(part.startswith("tool_") for part in path.relative_to(base).parts):
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8-sig"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef) and any(
+                _is_tool_decorator(decorator) for decorator in node.decorator_list
+            ):
+                names.add(node.name)
+
+    return names
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_exposes_all_registered_tools() -> None:
+    tools = await create_mcp_server().list_tools()
+    declared_tool_names = _declared_tool_names()
+    registered_tool_names = {tool.__name__ for tool in mcp_tool_registry.tools()}
+    exposed_tool_names = {tool.name for tool in tools}
+
+    assert registered_tool_names == declared_tool_names
+    assert exposed_tool_names == registered_tool_names


### PR DESCRIPTION
Closes #472.

## Problem

The MCP server registered tools by import side effect, then called `mcp_tool_registry.apply(mcp)` once. `repowise.server.mcp_server.__init__` only imported 10 tool modules before that call, so the remaining decorated
tools never reached the registry and were not exposed by FastMCP.

This left the packaged server advertising 10 tools even though the repo contains and documents 18 MCP tools.

## Changes

- Import every decorated MCP tool module before applying the shared registry,
  restoring the full 18-tool FastMCP surface.
- Add a drift regression test that compares:
  - decorated tool functions discovered from `tool_*` source files,
  - functions present in `mcp_tool_registry.tools()`,
  - tools exposed by `create_mcp_server().list_tools()`.
- Update public docs that still referenced older 9/10/11/17 tool counts and
  document the complete MCP tool set.

## Test plan

- [x] `uv run pytest tests/unit/server/mcp/test_tool_registration.py tests/unit/registry/test_mcp_tool_registry.py -q`
- [x] `uv run ruff check packages/server/src/repowise/server/mcp_server/__init__.py tests/unit/server/mcp/test_tool_registration.py`
- [x] Negative drift check: temporarily removed the `tool_metrics` import and confirmed `test_mcp_server_exposes_all_registered_tools` failed with missing `get_graph_metrics`; restored the import and confirmed the test passed again.
