### PR TITLE
feat(workspace): extract Rust reqwest HTTP consumers

### DIFF
--- a/docs/LANGUAGE_SUPPORT.md
+++ b/docs/LANGUAGE_SUPPORT.md
@@ -541,7 +541,7 @@ edits. The current coverage:
 
 | Contract | Providers | Consumers |
 |----------|-----------|-----------|
-| **HTTP** | Express, FastAPI, Spring, Laravel, Go (gin/echo/chi/net-http), ASP.NET (attribute + minimal), Rust (Axum routes, Actix/Rocket attribute macros) | `fetch` / `axios` / URL-literal wrapper calls (JS/TS), `requests` / `httpx` (Python), `HttpClient` / wrapper methods / `UnityWebRequest` / Best.HTTP (C#) |
+| **HTTP** | Express, FastAPI, Spring, Laravel, Go (gin/echo/chi/net-http), ASP.NET (attribute + minimal), Rust (Axum routes, Actix/Rocket attribute macros) | `fetch` / `axios` / URL-literal wrapper calls (JS/TS), `requests` / `httpx` (Python), `HttpClient` / wrapper methods / `UnityWebRequest` / Best.HTTP (C#), `reqwest` (Rust) |
 | **gRPC** | `.proto` IDL, Go, Java, Python, NestJS (`@GrpcMethod`), C# (gRPC-dotnet) | Go, Java, Python, C# |
 
 ---

--- a/packages/core/src/repowise/core/workspace/extractors/http/__init__.py
+++ b/packages/core/src/repowise/core/workspace/extractors/http/__init__.py
@@ -24,6 +24,7 @@ from .laravel import LaravelDialect
 from .paths import normalize_http_path
 from .python_clients import PythonClientsDialect
 from .rust_axum import RustAxumDialect
+from .rust_clients import RustClientsDialect
 from .spring import SpringDialect
 
 if TYPE_CHECKING:
@@ -47,6 +48,7 @@ CONSUMER_DIALECTS: tuple[HttpDialect, ...] = (
     JsClientsDialect(),
     PythonClientsDialect(),
     CSharpHttpDialect(),
+    RustClientsDialect(),
 )
 
 

--- a/packages/core/src/repowise/core/workspace/extractors/http/rust_clients.py
+++ b/packages/core/src/repowise/core/workspace/extractors/http/rust_clients.py
@@ -1,0 +1,70 @@
+"""Rust HTTP consumer dialect — ``reqwest`` client calls.
+
+Recognises ``reqwest`` method calls whose URL is recoverable at the call site:
+
+* string literals — ``client.get("http://host/path")`` / ``reqwest::get("...")``;
+* ``format!`` templates — ``client.get(format!("{}/systems/{}", base, id))``,
+  where the leading ``{}`` is the base placeholder and interior ``{}`` collapse
+  to ``{param}``.
+
+Calls with a bare variable URL (``client.get(&url)``) are left unmatched. Hyper
+is lower level — its method is set apart from the URI — and is not modelled.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from ..langs import RUST
+from .dialect import build_consumer_contract
+
+if TYPE_CHECKING:
+    from repowise.core.workspace.contracts import Contract
+
+    from ..base import ScanContext
+
+_VERBS = r"get|post|put|delete|patch|head"
+
+# client.get("...") / .post(&"...") — receiver method with a string literal.
+_METHOD_LIT_RE = re.compile(rf"""\.({_VERBS})\s*\(\s*&?\s*"([^"]*)\"""")
+# reqwest::get("...") — free function form.
+_FREE_LIT_RE = re.compile(rf"""\breqwest::({_VERBS})\s*\(\s*&?\s*"([^"]*)\"""")
+# client.get(format!("{}/path", ...)) — receiver method with a format! template.
+_METHOD_FMT_RE = re.compile(rf"""\.({_VERBS})\s*\(\s*&?\s*format!\s*\(\s*"([^"]*)\"""")
+# reqwest::get(format!("...", ...))
+_FREE_FMT_RE = re.compile(rf"""\breqwest::({_VERBS})\s*\(\s*&?\s*format!\s*\(\s*"([^"]*)\"""")
+
+# A Rust format! placeholder: `{}`, `{0}`, `{name}`. Rewritten to the `${expr}`
+# template form the shared path helpers understand (leading one stripped as the
+# base, interior ones collapsed to {param}).
+_FMT_PLACEHOLDER_RE = re.compile(r"\{[^}]*\}")
+
+
+class RustClientsDialect:
+    name = "rust-clients"
+    extensions = RUST
+
+    def extract(self, ctx: ScanContext) -> list[Contract]:
+        content = ctx.content
+        out: list[Contract] = []
+
+        def emit(method: str, url: str) -> None:
+            if "/" not in url:
+                return  # Not a URL path — skip map/collection .get("key") calls.
+            out.append(
+                build_consumer_contract(
+                    ctx, method=method.upper(), url=url, client="reqwest", confidence=0.65
+                )
+            )
+
+        for rx in (_METHOD_LIT_RE, _FREE_LIT_RE):
+            for m in rx.finditer(content):
+                emit(m.group(1), m.group(2))
+
+        for rx in (_METHOD_FMT_RE, _FREE_FMT_RE):
+            for m in rx.finditer(content):
+                url = _FMT_PLACEHOLDER_RE.sub("${x}", m.group(2))
+                emit(m.group(1), url)
+
+        return out

--- a/tests/unit/workspace/test_contracts.py
+++ b/tests/unit/workspace/test_contracts.py
@@ -245,6 +245,34 @@ class TestHttpExtractor:
         assert len(providers) == 1
         assert providers[0].contract_id == "http::GET::/systems/nearby"
 
+    def test_rust_reqwest_literal_consumer(self, tmp_path: Path) -> None:
+        self._write_file(tmp_path, "src/client.rs", """
+            let resp = client.post("http://backend:8000/api/data").send().await?;
+            let r = reqwest::get("http://svc/health").await?;
+        """)
+        contracts = HttpExtractor().extract(tmp_path, "rust-client")
+        ids = {c.contract_id for c in contracts if c.role == "consumer"}
+        assert "http::POST::/api/data" in ids
+        assert "http::GET::/health" in ids
+
+    def test_rust_reqwest_format_consumer(self, tmp_path: Path) -> None:
+        self._write_file(tmp_path, "src/client.rs", """
+            let r = client.get(format!("{}/systems/{}", base, id)).send().await?;
+        """)
+        contracts = HttpExtractor().extract(tmp_path, "rust-client")
+        consumers = [c for c in contracts if c.role == "consumer"]
+        assert len(consumers) == 1
+        assert consumers[0].contract_id == "http::GET::/systems/{param}"
+        assert consumers[0].meta.get("base_stripped") is True
+
+    def test_rust_reqwest_ignores_map_get(self, tmp_path: Path) -> None:
+        # A HashMap-style .get("key") has no slash and must not look like a route.
+        self._write_file(tmp_path, "src/lookup.rs", """
+            let v = config.get("database_url");
+        """)
+        contracts = HttpExtractor().extract(tmp_path, "rust-client")
+        assert [c for c in contracts if c.role == "consumer"] == []
+
     def test_csharp_wrapper_interpolated_consumer(self, tmp_path: Path) -> None:
         self._write_file(tmp_path, "ApiClient.cs", """
             public class ApiClient {


### PR DESCRIPTION
## Summary

Rust services calling other services through `reqwest` produced no consumer contracts, so cross-repo links from Rust callers were missing. This is the Rust-consumer half of #474's item 3.

## What changed

New `http/rust_clients.py` dialect recognising `reqwest` calls whose URL is recoverable at the call site:

- **String literals** — `client.get("http://host/path")`, `reqwest::get("...")` (verbs: get/post/put/delete/patch/head).
- **`format!` templates** — `client.get(format!("{}/systems/{}", base, id))`. The placeholder rewrite mirrors the JS/C# template handling: a leading `{}` is treated as the base placeholder (stripped, candidate link) and interior `{}` collapse to `{param}`.

Precision guards:
- a `/`-less argument (a HashMap/collection-style `.get("key")`) is skipped, so `config.get("database_url")` is not mistaken for a route;
- a bare variable URL (`client.get(&url)`) is left unmatched rather than guessed.

Hyper is lower level — its method is set apart from the URI — and is intentionally not modelled here.

## Examples

```rust
client.post("http://backend:8000/api/data")          // http::POST::/api/data
reqwest::get("http://svc/health")                     // http::GET::/health
client.get(format!("{}/systems/{}", base, id))        // http::GET::/systems/{param}
config.get("database_url")                            // ignored (not a URL)
```

## Tests

Adds literal, `format!`-template, and the map-`.get` false-positive guard. Full workspace suite passes; ruff clean. `LANGUAGE_SUPPORT.md` coverage table updated.
