### PR TITLE
fix(workspace): reframe co-change page as temporal hint and fix avg-strength display

### DIFF
--- a/packages/ui/src/workspace/co-change-table.tsx
+++ b/packages/ui/src/workspace/co-change-table.tsx
@@ -45,7 +45,15 @@ export function CoChangeTable({ coChanges, compact }: CoChangeTableProps) {
     },
     {
       key: "strength",
-      header: "Strength",
+      header: (
+        <span
+          title="Relative, recency-weighted frequency of same-author commits across these repos. Higher means more or more-recent shared activity. It is not a percentage or a verified dependency."
+          className="cursor-help underline decoration-dotted underline-offset-2"
+        >
+          Strength
+        </span>
+      ),
+      mobileLabel: "Strength",
       priority: 2,
       headerClassName: "w-32",
       render: (cc) => (

--- a/packages/web/src/app/workspace/co-changes/page.tsx
+++ b/packages/web/src/app/workspace/co-changes/page.tsx
@@ -33,7 +33,10 @@ export default function CoChangesPage() {
           </h1>
         </div>
         <p className="text-sm text-[var(--color-text-secondary)]">
-          Files across repositories that frequently change together — implicit coupling detected from git history.
+          Files the same author committed across repositories within a short time
+          window. This is a temporal work-pattern hint from git history, not a
+          verified technical dependency, so treat it as a starting point for
+          inspection rather than proof of coupling.
         </p>
       </div>
 
@@ -61,11 +64,11 @@ export default function CoChangesPage() {
           label="Avg Strength"
           value={
             data?.co_changes && data.co_changes.length > 0
-              ? `${Math.round(
+              ? Math.round(
                   (data.co_changes.reduce((sum, cc) => sum + cc.strength, 0) /
                     data.co_changes.length) *
-                    100,
-                )}%`
+                    10,
+                ) / 10
               : "—"
           }
           icon={<GitMerge className="h-4 w-4 text-orange-400" />}


### PR DESCRIPTION
## Summary

Follow-up to #480 on the UI side of #475. The cross-repo co-change page is a temporal, same-author signal, but its copy described it as "implicit coupling" and one stat still rendered the raw score as a percentage (the same scale mismatch that #430 fixed in the table and graph).

## Changes

- Reword the page description to state plainly that this is a temporal work-pattern hint from git history (same author committing across repos within a short window), not a verified technical dependency, so high scores are a starting point for inspection rather than proof of coupling.
- Fix the "Avg Strength" stat, which still rendered `score * 100 + "%"`; it now shows a raw one-decimal score consistent with the table and graph.
- Add a Strength column tooltip explaining the value is a relative, recency-weighted frequency, not a percentage or a dependency.

## Verification

- `npm run type-check`, `npm run lint`, and `npm run build` all pass.

Refs #475. Related: #430, #480.
