### PR TITLE
refactor(health): extract perf detection into a PerfDialect plugin registry

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/complexity/walker.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/walker.py
@@ -26,12 +26,8 @@ from typing import TYPE_CHECKING
 
 import structlog
 
-from ..perf.io_boundaries import (
-    HTTP_VERBS,
-    PY_SUBPROC_METHODS,
-    classify_call_sink,
-    collect_io_names,
-)
+from ..perf.dialects import PERF_DIALECTS
+from ..perf.io_boundaries import collect_io_names
 from .languages import LanguageNodeMap, get_language_map
 
 if TYPE_CHECKING:
@@ -954,165 +950,11 @@ def _collect_error_handling(
 #   2. Constant-bound-loop skip — ``for _ in range(<int literals>)`` and loops
 #      over literal / ALL_CAPS-named-constant collections are not data-dependent.
 
-# Python string-literal node kinds (f-strings parse as ``string`` too).
-_PY_STRING_KINDS = frozenset({"string", "concatenated_string"})
-_TS_STRING_KINDS = frozenset({"string", "template_string"})
-_AUG_ASSIGN_KINDS = frozenset({"augmented_assignment", "augmented_assignment_expression"})
-
-
-def _callee_root_name(call_node: Node) -> str | None:
-    """Root identifier of a call's callee: ``a.b.c()`` -> 'a', ``foo()`` -> 'foo'."""
-    fn = call_node.child_by_field_name("function")
-    if fn is None:
-        named = [c for c in call_node.children if c.is_named]
-        fn = named[0] if named else None
-    if fn is None:
-        return None
-    node = fn
-    for _ in range(8):
-        if node.type in ("identifier", "property_identifier", "field_identifier"):
-            break
-        obj = node.child_by_field_name("object") or node.child_by_field_name("value")
-        if obj is None:
-            named = [c for c in node.children if c.is_named]
-            if not named:
-                break
-            node = named[0]
-        else:
-            node = obj
-    txt = (node.text or b"").decode("utf-8", "replace")
-    return txt.split(".")[0] if txt else None
-
-
-def _callee_method_name(call_node: Node) -> str | None:
-    """Rightmost member of the callee (``x.execute`` -> 'execute')."""
-    fn = call_node.child_by_field_name("function")
-    if fn is None:
-        return None
-    prop = (
-        fn.child_by_field_name("property")
-        or fn.child_by_field_name("field")
-        or fn.child_by_field_name("attribute")
-    )
-    if prop is not None and prop.text:
-        return prop.text.decode("utf-8", "replace")
-    if fn.type == "identifier" and fn.text:
-        return fn.text.decode("utf-8", "replace")
-    ids = [c for c in fn.children if c.type == "identifier"]
-    if ids and ids[-1].text:
-        return ids[-1].text.decode("utf-8", "replace")
-    return None
-
-
-def _callee_is_attribute(call_node: Node) -> bool:
-    """True if the callee is a member access (``x.foo()``), not a bare call."""
-    fn = call_node.child_by_field_name("function")
-    if fn is None:
-        return False
-    return fn.type in (
-        "attribute",
-        "member_expression",
-        "field_expression",
-        "selector_expression",
-    )
-
-
 def _perf_func_name(node: Node) -> str | None:
     nm = node.child_by_field_name("name")
     if nm is not None and nm.text:
         return nm.text.decode("utf-8", "replace")
     return None
-
-
-def _has_async_modifier(node: Node) -> bool:
-    """True if a function node carries an ``async`` modifier token (TS/JS)."""
-    return any(c.type == "async" for c in node.children)
-
-
-def _is_constant_for(node: Node) -> bool:
-    """True if a Python for-loop iterates a compile-time-constant bound.
-
-    Catches ``for _ in range(<int literals>)``, ``for x in (<literal>)``, and —
-    a refinement over the Phase-0 probe — ``for x in ALL_CAPS`` (a named
-    module constant by convention). ``while`` loops are never constant.
-    """
-    if node.type != "for_statement":
-        return False
-    right = node.child_by_field_name("right")
-    if right is None:
-        return False
-    if right.type in ("list", "tuple", "set"):
-        return True
-    # A bare ALL_CAPS identifier is a named constant by convention.
-    if right.type == "identifier" and right.text is not None:
-        name = right.text.decode("utf-8", "replace")
-        if name.isupper() and len(name) > 1:
-            return True
-    if right.type == "call":
-        fn = right.child_by_field_name("function")
-        if fn is None or (fn.text or b"").decode("utf-8", "replace") != "range":
-            return False
-        args = right.child_by_field_name("arguments")
-        if args is None:
-            return False
-        for a in args.children:
-            if not a.is_named:
-                continue
-            if a.type == "integer":
-                continue
-            if a.type == "unary_operator" and any(c.type == "integer" for c in a.children):
-                continue
-            return False  # a non-literal arg (e.g. len(x)) ⇒ data-dependent
-        return True
-    return False
-
-
-def _blocking_sync_api(root: str, method: str) -> str | None:
-    """The offending API name if ``root.method`` is a known blocking sync call.
-
-    A small, high-precision allowlist (mirrors ruff ASYNC210/230/251): these
-    are always-synchronous stdlib / ``requests`` calls that block the event
-    loop when run inside an ``async def``.
-    """
-    if root == "time" and method == "sleep":
-        return "time.sleep"
-    if root == "requests" and method in HTTP_VERBS:
-        return f"requests.{method}"
-    if root == "subprocess" and method in PY_SUBPROC_METHODS:
-        return f"subprocess.{method}"
-    if root == "os" and method == "system":
-        return "os.system"
-    if root == "open" and method == "open":
-        return "open"
-    return None
-
-
-def _rhs_is_stringish(node: Node, language: str) -> bool:
-    """True if an augmented-assignment's RHS is provably string-typed.
-
-    Precision-first: only a string/template literal directly on the RHS (or as
-    an operand of a ``+`` on the RHS) counts. ``s += chunk`` where ``chunk`` is
-    an opaque variable is NOT flagged — we refuse to guess a numeric ``+=`` is
-    a string concat.
-    """
-    right = node.child_by_field_name("right")
-    if right is None:
-        return False
-    string_kinds = _PY_STRING_KINDS if language == "python" else _TS_STRING_KINDS
-    if right.type in string_kinds:
-        return True
-    if right.type in ("binary_operator", "binary_expression"):
-        return any(c.is_named and c.type in string_kinds for c in right.children)
-    return False
-
-
-def _is_string_concat(node: Node, language: str) -> bool:
-    """True if *node* is a ``+=`` string accumulation."""
-    if node.type not in _AUG_ASSIGN_KINDS:
-        return False
-    if not any(c.type == "+=" for c in node.children):
-        return False
-    return _rhs_is_stringish(node, language)
 
 
 def _collect_perf_hits(
@@ -1132,12 +974,17 @@ def _collect_perf_hits(
     or a bare sink) — the input to PR4's cross-function reachability.
     """
     call_kinds = lmap.call_kinds
-    if not call_kinds:
+    dialect = PERF_DIALECTS.get(language)
+    if not call_kinds or dialect is None:
         return [], {}, []
 
     io_names = collect_io_names(root, language)
     has_db_import = any(k == "db" for k in io_names.values())
-    is_py = language == "python"
+    markers = dialect.markers
+    do_string_concat = "string_concat_in_loop" in markers
+    do_blocking = "blocking_sync_in_async" in markers
+    do_loop_call_marker = "regex_compile_in_loop" in markers
+    do_loop_stmt_marker = "defer_in_loop" in markers
     loop_kinds = lmap.loop_kinds
     fn_kinds = lmap.function_kinds
     lambda_kinds = lmap.lambda_kinds
@@ -1162,11 +1009,11 @@ def _collect_perf_hits(
         t = node.type
 
         is_loop = t in loop_kinds
-        if is_loop and is_py and _is_constant_for(node):
+        if is_loop and dialect.is_constant_loop(node):
             is_loop = False
 
         entering_fn = t in fn_kinds or t in lambda_kinds
-        is_async_fn = t in async_fn_kinds or (entering_fn and _has_async_modifier(node))
+        is_async_fn = t in async_fn_kinds or (entering_fn and dialect.is_async_fn(node))
         next_async = True if is_async_fn else (False if entering_fn else in_async)
         next_func = func_name
         next_start = func_start
@@ -1175,42 +1022,64 @@ def _collect_perf_hits(
             next_start = node.start_point[0] + 1
 
         if t in call_kinds:
-            method = _callee_method_name(node) or ""
-            root_name = _callee_root_name(node) or ""
+            method = dialect.callee_method_name(node) or ""
+            root_name = dialect.callee_root_name(node) or ""
             parent = node.parent
             awaited = parent is not None and "await" in parent.type
             line = node.start_point[0] + 1
-            kind = classify_call_sink(
-                language,
+            kind = dialect.sink_kind(
                 root_name,
                 method,
                 awaited=awaited,
-                is_attribute=_callee_is_attribute(node),
+                is_attribute=dialect.callee_is_attribute(node),
                 io_names=io_names,
                 has_db_import=has_db_import,
             )
             if loop_depth >= 1:
                 if kind is not None:
                     hits.append(PerfHit("io_in_loop", line, next_func, kind))
-                elif method:
-                    # A loop-nested call to a non-sink helper: a candidate
-                    # entry for cross-function reachability (PR4). Keep the
-                    # first line we see the helper called at, for the finding.
-                    targets = _acc(next_start, next_func)[0]
-                    if method not in targets:
-                        targets[method] = line
+                else:
+                    marker = (
+                        dialect.loop_call_marker(root_name, method, node)
+                        if do_loop_call_marker
+                        else None
+                    )
+                    if marker is not None:
+                        hits.append(PerfHit(marker, line, next_func, ""))
+                    elif method:
+                        # A loop-nested call to a non-sink helper: a candidate
+                        # entry for cross-function reachability (PR4). Keep the
+                        # first line we see the helper called at, for the finding.
+                        targets = _acc(next_start, next_func)[0]
+                        if method not in targets:
+                            targets[method] = line
             elif kind is not None:
                 # A sink at loop_depth 0 makes this function a reachability
                 # target: a loop elsewhere calling into it runs the sink N times.
                 sink_slot = _acc(next_start, next_func)[1]
                 if sink_slot[0] is None:
                     sink_slot[0] = kind
-            if is_py and in_async and not awaited:
-                api = _blocking_sync_api(root_name, method)
+            if do_blocking and in_async and not awaited:
+                api = dialect.blocking_sync_api(root_name, method)
                 if api is not None:
                     hits.append(PerfHit("blocking_sync_in_async", line, next_func, api))
-        elif loop_depth >= 1 and _is_string_concat(node, language):
-            hits.append(PerfHit("string_concat_in_loop", node.start_point[0] + 1, next_func, ""))
+        else:
+            if do_blocking and in_async:
+                # A non-call member read that blocks in async (C# ``task.Result``).
+                mem = dialect.async_blocking_member(node)
+                if mem is not None:
+                    hits.append(
+                        PerfHit("blocking_sync_in_async", node.start_point[0] + 1, next_func, mem)
+                    )
+            if loop_depth >= 1:
+                if do_string_concat and dialect.is_string_concat(node):
+                    hits.append(
+                        PerfHit("string_concat_in_loop", node.start_point[0] + 1, next_func, "")
+                    )
+                elif do_loop_stmt_marker:
+                    sm = dialect.loop_stmt_marker(node)
+                    if sm is not None:
+                        hits.append(PerfHit(sm, node.start_point[0] + 1, next_func, ""))
 
         if is_loop:
             # Only the loop BODY runs per-iteration; the ``for x in <iterable>``

--- a/packages/core/src/repowise/core/analysis/health/perf/__init__.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/__init__.py
@@ -1,21 +1,27 @@
 """Performance-risk analysis helpers (the ``performance`` health dimension).
 
-This package holds the I/O-boundary call-site classifier (:mod:`.io_boundaries`)
-that the complexity walker's perf pass uses to turn a loop-nested call into a
-typed ``io_in_loop`` finding, the sink-agnostic bounded reachability engine
-(:mod:`.reachability`, Primitive 3), and the cross-function N+1 bridge
-(:mod:`.crossfn`) built on top of both.
+This package holds:
+
+* the shared import → I/O-boundary classifier (:mod:`.io_boundaries`) that maps
+  a file's imported names to ``io_kind``;
+* the per-language perf :mod:`.dialects` (callee extraction + execution-sink
+  lexicon + loop / string / async predicates + the per-language marker list)
+  that the complexity walker drives the perf pass off;
+* the sink-agnostic bounded reachability engine (:mod:`.reachability`,
+  Primitive 3) and the cross-function N+1 bridge (:mod:`.crossfn`) built on it.
 """
 
 from __future__ import annotations
 
 from .crossfn import collect_crossfn_io_in_loop
-from .io_boundaries import classify_call_sink, collect_io_names
+from .dialects import PERF_DIALECTS, BasePerfDialect
+from .io_boundaries import collect_io_names
 from .reachability import ReachInfo, path_to_sink, reachable_to_sink
 
 __all__ = [
+    "PERF_DIALECTS",
+    "BasePerfDialect",
     "ReachInfo",
-    "classify_call_sink",
     "collect_crossfn_io_in_loop",
     "collect_io_names",
     "path_to_sink",

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/__init__.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/__init__.py
@@ -1,0 +1,35 @@
+"""Per-language performance dialects, aggregated into ``PERF_DIALECTS``.
+
+Adding a language's perf support is two edits and one new module (mirroring
+``languages/specs/__init__.py``'s ``ALL_SPECS``):
+
+1. drop ``perf/dialects/<lang>.py`` exporting a ``DIALECT`` instance,
+2. register it under every ``LanguageTag`` it serves in ``_REGISTER`` below,
+3. add ``call_kinds`` (and any ``async_function_kinds``) to its
+   ``LanguageNodeMap`` in ``complexity/languages.py``.
+
+No edits to the walker. A language absent here ⇒ the perf pass is silent for it
+(no dialect = no signal), which is the safe default.
+"""
+
+from __future__ import annotations
+
+from . import python as _python
+from . import ts_js as _ts_js
+from .base import PERF_DIALECTS, BasePerfDialect
+
+# (LanguageTag, dialect instance). One dialect can serve several tags (TS/JS
+# share a grammar). Each entry's key is a ``LanguageTag`` from
+# ``ingestion/models.py``.
+_REGISTER: tuple[tuple[str, BasePerfDialect], ...] = (
+    ("python", _python.DIALECT),
+    ("typescript", _ts_js.DIALECT),
+    ("tsx", _ts_js.DIALECT),
+    ("javascript", _ts_js.DIALECT),
+    ("jsx", _ts_js.DIALECT),
+)
+
+for _tag, _dialect in _REGISTER:
+    PERF_DIALECTS[_tag] = _dialect
+
+__all__ = ["PERF_DIALECTS", "BasePerfDialect"]

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/base.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/base.py
@@ -1,0 +1,242 @@
+"""The ``PerfDialect`` plugin contract + the ``PERF_DIALECTS`` registry.
+
+The performance pass (``complexity/walker.py::_collect_perf_hits``) is
+language-agnostic: every language difference lives in a ``PerfDialect``. This
+mirrors the per-language plugin idiom the rest of the pipeline already uses
+(``resolvers/``, ``extractors/bindings/``, ``heritage/``, ``framework_edges/``,
+``workspace/extractors/http/``) — one module per language, registered in a dict,
+zero edits to the orchestrator to add one.
+
+A dialect owns the *semantic* layer the walker cannot generalise:
+
+================================  ============================================
+Member                            What it answers
+================================  ============================================
+``callee_root_name(node)``        ``a.b.c()`` -> ``"a"`` (the per-grammar seam)
+``callee_method_name(node)``      ``x.execute()`` -> ``"execute"``
+``callee_is_attribute(node)``     is the callee a member access vs a bare call?
+``sink_kind(...)``                is this call an *execution sink* at an I/O
+                                  boundary (db / network / fs / subprocess)?
+``is_constant_loop(node)``        is this loop's bound a compile-time constant
+                                  (so it is not data-dependent N+1)?
+``is_string_concat(node)``        is this a ``+=`` string accumulation?
+``is_async_fn(node)``             does this function carry an ``async`` modifier
+                                  token (combined with ``lmap.async_function_kinds``)?
+``blocking_sync_api(root, m)``    the offending name if ``root.m()`` is a known
+                                  blocking sync call (sync-in-async).
+``markers``                       the marker kinds this dialect can emit — lets
+                                  Go add ``defer_in_loop`` and Java/Go add
+                                  ``regex_compile_in_loop`` without touching the
+                                  walker.
+================================  ============================================
+
+Three *optional* hooks let a language emit markers beyond the original three,
+each defaulting to "no signal" so a language that does not set them is byte-for-
+byte unchanged:
+
+================================  ============================================
+``loop_call_marker(root, m, n)``  a loop-nested *call* that is a non-I/O marker
+                                  (``regexp.MustCompile`` / ``Pattern.compile``).
+``loop_stmt_marker(node)``        a loop-nested *non-call statement* marker
+                                  (Go ``defer`` in a loop -> handle leak).
+``async_blocking_member(node)``   a non-call member read that blocks in async
+                                  (C# ``task.Result``).
+================================  ============================================
+
+Every method has a safe default on :class:`BasePerfDialect`, so an unmapped
+language (no entry in ``PERF_DIALECTS``) produces no perf signal at all, and a
+mapped language that does not override a method gets "no signal" for that facet
+rather than a wrong guess. This is the precision-first contract the whole perf
+pillar depends on.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tree_sitter import Node
+
+# Node types whose callee is a member access (``x.foo()``) rather than a bare
+# identifier call. Covers Python ``attribute``, TS ``member_expression``, C++/
+# Rust ``field_expression``, Go ``selector_expression``. Languages that need
+# more (C# ``member_access_expression``) extend this; languages whose call node
+# has no wrapping member-access node at all (Java ``method_invocation``)
+# override :meth:`callee_is_attribute` outright.
+_ATTRIBUTE_CALLEE_KINDS: frozenset[str] = frozenset(
+    {"attribute", "member_expression", "field_expression", "selector_expression"}
+)
+
+
+class BasePerfDialect:
+    """Default ``PerfDialect`` implementation — every method is "no signal".
+
+    Language modules subclass this and override only what differs. The generic
+    callee extraction here works for Python / TS / JS / Go (field-name based);
+    Java and C# extend or replace it. All the *semantic* predicates default to
+    "no signal" so a new language is opt-in facet by facet.
+    """
+
+    #: Language tag this dialect serves (informational; the registry is the
+    #: source of truth for dispatch).
+    language: str = ""
+
+    #: Marker kinds this dialect can emit. The walker consults this before
+    #: attempting each marker, so an unlisted marker's detection code never
+    #: runs for this language.
+    markers: frozenset[str] = frozenset()
+
+    #: Callee node types treated as member access by :meth:`callee_is_attribute`.
+    attribute_callee_kinds: frozenset[str] = _ATTRIBUTE_CALLEE_KINDS
+
+    #: String-literal node kinds + compound-assignment node kinds for the
+    #: generic :meth:`is_string_concat`. Empty -> the predicate is always False.
+    string_literal_kinds: frozenset[str] = frozenset()
+    aug_assign_kinds: frozenset[str] = frozenset()
+
+    # -- callee extraction (the per-grammar seam) -----------------------------
+
+    def callee_root_name(self, call_node: Node) -> str | None:
+        """Root identifier of a call's callee: ``a.b.c()`` -> 'a', ``foo()`` -> 'foo'."""
+        fn = call_node.child_by_field_name("function")
+        if fn is None:
+            named = [c for c in call_node.children if c.is_named]
+            fn = named[0] if named else None
+        if fn is None:
+            return None
+        node = fn
+        for _ in range(8):
+            if node.type in ("identifier", "property_identifier", "field_identifier"):
+                break
+            obj = node.child_by_field_name("object") or node.child_by_field_name("value")
+            if obj is None:
+                named = [c for c in node.children if c.is_named]
+                if not named:
+                    break
+                node = named[0]
+            else:
+                node = obj
+        txt = (node.text or b"").decode("utf-8", "replace")
+        return txt.split(".")[0] if txt else None
+
+    def callee_method_name(self, call_node: Node) -> str | None:
+        """Rightmost member of the callee (``x.execute`` -> 'execute')."""
+        fn = call_node.child_by_field_name("function")
+        if fn is None:
+            return None
+        prop = (
+            fn.child_by_field_name("property")
+            or fn.child_by_field_name("field")
+            or fn.child_by_field_name("attribute")
+        )
+        if prop is not None and prop.text:
+            return prop.text.decode("utf-8", "replace")
+        if fn.type == "identifier" and fn.text:
+            return fn.text.decode("utf-8", "replace")
+        ids = [c for c in fn.children if c.type == "identifier"]
+        if ids and ids[-1].text:
+            return ids[-1].text.decode("utf-8", "replace")
+        return None
+
+    def callee_is_attribute(self, call_node: Node) -> bool:
+        """True if the callee is a member access (``x.foo()``), not a bare call."""
+        fn = call_node.child_by_field_name("function")
+        if fn is None:
+            return False
+        return fn.type in self.attribute_callee_kinds
+
+    # -- sink classification (the lexicon) ------------------------------------
+
+    def sink_kind(
+        self,
+        root: str,
+        method: str,
+        *,
+        awaited: bool,
+        is_attribute: bool,
+        io_names: dict[str, str],
+        has_db_import: bool,
+    ) -> str | None:
+        """Boundary kind (db / network / filesystem / subprocess) if this call
+        is an *execution sink*, else ``None`` ("not an I/O round-trip")."""
+        return None
+
+    # -- loop / string / async predicates -------------------------------------
+
+    def is_constant_loop(self, node: Node) -> bool:
+        """True if this loop's bound is a compile-time constant (not N+1)."""
+        return False
+
+    def is_string_concat(self, node: Node) -> bool:
+        """True if *node* is a ``+=`` accumulation onto a string."""
+        if not self.aug_assign_kinds or node.type not in self.aug_assign_kinds:
+            return False
+        if not any(c.type == "+=" for c in node.children):
+            return False
+        return self._rhs_is_stringish(node)
+
+    def _rhs_is_stringish(self, node: Node) -> bool:
+        """True if an augmented-assignment's RHS is provably string-typed.
+
+        Precision-first: only a string/template literal directly on the RHS (or
+        as an operand of a ``+`` on the RHS) counts. ``s += chunk`` where
+        ``chunk`` is an opaque variable is NOT flagged.
+        """
+        right = node.child_by_field_name("right")
+        if right is None:
+            return False
+        kinds = self.string_literal_kinds
+        if right.type in kinds:
+            return True
+        if right.type in ("binary_operator", "binary_expression"):
+            return any(c.is_named and c.type in kinds for c in right.children)
+        return False
+
+    def is_async_fn(self, node: Node) -> bool:
+        """True if a function node carries an ``async`` modifier token.
+
+        Combined by the walker with ``lmap.async_function_kinds`` (the
+        dedicated async node types). The default sniffs for a child of *type*
+        ``async`` — the shape Python (``async def`` is a ``function_definition``
+        with an ``async`` child) and TS/JS (``async`` arrow/function) both use.
+        Languages whose async marker is a modifier *token text* rather than a
+        node type (C# ``async``) override this.
+        """
+        return any(c.type == "async" for c in node.children)
+
+    def blocking_sync_api(self, root: str, method: str) -> str | None:
+        """The offending API name if ``root.method`` is a known blocking sync
+        call that stalls an event loop inside an async function, else ``None``."""
+        return None
+
+    # -- optional extra-marker hooks (default: no signal) ---------------------
+
+    def loop_call_marker(self, root: str, method: str, node: Node) -> str | None:
+        """Marker kind for a loop-nested *call* that is not an I/O sink.
+
+        Used for ``regex_compile_in_loop`` (``Pattern.compile`` /
+        ``regexp.MustCompile`` recompiled every iteration). Default ``None``.
+        """
+        return None
+
+    def loop_stmt_marker(self, node: Node) -> str | None:
+        """Marker kind for a loop-nested *non-call statement* node.
+
+        Used for Go ``defer_in_loop`` (a ``defer`` inside a loop leaks the
+        deferred handle until the enclosing function returns). Default ``None``.
+        """
+        return None
+
+    def async_blocking_member(self, node: Node) -> str | None:
+        """The offending name if *node* is a non-call member read that blocks
+        the event loop inside an async function (C# ``task.Result``), else
+        ``None``. The call forms (``.Wait()`` / ``.GetResult()``) go through
+        :meth:`blocking_sync_api` instead. Default ``None``.
+        """
+        return None
+
+
+# The registry, populated by ``dialects/__init__.py`` from each language module.
+# Keyed by ``LanguageTag``; a missing key ⇒ the perf pass is silent for that
+# language (no dialect = no signal).
+PERF_DIALECTS: dict[str, BasePerfDialect] = {}

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/python.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/python.py
@@ -1,0 +1,153 @@
+"""Python ``PerfDialect``.
+
+Extracted verbatim from the original ``_py_sink_kind`` (``io_boundaries.py``)
+and the Python branches of the walker (``_blocking_sync_api`` / ``_is_constant_for``
+/ the ``_PY_STRING_KINDS`` string-concat predicate). The 6a refactor changes
+zero Python behavior — the defect golden + perf suite lock that.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BasePerfDialect
+
+if TYPE_CHECKING:
+    from tree_sitter import Node
+
+# Network round-trip verbs (shared across languages that name HTTP methods).
+HTTP_VERBS: frozenset[str] = frozenset(
+    {"get", "post", "put", "delete", "patch", "head", "options", "request", "send", "stream"}
+)
+
+# Python DBAPI / SQLAlchemy execution sinks, split into three strata so the
+# ambiguous accessors can be gated harder than the unambiguous ones (see
+# ``sink_kind``).
+PY_DB_UNAMBIGUOUS: frozenset[str] = frozenset(
+    {
+        "execute",
+        "executemany",
+        "scalars",
+        "scalar",
+        "scalar_one",
+        "scalar_one_or_none",
+        "fetchone",
+        "fetchall",
+        "fetchmany",
+    }
+)
+PY_DB_COMMIT: frozenset[str] = frozenset({"commit"})
+PY_DB_AMBIGUOUS: frozenset[str] = frozenset({"all", "first", "one", "one_or_none"})
+PY_SUBPROC_METHODS: frozenset[str] = frozenset(
+    {"run", "call", "check_call", "check_output", "Popen"}
+)
+
+# Python string-literal node kinds (f-strings parse as ``string`` too).
+_PY_STRING_KINDS: frozenset[str] = frozenset({"string", "concatenated_string"})
+_PY_AUG_ASSIGN_KINDS: frozenset[str] = frozenset({"augmented_assignment"})
+
+
+class PythonPerfDialect(BasePerfDialect):
+    language = "python"
+    markers = frozenset({"io_in_loop", "string_concat_in_loop", "blocking_sync_in_async"})
+
+    string_literal_kinds = _PY_STRING_KINDS
+    aug_assign_kinds = _PY_AUG_ASSIGN_KINDS
+
+    def sink_kind(
+        self,
+        root: str,
+        method: str,
+        *,
+        awaited: bool,
+        is_attribute: bool,
+        io_names: dict[str, str],
+        has_db_import: bool,
+    ) -> str | None:
+        root_kind = io_names.get(root)
+        db_evidence = has_db_import or root_kind == "db"
+
+        if method in PY_DB_UNAMBIGUOUS:
+            # A real DB sink is always a method on a session/cursor/result
+            # object; a bare identifier call (the builtin ``all(...)``) is not.
+            return "db" if is_attribute else None
+        if method in PY_DB_COMMIT:
+            # ``.commit`` is a DB verb but GitPython exposes ``repo.commit()``.
+            # Require db evidence in the file / on the receiver.
+            return "db" if (is_attribute and db_evidence) else None
+        if method in PY_DB_AMBIGUOUS:
+            # ``.all`` / ``.first`` / ``.one`` collide with ordinary collection
+            # helpers — the riskiest stratum. Gate on db evidence.
+            return "db" if (is_attribute and db_evidence) else None
+        if root == "subprocess" and method in PY_SUBPROC_METHODS:
+            return "subprocess"
+        if method == "Popen":
+            return "subprocess"
+        if root == "open" and method == "open":  # bare ``open(...)`` builtin
+            return "filesystem"
+        if method == "urlopen":
+            return "network"
+        if root_kind == "network" and method in HTTP_VERBS:
+            return "network"
+        if awaited and root_kind == "network":
+            return "network"
+        return None
+
+    def is_constant_loop(self, node: Node) -> bool:
+        """True if a Python for-loop iterates a compile-time-constant bound.
+
+        Catches ``for _ in range(<int literals>)``, ``for x in (<literal>)``,
+        and ``for x in ALL_CAPS`` (a named module constant by convention).
+        ``while`` loops are never constant.
+        """
+        if node.type != "for_statement":
+            return False
+        right = node.child_by_field_name("right")
+        if right is None:
+            return False
+        if right.type in ("list", "tuple", "set"):
+            return True
+        # A bare ALL_CAPS identifier is a named constant by convention.
+        if right.type == "identifier" and right.text is not None:
+            name = right.text.decode("utf-8", "replace")
+            if name.isupper() and len(name) > 1:
+                return True
+        if right.type == "call":
+            fn = right.child_by_field_name("function")
+            if fn is None or (fn.text or b"").decode("utf-8", "replace") != "range":
+                return False
+            args = right.child_by_field_name("arguments")
+            if args is None:
+                return False
+            for a in args.children:
+                if not a.is_named:
+                    continue
+                if a.type == "integer":
+                    continue
+                if a.type == "unary_operator" and any(c.type == "integer" for c in a.children):
+                    continue
+                return False  # a non-literal arg (e.g. len(x)) ⇒ data-dependent
+            return True
+        return False
+
+    def blocking_sync_api(self, root: str, method: str) -> str | None:
+        """The offending API name if ``root.method`` is a known blocking sync call.
+
+        A small, high-precision allowlist (mirrors ruff ASYNC210/230/251):
+        always-synchronous stdlib / ``requests`` calls that block the event
+        loop when run inside an ``async def``.
+        """
+        if root == "time" and method == "sleep":
+            return "time.sleep"
+        if root == "requests" and method in HTTP_VERBS:
+            return f"requests.{method}"
+        if root == "subprocess" and method in PY_SUBPROC_METHODS:
+            return f"subprocess.{method}"
+        if root == "os" and method == "system":
+            return "os.system"
+        if root == "open" and method == "open":
+            return "open"
+        return None
+
+
+DIALECT = PythonPerfDialect()

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
@@ -1,0 +1,102 @@
+"""TypeScript / JavaScript ``PerfDialect``.
+
+Extracted verbatim from the original ``_ts_sink_kind`` (``io_boundaries.py``)
+and the TS branches of the walker (``_has_async_modifier`` and the
+``_TS_STRING_KINDS`` string-concat predicate). One instance serves both
+``typescript`` / ``tsx`` and ``javascript`` / ``jsx`` (identical call grammar).
+"""
+
+from __future__ import annotations
+
+from .base import BasePerfDialect
+from .python import HTTP_VERBS
+
+# TypeScript / JavaScript. Only DISTINCTIVE method names are trusted without
+# import resolution: bare create/update/delete/count/exec collide hard with
+# Map/Set/Array/RegExp and are pure noise. Generic fs/subprocess verbs are only
+# trusted when the root binds to an imported node:fs / child_process.
+PRISMA_METHODS: frozenset[str] = frozenset(
+    {
+        "findMany",
+        "findUnique",
+        "findFirst",
+        "findUniqueOrThrow",
+        "findFirstOrThrow",
+        "createMany",
+        "updateMany",
+        "deleteMany",
+        "upsert",
+        "aggregate",
+        "groupBy",
+    }
+)
+TS_FS_METHODS: frozenset[str] = frozenset(
+    {"readFileSync", "writeFileSync", "appendFileSync", "readdirSync"}
+)
+# Synchronous execution-sink verbs across the TS I/O ecosystems. Used to gate a
+# call on an imported I/O package: a *round-trip* method (or an awaited call),
+# never a sync helper like ``axios.isCancel`` / ``axios.create`` / a query
+# *builder* like ``.where()``. Async sinks (``axios.get``, prisma queries,
+# ``fs/promises`` reads) are caught by the ``awaited`` arm instead.
+TS_SINK_METHODS: frozenset[str] = (
+    HTTP_VERBS
+    | PRISMA_METHODS
+    | TS_FS_METHODS
+    | frozenset(
+        {
+            "query",
+            "execute",
+            "exec",
+            "execSync",
+            "spawn",
+            "spawnSync",
+            "execFile",
+            "execFileSync",
+            "raw",
+            "$queryRaw",
+            "$executeRaw",
+        }
+    )
+)
+
+_TS_STRING_KINDS: frozenset[str] = frozenset({"string", "template_string"})
+_TS_AUG_ASSIGN_KINDS: frozenset[str] = frozenset({"augmented_assignment_expression"})
+
+
+class TsJsPerfDialect(BasePerfDialect):
+    language = "typescript"
+    markers = frozenset({"io_in_loop", "string_concat_in_loop"})
+
+    string_literal_kinds = _TS_STRING_KINDS
+    aug_assign_kinds = _TS_AUG_ASSIGN_KINDS
+
+    def sink_kind(
+        self,
+        root: str,
+        method: str,
+        *,
+        awaited: bool,
+        is_attribute: bool,
+        io_names: dict[str, str],
+        has_db_import: bool,
+    ) -> str | None:
+        if method == "fetch":  # the ``fetch(...)`` global — no import to resolve
+            return "network"
+        root_kind = io_names.get(root)
+        if root_kind is not None:
+            # A call on an imported I/O package (``axios.get`` / ``db.query``) is
+            # a sink only when it is a known round-trip verb or is awaited — NOT
+            # a sync helper (``axios.isCancel`` / ``axios.create``) or a query
+            # builder (``.where()`` / ``.select()``), which over-fired before
+            # this gate.
+            if method in TS_SINK_METHODS or awaited:
+                return root_kind
+            return None
+        if method in PRISMA_METHODS:  # distinctive prisma-client verbs
+            return "db"
+        if method in TS_FS_METHODS:  # distinctive sync-fs verbs
+            return "filesystem"
+        return None
+
+
+DIALECT = TsJsPerfDialect()

--- a/packages/core/src/repowise/core/analysis/health/perf/io_boundaries.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/io_boundaries.py
@@ -1,35 +1,29 @@
-"""Resolve a loop-nested call site to a typed I/O boundary.
+"""Resolve a file's imports to typed I/O boundaries (the shared half).
 
 The performance pass needs to answer one question per call: *is this an
 execution of an I/O boundary (db / network / filesystem / subprocess), or just
-ordinary computation?* That decomposes into two pieces, both here:
+ordinary computation?* That decomposes into two pieces:
 
-1. **Dependency classification** — which imported names in a file originate from
-   an I/O library, and of what kind. This reuses the shared
+1. **Dependency classification** (this module) — which imported names in a file
+   originate from an I/O library, and of what kind. Reuses the shared
    :func:`...ingestion.external_systems.io_kind.classify_io_kind` table
    (Primitive 1) rather than a perf-private list, so the same maintained
    classification powers C4 typing, the perf pass, and a future security layer.
    :func:`collect_io_names` walks a file's import nodes and binds each imported
-   identifier to its ``io_kind``.
+   identifier to its ``io_kind``. This step is **language-agnostic** — an import
+   statement is a quoted module source (TS) or a dotted path (Python/Java/...);
+   either way the classifier is keyed on names.
 
-2. **Execution-sink gating** — a *query builder* (`select().where()`) is not a
-   round-trip; only *executing* it is. :func:`classify_call_sink` returns a
-   boundary kind ONLY for the execution sinks (``.execute`` / ``.scalars`` /
-   ``.commit`` / ``subprocess.run`` / awaited HTTP / ``fetch`` / prisma
-   verbs...), never for builder chaining. This is the refinement that took the
-   Phase-0 probe from a noisy lexicon to a high-precision signal.
+2. **Execution-sink gating** (per language) — a *query builder* (`select()
+   .where()`) is not a round-trip; only *executing* it is. That lexicon lives in
+   the per-language :class:`...perf.dialects.base.PerfDialect`, because the verb
+   set and the callee grammar differ by language. :meth:`PerfDialect.sink_kind`
+   returns a boundary kind ONLY for execution sinks.
 
-The riskiest stratum is the ambiguous DBAPI result accessors (``.all`` /
-``.first`` / ``.one``) and ``.commit`` — they collide with ordinary collection
-methods (``list.commit`` does not exist, but ``results.all`` and a GitPython
-``repo.commit()`` do). Those are gated on **DB-typed-receiver evidence**: the
-file must import a db library, or the call's receiver root must bind to one.
-This drops the GitPython ``repo.commit()`` false positives the probe flagged.
-
-This module is pure: it takes already-extracted ``(root, method, awaited,
-is_attribute)`` tuples plus the resolved ``io_names`` map. The AST extraction
-lives in the walker. Unknown inputs return ``None`` ("not an I/O sink") so the
-detector degrades to "no signal", never a false positive.
+This module is pure: :func:`collect_io_names` takes a tree root + language tag
+and returns the ``{imported_name: io_kind}`` map the dialect's ``sink_kind``
+consumes. Unknown imports are simply absent (so the detector degrades to "no
+signal", never a false positive).
 """
 
 from __future__ import annotations
@@ -38,92 +32,6 @@ import re
 from typing import Protocol
 
 from ....ingestion.external_systems.io_kind import classify_io_kind
-
-# Languages whose call grammar + import shape this module understands. The perf
-# pass is opt-in elsewhere (an empty boundary map ⇒ no hits).
-TS_LIKE: frozenset[str] = frozenset({"typescript", "javascript"})
-
-# ---------------------------------------------------------------------------
-# Execution-sink lexicons (the gate). Method-name based.
-# ---------------------------------------------------------------------------
-HTTP_VERBS: frozenset[str] = frozenset(
-    {"get", "post", "put", "delete", "patch", "head", "options", "request", "send", "stream"}
-)
-
-# Python DBAPI / SQLAlchemy execution sinks. Split into three strata so the
-# ambiguous accessors can be gated harder than the unambiguous ones:
-#   * UNAMBIGUOUS — names that essentially only exist on a cursor / session /
-#     result object. Trusted on any attribute call.
-#   * COMMIT — ``.commit`` is unambiguous as a DB verb but collides with
-#     GitPython's ``repo.commit()``; gated on db evidence.
-#   * AMBIGUOUS — ``.all`` / ``.first`` / ``.one`` collide with ordinary
-#     collection/query helpers; the riskiest stratum, gated on db evidence.
-PY_DB_UNAMBIGUOUS: frozenset[str] = frozenset(
-    {
-        "execute",
-        "executemany",
-        "scalars",
-        "scalar",
-        "scalar_one",
-        "scalar_one_or_none",
-        "fetchone",
-        "fetchall",
-        "fetchmany",
-    }
-)
-PY_DB_COMMIT: frozenset[str] = frozenset({"commit"})
-PY_DB_AMBIGUOUS: frozenset[str] = frozenset({"all", "first", "one", "one_or_none"})
-PY_SUBPROC_METHODS: frozenset[str] = frozenset(
-    {"run", "call", "check_call", "check_output", "Popen"}
-)
-
-# TypeScript / JavaScript. Only DISTINCTIVE method names are trusted without
-# import resolution: bare create/update/delete/count/exec collide hard with
-# Map/Set/Array/RegExp and are pure noise. Generic fs/subprocess verbs are only
-# trusted when the root binds to an imported node:fs / child_process.
-PRISMA_METHODS: frozenset[str] = frozenset(
-    {
-        "findMany",
-        "findUnique",
-        "findFirst",
-        "findUniqueOrThrow",
-        "findFirstOrThrow",
-        "createMany",
-        "updateMany",
-        "deleteMany",
-        "upsert",
-        "aggregate",
-        "groupBy",
-    }
-)
-TS_FS_METHODS: frozenset[str] = frozenset(
-    {"readFileSync", "writeFileSync", "appendFileSync", "readdirSync"}
-)
-# Synchronous execution-sink verbs across the TS I/O ecosystems. Used to gate a
-# call on an imported I/O package: a *round-trip* method (or an awaited call),
-# never a sync helper like ``axios.isCancel`` / ``axios.create`` / a query
-# *builder* like ``.where()``. Async sinks (``axios.get``, prisma queries,
-# ``fs/promises`` reads) are caught by the ``awaited`` arm instead.
-TS_SINK_METHODS: frozenset[str] = (
-    HTTP_VERBS
-    | PRISMA_METHODS
-    | TS_FS_METHODS
-    | frozenset(
-        {
-            "query",
-            "execute",
-            "exec",
-            "execSync",
-            "spawn",
-            "spawnSync",
-            "execFile",
-            "execFileSync",
-            "raw",
-            "$queryRaw",
-            "$executeRaw",
-        }
-    )
-)
 
 # Tokens that are syntax, not bindable import names.
 _IMPORT_KW: frozenset[str] = frozenset(
@@ -145,27 +53,49 @@ def _decode(node: _NodeLike) -> str:
     return (node.text or b"").decode("utf-8", "replace")
 
 
+def _candidate_variants(tok: str) -> set[str]:
+    """Every name a single import token could classify under.
+
+    Two expansions, both needed for cross-language coverage and both supersets
+    of the original ``split("/")[0]`` / ``split(".")[0]`` behaviour:
+
+    * **all ``/``-segments** — so a Go module path ``github.com/go-redis/redis``
+      yields ``redis`` (its interior segment), and a TS scoped package
+      ``@prisma/client`` keeps resolving via its full form.
+    * **progressive dotted prefixes** — so a Java FQN ``java.nio.file.Files``
+      yields the dotted prefix ``java.nio.file`` (the row the JVM io_kind table
+      keys on), not just the leaf ``Files`` or the root ``java``.
+    """
+    out: set[str] = {tok}
+    parts = [p for p in tok.split("/") if p]
+    out.update(parts)
+    for seg in parts:
+        dotted = seg.split(".")
+        for i in range(1, len(dotted) + 1):
+            out.add(".".join(dotted[:i]))
+    return out
+
+
 def _classify_import(node: _NodeLike) -> tuple[str | None, list[str]]:
     """``(io_kind, bound_names)`` for an import node, else ``(None, [])``.
 
     The module is classified through the shared :func:`classify_io_kind` table:
     every candidate token (a quoted TS source like ``"node:fs"`` /
-    ``"@prisma/client"``, or a Python dotted module's full path + top-level
-    package) is tried until one resolves. When it does, every importable
-    identifier in the statement is bound to that kind. Over-binding is
-    deliberate and harmless: an imported name only becomes a finding when it is
-    later *called as an execution sink*, which a non-I/O symbol never is.
+    ``"@prisma/client"``, or a Python/Java dotted module's full path + interior
+    segments + progressive prefixes) is tried until one resolves. When it does,
+    every importable identifier in the statement is bound to that kind.
+    Over-binding is deliberate and harmless: an imported name only becomes a
+    finding when it is later *called as an execution sink*, which a non-I/O
+    symbol never is.
     """
     text = _decode(node)
     candidates: set[str] = set()
     # TS / JS module sources are quoted string literals.
     for m in re.findall(r"""["']([^"']+)["']""", text):
-        candidates.add(m)
-        candidates.add(m.split("/")[0])
-    # Python dotted modules / bare identifiers.
+        candidates |= _candidate_variants(m)
+    # Python / Java / ... dotted modules / bare identifiers.
     for tok in re.findall(r"[A-Za-z0-9_.:@/]+", text):
-        candidates.add(tok)
-        candidates.add(tok.split(".")[0])
+        candidates |= _candidate_variants(tok)
 
     kind: str | None = None
     for cand in candidates:
@@ -201,91 +131,3 @@ def collect_io_names(tree_root: _NodeLike, language: str) -> dict[str, str]:
         for child in node.children:
             stack.append(child)
     return names
-
-
-def _py_sink_kind(
-    root: str,
-    method: str,
-    awaited: bool,
-    is_attribute: bool,
-    io_names: dict[str, str],
-    has_db_import: bool,
-) -> str | None:
-    root_kind = io_names.get(root)
-    db_evidence = has_db_import or root_kind == "db"
-
-    if method in PY_DB_UNAMBIGUOUS:
-        # A real DB sink is always a method on a session/cursor/result object;
-        # a bare identifier call (the builtin ``all(...)``) is not.
-        return "db" if is_attribute else None
-    if method in PY_DB_COMMIT:
-        # ``.commit`` is a DB verb but GitPython exposes ``repo.commit()``.
-        # Require db evidence in the file / on the receiver.
-        return "db" if (is_attribute and db_evidence) else None
-    if method in PY_DB_AMBIGUOUS:
-        # ``.all`` / ``.first`` / ``.one`` collide with ordinary collection
-        # helpers — the riskiest stratum. Gate on db evidence.
-        return "db" if (is_attribute and db_evidence) else None
-    if root == "subprocess" and method in PY_SUBPROC_METHODS:
-        return "subprocess"
-    if method == "Popen":
-        return "subprocess"
-    if root == "open" and method == "open":  # bare ``open(...)`` builtin
-        return "filesystem"
-    if method == "urlopen":
-        return "network"
-    if root_kind == "network" and method in HTTP_VERBS:
-        return "network"
-    if awaited and root_kind == "network":
-        return "network"
-    return None
-
-
-def _ts_sink_kind(
-    root: str,
-    method: str,
-    awaited: bool,
-    io_names: dict[str, str],
-) -> str | None:
-    if method == "fetch":  # the ``fetch(...)`` global — no import to resolve
-        return "network"
-    root_kind = io_names.get(root)
-    if root_kind is not None:
-        # A call on an imported I/O package (``axios.get`` / ``db.query``) is a
-        # sink only when it is a known round-trip verb or is awaited — NOT a
-        # sync helper (``axios.isCancel`` / ``axios.create``) or a query builder
-        # (``.where()`` / ``.select()``), which over-fired before this gate.
-        if method in TS_SINK_METHODS or awaited:
-            return root_kind
-        return None
-    if method in PRISMA_METHODS:  # distinctive prisma-client verbs
-        return "db"
-    if method in TS_FS_METHODS:  # distinctive sync-fs verbs
-        return "filesystem"
-    return None
-
-
-def classify_call_sink(
-    language: str,
-    root: str,
-    method: str,
-    *,
-    awaited: bool,
-    is_attribute: bool,
-    io_names: dict[str, str],
-    has_db_import: bool,
-) -> str | None:
-    """Boundary kind for a call site if it is an execution sink, else ``None``.
-
-    ``root`` is the callee's root identifier (``a.b.c()`` → ``"a"``); ``method``
-    is the rightmost member (``x.execute()`` → ``"execute"``); ``awaited`` is
-    whether the call is the operand of an ``await``; ``is_attribute`` is whether
-    the callee is a member access (vs a bare-identifier call). ``io_names`` maps
-    imported names to their ``io_kind`` (from :func:`collect_io_names`);
-    ``has_db_import`` is whether the file imports any db library.
-    """
-    if language == "python":
-        return _py_sink_kind(root, method, awaited, is_attribute, io_names, has_db_import)
-    if language in TS_LIKE:
-        return _ts_sink_kind(root, method, awaited, io_names)
-    return None


### PR DESCRIPTION
## What

The performance health signal was the one analysis subsystem still using hardcoded `if language ==` dispatch instead of the per-language plugin pattern the rest of the pipeline uses (resolvers, bindings, heritage, framework edges, workspace HTTP dialects). This refactor introduces `analysis/health/perf/dialects/` — one module per language exporting a `PerfDialect`.

A dialect owns the semantic layer the walker cannot generalize:
- callee extraction (the per-grammar seam),
- the execution-sink lexicon (`sink_kind`),
- the constant-loop / string-concat / async predicates,
- and its own marker list.

`_collect_perf_hits` is now fully language-agnostic: it looks up `PERF_DIALECTS[language]`, early-outs when none is registered, and drives the DFS off the dialect's predicates. Every dialect method has a safe "no signal" default, so an unmapped language produces no perf findings rather than wrong ones.

Python and TypeScript/JavaScript are extracted **verbatim** into `python.py` / `ts_js.py`.

## Behavior

No behavior change. The defect golden test and the full performance suite lock the Python/TS output byte-for-byte (457 health tests green).

Two language-agnostic fixes ride along:
- `_classify_import` now emits every `/`-segment and progressive dotted prefix of an import token, so an interior module name resolves (e.g. `github.com/go-redis/redis` -> `redis`). This is a strict superset of the prior behavior and also helps scoped npm packages.
- `is_async_fn` is now a dialect method, so an async-as-modifier-text shape can be handled per language without disturbing the existing child-type sniff used by Python and TS.

Moving callee extraction into the dialect means a new language's perf support becomes a self-contained module plus a `call_kinds` line on its `LanguageNodeMap` and its `io_kind` rows — no walker edits.

## Test plan
- [x] Defect golden + full perf suite byte-for-byte unchanged
- [x] `ruff check` + `ruff format --check` clean