### PR TITLE
feat(cli): polished, quieter update UX matching init

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -114,6 +114,7 @@ Incrementally update wiki pages for files changed since the last sync.
 | `--repo` | Update a specific workspace repo by alias |
 | `--full` | Upgrade a fast (`--mode fast`) index to a full one — see below. Single-repo only. |
 | `--agents / --no-agents` | Generate or skip managed `AGENTS.md` after update. Persists the preference. |
+| `-v`, `--verbose` | Show the full changed-file list and per-phase internals (cascade budget, decision-marker/evolution counts, best-effort skip warnings, detailed generation report). Off by default for a compact summary. |
 
 **First-time indexing:** as of v0.8, `update --workspace` now runs full first-time indexing for workspace entries that have no `.repowise/` dir yet (previously skipped with `"not_indexed"`). The pipeline runs index-only — no LLM cost — and writes a state.json marker so `repowise update --repo <alias> --docs` later picks up doc generation cleanly.
 
@@ -129,6 +130,7 @@ repowise update --reasoning off        # one-off supported-provider thinking-off
 repowise update --workspace            # all workspace repos (incl. first-time indexing)
 repowise update --repo backend         # specific workspace repo
 repowise update --no-workspace         # force single-repo mode in a workspace root
+repowise update -v                     # verbose: full file list + per-phase internals
 repowise update --full --provider anthropic   # upgrade a fast index to full
 ```
 

--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -48,7 +48,13 @@ from .persistence import (
     _persist_partial_health,
     _run_full_health_rescore,
 )
-from .reporting import _render_update_report
+from .reporting import (
+    _render_update_report,
+    make_generation_progress,
+    render_changed_files,
+    render_header,
+    show_full_completion,
+)
 from .workspace import _workspace_update
 
 
@@ -147,6 +153,17 @@ from .workspace import _workspace_update
     default=None,
     help="Generate managed AGENTS.md after update (default: config or enabled).",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help=(
+        "Show the full changed-file list and per-phase internals (adaptive "
+        "cascade budget, decision-marker/evolution counts, best-effort skip "
+        "warnings, and the detailed generation report)."
+    ),
+)
 def update_command(
     path: str | None,
     provider_name: str | None,
@@ -164,6 +181,7 @@ def update_command(
     agents_md: bool | None = None,
     concurrency: int = 10,
     no_cost_tracking: bool = False,
+    verbose: bool = False,
 ) -> None:
     """Incrementally update wiki pages for files changed since last sync.
 
@@ -188,7 +206,7 @@ def update_command(
                 "--full is single-repo only. Run it inside a specific repo "
                 "(or pass --no-workspace / --repo <alias>)."
             )
-        _workspace_update(target, dry_run=dry_run, agents_md=agents_md)
+        _workspace_update(target, dry_run=dry_run, agents_md=agents_md, verbose=verbose)
         return
 
     # --- Single-repo path from here on. ---
@@ -325,8 +343,7 @@ def update_command(
     atexit.register(release_update_lock, repo_path)
     atexit.register(clear_update_queued, repo_path)
 
-    console.print(f"[bold]repowise update[/bold] — {repo_path}")
-    console.print(f"Diffing [cyan]{base_ref[:8]}..{(head or 'HEAD')[:8]}[/cyan]")
+    render_header(repo_path, base_ref, head)
 
     from repowise.core.ingestion import ChangeDetector
 
@@ -353,13 +370,7 @@ def update_command(
         _run_full_health_rescore(repo_path, exclude_patterns, state, head, curr_config_fp)
         return
 
-    console.print(f"Changed files: [yellow]{len(file_diffs)}[/yellow]")
-
-    # Show changed files
-    for fd in file_diffs:
-        status_color = {"added": "green", "deleted": "red", "modified": "yellow", "renamed": "blue"}
-        color = status_color.get(fd.status, "white")
-        console.print(f"  [{color}]{fd.status:>10}[/{color}]  {fd.path}")
+    render_changed_files(file_diffs, verbose=verbose)
 
     # Re-parse changed files and rebuild graph for affected pages
     cfg = load_config(repo_path)
@@ -384,7 +395,8 @@ def update_command(
         from repowise.core.ingestion.change_detector import compute_adaptive_budget
 
         cascade_budget = compute_adaptive_budget(file_diffs, file_count)
-        console.print(f"Adaptive cascade budget: [cyan]{cascade_budget}[/cyan]")
+        if verbose:
+            console.print(f"Adaptive cascade budget: [cyan]{cascade_budget}[/cyan]")
     affected = detector.get_affected_pages(file_diffs, graph_builder.graph(), cascade_budget)
 
     console.print(f"Pages to regenerate: [cyan]{len(affected.regenerate)}[/cyan]")
@@ -471,12 +483,16 @@ def update_command(
             new_decision_markers = run_async(
                 extractor.scan_inline_markers(restrict_to_files=changed_paths)
             )
-            if new_decision_markers:
+            if new_decision_markers and verbose:
                 console.print(
                     f"New decision markers found: [green]{len(new_decision_markers)}[/green]"
                 )
     except Exception as exc:
-        console.print(f"[yellow]Decision re-scan skipped: {exc}[/yellow]")
+        if verbose:
+            console.print(f"[yellow]Decision re-scan skipped: {exc}[/yellow]")
+
+    # Count of decision records touched by evolution, surfaced in the panel.
+    decisions_evolved = 0
 
     # Build the shared vector store once: reused by the supersession detector
     # below and by the decision upsert in _persist (semantic dedup + search).
@@ -543,6 +559,9 @@ def update_command(
                 return res
 
             evo = run_async(_run_evolution())
+            decisions_evolved = (
+                evo.get("superseded", 0) + evo.get("amended", 0) + evo.get("reaffirmed", 0)
+            )
             evo_regen = evo.get("regen_files") or set()
             if evo_regen:
                 # page_id == file path for file pages, so adding the governed
@@ -550,14 +569,16 @@ def update_command(
                 affected.regenerate = list(
                     dict.fromkeys([*affected.regenerate, *sorted(evo_regen)])
                 )
-                console.print(
-                    f"Decision evolution: [cyan]{evo.get('superseded', 0)} superseded[/cyan], "
-                    f"[cyan]{evo.get('amended', 0)} amended[/cyan], "
-                    f"[green]{evo.get('reaffirmed', 0)} reaffirmed[/green]; "
-                    f"+{len(evo_regen)} governed page(s) queued for regen."
-                )
+                if verbose:
+                    console.print(
+                        f"Decision evolution: [cyan]{evo.get('superseded', 0)} superseded[/cyan], "
+                        f"[cyan]{evo.get('amended', 0)} amended[/cyan], "
+                        f"[green]{evo.get('reaffirmed', 0)} reaffirmed[/green]; "
+                        f"+{len(evo_regen)} governed page(s) queued for regen."
+                    )
     except Exception as exc:
-        console.print(f"[yellow]Decision evolution skipped: {exc}[/yellow]")
+        if verbose:
+            console.print(f"[yellow]Decision evolution skipped: {exc}[/yellow]")
 
     # Filter to only affected files
     regen_set = set(affected.regenerate)
@@ -605,17 +626,31 @@ def update_command(
     )
     repo_name = repo_path.name
 
-    generated_pages = run_async(
-        generator.generate_all(
-            affected_parsed,
-            affected_source,
-            graph_builder,
-            repo_structure,
-            repo_name,
-            git_meta_map=git_meta_map,
-            repo_path=repo_path,
+    # Drive a live progress bar (owl spinner + running cost) off generate_all's
+    # page callbacks, matching init's generation phase. Cost is read from the
+    # tracker as each page lands so the readout ticks up in real time.
+    with make_generation_progress() as gen_progress:
+        gen_task = gen_progress.add_task("Generating pages...", total=None, cost=0.0)
+
+        def _on_total_known(total: int) -> None:
+            gen_progress.update(gen_task, total=total)
+
+        def _on_page_done(_page_id: str) -> None:
+            gen_progress.update(gen_task, advance=1, cost=cost_tracker.session_cost)
+
+        generated_pages = run_async(
+            generator.generate_all(
+                affected_parsed,
+                affected_source,
+                graph_builder,
+                repo_structure,
+                repo_name,
+                on_page_done=_on_page_done,
+                on_total_known=_on_total_known,
+                git_meta_map=git_meta_map,
+                repo_path=repo_path,
+            )
         )
-    )
 
     # Flush the buffered LLM cost rows now that generation is done — a single
     # transaction outside the contended generation window (issue #326).
@@ -656,7 +691,8 @@ def update_command(
 
                 await mark_tombstone_pages(session, repo_id, tombstone_candidates(file_diffs))
             except Exception as exc:
-                console.print(f"[yellow]Tombstone marking skipped: {exc}[/yellow]")
+                if verbose:
+                    console.print(f"[yellow]Tombstone marking skipped: {exc}[/yellow]")
 
         # Persist updated git metadata + recompute percentiles
         if git_meta_map:
@@ -883,4 +919,14 @@ def update_command(
         pass  # cross-repo hooks must never fail the update
 
     elapsed = time.monotonic() - start
-    _render_update_report(generated_pages, affected, new_decision_markers, elapsed)
+    show_full_completion(
+        generated_pages=generated_pages,
+        decay_count=len(affected.decay_only),
+        decisions_changed=len(new_decision_markers) + decisions_evolved,
+        provider=provider,
+        cost=cost_tracker.session_cost,
+        tokens=cost_tracker.session_tokens,
+        elapsed=elapsed,
+    )
+    if verbose:
+        _render_update_report(generated_pages, affected, new_decision_markers, elapsed)

--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -77,9 +77,14 @@ def _persist_index_only_update(
         {**state, "last_sync_commit": head, "config_fingerprint": config_fingerprint(repo_path)},
     )
     elapsed = time.monotonic() - start
-    console.print(
-        f"[green]Index-only update complete[/green] in {elapsed:.1f}s — "
-        "graph + git + dead-code refreshed; LLM pages unchanged."
+    from .reporting import show_index_only_completion
+
+    show_index_only_completion(
+        graph_builder=graph_builder,
+        dead_code_report=dead_code_report,
+        changed_count=len(changed_paths),
+        git_files=len(git_meta_map or {}),
+        elapsed=elapsed,
     )
 
 

--- a/packages/cli/src/repowise/cli/commands/update_cmd/reporting.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/reporting.py
@@ -1,15 +1,209 @@
 """Console rendering for ``repowise update``.
 
-Pure presentation: takes finished generation data and prints the incremental
-update report. No persistence or generation work happens here. The richer
-panel/summary helpers added in the UX pass land here next to this report.
+Pure presentation: headers, the changed-file summary, the live generation
+progress bar, and the completion panels for the three update paths (full,
+index-only, workspace). Reuses the shared ``cli/ui`` panel + progress helpers
+so ``update`` looks and feels like ``init``. No persistence or generation work
+happens here.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+
 from repowise.cli.helpers import console
+from repowise.cli.ui import (
+    BRAND_STYLE,
+    OWL_SPINNER,
+    MaybeCountColumn,
+    build_completion_panel,
+    format_elapsed,
+)
+
+# Status -> display color, shared by the changed-file summary.
+_STATUS_COLOR = {"added": "green", "deleted": "red", "modified": "yellow", "renamed": "blue"}
+
+# How many changed files to list before collapsing to a "+N more" line.
+_CHANGED_FILE_PREVIEW = 10
+
+
+# ---------------------------------------------------------------------------
+# Headers + changed-file summary
+# ---------------------------------------------------------------------------
+
+
+def render_header(repo_path: Any, base_ref: str, head: str | None) -> None:
+    """Compact single-repo update header: repo name + the diff range."""
+    console.print(f"[bold]repowise update[/bold] [dim]·[/dim] {repo_path.name}")
+    console.print(f"[dim]{base_ref[:8]}..{(head or 'HEAD')[:8]}[/dim]")
+
+
+def render_changed_files(file_diffs: list, *, verbose: bool) -> None:
+    """Summarise changed files: a count breakdown, a short preview, then a
+    ``+N more`` collapse — unless ``verbose`` is set, which lists them all.
+    """
+    from collections import Counter
+
+    counts = Counter(fd.status for fd in file_diffs)
+    breakdown = ", ".join(
+        f"{counts[status]} {status}"
+        for status in ("modified", "added", "deleted", "renamed")
+        if counts.get(status)
+    )
+    summary = f"[bold]{len(file_diffs)}[/bold] changed"
+    if breakdown:
+        summary += f" [dim]·[/dim] {breakdown}"
+    console.print(summary)
+
+    shown = file_diffs if verbose else file_diffs[:_CHANGED_FILE_PREVIEW]
+    for fd in shown:
+        color = _STATUS_COLOR.get(fd.status, "white")
+        console.print(f"  [{color}]{fd.status:>10}[/{color}]  {fd.path}")
+
+    hidden = len(file_diffs) - len(shown)
+    if hidden > 0:
+        console.print(f"  [dim]+{hidden} more (use -v to list all)[/dim]")
+
+
+# ---------------------------------------------------------------------------
+# Live generation progress
+# ---------------------------------------------------------------------------
+
+
+def make_generation_progress() -> Progress:
+    """Build the live page-generation progress bar (owl spinner + running cost),
+    matching the columns ``init`` uses for its generation phase.
+    """
+    return Progress(
+        SpinnerColumn(spinner_name=OWL_SPINNER, style=BRAND_STYLE),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        MaybeCountColumn(),
+        TimeElapsedColumn(),
+        TextColumn("[green]${task.fields[cost]:.3f}[/green]"),
+        console=console,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Completion panels
+# ---------------------------------------------------------------------------
+
+
+def _dead_code_counts(dead_code_report: Any) -> tuple[int, int]:
+    """Return ``(unreachable_files, unused_exports)`` from a dead-code report."""
+    findings = dead_code_report.findings if dead_code_report else []
+    unreachable = sum(1 for f in findings if f.kind.value == "unreachable_file")
+    unused = sum(1 for f in findings if f.kind.value == "unused_export")
+    return unreachable, unused
+
+
+def show_full_completion(
+    *,
+    generated_pages: list,
+    decay_count: int,
+    decisions_changed: int,
+    provider: Any,
+    cost: float,
+    tokens: int,
+    elapsed: float,
+) -> None:
+    """Render the completion panel for a full (LLM-regenerating) update."""
+    metrics: list[tuple[str, str]] = [("Pages updated", str(len(generated_pages)))]
+    if decay_count:
+        metrics.append(("Pages decayed", str(decay_count)))
+    if decisions_changed:
+        metrics.append(("Decisions", f"{decisions_changed} changed"))
+    if tokens:
+        metrics.append(("Total tokens", f"{tokens:,}"))
+    if provider is not None:
+        metrics.append(("Provider", f"{provider.provider_name} / {provider.model_name}"))
+    if cost:
+        metrics.append(("Cost", f"${cost:.3f}"))
+    metrics.append(("Elapsed", format_elapsed(elapsed)))
+
+    next_steps = [
+        ("repowise serve", "browse the updated wiki at localhost:3000"),
+        ("repowise search <query>", "search the wiki"),
+    ]
+    console.print()
+    console.print(build_completion_panel("repowise update complete", metrics, next_steps=next_steps))
+    console.print()
+
+
+def show_index_only_completion(
+    *,
+    graph_builder: Any,
+    dead_code_report: Any,
+    changed_count: int,
+    git_files: int,
+    elapsed: float,
+) -> None:
+    """Render the completion panel for an index-only update (no LLM regen)."""
+    graph = graph_builder.graph()
+    unreachable, unused = _dead_code_counts(dead_code_report)
+
+    metrics: list[tuple[str, str]] = [
+        ("Files changed", str(changed_count)),
+        ("Graph", f"{graph.number_of_nodes():,} nodes · {graph.number_of_edges():,} edges"),
+        ("Dead code", f"{unreachable} unreachable · {unused} unused exports"),
+    ]
+    if git_files:
+        metrics.append(("Git history", f"{git_files} files refreshed"))
+    metrics.append(("Elapsed", format_elapsed(elapsed)))
+
+    next_steps = [
+        ("repowise serve", "browse the index at localhost:3000"),
+        ("repowise update --docs", "regenerate docs for the changed files"),
+    ]
+    console.print()
+    console.print(
+        build_completion_panel("repowise index-only update complete", metrics, next_steps=next_steps)
+    )
+    console.print()
+
+
+def show_workspace_completion(
+    *,
+    ws_name: str,
+    updated: int,
+    skipped: int,
+    errors: int,
+    total_files: int,
+    total_symbols: int,
+    elapsed: float,
+) -> None:
+    """Render the completion panel for a workspace update."""
+    metrics: list[tuple[str, str]] = [
+        ("Workspace", ws_name),
+        ("Repos updated", str(updated)),
+    ]
+    if skipped:
+        metrics.append(("Skipped", str(skipped)))
+    if errors:
+        metrics.append(("Errors", str(errors)))
+    if total_files:
+        metrics.append(("Files", str(total_files)))
+    if total_symbols:
+        metrics.append(("Symbols", f"{total_symbols:,}"))
+    metrics.append(("Elapsed", format_elapsed(elapsed)))
+
+    next_steps = [
+        ("repowise status --workspace", "show workspace status"),
+        ("repowise serve", "browse a repo wiki at localhost:3000"),
+    ]
+    console.print()
+    console.print(
+        build_completion_panel("repowise workspace update complete", metrics, next_steps=next_steps)
+    )
+    console.print()
+
+
+# ---------------------------------------------------------------------------
+# Verbose detail (opt-in via -v)
+# ---------------------------------------------------------------------------
 
 
 def _render_update_report(
@@ -18,7 +212,7 @@ def _render_update_report(
     new_decision_markers: list,
     elapsed: float,
 ) -> None:
-    """Render the incremental-update generation report (with a plain fallback)."""
+    """Render the detailed generation report table (verbose mode / fallback)."""
     try:
         from repowise.core.generation.report import GenerationReport, render_report
 

--- a/packages/cli/src/repowise/cli/commands/update_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/workspace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,7 @@ def _workspace_update(
     *,
     dry_run: bool = False,
     agents_md: bool | None = None,
+    verbose: bool = False,
 ) -> None:
     """Update stale repos in a workspace.
 
@@ -23,6 +25,7 @@ def _workspace_update(
     """
     from repowise.core.workspace import check_repo_staleness, update_workspace
 
+    start = time.monotonic()
     ws_root = target.ws_root
     ws_config = target.ws_config
     repo_alias = target.repo_filter
@@ -36,20 +39,32 @@ def _workspace_update(
     console.print()
 
     stale_count = 0
+    up_to_date_count = 0
     for entry in ws_config.repos:
         if repo_alias and entry.alias != repo_alias:
             continue
         abs_path = (ws_root / entry.path).resolve()
         stored = entry.last_commit_at_index
-        is_stale, head, behind = check_repo_staleness(abs_path, stored)
-        status = (
-            f"[yellow]{behind} new commit(s)[/yellow]" if is_stale else "[green]up to date[/green]"
-        )
-        if not (abs_path / ".repowise").is_dir():
+        is_stale, _head, behind = check_repo_staleness(abs_path, stored)
+        indexed = (abs_path / ".repowise").is_dir()
+        if not indexed:
             status = "[dim]not indexed[/dim]"
-        console.print(f"  {entry.alias:<20} {status}")
+        elif is_stale:
+            status = f"[yellow]{behind} new commit(s)[/yellow]"
+        else:
+            status = "[green]up to date[/green]"
+        # Default to a focused list (stale + not-indexed); up-to-date repos
+        # collapse into a single count line unless -v lists everything.
         if is_stale:
             stale_count += 1
+        if indexed and not is_stale:
+            up_to_date_count += 1
+            if not verbose:
+                continue
+        console.print(f"  {entry.alias:<20} {status}")
+
+    if up_to_date_count and not verbose:
+        console.print(f"  [dim]{up_to_date_count} repo(s) up to date[/dim]")
 
     console.print()
 
@@ -116,16 +131,26 @@ def _workspace_update(
     updated = sum(1 for r in results if r.updated)
     errors = sum(1 for r in results if r.error)
     skipped = sum(1 for r in results if r.skipped_reason)
-    console.print()
-    console.print(
-        f"[bold]Done:[/bold] {updated} updated, {skipped} skipped"
-        + (f", {errors} errors" if errors else "")
-    )
+    total_files = sum(r.file_count for r in results if r.updated)
+    total_symbols = sum(r.symbol_count for r in results if r.updated)
+
     _refresh_workspace_editor_project_files(
         ws_root=ws_root,
         ws_config=ws_config,
         repo_filter=repo_alias,
         agents_md=agents_md,
+    )
+
+    from .reporting import show_workspace_completion
+
+    show_workspace_completion(
+        ws_name=ws_root.name,
+        updated=updated,
+        skipped=skipped,
+        errors=errors,
+        total_files=total_files,
+        total_symbols=total_symbols,
+        elapsed=time.monotonic() - start,
     )
 
 

--- a/tests/unit/cli/test_update_reporting.py
+++ b/tests/unit/cli/test_update_reporting.py
@@ -1,0 +1,127 @@
+"""Tests for `repowise update`'s presentation layer (update_cmd.reporting).
+
+Covers the changed-file summary's preview/collapse behavior and that the
+completion panels render without raising for representative inputs.
+"""
+
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+
+from rich.console import Console
+
+from repowise.cli.commands.update_cmd import reporting
+
+
+class _Buffer:
+    """Captures rendered (markup-stripped) output line by line.
+
+    Uses a real Rich Console so panels and markup render to plain text, which
+    is what the assertions inspect.
+    """
+
+    def __init__(self) -> None:
+        self._buf = io.StringIO()
+        self._console = Console(file=self._buf, width=200, force_terminal=False)
+
+    def print(self, *args, **kwargs):
+        self._console.print(*args, **kwargs)
+
+    @property
+    def lines(self) -> list[str]:
+        return self._buf.getvalue().splitlines()
+
+
+def _capture(monkeypatch) -> _Buffer:
+    buf = _Buffer()
+    monkeypatch.setattr(reporting, "console", buf)
+    return buf
+
+
+def _diffs(n: int, status: str = "modified") -> list:
+    return [SimpleNamespace(status=status, path=f"src/file_{i}.py") for i in range(n)]
+
+
+class TestRenderChangedFiles:
+    def test_collapses_to_preview_plus_more_by_default(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting.render_changed_files(_diffs(59), verbose=False)
+
+        # Summary line with the total.
+        assert any("59 changed" in line for line in printed.lines)
+        # Only the preview window is listed, plus a "+N more" collapse line.
+        listed = [line for line in printed.lines if "src/file_" in line]
+        assert len(listed) == reporting._CHANGED_FILE_PREVIEW
+        assert any("more (use -v to list all)" in line for line in printed.lines)
+
+    def test_verbose_lists_everything_without_more_line(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting.render_changed_files(_diffs(59), verbose=True)
+
+        listed = [line for line in printed.lines if "src/file_" in line]
+        assert len(listed) == 59
+        assert not any("more (use -v" in line for line in printed.lines)
+
+    def test_no_more_line_when_under_preview_limit(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting.render_changed_files(_diffs(3), verbose=False)
+
+        assert not any("more (use -v" in line for line in printed.lines)
+
+    def test_status_breakdown_counts(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        diffs = _diffs(2, "modified") + _diffs(1, "added") + _diffs(1, "deleted")
+        reporting.render_changed_files(diffs, verbose=False)
+
+        summary = next(line for line in printed.lines if "changed" in line)
+        assert "2 modified" in summary
+        assert "1 added" in summary
+        assert "1 deleted" in summary
+
+
+class TestCompletionPanels:
+    def test_full_completion_renders(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        provider = SimpleNamespace(provider_name="gemini", model_name="gemini-2.5-flash")
+        reporting.show_full_completion(
+            generated_pages=[SimpleNamespace(), SimpleNamespace()],
+            decay_count=3,
+            decisions_changed=1,
+            provider=provider,
+            cost=0.0123,
+            tokens=185000,
+            elapsed=42.7,
+        )
+        assert any("repowise update complete" in line for line in printed.lines)
+
+    def test_index_only_completion_renders(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        graph = SimpleNamespace(number_of_nodes=lambda: 10, number_of_edges=lambda: 20)
+        dcr = SimpleNamespace(
+            findings=[
+                SimpleNamespace(kind=SimpleNamespace(value="unreachable_file")),
+                SimpleNamespace(kind=SimpleNamespace(value="unused_export")),
+            ]
+        )
+        reporting.show_index_only_completion(
+            graph_builder=SimpleNamespace(graph=lambda: graph),
+            dead_code_report=dcr,
+            changed_count=12,
+            git_files=12,
+            elapsed=8.3,
+        )
+        assert any("index-only update complete" in line for line in printed.lines)
+
+    def test_workspace_completion_renders(self, monkeypatch):
+        printed = _capture(monkeypatch)
+        reporting.show_workspace_completion(
+            ws_name="myws",
+            updated=2,
+            skipped=1,
+            errors=0,
+            total_files=37,
+            total_symbols=4210,
+            elapsed=63.1,
+        )
+        assert any("workspace update complete" in line for line in printed.lines)

--- a/tests/unit/cli/test_workspace_autodetect_e2e.py
+++ b/tests/unit/cli/test_workspace_autodetect_e2e.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from repowise.cli.commands.status_cmd import status_command
@@ -52,7 +51,7 @@ def test_update_from_workspace_root_does_not_create_stray_repowise(
     # spawn a real pipeline, so we intercept _workspace_update.
     called = {}
 
-    def _fake_workspace_update(target, *, dry_run, agents_md=None):
+    def _fake_workspace_update(target, *, dry_run, agents_md=None, verbose=False):
         called["target"] = target
         called["dry_run"] = dry_run
         called["agents_md"] = agents_md


### PR DESCRIPTION
## What

`repowise update` now renders through the shared `cli/ui` panel + progress helpers, so it looks and feels like `init`, and defaults to a compact summary instead of a debug firehose. This is presentation only: nothing about what `update` computes or persists changes. All new rendering lives in `update_cmd/reporting.py`.

### Before (default)
```
repowise update — C:\Users\...\repowise
Diffing 30d25380..a305eafd
Changed files: 59
   modified  .claude-plugin/marketplace.json
   ... (57 more lines, one per file)
Adaptive cascade budget: 50
Pages to regenerate: 50
Pages to decay: 140
New decision markers found: 3
Decision evolution: 1 superseded, 0 amended, 2 reaffirmed; +4 governed page(s) queued for regen.
Generation Report (table)
```

### After (default)
```
repowise update · repowise
30d2538..a305eaf
59 changed · 43 modified, 15 added, 1 renamed
   modified  .claude-plugin/marketplace.json
   ... (9 shown)
  +49 more (use -v to list all)
Pages to regenerate: 50
Pages to decay: 140
<live owl progress bar with running $cost during generation>

┌──────── {^ ^}  repowise update complete ────────┐
│   Pages updated   50                             │
│   Pages decayed   140                            │
│   Decisions       3 changed                      │
│   Total tokens    185,000                        │
│   Provider        gemini / gemini-2.5-flash      │
│   Cost            $0.012                          │
│   Elapsed         42.7s                           │
│   What's next: ...                               │
└──────────────────────────────────────────────────┘
```

## Changes

- **Compact header** (repo basename + dim diff range) and a **changed-file summary** (count breakdown + 10-file preview + `+N more`) replacing the unbounded per-file list.
- **Live page-generation progress** (owl spinner + running cost) driven off `generate_all`'s `on_total_known`/`on_page_done` callbacks, matching `init`'s generation phase.
- **Completion panels for all three paths** (full, index-only, workspace), built from `build_completion_panel` with contextual next steps.
- **New `-v`/`--verbose` flag.** Clean by default; `-v` restores the full file list, adaptive cascade budget, decision-marker/evolution counts, best-effort skip warnings, and the detailed generation report. The workspace staleness table also collapses up-to-date repos into a count unless `-v`.

## Tests

- New `test_update_reporting.py` covers the preview/collapse logic, status breakdown, and that each completion panel renders.
- All 565 CLI unit tests pass; ruff clean.
- Runtime smoke: `update --help`, clean vs `-v` dry-runs, and direct rendering of all three panels verified.

Builds on the `update_cmd` package split (#476).