### PR TITLE
fix(workspace): require gRPC context for C# client consumer extraction

### DIFF
--- a/packages/core/src/repowise/core/workspace/extractors/grpc/csharp.py
+++ b/packages/core/src/repowise/core/workspace/extractors/grpc/csharp.py
@@ -2,7 +2,10 @@
 
 Providers come from explicit ``MapGrpcService<T>()`` registration and from the
 generated server-base convention ``class Impl : ServiceName.ServiceNameBase``.
-Consumers come from ``new XxxClient(...)`` generated stubs.
+Consumers come from ``new XxxClient(...)`` generated stubs — but only in files
+that carry gRPC context (a ``GrpcChannel`` / ``Grpc.Net`` / ``Grpc.Core`` /
+``AddGrpcClient`` marker), since ``new XxxClient(...)`` on its own also matches
+TLS, HTTP, and other unrelated client classes.
 """
 
 from __future__ import annotations
@@ -27,6 +30,13 @@ _CSHARP_GRPC_CLIENT_RE = re.compile(r"\bnew\s+(\w+)Client\s*\(")
 
 # Generic-class false positives — test doubles and non-gRPC clients.
 _CONSUMER_FALSE_PREFIXES = ("mock", "test", "fake", "http")
+
+# Markers that a file actually uses gRPC-dotnet, required before a bare
+# `new XxxClient(...)` is treated as a gRPC consumer.
+_GRPC_CONTEXT_RE = re.compile(
+    r"\bGrpcChannel\b|\bGrpc\.(?:Net|Core)\b|\bCallInvoker\b|\bChannelBase\b"
+    r"|\bAddGrpcClient\b|using\s+Grpc\b"
+)
 
 
 class CSharpGrpcDialect:
@@ -59,6 +69,10 @@ class CSharpGrpcDialect:
                     meta={"service": svc, "source": "csharp_base"},
                 )
             )
+        # Consumers are only credible when the file shows real gRPC usage —
+        # otherwise `new XxxClient(...)` matches unrelated client classes.
+        if not _GRPC_CONTEXT_RE.search(ctx.content):
+            return out
         for m in _CSHARP_GRPC_CLIENT_RE.finditer(ctx.content):
             svc = m.group(1)
             if svc.lower().startswith(_CONSUMER_FALSE_PREFIXES):

--- a/tests/unit/workspace/test_contracts.py
+++ b/tests/unit/workspace/test_contracts.py
@@ -426,6 +426,36 @@ class TestGrpcExtractor:
         assert len(providers) == 1
         assert providers[0].contract_id == "grpc::AuthService/Login"
 
+    def test_csharp_consumer_requires_grpc_context(self, tmp_path: Path) -> None:
+        self._write_file(tmp_path, "Caller.cs", """
+            using Grpc.Net.Client;
+            public class Caller {
+                public void Go() {
+                    var channel = GrpcChannel.ForAddress("https://api");
+                    var client = new GreeterClient(channel);
+                }
+            }
+        """)
+        contracts = GrpcExtractor().extract(tmp_path, "web")
+        consumers = [c for c in contracts if c.role == "consumer"]
+        assert len(consumers) == 1
+        assert consumers[0].contract_id == "grpc::Greeter/*"
+
+    def test_csharp_consumer_skips_non_grpc_clients(self, tmp_path: Path) -> None:
+        # TLS/crypto client classes with no gRPC context must not be emitted as
+        # gRPC consumers (the false positives reported in #474).
+        self._write_file(tmp_path, "Tls.cs", """
+            public class Security {
+                public void Setup() {
+                    var tls = new TlsClient(config);
+                    var sodium = new SodiumClient();
+                }
+            }
+        """)
+        contracts = GrpcExtractor().extract(tmp_path, "game")
+        consumers = [c for c in contracts if c.role == "consumer"]
+        assert consumers == []
+
 
 # ---------------------------------------------------------------------------
 # TopicExtractor


### PR DESCRIPTION
## Summary

The C# gRPC consumer heuristic treated any `new XxxClient(...)` as a generated gRPC client stub, filtered only by a few name prefixes (`mock` / `test` / `fake` / `http`). In practice it fired on TLS, crypto, and other unrelated `*Client` classes, producing phantom gRPC consumers in repos with no gRPC at all (the false positives reported in #474, where 4 "gRPC consumers" were TLS/crypto clients and no gRPC providers existed).

## What changed

`grpc/csharp.py` now gates the consumer pass on **file-level gRPC context**: a `new XxxClient(...)` is only emitted as a gRPC consumer when the same file also shows a real gRPC marker —

- `GrpcChannel`
- `Grpc.Net` / `Grpc.Core`
- `CallInvoker` / `ChannelBase`
- `AddGrpcClient`
- a `using Grpc` import

Providers (`MapGrpcService<T>()`, generated `: ServiceName.ServiceNameBase`) are unambiguous gRPC and remain unconditional.

## Tests

- A generated client with `using Grpc.Net.Client;` + `GrpcChannel.ForAddress(...)` still produces the consumer (existing `test_dotnet_workspace.py` coverage preserved).
- A file with `new TlsClient(...)` / `new SodiumClient()` and no gRPC context produces no consumers.

Full workspace suite passes; ruff clean.
