### PR TITLE
feat(overview): rebuild repo overview around code health

### DIFF
--- a/packages/ui/src/dashboard/health-overview-card.tsx
+++ b/packages/ui/src/dashboard/health-overview-card.tsx
@@ -1,0 +1,309 @@
+import {
+  HeartPulse,
+  Flame,
+  TrendingUp,
+  TrendingDown,
+  ShieldAlert,
+  ArrowRight,
+} from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { fileEntityPath } from "../shared/entity/routes";
+import { truncatePath } from "../lib/format";
+
+export interface HealthOverviewPoint {
+  taken_at: string | null;
+  average_health: number;
+  hotspot_health: number;
+}
+
+export interface HealthOverviewData {
+  /** Repo-wide biomarker health average, 1–10 (null until first health run). */
+  average_health: number | null;
+  /** Health of the highest-churn files, 1–10. */
+  hotspot_health: number | null;
+  /** Lowest-scoring file and its score (1–10). */
+  worst_performer_path: string | null;
+  worst_performer_score: number | null;
+  /** Open biomarker findings, with a severity rollup. */
+  open_findings: number;
+  severity_breakdown: Record<string, number>;
+  /** Snapshot history, oldest→newest, for the trend sparkline. */
+  history: HealthOverviewPoint[];
+  snapshot_count: number;
+}
+
+interface HealthOverviewCardProps {
+  data: HealthOverviewData;
+  repoId: string;
+  /** Delta vs the previous snapshot (1–10 scale); drives the trend chips. */
+  averageDelta?: number | null;
+  hotspotDelta?: number | null;
+  className?: string;
+}
+
+/* 1–10 health bands — the moat metric, distinct from the 0–100 composite
+   shown in the header badge. */
+function band(v: number): { color: string; label: string } {
+  if (v >= 8) return { color: "var(--color-success)", label: "Excellent" };
+  if (v >= 6.5) return { color: "var(--color-success)", label: "Good" };
+  if (v >= 5) return { color: "var(--color-caution)", label: "Fair" };
+  if (v >= 3.5) return { color: "var(--color-warning)", label: "Needs work" };
+  return { color: "var(--color-error)", label: "Critical" };
+}
+
+const SEVERITY_ORDER = ["critical", "high", "medium", "low"] as const;
+const SEVERITY_COLOR: Record<string, string> = {
+  critical: "var(--color-error)",
+  high: "var(--color-accent-fill)",
+  medium: "var(--color-warning)",
+  low: "var(--color-text-tertiary)",
+};
+
+function TrendChip({ delta }: { delta: number | null | undefined }) {
+  if (delta == null || Math.abs(delta) < 0.05) return null;
+  const up = delta > 0;
+  const Icon = up ? TrendingUp : TrendingDown;
+  return (
+    <span
+      className="inline-flex items-center gap-0.5 text-[11px] font-medium tabular-nums"
+      style={{ color: up ? "var(--color-success)" : "var(--color-error)" }}
+      title={`${up ? "+" : ""}${delta.toFixed(2)} vs previous snapshot`}
+    >
+      <Icon className="h-3 w-3" />
+      {up ? "+" : ""}
+      {delta.toFixed(1)}
+    </span>
+  );
+}
+
+function Sparkline({ points }: { points: number[] }) {
+  if (points.length < 2) return null;
+  const w = 96;
+  const h = 28;
+  const min = Math.min(...points);
+  const max = Math.max(...points);
+  const span = max - min || 1;
+  const step = w / (points.length - 1);
+  const coords = points.map((v, i) => {
+    const x = i * step;
+    const y = h - 3 - ((v - min) / span) * (h - 6);
+    return [x, y] as const;
+  });
+  const line = coords.map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`).join(" ");
+  const area = `${line} L${w},${h} L0,${h} Z`;
+  return (
+    <svg width={w} height={h} className="shrink-0" aria-hidden>
+      <defs>
+        <linearGradient id="health-spark" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="var(--color-accent-fill)" stopOpacity="0.28" />
+          <stop offset="100%" stopColor="var(--color-accent-fill)" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={area} fill="url(#health-spark)" />
+      <path
+        d={line}
+        fill="none"
+        stroke="var(--color-accent-primary)"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function MetricTile({
+  icon,
+  label,
+  value,
+  delta,
+  band: b,
+  sparkline,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: number | null;
+  delta?: number | null | undefined;
+  band: { color: string; label: string } | null;
+  sparkline?: number[] | undefined;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5 px-4 py-3.5">
+      <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+        {icon}
+        {label}
+      </div>
+      {value == null ? (
+        <p className="text-sm text-[var(--color-text-tertiary)]">No data yet</p>
+      ) : (
+        <>
+          <div className="flex items-baseline gap-1.5">
+            <span className="text-3xl font-bold tabular-nums leading-none" style={{ color: b?.color }}>
+              {value.toFixed(1)}
+            </span>
+            <span className="text-sm text-[var(--color-text-tertiary)]">/10</span>
+            <TrendChip delta={delta} />
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            {b && (
+              <span
+                className="text-[11px] font-medium uppercase tracking-wide"
+                style={{ color: b.color }}
+              >
+                {b.label}
+              </span>
+            )}
+            {sparkline && <Sparkline points={sparkline} />}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Code Health hero for the Overview page — the product's moat surfaced first.
+ * Renders the repo-wide biomarker health and hotspot health (1–10, with trend
+ * and delta), the open-findings severity mix, and the single worst-scoring
+ * file, all from the overview-summary payload (no extra fetch). A "View
+ * report" link jumps to the full Code Health page.
+ */
+export function HealthOverviewCard({
+  data,
+  repoId,
+  averageDelta,
+  hotspotDelta,
+  className,
+}: HealthOverviewCardProps) {
+  const reportHref = `/repos/${repoId}/code-health`;
+  const avg = data.average_health;
+  const hot = data.hotspot_health;
+  const avgSeries = data.history.map((p) => p.average_health);
+  const hotSeries = data.history.map((p) => p.hotspot_health);
+
+  const severities = SEVERITY_ORDER.map((key) => ({
+    key,
+    count: data.severity_breakdown[key] ?? 0,
+    color: SEVERITY_COLOR[key]!,
+  })).filter((s) => s.count > 0);
+  const severityTotal = severities.reduce((s, x) => s + x.count, 0);
+
+  const hasData = avg != null || hot != null;
+
+  return (
+    <Card className={`overflow-hidden shadow-sm ${className ?? ""}`}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm flex items-center justify-between">
+          <span className="flex items-center gap-2">
+            <HeartPulse className="h-4 w-4 text-[var(--color-success)]" />
+            Code Health
+          </span>
+          <a
+            href={reportHref}
+            className="inline-flex items-center gap-1 text-[11px] font-normal text-[var(--color-accent-primary)] hover:underline"
+          >
+            View report <ArrowRight className="h-3 w-3" />
+          </a>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {!hasData ? (
+          <p className="px-4 pb-4 text-sm text-[var(--color-text-secondary)]">
+            Run <code className="font-mono text-xs">repowise health</code> to score complexity,
+            duplication, coverage, churn, and ownership across the repo.
+          </p>
+        ) : (
+          <>
+            {/* Two headline metrics */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-[var(--color-border-default)] border-b border-[var(--color-border-default)]">
+              <MetricTile
+                icon={<HeartPulse className="h-3 w-3" />}
+                label="Average health"
+                value={avg}
+                delta={averageDelta}
+                band={avg != null ? band(avg) : null}
+                sparkline={avgSeries}
+              />
+              <MetricTile
+                icon={<Flame className="h-3 w-3" />}
+                label="Hotspot health"
+                value={hot}
+                delta={hotspotDelta}
+                band={hot != null ? band(hot) : null}
+                sparkline={hotSeries}
+              />
+            </div>
+
+            {/* Findings + worst performer */}
+            <div className="px-4 py-3.5 space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+                  <ShieldAlert className="h-3 w-3" />
+                  Open findings
+                </span>
+                <a
+                  href={`${reportHref}?tab=triage`}
+                  className="text-sm font-bold tabular-nums text-[var(--color-text-primary)] hover:text-[var(--color-accent-primary)] transition-colors"
+                >
+                  {data.open_findings.toLocaleString()}
+                </a>
+              </div>
+
+              {severityTotal > 0 ? (
+                <>
+                  <div className="flex h-2 w-full overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
+                    {severities.map((s) => (
+                      <div
+                        key={s.key}
+                        className="h-full"
+                        style={{ width: `${(s.count / severityTotal) * 100}%`, background: s.color }}
+                        title={`${s.count} ${s.key}`}
+                      />
+                    ))}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+                    {severities.map((s) => (
+                      <span
+                        key={s.key}
+                        className="flex items-center gap-1.5 text-[11px] text-[var(--color-text-secondary)] capitalize"
+                      >
+                        <span className="h-2 w-2 rounded-full" style={{ background: s.color }} />
+                        {s.key}
+                        <span className="tabular-nums text-[var(--color-text-tertiary)]">{s.count}</span>
+                      </span>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <p className="text-[11px] text-[var(--color-success)]">No open findings — clean bill of health.</p>
+              )}
+
+              {data.worst_performer_path && data.worst_performer_score != null && (
+                <a
+                  href={fileEntityPath(`/repos/${repoId}`, data.worst_performer_path)}
+                  className="flex items-center justify-between gap-3 -mx-2 mt-1 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--color-bg-elevated)] group"
+                >
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    <Flame className="h-3 w-3 shrink-0 text-[var(--color-error)]" />
+                    <span className="text-[10px] uppercase tracking-wider text-[var(--color-text-tertiary)] shrink-0">
+                      Worst file
+                    </span>
+                    <span className="truncate font-mono text-[11px] text-[var(--color-text-secondary)] group-hover:text-[var(--color-accent-primary)] transition-colors">
+                      {truncatePath(data.worst_performer_path, 40)}
+                    </span>
+                  </span>
+                  <span
+                    className="shrink-0 text-[11px] font-bold tabular-nums"
+                    style={{ color: band(data.worst_performer_score).color }}
+                  >
+                    {data.worst_performer_score.toFixed(1)}/10
+                  </span>
+                </a>
+              )}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/ui/src/dashboard/index.ts
+++ b/packages/ui/src/dashboard/index.ts
@@ -2,6 +2,7 @@ export * from "./attention-panel";
 export * from "./commits-mini";
 export * from "./decisions-timeline";
 export * from "./health-score-badge";
+export * from "./health-overview-card";
 export * from "./savings-mini";
 export * from "./where-to-start";
 export * from "./dependency-heatmap";

--- a/packages/ui/src/dashboard/savings-mini.tsx
+++ b/packages/ui/src/dashboard/savings-mini.tsx
@@ -66,7 +66,7 @@ export function SavingsMini({ data, repoId, langDistribution, langHref }: Saving
   if (langOther > 0) langShown.push({ name: "other", value: langOther });
 
   return (
-    <Card className="h-full">
+    <Card>
       <CardHeader className="pb-2">
         <CardTitle className="text-sm flex items-center justify-between">
           <span className="flex items-center gap-2">
@@ -118,19 +118,23 @@ export function SavingsMini({ data, repoId, langDistribution, langHref }: Saving
                 />
               )}
             </div>
-            <div className="flex items-center justify-between text-[11px]">
-              <span className="flex items-center gap-1.5 text-[var(--color-text-secondary)]">
-                <span className="h-2 w-2 rounded-full bg-cyan-500" /> Distill
-                <span className="tabular-nums text-[var(--color-text-tertiary)]">
+            <div className="space-y-1 text-[11px]">
+              <div className="flex items-center justify-between gap-2">
+                <span className="flex items-center gap-1.5 text-[var(--color-text-secondary)] whitespace-nowrap">
+                  <span className="h-2 w-2 rounded-full bg-cyan-500 shrink-0" /> Distill
+                </span>
+                <span className="tabular-nums text-[var(--color-text-tertiary)] shrink-0">
                   {formatTokens(distillSaved)}
                 </span>
-              </span>
-              <span className="flex items-center gap-1.5 text-[var(--color-text-secondary)]">
-                <span className="h-2 w-2 rounded-full bg-violet-500" /> MCP
-                <span className="tabular-nums text-[var(--color-text-tertiary)]">
+              </div>
+              <div className="flex items-center justify-between gap-2">
+                <span className="flex items-center gap-1.5 text-[var(--color-text-secondary)] whitespace-nowrap">
+                  <span className="h-2 w-2 rounded-full bg-violet-500 shrink-0" /> MCP tools
+                </span>
+                <span className="tabular-nums text-[var(--color-text-tertiary)] shrink-0">
                   {formatTokens(mcpSaved)}
                 </span>
-              </span>
+              </div>
             </div>
           </div>
         ) : (

--- a/packages/ui/src/git/contributors-strip.tsx
+++ b/packages/ui/src/git/contributors-strip.tsx
@@ -1,0 +1,186 @@
+import { Users, Bot, ArrowRight } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+
+export interface StripOwner {
+  name: string;
+  pct: number;
+  file_count: number;
+  email?: string | undefined;
+}
+
+export interface StripProvenance {
+  /** Share of indexed commits attributed to coding agents, 0–100. */
+  agentPct: number;
+  agentCommits: number;
+  totalCommits: number;
+  /** Per-agent commit counts, biggest first. */
+  agentNames: { name: string; count: number }[];
+}
+
+interface ContributorsStripProps {
+  owners: StripOwner[];
+  /** Approx number of distinct contributors (defaults to owners.length). */
+  contributorCount?: number;
+  /** Agent-vs-human authorship; omit/null when provenance isn't indexed. */
+  provenance?: StripProvenance | null;
+  ownersHref: string;
+  commitsHref: string;
+}
+
+/* Categorical hues that read in both themes (community ramp is built for
+   exactly this — distinguishable, brand-anchored). */
+const SEG_COLORS = [
+  "var(--color-community-1)",
+  "var(--color-community-2)",
+  "var(--color-community-3)",
+  "var(--color-community-6)",
+  "var(--color-community-7)",
+];
+const OTHER_COLOR = "var(--color-text-tertiary)";
+
+function firstName(name: string): string {
+  return name.split(/\s+/)[0] ?? name;
+}
+
+/**
+ * Thin Overview strip: who owns the code (stacked share bar of top authors +
+ * legend) and — when agent-provenance is indexed — what share of commits came
+ * from coding agents. Degrades to contributors-only when provenance is absent
+ * or zero, so repos without agent activity still render cleanly.
+ */
+export function ContributorsStrip({
+  owners,
+  contributorCount,
+  provenance,
+  ownersHref,
+  commitsHref,
+}: ContributorsStripProps) {
+  const top = owners.slice(0, 5);
+  const shownPct = top.reduce((s, o) => s + (o.pct ?? 0), 0);
+  const otherPct = Math.max(0, 100 - shownPct);
+  const count = contributorCount ?? owners.length;
+  const lead = top[0];
+
+  const hasProvenance =
+    !!provenance && provenance.agentCommits > 0 && provenance.totalCommits > 0;
+
+  if (owners.length === 0) return null;
+
+  return (
+    <Card className="overflow-hidden shadow-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm flex items-center justify-between">
+          <span className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-[var(--color-accent-secondary)]" />
+            Contributors
+            <span className="text-[11px] font-normal text-[var(--color-text-tertiary)] tabular-nums">
+              {count}
+            </span>
+          </span>
+          <a
+            href={ownersHref}
+            className="inline-flex items-center gap-1 text-[11px] font-normal text-[var(--color-accent-primary)] hover:underline"
+          >
+            View owners <ArrowRight className="h-3 w-3" />
+          </a>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0 space-y-2.5">
+        {/* Ownership share */}
+        <div className="flex h-2 w-full overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
+          {top.map((o, i) => (
+            <div
+              key={o.email ?? o.name}
+              className="h-full"
+              style={{ width: `${o.pct}%`, background: SEG_COLORS[i % SEG_COLORS.length] }}
+              title={`${o.name} — ${Math.round(o.pct)}% of files`}
+            />
+          ))}
+          {otherPct > 1 && (
+            <div className="h-full" style={{ width: `${otherPct}%`, background: OTHER_COLOR }} />
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          {top.slice(0, 4).map((o, i) => (
+            <span
+              key={o.email ?? o.name}
+              className="flex items-center gap-1.5 text-[11px] text-[var(--color-text-secondary)] min-w-0"
+            >
+              <span
+                className="h-2 w-2 rounded-full shrink-0"
+                style={{ background: SEG_COLORS[i % SEG_COLORS.length] }}
+              />
+              <span className="truncate max-w-[120px]">{firstName(o.name)}</span>
+              <span className="tabular-nums text-[var(--color-text-tertiary)]">
+                {Math.round(o.pct)}%
+              </span>
+            </span>
+          ))}
+          {owners.length > 4 && (
+            <span className="text-[11px] text-[var(--color-text-tertiary)]">
+              +{owners.length - 4} more
+            </span>
+          )}
+        </div>
+        {lead && (
+          <p className="text-[11px] text-[var(--color-text-tertiary)]">
+            {firstName(lead.name)} owns {Math.round(lead.pct)}% of files
+            {count > 1 ? ` across ${count} contributors` : ""}.
+          </p>
+        )}
+
+        {/* Agent provenance — only when there's something to report */}
+        {hasProvenance && (
+          <div className="mt-1 border-t border-[var(--color-border-default)] pt-2.5 space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <span className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+                <Bot className="h-3 w-3" />
+                Authorship
+              </span>
+              <a
+                href={commitsHref}
+                className="text-[11px] tabular-nums text-[var(--color-text-secondary)] hover:text-[var(--color-accent-primary)] transition-colors"
+              >
+                <span className="font-semibold text-[var(--color-accent-primary)]">
+                  {Math.round(provenance!.agentPct)}%
+                </span>{" "}
+                agent-written
+              </a>
+            </div>
+            <div className="flex h-2 w-full overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
+              <div
+                className="h-full"
+                style={{ width: `${100 - provenance!.agentPct}%`, background: "var(--color-text-tertiary)" }}
+                title={`Human — ${Math.round(100 - provenance!.agentPct)}%`}
+              />
+              <div
+                className="h-full"
+                style={{ width: `${provenance!.agentPct}%`, background: "var(--color-accent-fill)" }}
+                title={`Agents — ${Math.round(provenance!.agentPct)}%`}
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-[var(--color-text-secondary)]">
+              <span className="flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-[var(--color-text-tertiary)]" />
+                Human
+                <span className="tabular-nums text-[var(--color-text-tertiary)]">
+                  {Math.round(100 - provenance!.agentPct)}%
+                </span>
+              </span>
+              {provenance!.agentNames.slice(0, 2).map((a) => {
+                const pct = Math.round((a.count / provenance!.totalCommits) * 100);
+                return (
+                  <span key={a.name} className="flex items-center gap-1.5 min-w-0">
+                    <span className="h-2 w-2 rounded-full bg-[var(--color-accent-fill)]" />
+                    <span className="truncate max-w-[120px]">{a.name}</span>
+                    <span className="tabular-nums text-[var(--color-text-tertiary)]">{pct}%</span>
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/ui/src/git/index.ts
+++ b/packages/ui/src/git/index.ts
@@ -6,6 +6,7 @@ export * from "./co-change-list";
 export * from "./commit-category-donut";
 export * from "./commit-category-sparkline";
 export * from "./contributor-bar";
+export * from "./contributors-strip";
 export * from "./contributor-network";
 export * from "./hotspot-table";
 export * from "./ownership-table";

--- a/packages/ui/src/ui/card.tsx
+++ b/packages/ui/src/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
     <div
       ref={ref}
       className={cn(
-        "rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-text-primary)]",
+        "rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-text-primary)] shadow-sm",
         className,
       )}
       {...props}

--- a/packages/web/src/app/repos/[id]/overview/page.tsx
+++ b/packages/web/src/app/repos/[id]/overview/page.tsx
@@ -4,18 +4,18 @@ import { Hash } from "lucide-react";
 import { getOverviewSummary } from "@/lib/api/overview";
 import { getProviders } from "@/lib/api/providers";
 import { Badge } from "@repowise-dev/ui/ui/badge";
-import { StatCard } from "@repowise-dev/ui/shared/stat-card";
+import { Card } from "@repowise-dev/ui/ui/card";
 import { EmptyState } from "@repowise-dev/ui/shared";
 import { HealthScoreBadge } from "@repowise-dev/ui/dashboard/health-score-badge";
-import { AttentionPanel } from "@repowise-dev/ui/dashboard/attention-panel";
+import { HealthOverviewCard } from "@repowise-dev/ui/dashboard/health-overview-card";
 import { WhereToStartCard } from "@repowise-dev/ui/dashboard/where-to-start";
 import { SavingsMini } from "@repowise-dev/ui/dashboard/savings-mini";
 import { LanguageDonut } from "@repowise-dev/ui/dashboard/language-donut";
 import { QuickActionsWrapper as QuickActions } from "@/components/dashboard/quick-actions-wrapper";
 import { OverviewTabs } from "@/components/overview/overview-tabs";
+import { ContributorsStripCard } from "@/components/overview/contributors-strip-card";
 import { computeHealthScore } from "@/lib/utils/health-score";
 import { formatNumber, formatRelativeTime } from "@repowise-dev/ui/lib/format";
-import type { AttentionItem } from "@repowise-dev/ui/dashboard/attention-panel";
 
 export const metadata: Metadata = { title: "Overview" };
 
@@ -31,12 +31,54 @@ async function safeFetch<T>(fn: () => Promise<T>): Promise<T | null> {
   }
 }
 
-function trendFor(delta: number | null | undefined, suffix = "") {
+interface Kpi {
+  label: string;
+  value: string;
+  href: string;
+  delta?: { value: string; positive: boolean };
+}
+
+function kpiDelta(delta: number | null | undefined): Kpi["delta"] {
   if (delta == null || delta === 0) return undefined;
-  return {
-    value: `${delta > 0 ? "+" : ""}${delta}${suffix}`,
-    positive: delta > 0,
-  };
+  return { value: `${delta > 0 ? "+" : ""}${delta}`, positive: delta > 0 };
+}
+
+/** Aligned enterprise-style KPI bar — one card, evenly divided cells. */
+function KpiStrip({ items }: { items: Kpi[] }) {
+  return (
+    <Card className="overflow-hidden shadow-sm">
+      <div className="grid grid-cols-2 divide-x divide-y divide-[var(--color-border-default)] sm:grid-cols-3 sm:divide-y-0 lg:grid-cols-5">
+        {items.map((kpi) => (
+          <a
+            key={kpi.label}
+            href={kpi.href}
+            className="group flex flex-col gap-1 px-4 py-3.5 transition-colors hover:bg-[var(--color-bg-elevated)]"
+          >
+            <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+              {kpi.label}
+            </span>
+            <span className="flex items-baseline gap-1.5">
+              <span className="text-2xl font-bold tabular-nums leading-none text-[var(--color-text-primary)] group-hover:text-[var(--color-accent-primary)] transition-colors">
+                {kpi.value}
+              </span>
+              {kpi.delta && (
+                <span
+                  className="text-xs font-medium tabular-nums"
+                  style={{
+                    color: kpi.delta.positive
+                      ? "var(--color-success)"
+                      : "var(--color-error)",
+                  }}
+                >
+                  {kpi.delta.positive ? "↑" : "↓"} {kpi.delta.value}
+                </span>
+              )}
+            </span>
+          </a>
+        ))}
+      </div>
+    </Card>
+  );
 }
 
 export default async function OverviewPage({ params }: Props) {
@@ -48,7 +90,7 @@ export default async function OverviewPage({ params }: Props) {
   ]);
   if (!summary) notFound();
 
-  const { repo, stats, health, attention, sync } = summary;
+  const { repo, stats, health, sync } = summary;
   const isFresh = stats.file_count === 0;
 
   const healthScore = computeHealthScore({
@@ -62,17 +104,34 @@ export default async function OverviewPage({ params }: Props) {
     totalModules: stats.module_count || 1,
   });
 
-  const attentionItems: AttentionItem[] = attention.map((a) => ({
-    id: a.id,
-    type: a.type,
-    title: a.title,
-    description: a.description,
-    severity: a.severity,
-    href:
-      a.type === "stale_decision" || a.type === "proposed_decision"
-        ? `/repos/${id}/decisions/${a.target_id}`
-        : undefined,
-  }));
+  const kpis: Kpi[] = [
+    {
+      label: "Files",
+      value: formatNumber(stats.file_count),
+      href: `/repos/${id}/architecture?view=graph`,
+      delta: kpiDelta(stats.deltas.file_count),
+    },
+    {
+      label: "Symbols",
+      value: formatNumber(stats.symbol_count),
+      href: `/repos/${id}/architecture?view=symbols`,
+    },
+    {
+      label: "Doc Coverage",
+      value: `${Math.round(stats.doc_coverage_pct)}%`,
+      href: `/repos/${id}/docs/coverage`,
+    },
+    {
+      label: "Dead Exports",
+      value: formatNumber(stats.dead_export_count),
+      href: `/repos/${id}/code-health?tab=dead-code`,
+    },
+    {
+      label: "Hotspots",
+      value: formatNumber(stats.hotspot_count),
+      href: `/repos/${id}/code-health?tab=hotspots`,
+    },
+  ];
 
   const langDistribution: Record<string, number> = {};
   for (const l of summary.languages) langDistribution[l.language] = l.file_count;
@@ -137,50 +196,24 @@ export default async function OverviewPage({ params }: Props) {
         />
       ) : (
         <>
-          {/* ── Attention strip leads ── */}
+          {/* ── KPI bar leads ── */}
+          <KpiStrip items={kpis} />
+
+          {/* ── Code Health (our moat) leads, with onboarding + savings rail ── */}
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-            <div className="lg:col-span-2">
-              <AttentionPanel items={attentionItems} repoId={id} />
+            <div className="space-y-4 lg:col-span-2">
+              <HealthOverviewCard
+                data={health}
+                repoId={id}
+                averageDelta={stats.deltas.average_health}
+                hotspotDelta={stats.deltas.hotspot_health}
+              />
+              <ContributorsStripCard repoId={id} />
             </div>
             <div className="space-y-4">
               <WhereToStartCard targets={summary.onboarding_targets} repoId={id} />
               <SavingsMini data={summary.savings} repoId={id} />
             </div>
-          </div>
-
-          {/* ── Stat strip with deltas ── */}
-          <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
-            <StatCard
-              label="Files"
-              value={formatNumber(stats.file_count)}
-              trend={trendFor(stats.deltas.file_count)}
-              href={`/repos/${id}/architecture?view=graph`}
-              dense
-            />
-            <StatCard
-              label="Symbols"
-              value={formatNumber(stats.symbol_count)}
-              href={`/repos/${id}/architecture?view=symbols`}
-              dense
-            />
-            <StatCard
-              label="Doc Coverage"
-              value={`${Math.round(stats.doc_coverage_pct)}%`}
-              href={`/repos/${id}/docs/coverage`}
-              dense
-            />
-            <StatCard
-              label="Dead Exports"
-              value={formatNumber(stats.dead_export_count)}
-              href={`/repos/${id}/code-health?tab=dead-code`}
-              dense
-            />
-            <StatCard
-              label="Hotspots"
-              value={formatNumber(stats.hotspot_count)}
-              href={`/repos/${id}/code-health?tab=hotspots`}
-              dense
-            />
           </div>
 
           {/* ── Pulse / Structure ── */}

--- a/packages/web/src/components/overview/contributors-strip-card.tsx
+++ b/packages/web/src/components/overview/contributors-strip-card.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import useSWR from "swr";
+import { ContributorsStrip, type StripProvenance } from "@repowise-dev/ui/git/contributors-strip";
+import { Card, CardContent, CardHeader } from "@repowise-dev/ui/ui/card";
+import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
+import { getAgentTrend, getGitSummary } from "@/lib/api/git";
+
+const SWR_OPTS = { revalidateOnFocus: false, revalidateOnReconnect: false };
+
+/**
+ * Overview contributors strip — who owns the code, plus agent-vs-human
+ * authorship when provenance is indexed. Ownership comes from the git
+ * summary; provenance is best-effort (older indexes / repos with no agent
+ * commits simply omit that row).
+ */
+export function ContributorsStripCard({ repoId }: { repoId: string }) {
+  const { data: summary, isLoading } = useSWR(
+    `overview-git-summary:${repoId}`,
+    () => getGitSummary(repoId, 50),
+    SWR_OPTS,
+  );
+  // Provenance is optional: swallow errors so the strip still renders owners.
+  const { data: trend } = useSWR(
+    `overview-agent-trend:${repoId}`,
+    () => getAgentTrend(repoId).catch(() => null),
+    SWR_OPTS,
+  );
+
+  if (isLoading) {
+    return (
+      <Card className="shadow-sm">
+        <CardHeader className="pb-2">
+          <Skeleton className="h-4 w-32" />
+        </CardHeader>
+        <CardContent className="pt-0 space-y-2.5">
+          <Skeleton className="h-2 w-full rounded-full" />
+          <Skeleton className="h-4 w-3/4" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // git-summary returns pct as a 0–1 fraction; the strip works in 0–100.
+  const owners = (summary?.top_owners ?? []).map((o) => ({
+    ...o,
+    pct: (o.pct ?? 0) * 100,
+  }));
+  if (owners.length === 0) return null;
+
+  const provenance: StripProvenance | null =
+    trend && trend.agent_commits > 0
+      ? {
+          agentPct: trend.agent_pct,
+          agentCommits: trend.agent_commits,
+          totalCommits: trend.total_commits,
+          agentNames: trend.agent_names ?? [],
+        }
+      : null;
+
+  return (
+    <ContributorsStrip
+      owners={owners}
+      contributorCount={owners.length}
+      provenance={provenance}
+      ownersHref={`/repos/${repoId}/owners`}
+      commitsHref={`/repos/${repoId}/commits?authorship=agent`}
+    />
+  );
+}

--- a/packages/web/src/components/overview/structure-tab.tsx
+++ b/packages/web/src/components/overview/structure-tab.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import useSWR from "swr";
-import { DependencyHeatmap } from "@repowise-dev/ui/dashboard/dependency-heatmap";
 import { ModuleOverviewGrid } from "@repowise-dev/ui/dashboard/module-overview-grid";
 import { OwnershipTreemap } from "@repowise-dev/ui/dashboard/ownership-treemap";
 import { ExecutionFlowsPanel } from "@repowise-dev/ui/dashboard/execution-flows-panel";
@@ -67,25 +66,11 @@ export function StructureTab({ repoId }: StructureTabProps) {
         />
       )}
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        {modulesLoading ? (
-          <PanelSkeleton />
-        ) : hasModules ? (
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium">Module Dependencies</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <DependencyHeatmap moduleGraph={moduleGraph} />
-            </CardContent>
-          </Card>
-        ) : null}
-        {communitiesLoading ? (
-          <PanelSkeleton />
-        ) : communities && communities.length > 0 ? (
-          <CommunitySummaryGridWrapper communities={communities} repoId={repoId} />
-        ) : null}
-      </div>
+      {communitiesLoading ? (
+        <PanelSkeleton />
+      ) : communities && communities.length > 0 ? (
+        <CommunitySummaryGridWrapper communities={communities} repoId={repoId} />
+      ) : null}
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         {flowsLoading ? (


### PR DESCRIPTION
Reworks the repo Overview page to lead with code health and read like an enterprise dashboard.

## What changed
- **KPI bar leads the page.** Files, Symbols, Doc Coverage, Dead Exports, and Hotspots are now a single aligned, divided bar at the top (was a misaligned strip at the bottom).
- **Code Health hero replaces the attention panel.** Surfaces the moat metric first: average and hotspot health on the 1-10 scale with per-snapshot deltas, an open-findings severity mix, the worst-scoring file, and a trend sparkline. Links to the full Code Health report. Built from the existing overview-summary payload (no extra fetch).
- **Contributors strip.** A stacked share bar of top authors plus an agent-vs-human authorship row. The authorship row only renders when provenance is indexed and there are agent commits, so repos without agent activity (or older indexes) degrade to contributors-only.
- **Dropped the module dependencies heatmap** from the Structure tab (illegible at this size; still available on the Code Health / Architecture pages).
- **Visual polish.** Subtle elevation on cards, and fixes to the agent savings card height and legend alignment.

## Notes
- Owner share is normalized from the git-summary 0-1 fraction to 0-100 for display.
- The contributor count reflects the top-owners list returned by the git summary (capped), not a distinct-author count.

Type-check and lint pass.