### PR TITLE
fix(ingestion): skip Unity-generated .NET scan paths

### DIFF
--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/index.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/index.py
@@ -11,7 +11,12 @@ import structlog
 from repowise.core.fs_walk import iter_glob
 
 from .global_usings import collect_project_global_usings
-from .msbuild import MSBuildProject, find_csproj_files, find_directory_build_props, parse_csproj
+from .msbuild import (
+    MSBuildProject,
+    find_csproj_files,
+    parse_csproj,
+    path_has_dotnet_scan_skip_dir,
+)
 from .namespace_map import build_namespace_map
 from .solution import find_sln_files, parse_sln
 
@@ -151,9 +156,6 @@ class DotNetProjectIndex:
         return package_id in self.package_refs.get(csproj, set())
 
 
-_CS_WALK_SKIP_DIRS = frozenset({"bin", "obj", ".vs", "node_modules", ".git", "packages"})
-
-
 def _walk_repo_cs_files(repo_path: Path, *, prune_nested_git: bool = True) -> list[Path]:
     """Single repo-wide rglob for ``*.cs`` files, dedup by resolved path.
 
@@ -164,7 +166,7 @@ def _walk_repo_cs_files(repo_path: Path, *, prune_nested_git: bool = True) -> li
     seen: set[Path] = set()
     out: list[Path] = []
     for cs in iter_glob(repo_path, "*.cs", prune_nested_git=prune_nested_git):
-        if any(part in _CS_WALK_SKIP_DIRS for part in cs.parts):
+        if path_has_dotnet_scan_skip_dir(cs, repo_path):
             continue
         try:
             resolved = cs.resolve()
@@ -317,7 +319,7 @@ def build_index(repo_path: Path, *, prune_nested_git: bool = True) -> DotNetProj
 _INDEX_KEY = "_dotnet_index"
 
 
-def get_or_build_index(ctx: "ResolverContext") -> DotNetProjectIndex | None:
+def get_or_build_index(ctx: ResolverContext) -> DotNetProjectIndex | None:
     """Return the cached DotNetProjectIndex, building it on first access."""
     if not ctx.repo_path:
         return None

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/msbuild.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/msbuild.py
@@ -19,6 +19,30 @@ from repowise.core.fs_walk import iter_glob
 log = structlog.get_logger(__name__)
 
 
+# Directory basenames the .NET / Unity resolver should never scan for
+# projects or source. These are intentionally scoped to the dotnet path,
+# not shared global fs_walk pruning, because names like Library/ or Logs/
+# can be legitimate source trees in non-Unity repos.
+DOTNET_SCAN_SKIP_DIRS: frozenset[str] = frozenset(
+    {
+        "bin",
+        "obj",
+        ".vs",
+        "node_modules",
+        ".git",
+        "packages",
+        "TestResults",
+        "Library",
+        "Temp",
+        "Logs",
+        "UserSettings",
+        "MemoryCaptures",
+        "Builds",
+    }
+)
+_DOTNET_SCAN_SKIP_DIRS_CASEFOLDED = frozenset(part.casefold() for part in DOTNET_SCAN_SKIP_DIRS)
+
+
 @dataclass
 class MSBuildProject:
     """Parsed MSBuild project file."""
@@ -91,13 +115,21 @@ def parse_csproj(csproj_path: Path) -> MSBuildProject | None:
 
 def find_csproj_files(repo_path: Path, *, prune_nested_git: bool = True) -> list[Path]:
     """Return all .csproj files under *repo_path*, skipping bin/obj output."""
-    skip = {"bin", "obj", ".vs", "node_modules", ".git", "packages", "TestResults"}
     out: list[Path] = []
     for csproj in iter_glob(repo_path, "*.csproj", prune_nested_git=prune_nested_git):
-        if any(part in skip for part in csproj.parts):
+        if path_has_dotnet_scan_skip_dir(csproj, repo_path):
             continue
         out.append(csproj)
     return out
+
+
+def path_has_dotnet_scan_skip_dir(path: Path, repo_root: Path) -> bool:
+    """Return True when *path* lives under a dotnet-skip directory in *repo_root*."""
+    try:
+        parts = path.relative_to(repo_root).parts
+    except ValueError:
+        parts = path.parts
+    return any(part.casefold() in _DOTNET_SCAN_SKIP_DIRS_CASEFOLDED for part in parts)
 
 
 def find_directory_build_props(start: Path, repo_root: Path) -> list[Path]:

--- a/packages/core/src/repowise/core/ingestion/resolvers/dotnet/solution.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/dotnet/solution.py
@@ -18,6 +18,8 @@ import structlog
 
 from repowise.core.fs_walk import iter_glob
 
+from .msbuild import path_has_dotnet_scan_skip_dir
+
 log = structlog.get_logger(__name__)
 
 # Project("{TYPE}") = "Name", "rel\path.csproj", "{GUID}"
@@ -59,10 +61,9 @@ def parse_sln(sln_path: Path) -> list[SolutionEntry]:
 
 
 def find_sln_files(repo_path: Path, *, prune_nested_git: bool = True) -> list[Path]:
-    skip = {".git", "node_modules", "bin", "obj"}
     out: list[Path] = []
     for sln in iter_glob(repo_path, "*.sln", prune_nested_git=prune_nested_git):
-        if any(part in skip for part in sln.parts):
+        if path_has_dotnet_scan_skip_dir(sln, repo_path):
             continue
         out.append(sln)
     return out

--- a/packages/core/src/repowise/core/ingestion/traverser.py
+++ b/packages/core/src/repowise/core/ingestion/traverser.py
@@ -92,6 +92,13 @@ _BLOCKED_DIRS: frozenset[str] = frozenset(
         ".eggs",
         "site-packages",
         ".cache",
+        # Unity generated state / editor data
+        "Library",
+        "Temp",
+        "Logs",
+        "UserSettings",
+        "MemoryCaptures",
+        "Builds",
         ".idea",
         ".vscode",
         # NOTE: test/tests/spec/specs/__tests__ are intentionally NOT
@@ -117,7 +124,27 @@ _BLOCKED_DIRS: frozenset[str] = frozenset(
 )
 
 _BLOCKED_EXTENSIONS: frozenset[str] = frozenset(
-    {".pyc", ".pyo", ".pyd", ".so", ".dll", ".dylib", ".exe", ".o", ".a", ".wasm"}
+    {
+        ".pyc",
+        ".pyo",
+        ".pyd",
+        ".so",
+        ".dll",
+        ".dylib",
+        ".exe",
+        ".o",
+        ".a",
+        ".wasm",
+        # Unity non-code assets. These are large, numerous, and currently
+        # provide no parser/graph value, so skip them before binary sniffing.
+        ".meta",
+        ".prefab",
+        ".unity",
+        ".asset",
+        ".mat",
+        ".anim",
+        ".controller",
+    }
 )
 
 _BLOCKED_FILENAME_PATTERNS: list[str] = [

--- a/tests/unit/ingestion/test_csharp_resolver.py
+++ b/tests/unit/ingestion/test_csharp_resolver.py
@@ -26,7 +26,6 @@ from repowise.core.ingestion.resolvers.dotnet.global_usings import scan_global_u
 from repowise.core.ingestion.resolvers.dotnet.index import build_index
 from repowise.core.ingestion.resolvers.dotnet.namespace_map import declared_namespaces
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -263,6 +262,35 @@ class TestProjectIndexCaching:
         assert isinstance(first, DotNetProjectIndex)
         assert first.repo_path == tmp_path.resolve()
         assert "Foo" in first.namespace_map
+
+    def test_build_index_skips_unity_generated_dirs(self, tmp_path: Path) -> None:
+        (tmp_path / "Game.csproj").write_text(_csproj())
+        (tmp_path / "Assets" / "Scripts").mkdir(parents=True)
+        (tmp_path / "Assets" / "Scripts" / "Player.cs").write_text(
+            "namespace Game;\npublic class Player {}\n"
+        )
+        (tmp_path / "Library" / "PackageCache").mkdir(parents=True)
+        (tmp_path / "Library" / "PackageCache" / "Ghost.cs").write_text(
+            "namespace Noise;\npublic class Ghost {}\n"
+        )
+        (tmp_path / "Library" / "Generated.csproj").write_text(_csproj())
+        (tmp_path / "Temp" / "StagingArea").mkdir(parents=True)
+        (tmp_path / "Temp" / "StagingArea" / "TempFile.cs").write_text(
+            "namespace Noise;\npublic class TempFile {}\n"
+        )
+        (tmp_path / "Builds" / "Windows").mkdir(parents=True)
+        (tmp_path / "Builds" / "Windows" / "Exported.cs").write_text(
+            "namespace Noise;\npublic class Exported {}\n"
+        )
+        (tmp_path / "Builds" / "Windows" / "Exported.csproj").write_text(_csproj())
+
+        index = build_index(tmp_path)
+
+        assert {proj.name for proj in index.projects.values()} == {"Game"}
+        assert "Player" in index.type_map
+        assert "Ghost" not in index.type_map
+        assert "TempFile" not in index.type_map
+        assert "Exported" not in index.type_map
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/ingestion/test_fs_walk.py
+++ b/tests/unit/ingestion/test_fs_walk.py
@@ -131,8 +131,12 @@ class TestPruning:
         at ``build/go.mod`` must stay discoverable."""
         _write(tmp_path, "coverage/__init__.py")
         _write(tmp_path, "build/go.mod")
+        _write(tmp_path, "Library/app.py")
+        _write(tmp_path, "Logs/worker.py")
         assert list(iter_glob(tmp_path, "__init__.py")) == [tmp_path / "coverage" / "__init__.py"]
         assert list(iter_glob(tmp_path, "go.mod")) == [tmp_path / "build" / "go.mod"]
+        assert list(iter_glob(tmp_path, "app.py")) == [tmp_path / "Library" / "app.py"]
+        assert list(iter_glob(tmp_path, "worker.py")) == [tmp_path / "Logs" / "worker.py"]
 
     def test_derived_set_prunes_output_dirs(self, tmp_path: Path) -> None:
         """PRUNED_DIRS_DERIVED (dynamic hints) prunes derived-output names."""
@@ -145,6 +149,8 @@ class TestPruning:
         """Canary: the dirs behind past incidents stay pruned."""
         for d in ("node_modules", ".venv", "__pycache__", ".git", ".repowise", ".next"):
             assert d in PRUNED_DIRS
+        for d in ("Library", "Temp", "Logs", "UserSettings", "MemoryCaptures"):
+            assert d not in PRUNED_DIRS
         for d in ("dist", "build", "out", "coverage"):
             assert d not in PRUNED_DIRS  # possible source dirs — derived set only
             assert d in PRUNED_DIRS_DERIVED

--- a/tests/unit/ingestion/test_traverser.py
+++ b/tests/unit/ingestion/test_traverser.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from repowise.core.ingestion import traverser as traverser_mod
 from repowise.core.ingestion.traverser import FileTraverser, _detect_language
 
 # ---------------------------------------------------------------------------
@@ -101,6 +102,40 @@ class TestFileTraverser:
         traverser = FileTraverser(simple_repo)
         paths = [f.path for f in traverser.traverse()]
         assert not any("__pycache__" in p for p in paths)
+
+    def test_skips_unity_generated_dirs(self, tmp_path: Path) -> None:
+        (tmp_path / "Assets" / "Scripts").mkdir(parents=True)
+        (tmp_path / "Assets" / "Scripts" / "Game.cs").write_text("class Game {}")
+        (tmp_path / "Library" / "PackageCache").mkdir(parents=True)
+        (tmp_path / "Library" / "PackageCache" / "Fake.cs").write_text("class Fake {}")
+        (tmp_path / "Temp" / "StagingArea").mkdir(parents=True)
+        (tmp_path / "Temp" / "StagingArea" / "Temp.cs").write_text("class TempFile {}")
+        traverser = FileTraverser(tmp_path)
+        paths = [f.path for f in traverser.traverse()]
+        assert "Assets/Scripts/Game.cs" in paths
+        assert not any(p.startswith("Library/") for p in paths)
+        assert not any(p.startswith("Temp/") for p in paths)
+
+    def test_skips_unity_asset_extensions_before_binary_detection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "Assets").mkdir()
+        (tmp_path / "Assets" / "Scene.unity").write_text("%YAML 1.1\n")
+        (tmp_path / "Assets" / "Main.cs").write_text("class Main {}")
+
+        def _fail_binary(_path: Path) -> bool:
+            raise AssertionError("Unity asset hit binary detection")
+
+        def _fail_shebang(_path: Path) -> str:
+            raise AssertionError("Unity asset hit shebang detection")
+
+        monkeypatch.setattr(traverser_mod, "_is_binary", _fail_binary)
+        monkeypatch.setattr(traverser_mod, "_detect_by_shebang", _fail_shebang)
+
+        traverser = FileTraverser(tmp_path)
+        paths = [f.path for f in traverser.traverse()]
+        assert "Assets/Main.cs" in paths
+        assert "Assets/Scene.unity" not in paths
 
     def test_skips_binary_files(self, tmp_path: Path) -> None:
         binary = tmp_path / "binary.so"


### PR DESCRIPTION
## Summary

- Skip Unity-generated directories and Unity asset files during ingestion traversal so Unity repos do not spend time indexing editor state and build output.
- Apply the same Unity-aware skip policy to the .NET warmup path for .csproj, .sln, and .cs scans, using repo-relative and case-insensitive matching.
- Keep those Unity names out of the global shared filesystem prune set so non-Unity repos with directories like Library/ or Logs/ do not lose valid source files.

## Related Issues

Fixes #498

## Test Plan

- [x] Tests pass (uv run pytest tests/unit/ingestion/test_fs_walk.py tests/unit/ingestion/test_traverser.py tests/unit/ingestion/test_csharp_resolver.py)
- [x] Lint passes (uv run ruff check packages/core/src/repowise/core/fs_walk.py packages/core/src/repowise/core/ingestion/traverser.py packages/core/src/repowise/core/ingestion/resolvers/dotnet/msbuild.py packages/core/src/repowise/core/ingestion/resolvers/dotnet/solution.py packages/core/src/repowise/core/ingestion/resolvers/dotnet/index.py tests/unit/ingestion/test_fs_walk.py tests/unit/ingestion/test_traverser.py tests/unit/ingestion/test_csharp_resolver.py)
- [ ] Web build passes (
pm run build) *(if frontend changes)*

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed