### PR TITLE
release: v0.21.0 — workspace architecture intelligence + configurable MCP surface

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,14 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.21.0] — 2026-06-19
 
 ### Added
-- **Configurable MCP tool surface.** The set of tools the MCP server advertises is now configurable. Workspace-only tools (`get_blast_radius`, `get_conformance`, `get_architecture`) are advertised only in workspace mode instead of always, and two extra tools (`get_dependency_path`, `get_execution_flows`) can be opted in. Configure it with an `mcp.tools` block in `.repowise/config.yaml` (`+`/`-` deltas, an explicit allowlist, or `all`) or per launch with `repowise mcp --tools` / `--all`.
-- **MCP tool surface editor in the dashboard.** The Settings page now lists every tool with its description and lets you toggle the surface per repo, writing the selection back to that repo's `mcp.tools` config. Backed by `GET`/`PATCH /api/mcp/tools`.
+- **Cross-repo workspace intelligence.** Workspace mode gained a live system map of cross-repo services, backed by a service-granular system graph with extraction diagnostics, cross-repo blast radius and change risk, and a breaking-change guard that flags edits to contracts other repos depend on. (#511, #512, #513, #514)
+- **Architecture analysis.** New architecture conformance checks, dependency-cycle detection, a design-structure-matrix (DSM) view, and architecture metrics (propagation cost, core/periphery roles, and a 1-10 architecture score). (#515, #517)
+- **Repo-wide change-coupling graph.** A new graph surfaces files that tend to change together across the whole repo. (#497)
+- **Wider cross-repo contract extraction.** HTTP contract extraction now spans more languages and frameworks: Rust HTTP route providers and reqwest consumers, C#/Unity consumers, and JS wrapper / variable-URL consumers. Extractors were split into per-framework dialects for maintainability. (#505, #506, #507, #508, #510)
+- **Configurable MCP tool surface.** The set of tools the MCP server advertises is now configurable. Workspace-only tools (`get_blast_radius`, `get_conformance`, `get_architecture`) are advertised only in workspace mode instead of always, and two extra tools (`get_dependency_path`, `get_execution_flows`) can be opted in. Configure it with an `mcp.tools` block in `.repowise/config.yaml` (`+`/`-` deltas, an explicit allowlist, or `all`) or per launch with `repowise mcp --tools` / `--all`. (#520)
+- **MCP tool surface editor in the dashboard.** The Settings page now lists every tool with its description and lets you toggle the surface per repo, writing the selection back to that repo's `mcp.tools` config. Backed by `GET`/`PATCH /api/mcp/tools`. (#521)
 
 ### Changed
-- **Consolidated the MCP tool surface.** Removed six redundant MCP tools (`annotate_file`, `get_callers_callees`, `get_community`, `get_graph_metrics`, `get_architecture_diagram`, `update_decision_records`) whose capabilities are already covered by `get_context(include=[...])` and `get_why`. The MCP server exposes 13 tools: 10 in single-repo mode plus three workspace-only tools (`get_blast_radius`, `get_conformance`, `get_architecture`). Documentation and tool counts across the project were reconciled to match.
+- **Code-health-first repo overview.** The repo overview page was rebuilt around code health. (#501)
+- **Airier, diagram-first web UI.** A UX overhaul restyles the dashboard on a shared composition backbone, with more whitespace and diagram-forward layouts. (#504)
+- **Consolidated the MCP tool surface.** Removed six redundant MCP tools (`annotate_file`, `get_callers_callees`, `get_community`, `get_graph_metrics`, `get_architecture_diagram`, `update_decision_records`) whose capabilities are already covered by `get_context(include=[...])` and `get_why`. The MCP server exposes 13 tools: 10 in single-repo mode plus three workspace-only tools (`get_blast_radius`, `get_conformance`, `get_architecture`). Documentation and tool counts across the project were reconciled to match. (#519)
+
+### Fixed
+- **Contract extraction no longer scans nested repos.** Workspace contract extraction could hang scanning up to a million files when a repo contained nested checkouts; it now uses the shared file traverser and skips nested repos. (#516)
+- **C# gRPC consumer extraction requires gRPC context** before treating a client call as a cross-repo consumer, removing false positives. (#509)
+- **Skip Unity-generated dotnet scan paths during ingestion.** (#499)
+
+### Documentation
+- Plugin: version bump to 0.21.0; MCP tool surface docs reconciled to the consolidated, configurable set.
 
 ---
 

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -241,7 +241,7 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
           </ScrollArea>
 
           <div className="border-t border-[var(--color-border-default)] px-4 py-3">
-            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.20.0</p>
+            <p className="text-xs text-[var(--color-text-tertiary)]">repowise v0.21.0</p>
           </div>
         </SheetContent>
       </Sheet>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -354,7 +354,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
         <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
           <ThemeToggle className="w-full justify-between" />
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            repowise v0.20.0
+            repowise v0.21.0
           </p>
         </div>
       )}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.21.0
+
+### Changed
+- Reconciled the documented MCP tool surface to the consolidated, configurable
+  set: ten tools in single-repo mode, three more added automatically in
+  workspace mode (`get_blast_radius`, `get_conformance`, `get_architecture`),
+  and two opt-in tools (`get_dependency_path`, `get_execution_flows`). The six
+  removed redundant tools no longer appear in any command or skill.
+
 ## 0.20.0
 
 Version bump to track the repowise 0.20.0 release. No changes to the plugin's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.20.0"
+version = "0.21.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Cuts repowise **v0.21.0**. Bump-only release branch off `main`.

## Summary
- Version bump 0.20.0 → 0.21.0 across the four Python files, both web sidebar/mobile footers, and both plugin manifests; `uv.lock` regenerated.
- `docs/CHANGELOG.md` 0.21.0 section covering the 20 commits since v0.20.0.
- Plugin `CHANGELOG.md` entry; MCP tool-surface docs reconciled to the consolidated/configurable set.

### Highlights this release
- **Cross-repo workspace intelligence** — live system map, service-granular graph, cross-repo blast radius / change risk, breaking-change guard.
- **Architecture analysis** — conformance, dependency cycles, DSM view, and a 1-10 architecture score.
- **Repo-wide change-coupling graph**; **wider HTTP contract extraction** (Rust providers + reqwest, C#/Unity, JS wrappers).
- **Code-health-first overview** and an **airier, diagram-first UX overhaul**.
- **Configurable MCP tool surface** + in-dashboard tool editor; consolidated to 13 tools.

## Merge convention
**Use a regular merge commit — do NOT squash.** The tag must point at a real merge commit on `main` so artifact provenance is traceable.

## Test plan
- [x] Version drift grep clean (no `0.20.0` left; `0.21.0` in all expected files)
- [x] `uv build --wheel` clean — 43 commands, `serve_cmd.py`, `.scm`/`.j2` data present
- [x] `uv.lock` self-entry bumped to 0.21.0
- [x] `npm ci` + `npm run build --workspace packages/web` green — standalone `server.js` emitted, workspace-package code transpiled into chunks
- [ ] Post-merge: tag `v0.21.0` on the merge commit, push tag, watch `publish.yml`
- [ ] Post-release: GitHub release has 3 assets; PyPI shows 0.21.0; tarball has flat `server.js`