### PR TITLE
fix(workspace): keep job progress state accurate

### DIFF
--- a/packages/server/src/repowise/server/app.py
+++ b/packages/server/src/repowise/server/app.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 import logging
 import os
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
+from datetime import UTC, datetime
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from sqlalchemy import update as sa_update
 
 from repowise.core.persistence.database import (
     create_engine,
@@ -23,6 +25,7 @@ from repowise.core.persistence.database import (
     init_db,
     resolve_db_url,
 )
+from repowise.core.persistence.models import GenerationJob
 from repowise.core.persistence.search import FullTextSearch
 from repowise.core.persistence.vector_store import InMemoryVectorStore
 from repowise.core.providers.embedding.base import MockEmbedder
@@ -58,6 +61,24 @@ from repowise.server.routers import (
 from repowise.server.scheduler import setup_scheduler
 
 logger = logging.getLogger(__name__)
+
+
+async def reset_workspace_stale_jobs(app_state) -> int:
+    """Mark interrupted pending/running jobs failed across workspace repo DBs."""
+    reset_count = 0
+    for ws_factory in getattr(app_state, "workspace_sessions", {}).values():
+        async with get_session(ws_factory) as session:
+            stale_result = await session.execute(
+                sa_update(GenerationJob)
+                .where(GenerationJob.status.in_(["running", "pending"]))
+                .values(
+                    status="failed",
+                    error_message="Server restarted; job interrupted",
+                    finished_at=datetime.now(UTC),
+                )
+            )
+            reset_count += stale_result.rowcount or 0
+    return reset_count
 
 
 def _build_embedder():
@@ -272,6 +293,20 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                     extra={"count": len(app.state.workspace_sessions)},
                 )
 
+            # Reset stale jobs in non-primary workspace DBs too. The primary
+            # DB was handled before workspace detection, but each secondary
+            # repo has its own generation_jobs table and stale running rows
+            # there would keep the UI showing an in-progress sync forever.
+            try:
+                reset_count = await reset_workspace_stale_jobs(app.state)
+                if reset_count:
+                    logger.warning(
+                        "reset_workspace_stale_jobs",
+                        extra={"count": reset_count},
+                    )
+            except Exception as exc:
+                logger.warning("workspace_stale_job_reset_failed", extra={"error": str(exc)})
+
             from repowise.core.workspace.contracts import CONTRACTS_FILENAME
             from repowise.server.mcp_server._enrichment import CrossRepoEnricher
 
@@ -308,10 +343,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         logger.debug("workspace_vector_store_close_failed", exc_info=True)
     # Dispose workspace repo engines first
     for ws_engine in getattr(app.state, "workspace_engines", []):
-        try:
+        with suppress(Exception):
             await ws_engine.dispose()
-        except Exception:
-            pass
     await engine.dispose()
     logger.info("repowise_server_stopped")
 

--- a/packages/server/src/repowise/server/routers/jobs.py
+++ b/packages/server/src/repowise/server/routers/jobs.py
@@ -5,15 +5,14 @@ from __future__ import annotations
 import asyncio
 import json
 
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import func, select
-from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import StreamingResponse
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from repowise.core.persistence import crud
 from repowise.core.persistence.database import get_session
 from repowise.core.persistence.models import GenerationJob, LlmCost
-from repowise.server.deps import get_db_session, verify_api_key
+from repowise.server.deps import resolve_session_factory, verify_api_key
 from repowise.server.schemas import JobResponse
 
 router = APIRouter(
@@ -53,23 +52,45 @@ async def _find_job_factory(app_state, job_id: str):
 
 @router.get("", response_model=list[JobResponse])
 async def list_jobs(
+    request: Request,
     repo_id: str | None = Query(None),
     status: str | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
-    session: AsyncSession = Depends(get_db_session),  # noqa: B008
 ) -> list[JobResponse]:
     """List generation jobs, optionally filtered by repository or status."""
-    q = select(GenerationJob)
-    if repo_id:
-        q = q.where(GenerationJob.repository_id == repo_id)
-    if status:
-        q = q.where(GenerationJob.status == status)
-    q = q.order_by(GenerationJob.created_at.desc()).limit(limit).offset(offset)
+    async def _query_jobs(factory) -> list[GenerationJob]:
+        q = select(GenerationJob)
+        if repo_id:
+            q = q.where(GenerationJob.repository_id == repo_id)
+        if status:
+            q = q.where(GenerationJob.status == status)
+        q = q.order_by(GenerationJob.created_at.desc()).limit(limit + offset)
+        async with get_session(factory) as session:
+            result = await session.execute(q)
+            return list(result.scalars().all())
 
-    result = await session.execute(q)
-    jobs = result.scalars().all()
-    return [JobResponse.from_orm(j) for j in jobs]
+    if repo_id:
+        factories = [resolve_session_factory(request.app.state, repo_id)]
+    else:
+        factories = [request.app.state.session_factory]
+        ws = getattr(request.app.state, "workspace_sessions", None)
+        if ws:
+            factories.extend(ws.values())
+
+    jobs: list[GenerationJob] = []
+    seen_factories: set[int] = set()
+    for factory in factories:
+        if id(factory) in seen_factories:
+            continue
+        seen_factories.add(id(factory))
+        try:
+            jobs.extend(await _query_jobs(factory))
+        except Exception:
+            continue
+
+    jobs.sort(key=lambda j: j.created_at, reverse=True)
+    return [JobResponse.from_orm(j) for j in jobs[offset : offset + limit]]
 
 
 @router.get("/{job_id}", response_model=JobResponse)

--- a/packages/ui/__tests__/jobs/generation-progress.test.tsx
+++ b/packages/ui/__tests__/jobs/generation-progress.test.tsx
@@ -42,4 +42,26 @@ describe("GenerationProgress", () => {
     );
     expect(screen.getByText(/Job hasn't started/)).toBeTruthy();
   });
+
+  it("renders backend phase labels instead of generation level numbers", () => {
+    render(
+      <GenerationProgress
+        job={{
+          id: "j1",
+          status: "running",
+          total_pages: 10,
+          completed_pages: 3,
+          current_level: 1,
+        }}
+        log={[]}
+        elapsed={10_000}
+        actualCost={null}
+        stuckPending={false}
+        cancelling={false}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Analysing…")).toBeTruthy();
+    expect(screen.queryByText(/Generating level/)).toBeNull();
+  });
 });

--- a/packages/ui/src/jobs/generation-progress.tsx
+++ b/packages/ui/src/jobs/generation-progress.tsx
@@ -33,6 +33,12 @@ export interface GenerationProgressProps {
   onCancel: () => void;
 }
 
+const PHASE_LABELS: Record<number, string> = {
+  0: "Indexing",
+  1: "Analysing",
+  2: "Generating docs",
+};
+
 export function GenerationProgress({
   job,
   log,
@@ -54,6 +60,10 @@ export function GenerationProgress({
   const isInflight = isPending || isRunning;
   const isDone = job?.status === "completed";
   const isFailed = job?.status === "failed";
+  const phaseLabel =
+    job?.current_level == null
+      ? "Processing"
+      : PHASE_LABELS[job.current_level] ?? `Processing phase ${job.current_level}`;
 
   return (
     <div className="space-y-3">
@@ -64,7 +74,7 @@ export function GenerationProgress({
 
         <span className="text-sm font-medium text-[var(--color-text-primary)]">
           {isPending && "Queued — waiting for worker…"}
-          {isRunning && `Generating level ${job?.current_level ?? "?"}…`}
+          {isRunning && `${phaseLabel}…`}
           {isDone && "Generation complete"}
           {isFailed && "Generation failed"}
         </span>

--- a/packages/web/src/components/jobs/generation-progress-wrapper.tsx
+++ b/packages/web/src/components/jobs/generation-progress-wrapper.tsx
@@ -7,6 +7,7 @@ import { useJob } from "@/lib/hooks/use-job";
 import { cancelJob } from "@/lib/api/jobs";
 import { formatNumber } from "@repowise-dev/ui/lib/format";
 import type { JobProgressEvent } from "@/lib/api/types";
+import { computeElapsedMs } from "@/lib/jobs/progress";
 
 interface Props {
   jobId: string;
@@ -22,13 +23,14 @@ export function GenerationProgressWrapper({ jobId, repoName, onDone }: Props) {
   const [elapsed, setElapsed] = useState(0);
   const [actualCost, setActualCost] = useState<number | null>(null);
   const [cancelling, setCancelling] = useState(false);
-  const startRef = useRef(Date.now());
   const notifiedRef = useRef(false);
 
   useEffect(() => {
-    const id = setInterval(() => setElapsed(Date.now() - startRef.current), 1000);
+    const updateElapsed = () => setElapsed(computeElapsedMs(job));
+    updateElapsed();
+    const id = setInterval(updateElapsed, 1000);
     return () => clearInterval(id);
-  }, []);
+  }, [job]);
 
   useEffect(() => {
     if (!sse.data) return;
@@ -95,3 +97,4 @@ export function GenerationProgressWrapper({ jobId, repoName, onDone }: Props) {
     />
   );
 }
+

--- a/packages/web/src/lib/api/types/pages.ts
+++ b/packages/web/src/lib/api/types/pages.ts
@@ -71,8 +71,10 @@ export interface JobResponse {
 export interface JobProgressEvent {
   event: "progress" | "done" | "error";
   job_id: string;
+  status?: "pending" | "running" | "completed" | "failed" | "paused";
   completed_pages: number;
   total_pages: number;
+  failed_pages?: number;
   current_page?: string;
   current_level?: number;
   tokens_input?: number;

--- a/packages/web/src/lib/hooks/use-job.ts
+++ b/packages/web/src/lib/hooks/use-job.ts
@@ -1,9 +1,11 @@
 "use client";
 
+import { useEffect, useMemo } from "react";
 import useSWR from "swr";
 import { getJob, getJobStreamUrl } from "@/lib/api/jobs";
 import { useSSE } from "./use-sse";
 import type { JobResponse, JobProgressEvent } from "@/lib/api/types";
+import { mergeJobProgress } from "@/lib/jobs/progress";
 
 /**
  * Combines polling (SWR) for job metadata with SSE for live progress events.
@@ -25,10 +27,17 @@ export function useJob(jobId: string | null) {
 
   const sse = useSSE<JobProgressEvent>(streamUrl, { enabled: !!streamUrl });
 
-  // When SSE marks done, trigger a final SWR revalidation
-  if (sse.isDone && isActive) {
-    mutate();
-  }
+  // When SSE marks done, trigger a final SWR revalidation.
+  useEffect(() => {
+    if (sse.isDone && isActive) {
+      void mutate();
+    }
+  }, [isActive, mutate, sse.isDone]);
 
-  return { job, sse, isActive };
+  const liveJob = useMemo(() => {
+    const ev = sse.data as JobProgressEvent | null;
+    return mergeJobProgress(job, ev);
+  }, [job, sse.data]);
+
+  return { job: liveJob, sse, isActive };
 }

--- a/packages/web/src/lib/jobs/progress.test.ts
+++ b/packages/web/src/lib/jobs/progress.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { JobProgressEvent, JobResponse } from "@/lib/api/types";
+import { computeElapsedMs, mergeJobProgress } from "./progress";
+
+function job(overrides: Partial<JobResponse> = {}): JobResponse {
+  return {
+    id: "job-1",
+    repository_id: "repo-1",
+    status: "running",
+    provider_name: "mock",
+    model_name: "mock",
+    total_pages: 10,
+    completed_pages: 1,
+    failed_pages: 0,
+    current_level: 0,
+    error_message: null,
+    config: {},
+    created_at: "2026-06-15T10:00:00.000Z",
+    updated_at: "2026-06-15T10:01:00.000Z",
+    started_at: "2026-06-15T10:00:30.000Z",
+    finished_at: null,
+    ...overrides,
+  };
+}
+
+describe("job progress helpers", () => {
+  it("derives running elapsed time from persisted start time", () => {
+    expect(computeElapsedMs(job(), Date.parse("2026-06-15T10:02:00.000Z"))).toBe(90_000);
+  });
+
+  it("freezes completed elapsed time at finished_at", () => {
+    expect(
+      computeElapsedMs(
+        job({
+          status: "completed",
+          finished_at: "2026-06-15T10:03:00.000Z",
+        }),
+        Date.parse("2026-06-15T10:10:00.000Z"),
+      ),
+    ).toBe(150_000);
+  });
+
+  it("merges SSE progress into a stale polled job snapshot", () => {
+    const event: JobProgressEvent = {
+      event: "progress",
+      job_id: "job-1",
+      status: "running",
+      completed_pages: 7,
+      total_pages: 12,
+      failed_pages: 2,
+      current_level: 2,
+    };
+
+    expect(mergeJobProgress(job(), event)).toMatchObject({
+      status: "running",
+      completed_pages: 7,
+      total_pages: 12,
+      failed_pages: 2,
+      current_level: 2,
+    });
+  });
+
+  it("ignores SSE progress for a different job", () => {
+    const current = job();
+    expect(
+      mergeJobProgress(current, {
+        event: "progress",
+        job_id: "other-job",
+        completed_pages: 9,
+        total_pages: 9,
+      }),
+    ).toBe(current);
+  });
+});

--- a/packages/web/src/lib/jobs/progress.ts
+++ b/packages/web/src/lib/jobs/progress.ts
@@ -1,0 +1,28 @@
+import type { JobProgressEvent, JobResponse } from "@/lib/api/types";
+
+export function computeElapsedMs(job: JobResponse | undefined, nowMs = Date.now()): number {
+  if (!job) return 0;
+  const start = Date.parse(job.started_at ?? job.created_at);
+  if (!Number.isFinite(start)) return 0;
+  const end =
+    job.status === "completed" || job.status === "failed"
+      ? Date.parse(job.finished_at ?? "")
+      : nowMs;
+  const effectiveEnd = Number.isFinite(end) ? end : nowMs;
+  return Math.max(0, effectiveEnd - start);
+}
+
+export function mergeJobProgress(
+  job: JobResponse | undefined,
+  ev: JobProgressEvent | null,
+): JobResponse | undefined {
+  if (!job || !ev || ev.job_id !== job.id) return job;
+  return {
+    ...job,
+    status: ev.status ?? job.status,
+    completed_pages: ev.completed_pages ?? job.completed_pages,
+    total_pages: ev.total_pages ?? job.total_pages,
+    failed_pages: ev.failed_pages ?? job.failed_pages,
+    current_level: ev.current_level ?? job.current_level,
+  };
+}

--- a/tests/unit/server/test_jobs.py
+++ b/tests/unit/server/test_jobs.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
 
 from repowise.core.persistence import crud
-from repowise.core.persistence.database import get_session
+from repowise.core.persistence.database import get_session, init_db
+from repowise.core.persistence.models import GenerationJob
+from repowise.server.app import reset_workspace_stale_jobs
 from tests.unit.server.conftest import create_test_repo
 
 
@@ -59,6 +66,97 @@ async def test_list_jobs_filter_by_repo(client: AsyncClient, app) -> None:
     resp = await client.get("/api/jobs", params={"repo_id": "nonexistent"})
     assert resp.status_code == 200
     assert len(resp.json()) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_jobs_filter_by_workspace_repo(client: AsyncClient, app) -> None:
+    """Workspace-mode job listing must query the repo's own wiki.db."""
+    ws_engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    await init_db(ws_engine)
+    ws_factory = async_sessionmaker(ws_engine, expire_on_commit=False, class_=AsyncSession)
+
+    try:
+        async with get_session(ws_factory) as session:
+            repo = await crud.upsert_repository(
+                session,
+                name="workspace-repo",
+                local_path="/tmp/workspace-repo",
+            )
+            await crud.upsert_generation_job(
+                session,
+                repository_id=repo.id,
+                status="running",
+                total_pages=12,
+            )
+            repo_id = repo.id
+
+        app.state.workspace_sessions = {repo_id: ws_factory}
+
+        resp = await client.get("/api/jobs", params={"repo_id": repo_id})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["repository_id"] == repo_id
+        assert data[0]["status"] == "running"
+        assert data[0]["total_pages"] == 12
+    finally:
+        await ws_engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_reset_workspace_stale_jobs_marks_secondary_db_jobs_failed() -> None:
+    """Interrupted workspace jobs must not survive as running after restart."""
+    ws_engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    await init_db(ws_engine)
+    ws_factory = async_sessionmaker(ws_engine, expire_on_commit=False, class_=AsyncSession)
+
+    try:
+        async with get_session(ws_factory) as session:
+            repo = await crud.upsert_repository(
+                session,
+                name="workspace-repo",
+                local_path="/tmp/workspace-repo",
+            )
+            running_job = await crud.upsert_generation_job(
+                session,
+                repository_id=repo.id,
+                status="running",
+                total_pages=12,
+            )
+            completed_job = await crud.upsert_generation_job(
+                session,
+                repository_id=repo.id,
+                status="completed",
+                total_pages=1,
+            )
+
+        reset_count = await reset_workspace_stale_jobs(
+            SimpleNamespace(workspace_sessions={repo.id: ws_factory})
+        )
+
+        async with get_session(ws_factory) as session:
+            result = await session.execute(
+                select(GenerationJob).where(
+                    GenerationJob.id.in_([running_job.id, completed_job.id])
+                )
+            )
+            jobs = {job.id: job for job in result.scalars().all()}
+
+        assert reset_count == 1
+        assert jobs[running_job.id].status == "failed"
+        assert jobs[running_job.id].finished_at is not None
+        assert jobs[running_job.id].error_message == "Server restarted; job interrupted"
+        assert jobs[completed_job.id].status == "completed"
+    finally:
+        await ws_engine.dispose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fix workspace job listing/state resolution so job progress reads from the correct repo DB and stale workspace jobs are reset after restart.
- Keep frontend progress display tied to persisted job timestamps and live SSE progress instead of component mount time or stale polling snapshots.
- Add regression coverage for workspace DB lookup, stale job cleanup, SSE progress merging, elapsed time calculation, and phase labels.

## Related Issues

Fixes #486

## Test Plan

- [x] Tests pass (`uv run pytest tests/unit/server/test_jobs.py`)
- [x] Lint passes (`uv run ruff check packages/server/src/repowise/server/routers/jobs.py packages/server/src/repowise/server/app.py tests/unit/server/test_jobs.py`)
- [x] Web build passes (`npm.cmd run build`)
- [x] Type check passes (`npm.cmd run type-check`)
- [x] Web lint passes (`npm.cmd run lint`)
- [x] Web progress helper tests pass (`npm.cmd --workspace packages/web run test -- src/lib/jobs/progress.test.ts`)
- [x] UI progress component tests pass (`npm.cmd --workspace packages/ui run test -- __tests__/jobs/generation-progress.test.tsx`)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
