### PR TITLE
release: v0.20.0 — health surfacing suite, update UX, workspace fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.19.1",
+      "version": "0.20.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.20.0] — 2026-06-16
+
+### Added
+- **Churn x complexity quadrant on the hotspots tab.** The hotspots view now plots files on a churn-versus-complexity quadrant, making it easy to spot the high-churn, high-complexity files that warrant attention first. (#491)
+- **Per-file process, people, and topology signals.** The file page now surfaces per-file process signals (how the file changes over time), people signals (ownership and contributor spread), and topology signals (how connected the file is), each already computed during indexing. (#490)
+- **Per-file health score over time.** The file page, the file drawer, and the MCP `get_health` surface now show a file's health score history, so you can see whether a file is trending better or worse. (#489)
+- **Health bands, repo distribution, and a README badge.** Code health is now bucketed into named bands with a repo-wide distribution view, and a health badge can be embedded in your README. (#485)
+
+### Changed
+- **Quieter, polished `update` CLI UX.** `repowise update` now uses the same calm, panel-based progress output as `init`, with a `-v` flag for verbose detail. The previously monolithic update command was also split into a package for maintainability. (#476, #477)
+- **Co-change page reframed as a temporal hint.** The cross-repo co-change page now presents its data as a temporal hint rather than an authoritative dependency, and the average-strength figure is displayed correctly. (#481)
+
+### Fixed
+- **Workspace job progress stays accurate.** In multi-repo workspace mode, job listing and progress now read from the correct per-repo database, stale jobs left running after a server restart are reset, and the progress timer and phase labels reflect persisted state instead of component mount time. (#487)
+- **Co-change noise filtering and cross-repo strength normalization.** Noise files are filtered out of co-change analysis and cross-repo co-change strength is normalized so the signal is comparable across repos. (#480)
+- **Like-with-like population comparison in coordinator health.** Coordinator health now compares files against like-sized populations rather than mixing dissimilar groups. (#479)
+
+### Documentation
+- **README dual-audience positioning.** The README was reworked for a dual-audience frame and now surfaces change-risk, agent provenance, and wiki styles. (#478)
+- Plugin: version bump to 0.20.0 (no command/skill/hook/MCP-surface changes).
+
+### Dependencies
+- Bumped `pyjwt` from 2.12.1 to 2.13.0, a security release bundling five advisory fixes. (#488)
+
+---
+
 ## [0.19.1] — 2026-06-13
 
 ### Fixed

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.19.1"
+__version__ = "0.20.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.19.1"
+__version__ = "0.20.0"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.19.1"
+__version__ = "0.20.0"

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -241,7 +241,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.19.1</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.20.0</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -323,7 +323,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
         <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
           <ThemeToggle className="w-full justify-between" />
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.19.1
+            repowise v0.20.0
           </p>
         </div>
       )}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.20.0
+
+Version bump to track the repowise 0.20.0 release. No changes to the plugin's
+commands, skills, hooks, or MCP tool surface this cycle.
+
 ## 0.19.1
 
 Version bump to track the repowise 0.19.1 release. No changes to the plugin's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.19.1"
+version = "0.20.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.19.1"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Release v0.20.0. A minor release led by the code-health surfacing suite, plus the `update` CLI UX overhaul, workspace fixes, and a security dependency bump.

Highlights:
- **Health surfacing:** churn x complexity quadrant on the hotspots tab (#491), per-file process/people/topology signals (#490), per-file health score over time on the file page, drawer, and MCP (#489), and health bands, repo distribution, and a README badge (#485).
- **CLI:** quieter, panel-based `update` UX matching `init`, with a `-v` flag; the update command was also split into a package (#476, #477).
- **Workspace fixes:** accurate job progress state in multi-repo mode (#487), co-change noise filtering and cross-repo strength normalization (#480), co-change page reframed as a temporal hint (#481), and like-with-like population comparison in coordinator health (#479).
- **Docs:** README dual-audience positioning surfacing change-risk, provenance, and wiki styles (#478).
- **Dependencies:** pyjwt 2.12.1 -> 2.13.0, a security release bundling five advisory fixes (#488).

Version bumped across the four Python packages, the web footer (sidebar + mobile nav), and the Claude Code plugin manifests; `uv.lock` regenerated. No CLI/MCP/hook surface changes this cycle, so the plugin work is the version bump only.

## Test plan

- [x] Wheel builds cleanly (`uv build --wheel`) with expected structure (commands, serve_cmd, `.scm`/`.j2` data files)
- [x] `uv.lock` self-entry bumped to 0.20.0
- [x] Web build passes the hard gate (`npm ci && npm run build --workspace packages/web`), standalone `server.js` present, workspace-package code bundled
- [x] No stale 0.19.1 version references remain
- [x] Plugin MCP tool-surface parity grep clean (only the 9 exposed tools in skills/commands/README)
- [ ] Tag `v0.20.0` on the merge commit and watch `publish.yml` (post-merge)

## Merge convention

Merge with a **regular merge commit, not squash**, so the tag points at a real merge of the bump-only diff and artifact provenance stays traceable.
