### PR TITLE
feat(workspace): follow JS wrapper and variable-URL HTTP consumers

### DIFF
--- a/docs/LANGUAGE_SUPPORT.md
+++ b/docs/LANGUAGE_SUPPORT.md
@@ -541,7 +541,7 @@ edits. The current coverage:
 
 | Contract | Providers | Consumers |
 |----------|-----------|-----------|
-| **HTTP** | Express, FastAPI, Spring, Laravel, Go (gin/echo/chi/net-http), ASP.NET (attribute + minimal), Rust (Axum routes, Actix/Rocket attribute macros) | `fetch` / `axios` (JS/TS), `requests` / `httpx` (Python), `HttpClient` / wrapper methods / `UnityWebRequest` / Best.HTTP (C#) |
+| **HTTP** | Express, FastAPI, Spring, Laravel, Go (gin/echo/chi/net-http), ASP.NET (attribute + minimal), Rust (Axum routes, Actix/Rocket attribute macros) | `fetch` / `axios` / URL-literal wrapper calls (JS/TS), `requests` / `httpx` (Python), `HttpClient` / wrapper methods / `UnityWebRequest` / Best.HTTP (C#) |
 | **gRPC** | `.proto` IDL, Go, Java, Python, NestJS (`@GrpcMethod`), C# (gRPC-dotnet) | Go, Java, Python, C# |
 
 ---

--- a/packages/core/src/repowise/core/workspace/extractors/http/js_clients.py
+++ b/packages/core/src/repowise/core/workspace/extractors/http/js_clients.py
@@ -1,4 +1,11 @@
-"""JavaScript / TypeScript HTTP consumer dialect — ``fetch`` and ``axios``."""
+"""JavaScript / TypeScript HTTP consumer dialect.
+
+Covers direct ``fetch`` / ``axios`` calls plus wrapper calls whose first
+argument is a concrete URL literal — e.g. ``fetchJSON(`${BASE}/path`, { method:
+"POST" })``. Wrapper detection is signal-gated (the callee name looks HTTP-ish,
+or the call carries a ``method:`` option) so ordinary `/`-prefixed string
+arguments — router navigation, i18n keys — are not mistaken for service calls.
+"""
 
 from __future__ import annotations
 
@@ -27,6 +34,21 @@ _AXIOS_RE = re.compile(
     rf"""axios\.({METHODS})\s*\(\s*['"]([^'"]+)['"]""",
     re.IGNORECASE,
 )
+
+# Wrapper call: IDENT("<url>" | `<url>`, ...) where the URL literal is concrete,
+# i.e. starts with `/`, a `${...}` base placeholder, or a scheme.
+_WRAPPER_CALL_RE = re.compile(
+    r"""\b(\w+)\s*\(\s*['"`]((?:/|\$\{|https?:)[^'"`]*)['"`]""",
+)
+
+# The callee names that read as an HTTP wrapper rather than navigation/util.
+_HTTP_NAME_RE = re.compile(r"(?i)fetch|request|http|api|ajax|rest|rpc")
+
+# A `method: "POST"` option inside the call's argument list.
+_METHOD_OPT_RE = re.compile(r"""method\s*:\s*['"](\w+)['"]""")
+
+# Callees already handled elsewhere, or never an HTTP wrapper.
+_WRAPPER_SKIP = frozenset({"fetch", "if", "for", "while", "switch", "catch", "return"})
 
 
 class JsClientsDialect:
@@ -58,6 +80,24 @@ class JsClientsDialect:
             out.append(
                 build_consumer_contract(
                     ctx, method=m.group(1).upper(), url=m.group(2), client="axios"
+                )
+            )
+
+        # Wrapper calls — fetchJSON(`${BASE}/path`, { method: "POST" }) etc.
+        for m in _WRAPPER_CALL_RE.finditer(content):
+            callee = m.group(1)
+            if callee in _WRAPPER_SKIP:
+                continue
+            nl = content.find("\n", m.end())
+            window = content[m.end() :] if nl == -1 else content[m.end() : nl]
+            method_opt = _METHOD_OPT_RE.search(window)
+            # Require an HTTP signal: an HTTP-ish callee name or a method option.
+            if not (_HTTP_NAME_RE.search(callee) or method_opt):
+                continue
+            method = method_opt.group(1).upper() if method_opt else "GET"
+            out.append(
+                build_consumer_contract(
+                    ctx, method=method, url=m.group(2), client="wrapper", confidence=0.65
                 )
             )
 

--- a/tests/unit/workspace/test_contracts.py
+++ b/tests/unit/workspace/test_contracts.py
@@ -281,6 +281,44 @@ class TestHttpExtractor:
         assert consumers[0].contract_id == "http::POST::/vix/my/bids"
         assert consumers[0].meta["client"] == "unitywebrequest"
 
+    def test_js_wrapper_consumer_with_method(self, tmp_path: Path) -> None:
+        self._write_file(tmp_path, "src/api.ts", """
+            fetchJSON(`${BASE}/path`, { method: "POST" });
+        """)
+        contracts = HttpExtractor().extract(tmp_path, "client")
+        consumers = [c for c in contracts if c.role == "consumer"]
+        assert len(consumers) == 1
+        assert consumers[0].contract_id == "http::POST::/path"
+        assert consumers[0].meta["client"] == "wrapper"
+
+    def test_js_wrapper_consumer_default_get_and_interior_param(self, tmp_path: Path) -> None:
+        self._write_file(tmp_path, "src/api.ts", """
+            fetchJSON(`${BASE}/health`);
+            fetchJSON(`${BASE}/systems/${Number(id)}`);
+        """)
+        contracts = HttpExtractor().extract(tmp_path, "client")
+        ids = {c.contract_id for c in contracts if c.role == "consumer"}
+        assert "http::GET::/health" in ids
+        assert "http::GET::/systems/{param}" in ids
+
+    def test_js_wrapper_method_signal_without_http_name(self, tmp_path: Path) -> None:
+        self._write_file(tmp_path, "src/api.ts", """
+            send("/orders", { method: "PUT" });
+        """)
+        contracts = HttpExtractor().extract(tmp_path, "client")
+        ids = {c.contract_id for c in contracts if c.role == "consumer"}
+        assert ids == {"http::PUT::/orders"}
+
+    def test_js_wrapper_ignores_navigation_and_keys(self, tmp_path: Path) -> None:
+        self._write_file(tmp_path, "src/app.tsx", """
+            navigate("/dashboard");
+            router.push("/home");
+            t("/some/i18n/key");
+        """)
+        contracts = HttpExtractor().extract(tmp_path, "client")
+        consumers = [c for c in contracts if c.role == "consumer"]
+        assert consumers == []
+
     def test_empty_file(self, tmp_path: Path) -> None:
         self._write_file(tmp_path, "empty.py", "")
         contracts = HttpExtractor().extract(tmp_path, "svc")


### PR DESCRIPTION
## Summary

Service-to-service calls routed through a small wrapper such as `fetchJSON(`${BASE}/path`, { method: "POST" })` produced no consumer contract, because the JS/TS dialect only recognised direct `fetch()` / `axios()` calls. The concrete path is present at the wrapper call site, so there is no need to follow the wrapper definition or do data-flow. This is the JS-consumer half of #474.

## What changed

Added a wrapper recogniser in `http/js_clients.py` for `IDENT("<url>" | `<url>`, ...)` where the URL literal is concrete — it starts with `/`, a `${...}` base placeholder, or a scheme.

It is **signal-gated** to avoid false positives: a match is only treated as a consumer when either

- the callee name looks HTTP-ish (`fetch` / `request` / `http` / `api` / `ajax` / `rest` / `rpc`), or
- the call carries a `method:` option.

So router navigation (`navigate("/dashboard")`, `router.push("/home")`), i18n keys (`t("/some/key")`), and other `/`-prefixed string arguments are not mistaken for service calls. The HTTP method is taken from the options object when present, else defaults to GET. The leading `${...}` base placeholder is stripped (candidate link) and interior expressions collapse to `{param}`, same as the existing fetch path.

## Examples

```js
fetchJSON(`${BASE}/path`, { method: "POST" })       // http::POST::/path
fetchJSON(`${BASE}/health`)                          // http::GET::/health
fetchJSON(`${BASE}/systems/${Number(id)}`)           // http::GET::/systems/{param}
send("/orders", { method: "PUT" })                   // http::PUT::/orders  (method signal)
navigate("/dashboard")                               // ignored (no HTTP signal)
```

## Tests

Adds wrapper-with-method, default-GET / interior-param, method-signal-without-HTTP-name, and a navigation/i18n false-positive guard. Full workspace suite (259 tests) passes; ruff clean. `LANGUAGE_SUPPORT.md` coverage table updated.
