### PR TITLE
feat(health): surface performance as a co-equal third health signal

### DIFF
--- a/docs/CODE_HEALTH.md
+++ b/docs/CODE_HEALTH.md
@@ -69,7 +69,12 @@ The final score is clamped to `[1.0, 10.0]`. The three repo-level KPIs:
 - **Average Health** — NLOC-weighted average over all files.
 - **Worst Performer** — single lowest-scoring file.
 
-## Two health signals: defect risk and maintainability
+## Three health signals: defect risk, maintainability, and performance
+
+Repowise surfaces **three orthogonal health signals** computed from the same
+biomarker stream by one shared scoring kernel: **defect risk** (the calibrated,
+overall number), **maintainability**, and **performance**. They are co-equal
+*views*, never blended into one number (see "The overall score" below for why).
 
 The score above is the **defect-risk** signal: it is calibrated against a defect
 corpus, the bands are calibrated to it (Alert files carry ~17x the defect rate
@@ -113,12 +118,75 @@ co-equal headline:
   `performance`) naming the pillar it homes under, so findings can be filtered
   per signal.
 
-A third dimension, **performance**, is computed by the same machinery but is not
-yet surfaced as its own pillar in the dashboard, MCP KPIs, or CLAUDE.md (that
-arrives in a later release); its per-file `performance_score` reads `null` on
-indexes built before the performance detectors landed. The dimension names are
-mirrored in `@repowise-dev/types` (`HEALTH_DIMENSIONS`) with a parity test on
-each side.
+## Performance: static performance risk
+
+The third signal, **performance**, flags *shapes that waste work* (code whose
+structure does redundant I/O), rather than measured runtime. It is deliberately
+**high-precision, low-recall**: a few real findings the rest of the toolchain
+can trust beat a wall of maybes. The detectors (all under one bounded `performance`
+category cap of 1.0, so the pillar stays advisory) are:
+
+- **`io_in_loop`**: a database call, network request, filesystem read, or
+  subprocess spawn that runs **once per loop iteration**: the classic N+1. This
+  is the moat. Two things make it more than a file-local lint:
+  - **Dependency classification.** The loop-nested call is resolved through a
+    shared I/O-boundary classifier (`io_kind ∈ {db, network, filesystem,
+    subprocess, lock}`) and only fires on a *classified* execution sink (an
+    actual round-trip like `.execute` / awaited HTTP / `subprocess.run`), not a
+    query-builder chain or a same-named pure helper.
+  - **Call-graph reachability.** The loop and the I/O call need not be in the
+    same function. A bounded-depth (≤3 hops) walk over the resolved `calls` graph
+    catches the interprocedural case (loop in `A`, sink in a helper `A` calls)
+    that no file-local linter can see. Cross-function findings carry their
+    resolved `caller -> ... -> sink` path for explainability.
+- **`string_concat_in_loop`**: quadratic `+=` string building in a loop.
+- **`blocking_sync_in_async`**: a synchronous blocking call inside an `async`
+  function, which stalls the whole event loop (mirrors ruff `ASYNC210/230/251`).
+
+Each performance finding's `details` carry the `boundary_kind` it crosses, a
+`cross_function` flag, and the reachability `path` for the cross-function case.
+Severity is ranked by **centrality** (an N+1 in a high-traffic, churny function
+outranks one in a leaf), not by raw count.
+
+**Soundness limits (honest, by design).** Performance is a *static* signal, so
+it under-reports rather than over-reports (these cap recall, not precision):
+dynamic dispatch / monkeypatching / callbacks-as-values produce no `calls` edge
+and are invisible; ORM lazy-load N+1 fires on attribute access (no visible call)
+and is explicitly out of scope; chains longer than three hops from the loop are
+not followed; and an unmodelled library is untyped (`None`), so its sinks don't
+fire. We call this **performance RISK**, never measured performance, and never
+fold it into the defect score. The commit-agreement precision study and its
+caveats live in `local-stash/performance-pillar/VALIDATION.md`.
+
+Performance surfaces exactly where maintainability does: a `performance_average`
+on the overview summary and MCP `kpis`, a per-file `performance_score`, a
+Performance KPI card and per-pillar finding filter on the dashboard, the
+per-file Health tab and drawer, and a `Performance risk` line in CLAUDE.md and
+the CLI `status` summary (each omitted/`null` on indexes built before the
+detectors landed). The dimension names are mirrored in `@repowise-dev/types`
+(`HEALTH_DIMENSIONS`) with a parity test on each side.
+
+## The overall score: defect, not a blend
+
+The single number repowise surfaces as the headline (the dashboard ring, the
+band, the badge, the "does the score find the bugs?" stat) is, and stays, the
+**defect score**. Maintainability and performance are presented as co-equal
+*pillars/views*, not blended into the headline. This is a deliberate decision,
+for three reasons:
+
+1. **Band calibration.** The Healthy/Warning/Alert cutoffs are calibrated to the
+   defect score (Alert ≈ 17× the defect rate). A blended headline would invalidate
+   those boundaries with no recalibration corpus behind the new number.
+2. **Honesty of the validation stat.** "Does the score find the bugs?" is a claim
+   about the *defect* pillar; it must stay bound to the number it measures.
+3. **Different precision profiles.** Maintainability is expert-set and performance
+   is high-precision/low-recall advisory — neither is a calibrated bug predictor,
+   so neither should move the bug-calibrated headline.
+
+A golden test (`tests/unit/health/test_scoring_dimensions`) locks the defect
+score byte-for-byte against the pre-split single score, so no pillar can ever
+regress it. Introducing a blended overall score would require a written rationale
+and a recalibration plan; until then, overall = defect.
 
 ## Bands and distribution
 
@@ -530,10 +598,11 @@ unchanged files stay put — no nightly full re-index needed.
 
 ## Status one-liner
 
-`repowise status` includes a single-line health summary:
+`repowise status` includes a single-line health summary (the maintainability and
+performance pillars append once the index has populated them):
 
 ```
-Health: 7.4 (avg) · 6.2 (hotspots) · 2.1 (worst: payments/processor.ts)
+Health: 7.4 (avg) · 6.2 (hotspots) · 2.1 (worst: payments/processor.ts) · 7.0 (maintainability) · 9.1 (performance)
 ```
 
 ## Comparison

--- a/packages/cli/src/repowise/cli/commands/status_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/status_cmd.py
@@ -191,16 +191,19 @@ def _query_health_line(repo_path: Path) -> str | None:
 
     band = band_for(float(data["average_health"]))
     band_color = {"healthy": "green", "warning": "yellow", "alert": "red"}[band]
-    # Maintainability is a co-surfaced second pillar; show it when the split has
-    # populated it (None on indexes that predate the split).
+    # Maintainability and performance are co-surfaced pillars; show each when the
+    # split has populated it (None on indexes that predate the relevant work).
     maint = data.get("maintainability_average")
     maint_part = f" · {maint:.1f} (maintainability)" if maint is not None else ""
+    perf = data.get("performance_average")
+    perf_part = f" · {perf:.1f} (performance)" if perf is not None else ""
     return (
         f"[bold]Health:[/bold] {data['average_health']:.1f} (avg) "
         f"[[{band_color}]{BAND_LABEL[band]}[/{band_color}]] · "
         f"{data['hotspot_health']:.1f} (hotspots) · "
         f"{worst_repr} (worst: {worst_path})"
         f"{maint_part}"
+        f"{perf_part}"
     )
 
 

--- a/packages/core/src/repowise/core/analysis/health/scoring.py
+++ b/packages/core/src/repowise/core/analysis/health/scoring.py
@@ -513,6 +513,10 @@ def compute_kpis(
       NLOC-weighted averages over the per-file ``maintainability_score``, so the
       maintainability pillar surfaces a repo headline alongside the defect one.
       ``None`` when no file carries a maintainability score.
+    - ``performance_average`` / ``performance_hotspot``: the same two
+      NLOC-weighted averages over the per-file ``performance_score`` (static
+      performance RISK), so the performance pillar surfaces a repo headline too.
+      ``None`` when no file carries a performance score.
     """
     if not metrics:
         return {
@@ -523,6 +527,8 @@ def compute_kpis(
             "file_count": 0,
             "maintainability_average": None,
             "maintainability_hotspot": None,
+            "performance_average": None,
+            "performance_hotspot": None,
         }
 
     def _wavg(rows: list[HealthFileMetricData]) -> float:
@@ -537,6 +543,8 @@ def compute_kpis(
     worst = min(metrics, key=lambda m: m.score)
     maint_avg = _wavg_attr(metrics, "maintainability_score")
     maint_hotspot = _wavg_attr(hotspots, "maintainability_score")
+    perf_avg = _wavg_attr(metrics, "performance_score")
+    perf_hotspot = _wavg_attr(hotspots, "performance_score")
     return {
         "hotspot_health": round(_wavg(hotspots), 2),
         "average_health": round(_wavg(metrics), 2),
@@ -545,4 +553,6 @@ def compute_kpis(
         "file_count": len(metrics),
         "maintainability_average": round(maint_avg, 2) if maint_avg is not None else None,
         "maintainability_hotspot": round(maint_hotspot, 2) if maint_hotspot is not None else None,
+        "performance_average": round(perf_avg, 2) if perf_avg is not None else None,
+        "performance_hotspot": round(perf_hotspot, 2) if perf_hotspot is not None else None,
     }

--- a/packages/core/src/repowise/core/generation/editor_files/data.py
+++ b/packages/core/src/repowise/core/generation/editor_files/data.py
@@ -54,6 +54,10 @@ class CodeHealthBlock:
     # maintainability scores). ``None`` until the split populates the column, so
     # the section omits it rather than printing a misleading 10.0.
     maintainability_average: float | None = None
+    # Performance pillar headline (NLOC-weighted average over the per-file
+    # performance scores: static performance RISK). ``None`` when unmeasured, so
+    # the section omits the line rather than printing a misleading 10.0.
+    performance_average: float | None = None
     critical_biomarkers: list[dict] = field(default_factory=list)
     untested_hotspots: list[dict] = field(default_factory=list)
 

--- a/packages/core/src/repowise/core/generation/editor_files/fetcher.py
+++ b/packages/core/src/repowise/core/generation/editor_files/fetcher.py
@@ -297,6 +297,19 @@ class EditorFileDataFetcher:
                 else sum(m.maintainability_score for m in maint_rows) / len(maint_rows)
             )
 
+        # Performance pillar headline: same NLOC-weighted average over the
+        # per-file performance scores (static performance RISK). ``None`` when
+        # unmeasured so the section omits the line rather than printing 10.0.
+        perf_rows = [m for m in metric_rows if getattr(m, "performance_score", None) is not None]
+        performance_average: float | None = None
+        if perf_rows:
+            p_nloc = sum(max(m.nloc, 1) for m in perf_rows)
+            performance_average = (
+                sum(m.performance_score * max(m.nloc, 1) for m in perf_rows) / p_nloc
+                if p_nloc
+                else sum(m.performance_score for m in perf_rows) / len(perf_rows)
+            )
+
         # Critical biomarkers: brain methods, or critical-severity findings
         # in hotspot files. Cap at 5 to keep CLAUDE.md tight.
         f_res = await self._session.execute(
@@ -332,6 +345,9 @@ class EditorFileDataFetcher:
             hotspot_trend="stable",
             maintainability_average=(
                 round(maintainability_average, 2) if maintainability_average is not None else None
+            ),
+            performance_average=(
+                round(performance_average, 2) if performance_average is not None else None
             ),
             critical_biomarkers=critical,
             untested_hotspots=[],  # Phase 2 fills this from coverage data

--- a/packages/core/src/repowise/core/generation/templates/claude_md.j2
+++ b/packages/core/src/repowise/core/generation/templates/claude_md.j2
@@ -78,13 +78,16 @@ Last indexed: {{ data.indexed_at }}{% if data.indexed_commit %} (commit {{ data.
 {% if data.code_health %}
 
 ## Code health
-Two signals: **defect risk** (the overall score) and **maintainability** (a separate pillar of the smells that hurt readability/change-cost without predicting bugs). See `docs/CODE_HEALTH.md`.
+Three signals: **defect risk** (the overall score), **maintainability** (smells that hurt readability/change-cost without predicting bugs), and **performance** (static performance RISK: I/O-in-loop / N+1 shapes that waste work, high-precision/low-recall). Maintainability and performance are co-equal views, never blended into the defect headline. See `docs/CODE_HEALTH.md`.
 
 Defect risk, Hotspot health: {{ data.code_health.hotspot_health }}/10 ({{ data.code_health.hotspot_trend }}) ·
 Average: {{ data.code_health.average_health }}/10 ·
 Worst: {{ data.code_health.worst_score }}/10 (`{{ data.code_health.worst_path }}`)
 {% if data.code_health.maintainability_average is not none %}
 Maintainability, Average: {{ data.code_health.maintainability_average }}/10
+{% endif %}
+{% if data.code_health.performance_average is not none %}
+Performance risk, Average: {{ data.code_health.performance_average }}/10
 {% endif %}
 {% if data.code_health.critical_biomarkers %}
 

--- a/packages/core/src/repowise/core/persistence/crud/analysis.py
+++ b/packages/core/src/repowise/core/persistence/crud/analysis.py
@@ -472,6 +472,7 @@ async def get_health_summary(session: AsyncSession, repository_id: str) -> dict:
             "worst_performer_score": None,
             "open_findings": 0,
             "maintainability_average": None,
+            "performance_average": None,
         }
     total_nloc = sum(max(m.nloc, 1) for m in metrics)
     if total_nloc:
@@ -497,6 +498,20 @@ async def get_health_summary(session: AsyncSession, repository_id: str) -> dict:
                 maint_scored
             )
 
+    # Performance headline: same NLOC-weighted average over the per-file
+    # performance scores (static performance RISK). ``None`` when no row carries
+    # a performance score so the surface reads "not measured" rather than 10.0.
+    perf_scored = [m for m in metrics if getattr(m, "performance_score", None) is not None]
+    performance_average: float | None = None
+    if perf_scored:
+        perf_nloc = sum(max(m.nloc, 1) for m in perf_scored)
+        if perf_nloc:
+            performance_average = (
+                sum(m.performance_score * max(m.nloc, 1) for m in perf_scored) / perf_nloc
+            )
+        else:
+            performance_average = sum(m.performance_score for m in perf_scored) / len(perf_scored)
+
     findings_count = await session.execute(
         select(func.count())
         .select_from(HealthFinding)
@@ -513,6 +528,9 @@ async def get_health_summary(session: AsyncSession, repository_id: str) -> dict:
         "open_findings": findings_count.scalar() or 0,
         "maintainability_average": (
             round(maintainability_average, 2) if maintainability_average is not None else None
+        ),
+        "performance_average": (
+            round(performance_average, 2) if performance_average is not None else None
         ),
     }
 

--- a/packages/server/src/repowise/server/mcp_server/tool_health.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_health.py
@@ -125,19 +125,20 @@ def _module_rollups(metrics: list[HealthFileMetric]) -> list[dict[str, Any]]:
     return out
 
 
-def _maintainability_average(metrics: list[HealthFileMetric]) -> float | None:
-    """NLOC-weighted maintainability headline, or ``None`` when unmeasured.
+def _dimension_average(metrics: list[HealthFileMetric], attr: str) -> float | None:
+    """NLOC-weighted headline over a per-dimension score attribute.
 
-    Skips rows without a ``maintainability_score`` (those predating the split)
-    so the KPI reads "not measured" rather than a misleading 10.0.
+    Skips rows without the attribute (those predating that pillar) so the KPI
+    reads "not measured" rather than a misleading 10.0; ``None`` when no row
+    carries it.
     """
-    scored = [m for m in metrics if getattr(m, "maintainability_score", None) is not None]
+    scored = [m for m in metrics if getattr(m, attr, None) is not None]
     if not scored:
         return None
     total_nloc = sum(max(m.nloc, 1) for m in scored)
     if not total_nloc:
-        return round(sum(m.maintainability_score for m in scored) / len(scored), 2)
-    return round(sum(m.maintainability_score * max(m.nloc, 1) for m in scored) / total_nloc, 2)
+        return round(sum(getattr(m, attr) for m in scored) / len(scored), 2)
+    return round(sum(getattr(m, attr) * max(m.nloc, 1) for m in scored) / total_nloc, 2)
 
 
 def _compute_kpis(metrics: list[HealthFileMetric]) -> dict[str, Any]:
@@ -148,6 +149,7 @@ def _compute_kpis(metrics: list[HealthFileMetric]) -> dict[str, Any]:
             "worst_performer_path": None,
             "worst_performer_score": None,
             "maintainability_average": None,
+            "performance_average": None,
         }
     total_nloc = sum(max(m.nloc, 1) for m in metrics)
     avg = sum(m.score * max(m.nloc, 1) for m in metrics) / total_nloc
@@ -158,8 +160,10 @@ def _compute_kpis(metrics: list[HealthFileMetric]) -> dict[str, Any]:
         "band": band_for(round(avg, 2)),
         "worst_performer_path": worst.file_path,
         "worst_performer_score": round(worst.score, 2),
-        # Maintainability pillar headline alongside the defect-backed average.
-        "maintainability_average": _maintainability_average(metrics),
+        # Maintainability + performance pillar headlines alongside the
+        # defect-backed average. Each is ``None`` until its pillar is measured.
+        "maintainability_average": _dimension_average(metrics, "maintainability_score"),
+        "performance_average": _dimension_average(metrics, "performance_score"),
     }
 
 
@@ -180,16 +184,22 @@ async def get_health(
     ``complex_method``. Phase 2 adds coverage biomarkers; Phase 3 adds
     duplication + organizational biomarkers.
 
-    Two-signal health: every file metric carries per-dimension scores from the
-    three-signal split. ``score`` is the overall, defect-calibrated number
-    surfaced everywhere (== ``defect_score``); ``maintainability_score`` is a
-    co-equal second signal made of the smells the defect calibration floors
-    (cohesion, brain methods, primitive obsession, duplication, error handling)
-    given full weight in their own pillar; ``performance_score`` is computed but
-    not yet surfaced as its own pillar. ``kpis.maintainability_average`` is the
-    NLOC-weighted repo headline for that pillar. Each finding carries a
-    ``dimension`` (``defect`` / ``maintainability`` / ``performance``) naming the
-    pillar it homes under, so findings can be filtered per dimension.
+    Three-signal health: every file metric carries per-dimension scores. ``score``
+    is the overall, defect-calibrated number surfaced everywhere (== ``defect_score``);
+    ``maintainability_score`` is a co-equal signal made of the smells the defect
+    calibration floors (cohesion, brain methods, primitive obsession, duplication,
+    error handling) given full weight in their own pillar; ``performance_score`` is
+    the third co-equal pillar: static performance RISK (I/O-in-loop / N+1 shapes that
+    waste work), high-precision / low-recall, NEVER blended into the defect headline.
+    ``kpis.maintainability_average`` and ``kpis.performance_average`` are the
+    NLOC-weighted repo headlines for those pillars (``None`` when unmeasured). Each
+    finding carries a ``dimension`` (``defect`` / ``maintainability`` /
+    ``performance``) naming the pillar it homes under, so findings can be filtered
+    per dimension. A performance finding's ``details`` carry the ``boundary_kind``
+    it crosses (``db`` / ``network`` / ``filesystem`` / ``subprocess`` / ``lock``),
+    a ``cross_function`` flag, and, for a cross-function N+1, the ``path`` (the
+    resolved ``caller -> ... -> sink`` symbol chain). Performance is a static signal:
+    dynamic dispatch, ORM lazy-load, and unmodelled libraries are out of scope.
 
     Args:
         targets: List of file paths. Empty → dashboard mode.

--- a/packages/types/__tests__/health.test.ts
+++ b/packages/types/__tests__/health.test.ts
@@ -9,7 +9,14 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { ALERT_MAX, HEALTHY_MIN, HEALTH_DIMENSIONS, bandForScore } from "../src/health.js";
+import {
+  ALERT_MAX,
+  HEALTHY_MIN,
+  HEALTH_DIMENSIONS,
+  PERF_BOUNDARY_LABEL,
+  bandForScore,
+} from "../src/health.js";
+import { C4_IO_KINDS } from "../src/external-systems.js";
 
 describe("health band cutoffs", () => {
   it("are the frozen defect-backed values", () => {
@@ -24,6 +31,14 @@ describe("health dimensions", () => {
     // packages/core/src/repowise/core/analysis/health/scoring.py. The Python
     // half of this guard lives in tests/unit/health/test_scoring_dimensions.py.
     expect(HEALTH_DIMENSIONS).toEqual(["defect", "maintainability", "performance"]);
+  });
+
+  it("labels exactly the canonical I/O-boundary kinds (perf finding detail)", () => {
+    // PERF_BOUNDARY_LABEL keys must cover the canonical io_kind set and nothing
+    // else, so every `boundary_kind` a perf finding can carry renders a label.
+    // C4_IO_KINDS is itself parity-locked to the Python IO_KINDS classifier in
+    // __tests__/contracts.test.ts + tests/unit/ingestion/test_io_kind.py.
+    expect(Object.keys(PERF_BOUNDARY_LABEL).sort()).toEqual([...C4_IO_KINDS].sort());
   });
 });
 

--- a/packages/types/src/files.ts
+++ b/packages/types/src/files.ts
@@ -5,7 +5,7 @@
  */
 
 import type { CoChangePartner, FileAuthor, Hotspot, SignificantCommit } from "./git.js";
-import type { FileHealthTrend, FileSignals } from "./health.js";
+import type { FileHealthTrend, FileSignals, HealthDimension } from "./health.js";
 
 export interface FileWikiPageRef {
   id: string;
@@ -30,6 +30,12 @@ export interface FileHealthFinding {
   reason: string;
   details: Record<string, unknown>;
   status: string;
+  /**
+   * The finding's "home" health dimension (`defect` / `maintainability` /
+   * `performance`), so the file page can tag findings by pillar. Optional /
+   * `defect` when an older payload omits it.
+   */
+  dimension?: HealthDimension;
 }
 
 export interface FileHealthMetric {
@@ -42,6 +48,15 @@ export interface FileHealthMetric {
   line_coverage_pct: number | null;
   module: string | null;
   duplication_pct: number | null;
+  /**
+   * Per-dimension scores from the three-signal split. `score` stays the overall
+   * surfaced number (== `defect_score`); `maintainability_score` and
+   * `performance_score` are the co-surfaced pillars. All optional/nullable so
+   * older payloads parse unchanged and unmeasured pillars read "—".
+   */
+  defect_score?: number | null;
+  maintainability_score?: number | null;
+  performance_score?: number | null;
 }
 
 export interface FileScoreBreakdownFinding {

--- a/packages/types/src/health.ts
+++ b/packages/types/src/health.ts
@@ -15,6 +15,8 @@
  * cutoffs anywhere else — derive from these consts or read the API `band`.
  */
 
+import type { C4IoKind } from "./external-systems.js";
+
 /** Finding severity used across the health surface. */
 export type HealthSeverity = "low" | "medium" | "high" | "critical";
 
@@ -24,11 +26,12 @@ export type HealthSeverity = "low" | "medium" | "high" | "critical";
 
 /**
  * The orthogonal health signals. `defect` is the historical, calibrated score
- * surfaced as the overall number; `maintainability` is a co-surfaced second
- * signal made of the smells the defect calibration floors (they don't predict
- * bugs, so they get a proper home here instead of diluting the defect score);
- * `performance` is defined but not yet surfaced (no detectors land until a
- * later release).
+ * surfaced as the overall number; `maintainability` is a co-surfaced signal
+ * made of the smells the defect calibration floors (they don't predict bugs, so
+ * they get a proper home here instead of diluting the defect score);
+ * `performance` is the co-surfaced third signal: static performance RISK
+ * (I/O-in-loop / N+1 shapes that waste work). All three are co-equal views; the
+ * overall number stays the defect score and is never a blend.
  *
  * Mirror of `DIMENSIONS` in
  * `packages/core/src/repowise/core/analysis/health/scoring.py`, kept in sync by
@@ -49,6 +52,21 @@ export const HEALTH_DIMENSION_LABEL: Record<HealthDimension, string> = {
   defect: "Defect risk",
   maintainability: "Maintainability",
   performance: "Performance",
+};
+
+/**
+ * Human-readable labels for the I/O-boundary kind a performance finding crosses
+ * (the `boundary_kind` on an `io_in_loop` finding's `details`). The kind set is
+ * the canonical `C4IoKind` from `external-systems.ts`, parity-locked against the
+ * Python `IO_KINDS` classifier; this only adds display strings, no new wire
+ * enum. Used to render "a database call runs once per loop iteration" detail.
+ */
+export const PERF_BOUNDARY_LABEL: Record<C4IoKind, string> = {
+  db: "Database",
+  network: "Network",
+  filesystem: "Filesystem",
+  subprocess: "Subprocess",
+  lock: "Lock",
 };
 
 /* ------------------------------------------------------------------ *
@@ -224,6 +242,14 @@ export interface HealthOverviewSummary {
    */
   maintainability_average?: number | null;
   maintainability_hotspot?: number | null;
+  /**
+   * NLOC-weighted repo headline for the performance pillar (the third surfaced
+   * signal: static performance RISK, not measured runtime). `null`/absent when
+   * no file carries a performance score. `performance_hotspot` is the same
+   * average restricted to hotspot files, when available.
+   */
+  performance_average?: number | null;
+  performance_hotspot?: number | null;
 }
 
 export interface HealthOverviewResponse {

--- a/packages/ui/src/files/file-health-tab.tsx
+++ b/packages/ui/src/files/file-health-tab.tsx
@@ -5,7 +5,15 @@ import { HeartPulse } from "lucide-react";
 import { EmptyState } from "../shared/empty-state";
 import { ScoreBreakdown, type ScoreBreakdownCategory } from "../health/score-breakdown";
 import { BiomarkerDetails, type BiomarkerDetailsRecord } from "../health/biomarker-details";
-import { biomarkerInfo, biomarkerLabel, CATEGORY_LABEL } from "../health/biomarker-glossary";
+import {
+  biomarkerInfo,
+  biomarkerLabel,
+  biomarkerDimension,
+  CATEGORY_LABEL,
+  DIMENSION_CHIP,
+  DIMENSION_LABEL,
+  type BiomarkerDimension,
+} from "../health/biomarker-glossary";
 import { SEVERITY_CHIP, SEVERITY_LABEL, scoreBadgeClass, type Severity } from "../health/tokens";
 import { FileTrendChart } from "../health/file-trend-chart";
 import { FileSignalsPanel } from "../health/file-signals-panel";
@@ -75,7 +83,7 @@ export function FileHealthTab({
       {metric && (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           <Stat
-            label="Score"
+            label="Defect risk"
             value={
               <span
                 className={`inline-flex items-baseline rounded px-2 py-0.5 font-bold tabular-nums ${scoreBadgeClass(metric.score)}`}
@@ -85,6 +93,8 @@ export function FileHealthTab({
               </span>
             }
           />
+          <Stat label="Maintainability" value={<DimScore score={metric.maintainability_score} />} />
+          <Stat label="Performance" value={<DimScore score={metric.performance_score} />} />
           <Stat label="Max CCN" value={<Num v={metric.max_ccn} />} />
           <Stat label="Max nesting" value={<Num v={metric.max_nesting} />} />
           <Stat label="NLOC" value={<Num v={metric.nloc} />} />
@@ -152,6 +162,7 @@ export function FileHealthTab({
                     <span className="text-[10px] uppercase tracking-wider text-[var(--color-text-tertiary)]">
                       {CATEGORY_LABEL[info.category]}
                     </span>
+                    <DimensionChip dimension={findingDimension(f)} />
                     {f.function_name && (
                       <span className="text-xs font-mono text-[var(--color-text-tertiary)]">
                         {f.function_name}
@@ -275,4 +286,42 @@ function Stat({ label, value }: { label: string; value: React.ReactNode }) {
 
 function Num({ v }: { v: number }) {
   return <span className="text-base font-semibold tabular-nums">{v}</span>;
+}
+
+/** A per-dimension pillar score badge, or "—" when the pillar is unmeasured. */
+function DimScore({ score }: { score?: number | null | undefined }) {
+  if (score == null) {
+    return <span className="text-xs text-[var(--color-text-tertiary)]">—</span>;
+  }
+  return (
+    <span
+      className={`inline-flex items-baseline rounded px-2 py-0.5 font-bold tabular-nums ${scoreBadgeClass(score)}`}
+    >
+      {score.toFixed(1)}
+      <span className="ml-0.5 text-[10px] font-normal opacity-70">/10</span>
+    </span>
+  );
+}
+
+/** A finding's home pillar, preferring the server value over the glossary. */
+function findingDimension(f: { dimension?: string; biomarker_type: string }): BiomarkerDimension {
+  if (
+    f.dimension === "defect" ||
+    f.dimension === "maintainability" ||
+    f.dimension === "performance"
+  ) {
+    return f.dimension;
+  }
+  return biomarkerDimension(f.biomarker_type);
+}
+
+function DimensionChip({ dimension }: { dimension: BiomarkerDimension }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-px text-[10px] font-medium ${DIMENSION_CHIP[dimension]}`}
+      title={`${DIMENSION_LABEL[dimension]} pillar`}
+    >
+      {DIMENSION_LABEL[dimension]}
+    </span>
+  );
 }

--- a/packages/ui/src/health/biomarker-details.tsx
+++ b/packages/ui/src/health/biomarker-details.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { ArrowLeftRight } from "lucide-react";
+import { PERF_BOUNDARY_LABEL } from "@repowise-dev/types/health";
+import type { C4IoKind } from "@repowise-dev/types/external-systems";
 
 export type BiomarkerDetailsRecord = Record<string, unknown>;
 
@@ -186,6 +188,45 @@ export function BiomarkerDetails({
           </div>
         ) : null}
       </div>
+    );
+  }
+
+  if (biomarkerType === "io_in_loop") {
+    const kind = str(details.boundary_kind);
+    const label = kind ? (PERF_BOUNDARY_LABEL[kind as C4IoKind] ?? kind) : null;
+    const crossFn = details.cross_function === true;
+    // The resolved caller -> ... -> sink chain (cross-function N+1 only). Each
+    // segment is "file.py::Name"; render the bare function names.
+    const path = Array.isArray(details.path)
+      ? (details.path as unknown[])
+          .map((seg) => (typeof seg === "string" ? seg.split("::").pop() ?? seg : null))
+          .filter((s): s is string => Boolean(s))
+      : [];
+    return (
+      <div className="text-xs text-[var(--color-text-tertiary)] space-y-0.5">
+        {label ? (
+          <div>
+            <span className="font-medium text-[var(--color-text-secondary)]">{label}</span>
+            {" boundary"}
+            {crossFn ? " · cross-function N+1" : " · in loop body"}
+          </div>
+        ) : null}
+        {path.length > 1 ? (
+          <div className="font-mono truncate" title={path.join(" → ")}>
+            {path.join(" → ")}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (biomarkerType === "blocking_sync_in_async") {
+    const api = str(details.api);
+    if (!api) return null;
+    return (
+      <StatLine>
+        <span className="font-mono">{api}</span> blocks the event loop
+      </StatLine>
     );
   }
 

--- a/packages/ui/src/health/biomarker-glossary.ts
+++ b/packages/ui/src/health/biomarker-glossary.ts
@@ -15,6 +15,7 @@ export type BiomarkerCategory =
   | "test_coverage_gradient"
   | "test_quality"
   | "error_handling"
+  | "performance"
   | "organizational";
 
 export interface BiomarkerInfo {
@@ -31,6 +32,7 @@ export const CATEGORY_LABEL: Record<BiomarkerCategory, string> = {
   test_coverage_gradient: "Coverage gradient",
   test_quality: "Test quality",
   error_handling: "Error handling",
+  performance: "Performance",
   organizational: "Organizational",
 };
 
@@ -43,6 +45,10 @@ export const CATEGORY_CAP: Record<BiomarkerCategory, number> = {
   duplication: 1.0,
   test_quality: 0.5,
   error_handling: 0.5,
+  // One bounded performance category cap (mirrors `_PERFORMANCE_CATEGORY_CAPS`
+  // in scoring.py): the whole performance pillar deducts at most 1.0, keeping it
+  // advisory.
+  performance: 1.0,
 };
 
 export const BIOMARKER_GLOSSARY: Record<string, BiomarkerInfo> = {
@@ -220,6 +226,24 @@ export const BIOMARKER_GLOSSARY: Record<string, BiomarkerInfo> = {
     description:
       "Two governing decisions on record contradict each other. The file is caught between conflicting documented intents.",
   },
+  io_in_loop: {
+    label: "I/O in loop",
+    category: "performance",
+    description:
+      "A database call, network request, filesystem read, or subprocess spawn that runs once per loop iteration — the classic N+1. Detected across function boundaries via the call graph, resolved to a classified I/O boundary. A static performance RISK (high precision, low recall), not measured runtime.",
+  },
+  string_concat_in_loop: {
+    label: "String concat in loop",
+    category: "performance",
+    description:
+      "A string built by repeated += inside a loop, which is quadratic in many runtimes (each concat copies the whole accumulated string). Use a buffer + join for linear cost.",
+  },
+  blocking_sync_in_async: {
+    label: "Blocking call in async",
+    category: "performance",
+    description:
+      "A synchronous blocking call (time.sleep, requests.get, subprocess.run) inside an async function blocks the whole event loop, stalling every other coroutine. Mirrors ruff's ASYNC210/230/251.",
+  },
 };
 
 export function biomarkerInfo(name: string): BiomarkerInfo {
@@ -240,7 +264,7 @@ export function biomarkerLabel(name: string): string {
  * Health dimensions: which pillar a biomarker "homes" under
  * ------------------------------------------------------------------ */
 
-export type BiomarkerDimension = "defect" | "maintainability";
+export type BiomarkerDimension = "defect" | "maintainability" | "performance";
 
 /**
  * The biomarkers whose "home" pillar is maintainability: the smells the defect
@@ -263,21 +287,37 @@ export const MAINTAINABILITY_HOME_BIOMARKERS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * The biomarkers whose "home" pillar is performance: static performance RISK
+ * detectors (I/O-in-loop / N+1, string-concat-in-loop, blocking-sync-in-async).
+ * Mirror of ``_PERFORMANCE_HOME`` in ``scoring.py``. Same fallback-only role as
+ * the maintainability set above — the server stamps the authoritative dimension.
+ */
+export const PERFORMANCE_HOME_BIOMARKERS: ReadonlySet<string> = new Set([
+  "io_in_loop",
+  "string_concat_in_loop",
+  "blocking_sync_in_async",
+]);
+
+/**
  * A biomarker's home dimension for display / filtering. Prefer a finding's
  * server-provided `dimension` field where available; this is the fallback when
  * only the biomarker type is known (e.g. a glossary entry).
  */
 export function biomarkerDimension(name: string): BiomarkerDimension {
-  return MAINTAINABILITY_HOME_BIOMARKERS.has(name) ? "maintainability" : "defect";
+  if (PERFORMANCE_HOME_BIOMARKERS.has(name)) return "performance";
+  if (MAINTAINABILITY_HOME_BIOMARKERS.has(name)) return "maintainability";
+  return "defect";
 }
 
 export const DIMENSION_LABEL: Record<BiomarkerDimension, string> = {
   defect: "Defect risk",
   maintainability: "Maintainability",
+  performance: "Performance",
 };
 
 /** Tailwind chip classes per pillar, matching the surrounding chip palette. */
 export const DIMENSION_CHIP: Record<BiomarkerDimension, string> = {
   defect: "bg-[var(--color-accent-primary)]/10 text-[var(--color-accent-primary)]",
   maintainability: "bg-[var(--color-accent-secondary)]/10 text-[var(--color-accent-secondary)]",
+  performance: "bg-[var(--color-info)]/10 text-[var(--color-info)]",
 };

--- a/packages/ui/src/health/biomarker-list.tsx
+++ b/packages/ui/src/health/biomarker-list.tsx
@@ -31,7 +31,13 @@ export interface BiomarkerFinding {
 
 /** A finding's home pillar, preferring the server value over the glossary. */
 function findingDimension(f: BiomarkerFinding): BiomarkerDimension {
-  if (f.dimension === "maintainability" || f.dimension === "defect") return f.dimension;
+  if (
+    f.dimension === "defect" ||
+    f.dimension === "maintainability" ||
+    f.dimension === "performance"
+  ) {
+    return f.dimension;
+  }
   return biomarkerDimension(f.biomarker_type);
 }
 

--- a/packages/ui/src/health/health-file-drawer.tsx
+++ b/packages/ui/src/health/health-file-drawer.tsx
@@ -168,6 +168,16 @@ export function HealthFileDrawer({
                     </span>
                   )
                 } />
+                <Stat label="Performance" value={
+                  metric.performance_score == null ? (
+                    <span className="text-xs text-[var(--color-text-tertiary)]">—</span>
+                  ) : (
+                    <span className={`inline-flex items-baseline rounded px-2 py-0.5 font-bold tabular-nums ${scoreBadgeClass(metric.performance_score)}`}>
+                      {metric.performance_score.toFixed(1)}
+                      <span className="ml-0.5 text-[10px] font-normal opacity-70">/10</span>
+                    </span>
+                  )
+                } />
                 <Stat label="Max CCN" value={<span className="text-base font-semibold tabular-nums">{metric.max_ccn}</span>} />
                 <Stat label="Nest" value={<span className="text-base font-semibold tabular-nums">{metric.max_nesting}</span>} />
                 <Stat label="NLOC" value={<span className="text-base font-semibold tabular-nums">{metric.nloc}</span>} />
@@ -266,7 +276,9 @@ export function HealthFileDrawer({
                             </span>
                             {(() => {
                               const dim =
-                                f.dimension === "maintainability" || f.dimension === "defect"
+                                f.dimension === "maintainability" ||
+                                f.dimension === "defect" ||
+                                f.dimension === "performance"
                                   ? f.dimension
                                   : biomarkerDimension(f.biomarker_type);
                               return (

--- a/packages/ui/src/health/kpi-cards.tsx
+++ b/packages/ui/src/health/kpi-cards.tsx
@@ -20,6 +20,9 @@ export interface HealthSummary {
   /** Maintainability pillar headline (the co-surfaced second signal). `null`
    *  when no file carries a maintainability score yet. */
   maintainability_average?: number | null;
+  /** Performance pillar headline (the co-surfaced third signal: static
+   *  performance RISK). `null` when no file carries a performance score yet. */
+  performance_average?: number | null;
 }
 
 export interface HealthKpiCardsProps {
@@ -45,8 +48,9 @@ export function HealthKpiCards({
 }: HealthKpiCardsProps) {
   const band = summary.band ?? bandForScore(summary.average_health);
   const maint = summary.maintainability_average;
+  const perf = summary.performance_average;
   return (
-    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-7">
       <Card label="Files Analyzed">
         <p className="text-2xl font-bold text-[var(--color-text-primary)] tabular-nums">
           {formatNumber(summary.file_count)}
@@ -91,6 +95,31 @@ export function HealthKpiCards({
             </span>
             <span className={`text-xs font-semibold uppercase tracking-wide ${healthBandTextColor(bandForScore(maint))}`}>
               {HEALTH_BAND_LABEL[bandForScore(maint)]}
+            </span>
+          </p>
+        )}
+      </Card>
+      <Card
+        label="Performance"
+        hint="A third, parallel health signal: static performance RISK — I/O-in-loop / N+1 shapes (a DB, network, filesystem, or subprocess call per loop iteration), detected across function boundaries via the call graph and resolved to a classified I/O boundary. High precision, low recall; never blended into the defect score. NLOC-weighted across the repo."
+      >
+        {perf == null ? (
+          <p className="text-2xl font-bold tabular-nums text-[var(--color-text-tertiary)]">
+            —
+            <span className="ml-1 align-middle text-xs font-normal text-[var(--color-text-tertiary)]">
+              not measured
+            </span>
+          </p>
+        ) : (
+          <p
+            className={`flex items-baseline gap-2 text-2xl font-bold tabular-nums ${scoreTextColor(perf)}`}
+          >
+            <span>
+              {perf.toFixed(1)}
+              <span className="text-base font-normal text-[var(--color-text-secondary)]">/10</span>
+            </span>
+            <span className={`text-xs font-semibold uppercase tracking-wide ${healthBandTextColor(bandForScore(perf))}`}>
+              {HEALTH_BAND_LABEL[bandForScore(perf)]}
             </span>
           </p>
         )}

--- a/packages/web/src/components/code-health/triage-tab.tsx
+++ b/packages/web/src/components/code-health/triage-tab.tsx
@@ -125,7 +125,7 @@ export function TriageTab({
 
   // ---- One filter set coordinates the queue AND the findings sidebar ----
   const [minSeverity, setMinSeverity] = useState<Severity | "all">("all");
-  const [pillar, setPillar] = useState<"all" | "defect" | "maintainability">("all");
+  const [pillar, setPillar] = useState<"all" | "defect" | "maintainability" | "performance">("all");
   const [biomarker, setBiomarker] = useState<string>("all");
   const [maxEffort, setMaxEffort] = useState<string>("all");
   const [sort, setSort] = useState<RefactoringQuery["sort"]>("impact_per_effort");
@@ -250,8 +250,8 @@ export function TriageTab({
   return (
     <div className="space-y-6">
       {isLoading ? (
-        <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3">
-          {Array.from({ length: 6 }).map((_, i) => (
+        <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-7 gap-3">
+          {Array.from({ length: 7 }).map((_, i) => (
             <Skeleton key={i} className="h-24 w-full rounded-lg" />
           ))}
         </div>
@@ -330,7 +330,13 @@ export function TriageTab({
                 <select
                   value={pillar}
                   onChange={(e) =>
-                    setPillar(e.target.value as "all" | "defect" | "maintainability")
+                    setPillar(
+                      e.target.value as
+                        | "all"
+                        | "defect"
+                        | "maintainability"
+                        | "performance",
+                    )
                   }
                   aria-label="Health pillar"
                   className="text-xs px-2 py-1 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
@@ -338,6 +344,7 @@ export function TriageTab({
                   <option value="all">All pillars</option>
                   <option value="defect">Defect risk</option>
                   <option value="maintainability">Maintainability</option>
+                  <option value="performance">Performance</option>
                 </select>
                 <select
                   value={minSeverity}

--- a/tests/unit/generation/test_editor_file_base.py
+++ b/tests/unit/generation/test_editor_file_base.py
@@ -51,13 +51,17 @@ def test_render_contains_repo_name(gen):
     assert "test-repo" in result
 
 
-def _health_block(maintainability_average: float | None) -> CodeHealthBlock:
+def _health_block(
+    maintainability_average: float | None,
+    performance_average: float | None = None,
+) -> CodeHealthBlock:
     return CodeHealthBlock(
         hotspot_health=5.0,
         average_health=7.5,
         worst_score=2.0,
         worst_path="src/bad.py",
         maintainability_average=maintainability_average,
+        performance_average=performance_average,
     )
 
 
@@ -77,6 +81,26 @@ def test_render_omits_maintainability_when_unmeasured(gen):
     # Defect-risk block still renders; the maintainability line is suppressed.
     assert "Hotspot health" in result
     assert "Maintainability, Average" not in result
+
+
+def test_render_surfaces_performance_when_present(gen):
+    import dataclasses
+
+    data = dataclasses.replace(
+        _minimal_data(), code_health=_health_block(6.4, performance_average=9.2)
+    )
+    result = gen.render(data)
+    assert "Performance risk, Average: 9.2/10" in result
+
+
+def test_render_omits_performance_when_unmeasured(gen):
+    import dataclasses
+
+    data = dataclasses.replace(_minimal_data(), code_health=_health_block(6.4))
+    result = gen.render(data)
+    # Maintainability still renders; the performance line is suppressed.
+    assert "Maintainability, Average: 6.4/10" in result
+    assert "Performance risk, Average" not in result
 
 
 def test_write_creates_new_file(gen, tmp_path):

--- a/tests/unit/health/test_scoring.py
+++ b/tests/unit/health/test_scoring.py
@@ -70,6 +70,7 @@ def test_compute_kpis_empty_returns_defaults():
     assert kpis["average_health"] == 10.0
     assert kpis["file_count"] == 0
     assert kpis["maintainability_average"] is None
+    assert kpis["performance_average"] is None
 
 
 def test_compute_kpis_maintainability_average_nloc_weighted():
@@ -109,3 +110,42 @@ def test_compute_kpis_maintainability_none_when_unscored():
     ]
     kpis = compute_kpis(metrics, hotspot_paths=set())
     assert kpis["maintainability_average"] is None
+
+
+def test_compute_kpis_performance_average_nloc_weighted():
+    metrics = [
+        HealthFileMetricData(
+            "a.py",
+            score=5.0,
+            max_ccn=1,
+            max_nesting=1,
+            nloc=100,
+            has_test_file=False,
+            performance_score=8.0,
+        ),
+        HealthFileMetricData(
+            "b.py",
+            score=10.0,
+            max_ccn=1,
+            max_nesting=1,
+            nloc=10,
+            has_test_file=False,
+            performance_score=10.0,
+        ),
+    ]
+    kpis = compute_kpis(metrics, hotspot_paths={"a.py"})
+    # Weighted avg = (8*100 + 10*10) / 110 ≈ 8.18
+    assert abs(kpis["performance_average"] - 8.18) < 0.02
+    # Hotspot restricted to a.py -> its own performance score.
+    assert kpis["performance_hotspot"] == 8.0
+
+
+def test_compute_kpis_performance_none_when_unscored():
+    """Files predating the perf detectors (no performance_score) -> None, not 10.0."""
+    metrics = [
+        HealthFileMetricData(
+            "a.py", score=5.0, max_ccn=1, max_nesting=1, nloc=100, has_test_file=False
+        ),
+    ]
+    kpis = compute_kpis(metrics, hotspot_paths=set())
+    assert kpis["performance_average"] is None

--- a/tests/unit/server/mcp/conftest.py
+++ b/tests/unit/server/mcp/conftest.py
@@ -588,6 +588,7 @@ async def health_data(session: AsyncSession, populated_db: str) -> str:
                 "module": "auth",
                 "defect_score": 4.5,
                 "maintainability_score": 6.0,
+                "performance_score": 9.0,
             },
             {
                 "file_path": "src/db/models.py",
@@ -599,6 +600,7 @@ async def health_data(session: AsyncSession, populated_db: str) -> str:
                 "module": "db",
                 "defect_score": 8.5,
                 "maintainability_score": 9.0,
+                "performance_score": 10.0,
             },
         ],
     )
@@ -639,6 +641,22 @@ async def health_data(session: AsyncSession, populated_db: str) -> str:
                 "health_impact": 1.0,
                 "reason": "AuthService has low cohesion",
                 "dimension": "maintainability",
+            },
+            {
+                "file_path": "src/auth/service.py",
+                "biomarker_type": "io_in_loop",
+                "severity": "medium",
+                "function_name": "load_users",
+                "line_start": 42,
+                "line_end": 42,
+                "details": {
+                    "boundary_kind": "db",
+                    "cross_function": True,
+                    "path": ["src/auth/service.py::load_users", "src/db/models.py::fetch_one"],
+                },
+                "health_impact": 1.0,
+                "reason": "a database call is reached once per loop iteration (cross-function N+1)",
+                "dimension": "performance",
             },
         ],
     )

--- a/tests/unit/server/mcp/test_health.py
+++ b/tests/unit/server/mcp/test_health.py
@@ -19,7 +19,7 @@ async def test_get_health_dashboard(setup_mcp, health_data):
     assert result["kpis"]["worst_performer_path"] == "src/auth/service.py"
     assert len(result["worst_files"]) == 2
     assert result["worst_files"][0]["file_path"] == "src/auth/service.py"
-    assert len(result["top_findings"]) == 3
+    assert len(result["top_findings"]) == 4
 
 
 @pytest.mark.asyncio
@@ -31,14 +31,35 @@ async def test_get_health_dashboard_surfaces_maintainability(setup_mcp, health_d
     # Repo-level KPI headline for the maintainability pillar.
     # NLOC-weighted: (6.0*200 + 9.0*50) / 250 = 6.6.
     assert result["kpis"]["maintainability_average"] == 6.6
-    # Per-file metrics carry both dimension scores; perf is null (no detectors).
+    # Per-file metrics carry all three dimension scores.
     worst = result["worst_files"][0]
     assert worst["defect_score"] == 4.5
     assert worst["maintainability_score"] == 6.0
-    assert worst["performance_score"] is None
+    assert worst["performance_score"] == 9.0
     # Findings are tagged with their home pillar so they can be filtered.
     dims = {f["dimension"] for f in result["top_findings"]}
-    assert dims == {"defect", "maintainability"}
+    assert dims == {"defect", "maintainability", "performance"}
+
+
+@pytest.mark.asyncio
+async def test_get_health_dashboard_surfaces_performance(setup_mcp, health_data):
+    """The performance pillar is surfaced as a co-equal third signal."""
+    from repowise.server.mcp_server import get_health
+
+    result = await get_health()
+    # Repo-level KPI headline for the performance pillar.
+    # NLOC-weighted: (9.0*200 + 10.0*50) / 250 = 9.2.
+    assert result["kpis"]["performance_average"] == 9.2
+    # The perf finding carries its boundary kind + cross-function reachability path.
+    perf = [f for f in result["top_findings"] if f["dimension"] == "performance"]
+    assert len(perf) == 1
+    details = perf[0]["details"]
+    assert details["boundary_kind"] == "db"
+    assert details["cross_function"] is True
+    assert details["path"] == [
+        "src/auth/service.py::load_users",
+        "src/db/models.py::fetch_one",
+    ]
 
 
 @pytest.mark.asyncio
@@ -50,4 +71,5 @@ async def test_get_health_targeted(setup_mcp, health_data):
     assert len(result["metrics"]) == 1
     assert result["metrics"][0]["max_ccn"] == 15
     assert result["metrics"][0]["maintainability_score"] == 6.0
+    assert result["metrics"][0]["performance_score"] == 9.0
     assert all(f["file_path"] == "src/auth/service.py" for f in result["findings"])


### PR DESCRIPTION
Make the performance score a visible signal alongside defect risk and maintainability across the whole surface. The score data is already computed and persisted per file (static performance RISK: I/O-in-loop / N+1 shapes detected across function boundaries via the call graph and resolved to a classified I/O boundary); this wires it through to every consumer.

## What changed

- **types**: `performance_average`/`performance_hotspot` on the overview summary, per-dimension scores + a finding `dimension` on the file-detail wire type, and a boundary-kind label map reusing the parity-locked `C4IoKind`. Parity tests on both sides.
- **core**: `compute_kpis` and `get_health_summary` emit the performance average/hotspot; the generated CLAUDE.md and the CLI `status` line print a performance-risk headline next to defect and maintainability.
- **server + MCP**: the performance KPI, per-file `performance_score`, and per-finding `boundary_kind` / `cross_function` / reachability `path` threaded through; documented `get_health` fields; extended MCP contract test.
- **ui**: a Performance KPI card, a per-pillar finding filter option, a performance pillar chip on biomarkers, per-file performance scores in the file drawer and on the per-file Health tab, and a perf-finding detail rendering the boundary kind and the cross-function reachability path.
- **docs**: the three-signal model in `CODE_HEALTH.md`, the performance pillar's high-precision/low-recall framing and soundness limits, and the explicit decision that the overall headline stays the defect score.

## Overall score

The headline overall score stays the defect score; maintainability and performance are surfaced as co-equal views, never blended. The Healthy/Warning/Alert bands and the "does the score find the bugs?" stat are calibrated to the defect number, and neither new pillar is a calibrated bug predictor, so neither moves the headline. Rationale is documented in `docs/CODE_HEALTH.md`. The defect golden test stays green byte-for-byte.

## Validation

- Python: 427 health tests (including the defect golden and the maintainability surfacing) + 793 mcp/generation tests pass.
- TS: 36 types parity tests + 470 ui tests pass; type-check and web lint clean.
- End-to-end render against the live index DB shows defect, maintainability, and performance averages plus the three-signal CLAUDE.md block.
