### PR TITLE
feat(workspace): extract Rust HTTP route providers

### DIFF
--- a/docs/LANGUAGE_SUPPORT.md
+++ b/docs/LANGUAGE_SUPPORT.md
@@ -541,7 +541,7 @@ edits. The current coverage:
 
 | Contract | Providers | Consumers |
 |----------|-----------|-----------|
-| **HTTP** | Express, FastAPI, Spring, Laravel, Go (gin/echo/chi/net-http), ASP.NET (attribute + minimal) | `fetch` / `axios` (JS/TS), `requests` / `httpx` (Python), `HttpClient` (C#) |
+| **HTTP** | Express, FastAPI, Spring, Laravel, Go (gin/echo/chi/net-http), ASP.NET (attribute + minimal), Rust (Axum routes, Actix/Rocket attribute macros) | `fetch` / `axios` (JS/TS), `requests` / `httpx` (Python), `HttpClient` (C#) |
 | **gRPC** | `.proto` IDL, Go, Java, Python, NestJS (`@GrpcMethod`), C# (gRPC-dotnet) | Go, Java, Python, C# |
 
 ---

--- a/packages/core/src/repowise/core/workspace/extractors/http/__init__.py
+++ b/packages/core/src/repowise/core/workspace/extractors/http/__init__.py
@@ -23,6 +23,7 @@ from .js_clients import JsClientsDialect
 from .laravel import LaravelDialect
 from .paths import normalize_http_path
 from .python_clients import PythonClientsDialect
+from .rust_axum import RustAxumDialect
 from .spring import SpringDialect
 
 if TYPE_CHECKING:
@@ -38,6 +39,7 @@ PROVIDER_DIALECTS: tuple[HttpDialect, ...] = (
     LaravelDialect(),
     GoDialect(),
     AspNetDialect(),
+    RustAxumDialect(),
 )
 
 # HTTP-client call recognisers (one client/language each).

--- a/packages/core/src/repowise/core/workspace/extractors/http/rust_axum.py
+++ b/packages/core/src/repowise/core/workspace/extractors/http/rust_axum.py
@@ -1,0 +1,79 @@
+"""Rust HTTP provider dialect.
+
+Covers the route-declaration shapes used by the common Rust web frameworks:
+
+* **Axum** — ``.route("/path", get(handler))``, including method routers that
+  chain several verbs (``get(h).post(h2)``);
+* **Actix-web / Rocket** — attribute-macro routes (``#[get("/path")]``).
+
+Warp's filter-combinator routing (``warp::path!(...)``) has no stable literal
+path to anchor on and is intentionally not modelled here.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from ..langs import RUST
+from .dialect import build_provider_contract
+
+if TYPE_CHECKING:
+    from repowise.core.workspace.contracts import Contract
+
+    from ..base import ScanContext
+
+# Axum: the head of a `.route("/path", <method-router>)` call. The method router
+# itself is parsed separately so chained verbs (`get(h).post(h2)`) are all found.
+_AXUM_ROUTE_HEAD_RE = re.compile(r"""\.route\s*\(\s*["']([^"']+)["']\s*,""")
+
+# Method-router verbs inside a `.route(...)` second argument, or the verbs used
+# by `MethodRouter`/`on` builders. Lower-case function form, e.g. `get(`, `post(`.
+_AXUM_METHOD_RE = re.compile(r"""\b(get|post|put|delete|patch|head|options|trace)\s*\(""")
+
+# Actix-web / Rocket attribute macros: #[get("/path")], #[post("/path", ...)].
+_RUST_ATTR_ROUTE_RE = re.compile(
+    r"""#\[\s*(get|post|put|delete|patch|head|options)\s*\(\s*["']([^"']+)["']""",
+    re.IGNORECASE,
+)
+
+
+def _line_window(content: str, start: int) -> str:
+    """Return the text from *start* up to the next newline.
+
+    Axum routes are written one per line, so the method router for a given
+    ``.route(...)`` lives between the path literal and the end of the line.
+    """
+    nl = content.find("\n", start)
+    return content[start:] if nl == -1 else content[start:nl]
+
+
+class RustAxumDialect:
+    name = "rust-axum"
+    extensions = RUST
+
+    def extract(self, ctx: ScanContext) -> list[Contract]:
+        content = ctx.content
+        out: list[Contract] = []
+
+        # Axum `.route("/path", get(...).post(...))`.
+        for m in _AXUM_ROUTE_HEAD_RE.finditer(content):
+            path_raw = m.group(1)
+            window = _line_window(content, m.end())
+            methods = {mm.group(1).upper() for mm in _AXUM_METHOD_RE.finditer(window)}
+            for method in sorted(methods):
+                c = build_provider_contract(
+                    ctx, method=method, path_raw=path_raw, framework="axum"
+                )
+                if c is not None:
+                    out.append(c)
+
+        # Actix-web / Rocket attribute macros.
+        for m in _RUST_ATTR_ROUTE_RE.finditer(content):
+            c = build_provider_contract(
+                ctx, method=m.group(1).upper(), path_raw=m.group(2), framework="rust-attr"
+            )
+            if c is not None:
+                out.append(c)
+
+        return out

--- a/tests/unit/workspace/test_contracts.py
+++ b/tests/unit/workspace/test_contracts.py
@@ -212,6 +212,39 @@ class TestHttpExtractor:
         assert consumers[0].contract_id == "http::GET::/users/{param}"
         assert "base_stripped" not in consumers[0].meta
 
+    def test_rust_axum_provider(self, tmp_path: Path) -> None:
+        self._write_file(tmp_path, "src/main.rs", """
+            let app = Router::new()
+                .route("/path", post(find_path))
+                .route("/systems/{id}", get(get_system))
+                .route("/health", get(health));
+        """)
+        contracts = HttpExtractor().extract(tmp_path, "rust-svc")
+        providers = [c for c in contracts if c.role == "provider"]
+        ids = {c.contract_id for c in providers}
+        assert "http::POST::/path" in ids
+        assert "http::GET::/systems/{param}" in ids
+        assert "http::GET::/health" in ids
+
+    def test_rust_axum_chained_methods(self, tmp_path: Path) -> None:
+        self._write_file(tmp_path, "src/routes.rs", """
+            .route("/users", get(list_users).post(create_user))
+        """)
+        contracts = HttpExtractor().extract(tmp_path, "rust-svc")
+        ids = {c.contract_id for c in contracts if c.role == "provider"}
+        assert "http::GET::/users" in ids
+        assert "http::POST::/users" in ids
+
+    def test_rust_attribute_macro_provider(self, tmp_path: Path) -> None:
+        self._write_file(tmp_path, "src/handlers.rs", """
+            #[get("/systems/nearby")]
+            async fn get_nearby_systems() -> impl Responder { ... }
+        """)
+        contracts = HttpExtractor().extract(tmp_path, "rust-svc")
+        providers = [c for c in contracts if c.role == "provider"]
+        assert len(providers) == 1
+        assert providers[0].contract_id == "http::GET::/systems/nearby"
+
     def test_empty_file(self, tmp_path: Path) -> None:
         self._write_file(tmp_path, "empty.py", "")
         contracts = HttpExtractor().extract(tmp_path, "svc")


### PR DESCRIPTION
## Summary

Workspace contract extraction did not scan Rust source at all, so Axum-style REST routes never became provider contracts and could not link to their consumers in other repos. This is the Rust-provider half of #474.

## What changed

New `http/rust_axum.py` dialect covering the common Rust web frameworks:

- **Axum** — `.route("/path", get(handler))`, including method routers that chain several verbs (`get(h).post(h2)` emits both GET and POST).
- **Actix-web / Rocket** — attribute-macro routes (`#[get("/path")]`).

Warp's filter-combinator routing (`warp::path!(...)`) has no stable literal path to anchor on and is intentionally left unmodelled.

The dialect is registered in `PROVIDER_DIALECTS`; the orchestrator picks up `.rs` files automatically from the dialect's declared extensions, so no orchestrator edits were needed.

## Examples

```rust
.route("/path", post(find_path))          // http::POST::/path
.route("/systems/{id}", get(get_system))  // http::GET::/systems/{param}
.route("/health", get(health))            // http::GET::/health
#[get("/systems/nearby")]                 // http::GET::/systems/nearby
```

## Tests

Adds Axum (single + chained verbs) and attribute-macro provider tests. Full workspace suite passes; ruff clean. `LANGUAGE_SUPPORT.md` coverage table updated.
