### PR TITLE
Add loop-level performance markers across language dialects

### DIFF
--- a/docs/CODE_HEALTH.md
+++ b/docs/CODE_HEALTH.md
@@ -142,6 +142,20 @@ category cap of 1.0, so the pillar stays advisory) are:
 - **`string_concat_in_loop`**: quadratic `+=` string building in a loop.
 - **`blocking_sync_in_async`**: a synchronous blocking call inside an `async`
   function, which stalls the whole event loop (mirrors ruff `ASYNC210/230/251`).
+- **`resource_construction_in_loop`**: a heavy I/O client or connection
+  (`sqlite3.connect` / `httpx.Client` / `boto3.client` / `new PrismaClient` /
+  `new HttpClient` / `sql.Open`) constructed every iteration instead of hoisted:
+  connection churn, and socket exhaustion for `HttpClient`.
+- **`lock_in_loop`**: a mutex acquired on every iteration (`lock.acquire` /
+  `mu.Lock` / `synchronized` / `lock(x){}`): a contention site. Activates the
+  `lock` I/O-boundary kind.
+- **`serial_await_in_loop`**: an awaited I/O round-trip run one at a time in a
+  loop where a `gather` / `Promise.all` could fan it out. Advisory — a static
+  analyzer cannot prove the iterations are independent, so the finding suggests
+  rather than asserts.
+- **`membership_test_against_list_in_loop`**: `x in big_list` (or
+  `big_list.includes(x)`) inside a loop is O(n·m); a set makes each lookup O(1).
+  Fires only when the right operand is *provably* a list, never a set or dict.
 
 A few markers are language-specific, contributed by that language's dialect (see
 below) rather than the shared core:

--- a/docs/LANGUAGE_SUPPORT.md
+++ b/docs/LANGUAGE_SUPPORT.md
@@ -438,9 +438,12 @@ without touching the shared pipeline files:
   `object`/`name`, C# `member_access_expression`), the execution-sink
   lexicon (`sink_kind`), the constant-loop / string-concat / async
   predicates, and its own **marker list** --- so Go contributes
-  `defer_in_loop`, Java/Go contribute `regex_compile_in_loop`, and C#
-  contributes sync-over-async `blocking_sync_in_async`, none hardcoded in
-  the walker. Every method has a safe "no signal" default, so a language
+  `defer_in_loop`, Java/Go contribute `regex_compile_in_loop`, C#
+  contributes sync-over-async `blocking_sync_in_async`, and the Phase-7a loop
+  markers (`resource_construction_in_loop`, `lock_in_loop`,
+  `serial_await_in_loop`, `membership_test_against_list_in_loop`) are each
+  opt-in per dialect via the `loop_call_marker` / `loop_stmt_marker` hooks,
+  none hardcoded in the walker. Every method has a safe "no signal" default, so a language
   without a dialect (or one that overrides only some facets) produces no
   false perf findings. Adding a language's perf support is one module plus a
   `call_kinds` line on its `LanguageNodeMap` and its
@@ -453,14 +456,14 @@ the language's `LanguageNodeMap`); it is independent of the control-flow /
 class / assertion tiers. A language without a dialect simply emits no perf
 findings.
 
-| Language | io_in_loop | string_concat | Language-specific markers | sync-over-async |
-|----------|:---:|:---:|---|:---:|
-| Python | Y | Y | --- | `blocking_sync_in_async` |
-| TypeScript / JavaScript | Y | Y | --- | --- |
-| Java | Y | Y | `regex_compile_in_loop` | --- (no async syntax) |
-| Go | Y | Y | `defer_in_loop`, `regex_compile_in_loop` | --- (goroutines) |
-| C# | Y | Y | --- (.NET caches regexes) | `blocking_sync_in_async` (`.Result` / `.Wait()` / `.GetResult()`) |
-| Kotlin / Rust / C++ | --- | --- | --- | --- |
+| Language | io_in_loop | string_concat | Phase-7a loop markers | Other language-specific markers | sync-over-async |
+|----------|:---:|:---:|---|---|:---:|
+| Python | Y | Y | resource_construction, lock, serial_await, membership | --- | `blocking_sync_in_async` |
+| TypeScript / JavaScript | Y | Y | resource_construction, serial_await, membership | --- | --- |
+| Java | Y | Y | resource_construction, lock | `regex_compile_in_loop` | --- (no async syntax) |
+| Go | Y | Y | resource_construction, lock | `defer_in_loop`, `regex_compile_in_loop` | --- (goroutines) |
+| C# | Y | Y | resource_construction, lock, serial_await | --- (.NET caches regexes) | `blocking_sync_in_async` (`.Result` / `.Wait()` / `.GetResult()`) |
+| Kotlin / Rust / C++ | --- | --- | --- | --- | --- |
 
 Kotlin will be nearly free once it rides the JVM lexicon; Rust (sqlx /
 reqwest) and C++ are later. What each dialect classifies as a db / network /

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/lock_in_loop.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/lock_in_loop.py
@@ -1,0 +1,49 @@
+"""Lock-in-loop — a lock acquired on every loop iteration.
+
+Acquiring a mutex / lock each iteration (``lock.acquire`` / ``mu.Lock`` /
+``synchronized`` / ``lock(x){}``) serializes the loop body and is a contention
+hotspot: the critical section runs N times, and under multi-threading the
+repeated hand-off dominates. A ``performance`` dimension signal that activates
+the ``lock`` I/O boundary kind defined in ``io_kind.py``.
+
+Precision-first: only the acquisition verb fires (never ``release`` / ``unlock``,
+which would double-count the same critical section), and the per-language dialect
+gates it on a receiver method / lock statement. This detector lifts the
+pre-collected hits into findings.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "lock_in_loop"
+
+
+class LockInLoopDetector:
+    name = _KIND
+    category = "performance"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        out: list[BiomarkerResult] = []
+        for hit in ctx.perf_hits:
+            if hit.kind != _KIND:
+                continue
+            out.append(
+                BiomarkerResult(
+                    biomarker_type=self.name,
+                    severity=Severity.LOW,
+                    function_name=hit.function,
+                    line_start=hit.line,
+                    line_end=hit.line,
+                    details={},
+                    reason=(
+                        "a lock is acquired every loop iteration; hoist the "
+                        "lock outside the loop or batch the critical section"
+                    ),
+                )
+            )
+        return out
+
+
+BIOMARKER = LockInLoopDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/membership_test_against_list_in_loop.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/membership_test_against_list_in_loop.py
@@ -1,0 +1,48 @@
+"""Membership-test-against-list-in-loop — ``x in big_list`` inside a loop.
+
+Testing membership against a list is O(n); doing it once per loop iteration is
+O(n·m). A ``set`` (or ``dict`` for keyed lookups) makes each probe O(1), turning
+the loop linear. A ``performance`` dimension signal.
+
+Precision-first: the walker's perf pass flags this ONLY when the right operand
+(``big_list`` / the JS ``arr`` in ``arr.includes(x)``) is *provably* a list — a
+name bound to a list literal / comprehension / ``list(...)`` / ``sorted(...)`` in
+the same file. A set or dict membership test is already O(1) and never fires.
+This detector lifts the pre-collected hits into findings.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "membership_test_against_list_in_loop"
+
+
+class MembershipTestAgainstListInLoopDetector:
+    name = _KIND
+    category = "performance"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        out: list[BiomarkerResult] = []
+        for hit in ctx.perf_hits:
+            if hit.kind != _KIND:
+                continue
+            out.append(
+                BiomarkerResult(
+                    biomarker_type=self.name,
+                    severity=Severity.LOW,
+                    function_name=hit.function,
+                    line_start=hit.line,
+                    line_end=hit.line,
+                    details={},
+                    reason=(
+                        "membership tested against a list inside a loop (O(n·m)); "
+                        "use a set for O(1) lookups"
+                    ),
+                )
+            )
+        return out
+
+
+BIOMARKER = MembershipTestAgainstListInLoopDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/registry.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/registry.py
@@ -34,11 +34,15 @@ from .io_in_loop import IoInLoopDetector
 from .knowledge_loss import KnowledgeLossDetector
 from .large_assertion_block import LargeAssertionBlockDetector
 from .large_method import LargeMethodDetector
+from .lock_in_loop import LockInLoopDetector
 from .low_cohesion import LowCohesionDetector
+from .membership_test_against_list_in_loop import MembershipTestAgainstListInLoopDetector
 from .nested_complexity import NestedComplexityDetector
 from .ownership_risk import OwnershipRiskDetector
 from .primitive_obsession import PrimitiveObsessionDetector
 from .prior_defect import PriorDefectDetector
+from .resource_construction_in_loop import ResourceConstructionInLoopDetector
+from .serial_await_in_loop import SerialAwaitInLoopDetector
 from .string_concat_in_loop import StringConcatInLoopDetector
 from .untested_hotspot import UntestedHotspotDetector
 
@@ -73,6 +77,11 @@ _DETECTOR_FACTORIES: list[type[Biomarker]] = [
     IoInLoopDetector,  # type: ignore[list-item]
     StringConcatInLoopDetector,  # type: ignore[list-item]
     BlockingSyncInAsyncDetector,  # type: ignore[list-item]
+    # Phase 7a — cheap, high-precision loop markers.
+    ResourceConstructionInLoopDetector,  # type: ignore[list-item]
+    LockInLoopDetector,  # type: ignore[list-item]
+    SerialAwaitInLoopDetector,  # type: ignore[list-item]
+    MembershipTestAgainstListInLoopDetector,  # type: ignore[list-item]
 ]
 
 

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/resource_construction_in_loop.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/resource_construction_in_loop.py
@@ -1,0 +1,50 @@
+"""Resource-construction-in-loop — a heavy I/O client built each iteration.
+
+Constructing a database connection, HTTP client, or SDK client
+(``sqlite3.connect`` / ``httpx.Client`` / ``boto3.client`` / ``new
+PrismaClient`` / ``new HttpClient`` / ``sql.Open``) inside a loop opens a fresh
+connection or pool every iteration instead of reusing a single hoisted one — the
+classic connection-churn / socket-exhaustion bug. A ``performance`` dimension
+signal.
+
+Precision-first: the walker's perf pass flags this ONLY for a distinctive,
+classified resource constructor (matched per language in the dialect), never a
+plain object construction. This detector lifts the pre-collected hits into
+findings.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "resource_construction_in_loop"
+
+
+class ResourceConstructionInLoopDetector:
+    name = _KIND
+    category = "performance"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        out: list[BiomarkerResult] = []
+        for hit in ctx.perf_hits:
+            if hit.kind != _KIND:
+                continue
+            out.append(
+                BiomarkerResult(
+                    biomarker_type=self.name,
+                    severity=Severity.MEDIUM,
+                    function_name=hit.function,
+                    line_start=hit.line,
+                    line_end=hit.line,
+                    details={},
+                    reason=(
+                        "a heavy client / connection is constructed each loop "
+                        "iteration; hoist and reuse a single instance"
+                    ),
+                )
+            )
+        return out
+
+
+BIOMARKER = ResourceConstructionInLoopDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/serial_await_in_loop.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/serial_await_in_loop.py
@@ -1,0 +1,59 @@
+"""Serial-await-in-loop — an awaited I/O sink run serially in a loop body.
+
+``await``-ing an I/O round-trip inside a loop runs the calls one after another
+when they could often be fanned out (``asyncio.gather`` / ``Promise.all`` /
+``Task.WhenAll``). This is the *missed-concurrency* sibling of ``io_in_loop``: a
+different remediation (parallelize) from batching, so it rides as a separate,
+advisory signal alongside the N+1 finding rather than replacing it.
+
+Advisory by design: static analysis cannot prove the iterations are independent
+(a loop may genuinely need the awaited result before the next iteration), so the
+finding suggests rather than asserts. ``detail`` carries the boundary kind. This
+detector lifts the pre-collected hits into findings.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "serial_await_in_loop"
+
+_BOUNDARY_PHRASING: dict[str, str] = {
+    "db": "a database call",
+    "network": "a network call",
+    "filesystem": "a filesystem call",
+    "subprocess": "a subprocess spawn",
+    "lock": "a lock acquisition",
+}
+
+
+class SerialAwaitInLoopDetector:
+    name = _KIND
+    category = "performance"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        out: list[BiomarkerResult] = []
+        for hit in ctx.perf_hits:
+            if hit.kind != _KIND:
+                continue
+            phrasing = _BOUNDARY_PHRASING.get(hit.detail, "an awaited I/O call")
+            out.append(
+                BiomarkerResult(
+                    biomarker_type=self.name,
+                    severity=Severity.LOW,
+                    function_name=hit.function,
+                    line_start=hit.line,
+                    line_end=hit.line,
+                    details={"boundary_kind": hit.detail},
+                    reason=(
+                        f"{phrasing} is awaited serially in a loop; if the "
+                        "iterations are independent, fan out with "
+                        "gather / Promise.all"
+                    ),
+                )
+            )
+        return out
+
+
+BIOMARKER = SerialAwaitInLoopDetector()

--- a/packages/core/src/repowise/core/analysis/health/complexity/walker.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/walker.py
@@ -153,6 +153,22 @@ class PerfHit:
     - ``blocking_sync_in_async`` — a known blocking sync call (``time.sleep`` /
       sync ``requests`` / ``subprocess`` / ``os.system`` / bare ``open``) inside
       an ``async def``, not awaited. ``detail`` carries the offending API.
+    - ``resource_construction_in_loop`` — a heavy I/O client / connection
+      (``sqlite3.connect`` / ``httpx.Client`` / ``boto3.client`` / ``new
+      PrismaClient``) constructed each iteration instead of hoisted.
+    - ``lock_in_loop`` — a lock acquired each iteration (``lock.acquire`` /
+      ``mu.Lock`` / ``synchronized`` / ``lock(x){}``); a contention signal that
+      activates the ``lock`` I/O boundary kind.
+    - ``serial_await_in_loop`` — an awaited I/O sink in a loop body (the
+      missed-``gather`` / ``Promise.all`` shape). ``detail`` carries the
+      boundary kind. Rides alongside ``io_in_loop`` as an advisory co-signal.
+    - ``membership_test_against_list_in_loop`` — ``x in big_list`` (or
+      ``big_list.includes(x)``) inside a loop where the right operand is a known
+      list -> O(n·m); a set would make each probe O(1).
+
+    The Phase-7a markers above are emitted via the dialect ``loop_call_marker`` /
+    ``loop_stmt_marker`` hooks (and the inline awaited-sink path for
+    ``serial_await_in_loop``), so each is per-language opt-in.
     """
 
     kind: str
@@ -950,6 +966,27 @@ def _collect_error_handling(
 #   2. Constant-bound-loop skip — ``for _ in range(<int literals>)`` and loops
 #      over literal / ALL_CAPS-named-constant collections are not data-dependent.
 
+# Marker kinds emitted through each dialect hook. The walker consults a
+# dialect's ``markers`` set against these to decide whether to invoke the hook
+# at all, so a dialect that lists none of a hook's kinds never pays for it.
+_LOOP_CALL_MARKER_KINDS = frozenset(
+    {
+        "regex_compile_in_loop",
+        "resource_construction_in_loop",
+        "lock_in_loop",
+        "membership_test_against_list_in_loop",
+    }
+)
+_LOOP_STMT_MARKER_KINDS = frozenset(
+    {
+        "defer_in_loop",
+        "resource_construction_in_loop",
+        "lock_in_loop",
+        "membership_test_against_list_in_loop",
+    }
+)
+
+
 def _perf_func_name(node: Node) -> str | None:
     nm = node.child_by_field_name("name")
     if nm is not None and nm.text:
@@ -983,8 +1020,17 @@ def _collect_perf_hits(
     markers = dialect.markers
     do_string_concat = "string_concat_in_loop" in markers
     do_blocking = "blocking_sync_in_async" in markers
-    do_loop_call_marker = "regex_compile_in_loop" in markers
-    do_loop_stmt_marker = "defer_in_loop" in markers
+    do_loop_call_marker = bool(markers & _LOOP_CALL_MARKER_KINDS)
+    do_loop_stmt_marker = bool(markers & _LOOP_STMT_MARKER_KINDS)
+    do_serial_await = "serial_await_in_loop" in markers
+    # ``list_names`` is the precision gate for the membership marker; compute it
+    # once per file only when this dialect can emit that marker, then thread it
+    # to the loop-marker hooks (which ignore it for every other marker).
+    list_names = (
+        dialect.list_bound_names(root)
+        if "membership_test_against_list_in_loop" in markers
+        else frozenset()
+    )
     loop_kinds = lmap.loop_kinds
     fn_kinds = lmap.function_kinds
     lambda_kinds = lmap.lambda_kinds
@@ -1038,9 +1084,16 @@ def _collect_perf_hits(
             if loop_depth >= 1:
                 if kind is not None:
                     hits.append(PerfHit("io_in_loop", line, next_func, kind))
+                    if do_serial_await and awaited:
+                        # An *awaited* sink in a loop body is additionally a
+                        # missed-concurrency candidate (a serial round-trip that
+                        # a ``gather`` / ``Promise.all`` could fan out). Advisory
+                        # co-signal alongside ``io_in_loop``; ``detail`` carries
+                        # the boundary kind for the finding.
+                        hits.append(PerfHit("serial_await_in_loop", line, next_func, kind))
                 else:
                     marker = (
-                        dialect.loop_call_marker(root_name, method, node)
+                        dialect.loop_call_marker(root_name, method, node, list_names)
                         if do_loop_call_marker
                         else None
                     )
@@ -1077,7 +1130,7 @@ def _collect_perf_hits(
                         PerfHit("string_concat_in_loop", node.start_point[0] + 1, next_func, "")
                     )
                 elif do_loop_stmt_marker:
-                    sm = dialect.loop_stmt_marker(node)
+                    sm = dialect.loop_stmt_marker(node, list_names)
                     if sm is not None:
                         hits.append(PerfHit(sm, node.start_point[0] + 1, next_func, ""))
 

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/base.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/base.py
@@ -30,18 +30,32 @@ Member                            What it answers
                                   walker.
 ================================  ============================================
 
-Three *optional* hooks let a language emit markers beyond the original three,
+Four *optional* hooks let a language emit markers beyond the original three,
 each defaulting to "no signal" so a language that does not set them is byte-for-
 byte unchanged:
 
 ================================  ============================================
-``loop_call_marker(root, m, n)``  a loop-nested *call* that is a non-I/O marker
-                                  (``regexp.MustCompile`` / ``Pattern.compile``).
-``loop_stmt_marker(node)``        a loop-nested *non-call statement* marker
-                                  (Go ``defer`` in a loop -> handle leak).
+``loop_call_marker(root, m, n,    a loop-nested *call* that is a non-I/O marker
+``list_names)``                   (``regexp.MustCompile`` / ``Pattern.compile`` ·
+                                  ``sqlite3.connect`` resource construction ·
+                                  ``lock.acquire`` contention ·
+                                  ``big_list``-bound ``arr.includes`` membership).
+``loop_stmt_marker(node,          a loop-nested *non-call statement* marker
+``list_names)``                   (Go ``defer`` · C# ``lock(x){}`` · ``new
+                                  HttpClient()`` resource construction · Python
+                                  ``x in big_list`` membership test).
 ``async_blocking_member(node)``   a non-call member read that blocks in async
                                   (C# ``task.Result``).
+``list_bound_names(root)``        names provably bound to a list literal /
+                                  comprehension in this file — the gate for the
+                                  ``membership_test_against_list_in_loop`` marker.
 ================================  ============================================
+
+The ``list_names`` argument on the two loop-marker hooks is the frozenset
+returned by :meth:`list_bound_names` (computed once per file by the walker only
+when a dialect lists the membership marker); it lets a marker fire ``x in
+big_list`` only when ``big_list`` is a known list, not a set/dict that membership
+tests cheaply.
 
 Every method has a safe default on :class:`BasePerfDialect`, so an unmapped
 language (no entry in ``PERF_DIALECTS``) produces no perf signal at all, and a
@@ -211,21 +225,47 @@ class BasePerfDialect:
 
     # -- optional extra-marker hooks (default: no signal) ---------------------
 
-    def loop_call_marker(self, root: str, method: str, node: Node) -> str | None:
+    def loop_call_marker(
+        self, root: str, method: str, node: Node, list_names: frozenset[str]
+    ) -> str | None:
         """Marker kind for a loop-nested *call* that is not an I/O sink.
 
         Used for ``regex_compile_in_loop`` (``Pattern.compile`` /
-        ``regexp.MustCompile`` recompiled every iteration). Default ``None``.
+        ``regexp.MustCompile`` recompiled every iteration), the per-iteration
+        heavy-client construction ``resource_construction_in_loop``
+        (``sqlite3.connect`` / ``boto3.client``), the lock-contention
+        ``lock_in_loop`` (``lock.acquire`` / ``mu.Lock``), and the JS/TS
+        ``arr.includes`` form of ``membership_test_against_list_in_loop`` (gated
+        on ``root in list_names``). Default ``None``.
         """
         return None
 
-    def loop_stmt_marker(self, node: Node) -> str | None:
+    def loop_stmt_marker(self, node: Node, list_names: frozenset[str]) -> str | None:
         """Marker kind for a loop-nested *non-call statement* node.
 
         Used for Go ``defer_in_loop`` (a ``defer`` inside a loop leaks the
-        deferred handle until the enclosing function returns). Default ``None``.
+        deferred handle until the enclosing function returns), C# ``lock(x){}``
+        / Java ``synchronized`` blocks (``lock_in_loop``), constructor nodes the
+        language does not route through ``call_kinds`` (TS ``new PrismaClient``
+        / C# ``new HttpClient`` -> ``resource_construction_in_loop``), and the
+        Python ``x in big_list`` comparison form of
+        ``membership_test_against_list_in_loop`` (gated on ``list_names``).
+        Default ``None``.
         """
         return None
+
+    def list_bound_names(self, root: Node) -> frozenset[str]:
+        """Names provably bound to a *list* in this file (literal / comprehension
+        / ``list(...)`` / ``sorted(...)``).
+
+        The precision gate for ``membership_test_against_list_in_loop``: an
+        ``x in name`` test is O(n) per probe only when ``name`` is a list — a set
+        or dict membership test is O(1) and must not fire. Precision-first: only
+        bindings whose RHS is *provably* a list count, so an opaque
+        ``name = build()`` never enables the marker. Default: empty (the marker
+        cannot fire for a language that does not override this).
+        """
+        return frozenset()
 
     def async_blocking_member(self, node: Node) -> str | None:
         """The offending name if *node* is a non-call member read that blocks

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/csharp.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/csharp.py
@@ -160,9 +160,26 @@ FILE_METHODS: frozenset[str] = frozenset(
 )
 
 
+# Heavy clients/connections to hoist out of a ``foreach``. Built via ``new X()``
+# (an ``object_creation_expression``, which C# does NOT route through
+# ``call_kinds``, so it reaches ``loop_stmt_marker``).
+CSHARP_RESOURCE_CTORS: frozenset[str] = frozenset(
+    {"HttpClient", "SqlConnection", "NpgsqlConnection", "MongoClient", "SqlConnectionStringBuilder"}
+)
+
+
 class CSharpPerfDialect(BasePerfDialect):
     language = "csharp"
-    markers = frozenset({"io_in_loop", "string_concat_in_loop", "blocking_sync_in_async"})
+    markers = frozenset(
+        {
+            "io_in_loop",
+            "string_concat_in_loop",
+            "blocking_sync_in_async",
+            "resource_construction_in_loop",
+            "lock_in_loop",
+            "serial_await_in_loop",
+        }
+    )
 
     # ``invocation_expression`` -> ``member_access_expression`` is the call
     # shape; add it so a member call reads as attribute-style.
@@ -232,6 +249,30 @@ class CSharpPerfDialect(BasePerfDialect):
         nm = node.child_by_field_name("name")
         if nm is not None and nm.text and nm.text.decode("utf-8", "replace") == "Result":
             return ".Result"
+        return None
+
+    def loop_call_marker(
+        self, root: str, method: str, node: Node, list_names: frozenset[str]
+    ) -> str | None:
+        # ``Monitor.Enter(lock)`` — the call form of lock acquisition (the
+        # ``lock(x){}`` statement form is handled in ``loop_stmt_marker``).
+        if root == "Monitor" and method == "Enter":
+            return "lock_in_loop"
+        return None
+
+    def loop_stmt_marker(self, node: Node, list_names: frozenset[str]) -> str | None:
+        # ``new HttpClient()`` per iteration — the canonical C# socket-exhaustion
+        # bug — is an ``object_creation_expression`` (not an invocation).
+        if node.type == "object_creation_expression":
+            t = node.child_by_field_name("type")
+            if t is not None and t.text:
+                name = t.text.decode("utf-8", "replace").split(".")[-1]
+                if name in CSHARP_RESOURCE_CTORS:
+                    return "resource_construction_in_loop"
+            return None
+        # ``lock (gate) { ... }`` taken every iteration is a contention site.
+        if node.type == "lock_statement":
+            return "lock_in_loop"
         return None
 
 

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/go.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/go.py
@@ -79,11 +79,34 @@ GO_REGEX_COMPILE: frozenset[str] = frozenset(
 )
 _GO_STRING_KINDS: frozenset[str] = frozenset({"interpreted_string_literal", "raw_string_literal"})
 
+# Heavy connection / client constructors, keyed ``(package, func)``. Opening one
+# per ``for ... range`` iteration is the connection-churn anti-pattern.
+GO_RESOURCE_CTORS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("sql", "Open"),
+        ("sqlx", "Open"),
+        ("sqlx", "Connect"),
+        ("pgx", "Connect"),
+        ("pgxpool", "New"),
+        ("redis", "NewClient"),
+        ("mongo", "Connect"),
+    }
+)
+# ``sync.Mutex`` / ``sync.RWMutex`` acquisition (the contention side only).
+GO_LOCK_METHODS: frozenset[str] = frozenset({"Lock", "RLock"})
+
 
 class GoPerfDialect(BasePerfDialect):
     language = "go"
     markers = frozenset(
-        {"io_in_loop", "string_concat_in_loop", "defer_in_loop", "regex_compile_in_loop"}
+        {
+            "io_in_loop",
+            "string_concat_in_loop",
+            "defer_in_loop",
+            "regex_compile_in_loop",
+            "resource_construction_in_loop",
+            "lock_in_loop",
+        }
     )
 
     def sink_kind(
@@ -152,12 +175,20 @@ class GoPerfDialect(BasePerfDialect):
         targets = right.named_children if right.type == "expression_list" else [right]
         return any(c.type in _GO_STRING_KINDS for c in targets)
 
-    def loop_call_marker(self, root: str, method: str, node: Node) -> str | None:
+    def loop_call_marker(
+        self, root: str, method: str, node: Node, list_names: frozenset[str]
+    ) -> str | None:
         if root == "regexp" and method in GO_REGEX_COMPILE:
             return "regex_compile_in_loop"
+        if (root, method) in GO_RESOURCE_CTORS:
+            return "resource_construction_in_loop"
+        # ``mu.Lock()`` / ``mu.RLock()`` — a method on a receiver (the package-
+        # level ``sync.Lock`` does not exist, so the attribute gate is a guard).
+        if method in GO_LOCK_METHODS and self.callee_is_attribute(node):
+            return "lock_in_loop"
         return None
 
-    def loop_stmt_marker(self, node: Node) -> str | None:
+    def loop_stmt_marker(self, node: Node, list_names: frozenset[str]) -> str | None:
         if node.type == "defer_statement":
             return "defer_in_loop"
         return None

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/java.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/java.py
@@ -85,10 +85,31 @@ NET_CONSTRUCTORS: frozenset[str] = frozenset({"Socket", "ServerSocket"})
 # ``delete`` do not over-fire in a db-importing file.
 AMBIGUOUS_DB: frozenset[str] = frozenset({"find", "get", "execute", "save", "count"})
 
+# Heavy clients to hoist, not ``new`` each iteration. A ``new RestTemplate()``
+# arrives as an ``object_creation_expression`` whose extracted "method" is the
+# constructed type name (see ``callee_method_name``); ``getConnection`` is the
+# DataSource / DriverManager connection-acquisition verb. Deliberately limited
+# to framework-distinctive type names: a bare ``HttpClient`` is excluded because
+# it collides with user-defined wrappers and Apache's ``HttpClient`` *interface*
+# (resolved by last segment only, with no import gate) — a precision risk that
+# outweighs the recall.
+JAVA_RESOURCE_CTORS: frozenset[str] = frozenset({"RestTemplate", "OkHttpClient"})
+JAVA_RESOURCE_METHODS: frozenset[str] = frozenset({"getConnection"})
+# ``java.util.concurrent.locks.Lock`` acquisition (the contention side only).
+JAVA_LOCK_METHODS: frozenset[str] = frozenset({"lock", "lockInterruptibly"})
+
 
 class JavaPerfDialect(BasePerfDialect):
     language = "java"
-    markers = frozenset({"io_in_loop", "string_concat_in_loop", "regex_compile_in_loop"})
+    markers = frozenset(
+        {
+            "io_in_loop",
+            "string_concat_in_loop",
+            "regex_compile_in_loop",
+            "resource_construction_in_loop",
+            "lock_in_loop",
+        }
+    )
 
     # ``s += "x"`` is an ``assignment_expression`` with the literal directly on
     # the ``right`` field (no list wrapper, unlike Go).
@@ -168,7 +189,18 @@ class JavaPerfDialect(BasePerfDialect):
             return "db"
         return None
 
-    def loop_call_marker(self, root: str, method: str, node: Node) -> str | None:
+    def loop_call_marker(
+        self, root: str, method: str, node: Node, list_names: frozenset[str]
+    ) -> str | None:
+        # ``new RestTemplate()`` etc. — an ``object_creation_expression`` whose
+        # extracted method is the type name.
+        if node.type == "object_creation_expression":
+            return "resource_construction_in_loop" if method in JAVA_RESOURCE_CTORS else None
+        if method in JAVA_RESOURCE_METHODS:
+            return "resource_construction_in_loop"
+        # ``lock.lock()`` — a method on a receiver (not a bare ``lock()``).
+        if method in JAVA_LOCK_METHODS and node.child_by_field_name("object") is not None:
+            return "lock_in_loop"
         # ``Pattern.compile(...)`` recompiled per iteration (no cached Pattern).
         # ``root`` is the first segment, so an FQN ``java.util.regex.Pattern``
         # lands as ``java``; match on the receiver's last segment instead.
@@ -182,6 +214,13 @@ class JavaPerfDialect(BasePerfDialect):
                 else None
             )
         return "regex_compile_in_loop" if root == "Pattern" else None
+
+    def loop_stmt_marker(self, node: Node, list_names: frozenset[str]) -> str | None:
+        # ``synchronized (x) { ... }`` taken every iteration is a contention
+        # site, the block-statement counterpart of ``lock.lock()``.
+        if node.type == "synchronized_statement":
+            return "lock_in_loop"
+        return None
 
 
 DIALECT = JavaPerfDialect()

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/python.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/python.py
@@ -46,10 +46,66 @@ PY_SUBPROC_METHODS: frozenset[str] = frozenset(
 _PY_STRING_KINDS: frozenset[str] = frozenset({"string", "concatenated_string"})
 _PY_AUG_ASSIGN_KINDS: frozenset[str] = frozenset({"augmented_assignment"})
 
+# Heavy-resource constructors: building one of these per loop iteration opens a
+# fresh connection / client / pool instead of reusing a hoisted one. Keyed as
+# ``(root, method)`` pairs whose root is a distinctive I/O library (so the match
+# is unambiguous without import resolution) ...
+_PY_RESOURCE_CTORS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("sqlite3", "connect"),
+        ("psycopg", "connect"),
+        ("psycopg2", "connect"),
+        ("pymysql", "connect"),
+        ("MySQLdb", "connect"),
+        ("aiosqlite", "connect"),
+        ("httpx", "Client"),
+        ("httpx", "AsyncClient"),
+        ("requests", "Session"),
+        ("aiohttp", "ClientSession"),
+        ("boto3", "client"),
+        ("boto3", "resource"),
+        ("redis", "Redis"),
+        ("redis", "StrictRedis"),
+        ("pymongo", "MongoClient"),
+    }
+)
+# ... plus a few constructors distinctive enough on their own (the rightmost
+# name), so an aliased ``from sqlalchemy import create_engine`` still resolves.
+_PY_RESOURCE_METHODS: frozenset[str] = frozenset({"create_engine", "MongoClient"})
+
+# Lock acquisition (the contention side only — never ``release``, which would
+# double-count the same critical section). ``.acquire()`` is the threading /
+# asyncio / multiprocessing / filelock primitive verb.
+_PY_LOCK_METHODS: frozenset[str] = frozenset({"acquire"})
+
+# RHS node kinds that prove a name is bound to a list (the membership gate).
+_PY_LIST_RHS_KINDS: frozenset[str] = frozenset({"list", "list_comprehension"})
+# Builtins whose call result is provably a list.
+_PY_LIST_BUILTINS: frozenset[str] = frozenset({"list", "sorted"})
+# RHS shapes that make a name a NON-list container (a set/dict literal or
+# comprehension, or a ``set()`` / ``dict()`` / ``frozenset()`` call). A name
+# bound to one of these ANYWHERE in the file is ambiguous and excluded from the
+# membership gate, even if another scope binds the same name to a list — the
+# ``seen = []`` in one function / ``seen: set = set()`` in another collision.
+_PY_NONLIST_RHS_KINDS: frozenset[str] = frozenset(
+    {"set", "dictionary", "set_comprehension", "dictionary_comprehension"}
+)
+_PY_NONLIST_BUILTINS: frozenset[str] = frozenset({"set", "dict", "frozenset"})
+
 
 class PythonPerfDialect(BasePerfDialect):
     language = "python"
-    markers = frozenset({"io_in_loop", "string_concat_in_loop", "blocking_sync_in_async"})
+    markers = frozenset(
+        {
+            "io_in_loop",
+            "string_concat_in_loop",
+            "blocking_sync_in_async",
+            "resource_construction_in_loop",
+            "lock_in_loop",
+            "serial_await_in_loop",
+            "membership_test_against_list_in_loop",
+        }
+    )
 
     string_literal_kinds = _PY_STRING_KINDS
     aug_assign_kinds = _PY_AUG_ASSIGN_KINDS
@@ -148,6 +204,91 @@ class PythonPerfDialect(BasePerfDialect):
         if root == "open" and method == "open":
             return "open"
         return None
+
+    def loop_call_marker(
+        self, root: str, method: str, node: Node, list_names: frozenset[str]
+    ) -> str | None:
+        if (root, method) in _PY_RESOURCE_CTORS or method in _PY_RESOURCE_METHODS:
+            return "resource_construction_in_loop"
+        # ``lock.acquire()`` — a method call on a receiver (never the builtin
+        # ``acquire(...)``, which does not exist; the attribute gate is a cheap
+        # extra guard against a bare-name collision).
+        if method in _PY_LOCK_METHODS and self.callee_is_attribute(node):
+            return "lock_in_loop"
+        return None
+
+    def loop_stmt_marker(self, node: Node, list_names: frozenset[str]) -> str | None:
+        # ``x in big_list`` / ``x not in big_list`` where ``big_list`` is a
+        # known list -> O(n) per probe. A set/dict membership test is O(1) and
+        # must not fire, hence the ``list_names`` gate.
+        if not list_names or node.type != "comparison_operator":
+            return None
+        # ``x in y`` is an ``in`` operator token; ``x not in y`` is a single
+        # ``not in`` token. Either way it is an O(n) membership probe on a list.
+        if not any(c.type in ("in", "not in") for c in node.children):
+            return None
+        named = [c for c in node.children if c.is_named]
+        if len(named) < 2:
+            return None
+        right = named[-1]
+        if right.type != "identifier" or right.text is None:
+            return None
+        name = right.text.decode("utf-8", "replace")
+        return "membership_test_against_list_in_loop" if name in list_names else None
+
+    def list_bound_names(self, root: Node) -> frozenset[str]:
+        """Names assigned a provable list anywhere in the file, minus any name
+        also bound to a non-list container.
+
+        Covers ``name = [...]`` / ``name = [x for x in ...]`` / ``name =
+        list(...)`` / ``name = sorted(...)``. Conservative on purpose: an opaque
+        ``name = build()`` is not counted, and a name bound to a set/dict in any
+        scope of the file is dropped (the ``seen``-as-list-here /
+        ``seen``-as-set-there collision), so the membership marker only fires
+        against a name we can prove is always a list.
+        """
+        list_names: set[str] = set()
+        exclude: set[str] = set()
+        stack: list[Node] = [root]
+        while stack:
+            n = stack.pop()
+            if n.type == "assignment":
+                left = n.child_by_field_name("left")
+                right = n.child_by_field_name("right")
+                if (
+                    left is not None
+                    and left.type == "identifier"
+                    and left.text is not None
+                    and right is not None
+                ):
+                    name = left.text.decode("utf-8", "replace")
+                    if self._rhs_is_list(right):
+                        list_names.add(name)
+                    elif self._rhs_is_nonlist_container(right):
+                        exclude.add(name)
+            for c in n.children:
+                stack.append(c)
+        return frozenset(list_names - exclude)
+
+    @staticmethod
+    def _rhs_is_list(right: Node) -> bool:
+        if right.type in _PY_LIST_RHS_KINDS:
+            return True
+        if right.type == "call":
+            fn = right.child_by_field_name("function")
+            if fn is not None and fn.type == "identifier" and fn.text is not None:
+                return fn.text.decode("utf-8", "replace") in _PY_LIST_BUILTINS
+        return False
+
+    @staticmethod
+    def _rhs_is_nonlist_container(right: Node) -> bool:
+        if right.type in _PY_NONLIST_RHS_KINDS:
+            return True
+        if right.type == "call":
+            fn = right.child_by_field_name("function")
+            if fn is not None and fn.type == "identifier" and fn.text is not None:
+                return fn.text.decode("utf-8", "replace") in _PY_NONLIST_BUILTINS
+        return False
 
 
 DIALECT = PythonPerfDialect()

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
@@ -8,8 +8,13 @@ and the TS branches of the walker (``_has_async_modifier`` and the
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .base import BasePerfDialect
 from .python import HTTP_VERBS
+
+if TYPE_CHECKING:
+    from tree_sitter import Node
 
 # TypeScript / JavaScript. Only DISTINCTIVE method names are trusted without
 # import resolution: bare create/update/delete/count/exec collide hard with
@@ -62,10 +67,32 @@ TS_SINK_METHODS: frozenset[str] = (
 _TS_STRING_KINDS: frozenset[str] = frozenset({"string", "template_string"})
 _TS_AUG_ASSIGN_KINDS: frozenset[str] = frozenset({"augmented_assignment_expression"})
 
+# Heavy client/connection classes that should be hoisted, not re-``new``-ed each
+# iteration. Distinctive names only (``Client`` / ``Pool`` collide with worker
+# pools and unrelated SDKs, so they are deliberately excluded for precision).
+_TS_RESOURCE_CTORS: frozenset[str] = frozenset(
+    {
+        "PrismaClient",
+        "MongoClient",
+        "Sequelize",
+        "DataSource",
+        "Redis",
+        "IORedis",
+    }
+)
+
 
 class TsJsPerfDialect(BasePerfDialect):
     language = "typescript"
-    markers = frozenset({"io_in_loop", "string_concat_in_loop"})
+    markers = frozenset(
+        {
+            "io_in_loop",
+            "string_concat_in_loop",
+            "resource_construction_in_loop",
+            "serial_await_in_loop",
+            "membership_test_against_list_in_loop",
+        }
+    )
 
     string_literal_kinds = _TS_STRING_KINDS
     aug_assign_kinds = _TS_AUG_ASSIGN_KINDS
@@ -97,6 +124,51 @@ class TsJsPerfDialect(BasePerfDialect):
         if method in TS_FS_METHODS:  # distinctive sync-fs verbs
             return "filesystem"
         return None
+
+    def loop_call_marker(
+        self, root: str, method: str, node: Node, list_names: frozenset[str]
+    ) -> str | None:
+        # ``arr.includes(x)`` where ``arr`` is a known array -> O(n) membership.
+        if method == "includes" and root in list_names:
+            return "membership_test_against_list_in_loop"
+        return None
+
+    def loop_stmt_marker(self, node: Node, list_names: frozenset[str]) -> str | None:
+        # ``new PrismaClient(...)`` etc. is a ``new_expression`` (not a
+        # ``call_expression``), so it arrives here rather than via the call path.
+        if node.type != "new_expression":
+            return None
+        ctor = self._constructor_name(node)
+        return "resource_construction_in_loop" if ctor in _TS_RESOURCE_CTORS else None
+
+    @staticmethod
+    def _constructor_name(node: Node) -> str | None:
+        """Rightmost identifier of a ``new X()`` / ``new pkg.X()`` constructor."""
+        ctor = node.child_by_field_name("constructor")
+        if ctor is None or ctor.text is None:
+            return None
+        return ctor.text.decode("utf-8", "replace").split(".")[-1]
+
+    def list_bound_names(self, root: Node) -> frozenset[str]:
+        """Names bound to an array literal (``const arr = [...]``)."""
+        names: set[str] = set()
+        stack: list[Node] = [root]
+        while stack:
+            n = stack.pop()
+            if n.type == "variable_declarator":
+                name = n.child_by_field_name("name")
+                value = n.child_by_field_name("value")
+                if (
+                    name is not None
+                    and name.type == "identifier"
+                    and name.text is not None
+                    and value is not None
+                    and value.type == "array"
+                ):
+                    names.add(name.text.decode("utf-8", "replace"))
+            for c in n.children:
+                stack.append(c)
+        return frozenset(names)
 
 
 DIALECT = TsJsPerfDialect()

--- a/packages/core/src/repowise/core/analysis/health/scoring.py
+++ b/packages/core/src/repowise/core/analysis/health/scoring.py
@@ -212,6 +212,11 @@ _BIOMARKER_DIMENSIONS: dict[str, set[str]] = {
     "io_in_loop": {"performance"},
     "string_concat_in_loop": {"performance"},
     "blocking_sync_in_async": {"performance"},
+    # Phase 7a loop markers - performance-only, same as the originals.
+    "resource_construction_in_loop": {"performance"},
+    "lock_in_loop": {"performance"},
+    "serial_await_in_loop": {"performance"},
+    "membership_test_against_list_in_loop": {"performance"},
 }
 
 # Maintainability per-biomarker weight multipliers. Expert-set by definition -
@@ -279,6 +284,14 @@ _PERFORMANCE_WEIGHT_MULTIPLIER: dict[str, float] = {
     "io_in_loop": 1.0,
     "blocking_sync_in_async": 0.7,
     "string_concat_in_loop": 0.5,
+    # Phase 7a markers. Ship at advisory weight pending each one's Phase-0 gate
+    # (MARKER_BACKLOG.md); promote to full weight where corpus precision >= 70%.
+    # resource_construction is the highest-confidence (classified constructor),
+    # serial_await the lowest (cannot prove iteration independence).
+    "resource_construction_in_loop": 0.7,
+    "lock_in_loop": 0.5,
+    "membership_test_against_list_in_loop": 0.5,
+    "serial_await_in_loop": 0.4,
 }
 
 # All perf biomarkers share one ``performance`` category, so the single cap
@@ -287,6 +300,10 @@ _PERFORMANCE_CATEGORY: dict[str, str] = {
     "io_in_loop": "performance",
     "string_concat_in_loop": "performance",
     "blocking_sync_in_async": "performance",
+    "resource_construction_in_loop": "performance",
+    "lock_in_loop": "performance",
+    "serial_await_in_loop": "performance",
+    "membership_test_against_list_in_loop": "performance",
 }
 
 # One bounded performance category cap. ~1.0 keeps performance advisory.
@@ -296,7 +313,15 @@ _PERFORMANCE_CATEGORY_CAPS: dict[str, float] = {
 
 # Perf biomarkers home to ``performance`` for display / per-pillar filtering.
 _PERFORMANCE_HOME: frozenset[str] = frozenset(
-    {"io_in_loop", "string_concat_in_loop", "blocking_sync_in_async"}
+    {
+        "io_in_loop",
+        "string_concat_in_loop",
+        "blocking_sync_in_async",
+        "resource_construction_in_loop",
+        "lock_in_loop",
+        "serial_await_in_loop",
+        "membership_test_against_list_in_loop",
+    }
 )
 
 

--- a/packages/ui/src/health/biomarker-glossary.ts
+++ b/packages/ui/src/health/biomarker-glossary.ts
@@ -244,6 +244,30 @@ export const BIOMARKER_GLOSSARY: Record<string, BiomarkerInfo> = {
     description:
       "A synchronous blocking call (time.sleep, requests.get, subprocess.run) inside an async function blocks the whole event loop, stalling every other coroutine. Mirrors ruff's ASYNC210/230/251.",
   },
+  resource_construction_in_loop: {
+    label: "Resource built in loop",
+    category: "performance",
+    description:
+      "A heavy I/O client or connection (sqlite3.connect, httpx.Client, boto3.client, new PrismaClient, sql.Open) constructed every loop iteration instead of once. Opens a fresh connection/pool per iteration — connection churn and, for HttpClient, socket exhaustion. Hoist and reuse a single instance.",
+  },
+  lock_in_loop: {
+    label: "Lock in loop",
+    category: "performance",
+    description:
+      "A mutex or lock acquired on every loop iteration (lock.acquire, mu.Lock, synchronized, lock(x){}). Serializes the loop body and concentrates contention. Hoist the lock outside the loop or batch the critical section.",
+  },
+  serial_await_in_loop: {
+    label: "Serial await in loop",
+    category: "performance",
+    description:
+      "An awaited I/O round-trip run one-at-a-time inside a loop. When the iterations are independent, fan them out with gather / Promise.all / Task.WhenAll for concurrent execution. Advisory — a static analyzer cannot prove the iterations are independent.",
+  },
+  membership_test_against_list_in_loop: {
+    label: "List membership in loop",
+    category: "performance",
+    description:
+      "Testing `x in big_list` (or big_list.includes(x)) inside a loop is O(n·m); a set makes each lookup O(1), turning the loop linear. Only fires when the right operand is provably a list, never a set or dict.",
+  },
 };
 
 export function biomarkerInfo(name: string): BiomarkerInfo {
@@ -296,6 +320,10 @@ export const PERFORMANCE_HOME_BIOMARKERS: ReadonlySet<string> = new Set([
   "io_in_loop",
   "string_concat_in_loop",
   "blocking_sync_in_async",
+  "resource_construction_in_loop",
+  "lock_in_loop",
+  "serial_await_in_loop",
+  "membership_test_against_list_in_loop",
 ]);
 
 /**

--- a/tests/unit/health/test_perf_dialects.py
+++ b/tests/unit/health/test_perf_dialects.py
@@ -183,7 +183,8 @@ _CSHARP_CASES = [
         "class A{ async System.Threading.Tasks.Task M("
         "System.Collections.Generic.List<int> ids){"
         "foreach(var id in ids){ await ctx.Set().FirstOrDefaultAsync(); }}}",
-        [("io_in_loop", "db")],
+        # Awaited EF query in a loop: io_in_loop + the serial_await co-signal.
+        [("io_in_loop", "db"), ("serial_await_in_loop", "db")],
         "EF *Async family is unambiguous db (no import gate)",
     ),
 ]

--- a/tests/unit/health/test_perf_io_in_loop.py
+++ b/tests/unit/health/test_perf_io_in_loop.py
@@ -138,8 +138,10 @@ _CASES = [
     (
         "typescript",
         b"async function f(urls) {\n  for (const u of urls) {\n    await fetch(u);\n  }\n}\n",
-        [("io_in_loop", "network")],
-        "fetch in a loop",
+        # An awaited sink in a loop is BOTH an N+1 (io_in_loop) and a missed-
+        # concurrency candidate (serial_await_in_loop, advisory co-signal).
+        [("io_in_loop", "network"), ("serial_await_in_loop", "network")],
+        "fetch in a loop (awaited -> also serial_await)",
     ),
     (
         "typescript",

--- a/tests/unit/health/test_perf_phase7a.py
+++ b/tests/unit/health/test_perf_phase7a.py
@@ -1,0 +1,313 @@
+"""Unit tests for the Phase-7a perf markers.
+
+The four cheap, high-precision loop markers added on top of the ``PerfDialect``
+registry: ``resource_construction_in_loop`` (all dialects),
+``lock_in_loop`` (Py/Java/Go/C#), ``serial_await_in_loop`` (Py/TS/JS/C#), and
+``membership_test_against_list_in_loop`` (Py/TS/JS). Each case exercises the
+positive shape AND the precision gate that keeps it from over-firing.
+
+Grammar availability is best-effort: a missing tree-sitter grammar degrades to
+"no perf hits" (the registry guarantee), which these exact-match assertions
+would surface as an empty list rather than a wrong kind.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.analysis.health.biomarkers.base import FileContext
+from repowise.core.analysis.health.biomarkers.lock_in_loop import LockInLoopDetector
+from repowise.core.analysis.health.biomarkers.membership_test_against_list_in_loop import (
+    MembershipTestAgainstListInLoopDetector,
+)
+from repowise.core.analysis.health.biomarkers.registry import detect_all
+from repowise.core.analysis.health.biomarkers.resource_construction_in_loop import (
+    ResourceConstructionInLoopDetector,
+)
+from repowise.core.analysis.health.biomarkers.serial_await_in_loop import (
+    SerialAwaitInLoopDetector,
+)
+from repowise.core.analysis.health.complexity import PerfHit, walk_file
+from repowise.core.analysis.health.scoring import dimensions_for, score_file
+
+
+def _hits(lang: str, src: str):
+    fc = walk_file(f"t.{lang}", lang, src.encode())
+    return sorted((h.kind, h.detail) for h in fc.perf_hits)
+
+
+# ---------------------------------------------------------------------------
+# resource_construction_in_loop — all dialects
+# ---------------------------------------------------------------------------
+
+_RESOURCE_CASES = [
+    (
+        "python",
+        "import sqlite3\ndef f(paths):\n    for p in paths:\n        c = sqlite3.connect(p)\n",
+        [("resource_construction_in_loop", "")],
+        "sqlite3.connect per iteration",
+    ),
+    (
+        "python",
+        "import boto3\ndef f(rs):\n    for r in rs:\n        c = boto3.client('s3')\n",
+        [("resource_construction_in_loop", "")],
+        "boto3.client per iteration",
+    ),
+    (
+        "python",
+        "from sqlalchemy import create_engine\n"
+        "def f(urls):\n    for u in urls:\n        e = create_engine(u)\n",
+        [("resource_construction_in_loop", "")],
+        "create_engine resolved by distinctive name",
+    ),
+    (
+        "python",
+        "import sqlite3\ndef f(paths):\n    c = sqlite3.connect(':memory:')\n"
+        "    for p in paths:\n        use(c, p)\n",
+        [],
+        "a hoisted connection (outside the loop) does not fire",
+    ),
+    (
+        "typescript",
+        "function f(items){ for (const x of items){ const c = new PrismaClient(); } }",
+        [("resource_construction_in_loop", "")],
+        "new PrismaClient per iteration",
+    ),
+    (
+        "typescript",
+        "function f(items){ for (const x of items){ const w = new Worker(); } }",
+        [],
+        "a non-resource constructor (Worker) does not fire",
+    ),
+    (
+        "go",
+        'package m\nimport "database/sql"\n'
+        'func f(dsns []string){ for _, d := range dsns { db, _ := sql.Open("pg", d); _ = db } }',
+        [("resource_construction_in_loop", "")],
+        "sql.Open per range iteration",
+    ),
+    (
+        "java",
+        "class A{ void m(java.util.List<String> ids){"
+        "for(String id:ids){ RestTemplate r = new RestTemplate(); } } }",
+        [("resource_construction_in_loop", "")],
+        "new RestTemplate per iteration",
+    ),
+    (
+        "csharp",
+        "class A{ void M(System.Collections.Generic.List<int> ids){"
+        "foreach(var id in ids){ var c = new HttpClient(); } } }",
+        [("resource_construction_in_loop", "")],
+        "new HttpClient per iteration (socket exhaustion)",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "lang,src,expected,note", _RESOURCE_CASES, ids=[c[3] for c in _RESOURCE_CASES]
+)
+def test_resource_construction_cases(lang, src, expected, note):
+    assert _hits(lang, src) == sorted(expected), note
+
+
+# ---------------------------------------------------------------------------
+# lock_in_loop — Py/Java/Go/C# (activates the dormant ``lock`` boundary kind)
+# ---------------------------------------------------------------------------
+
+_LOCK_CASES = [
+    (
+        "python",
+        "def f(items, lock):\n    for x in items:\n        lock.acquire()\n        use(x)\n",
+        [("lock_in_loop", "")],
+        "lock.acquire per iteration",
+    ),
+    (
+        "python",
+        "def f(items, lock):\n    for x in items:\n        lock.release()\n",
+        [],
+        "release does not fire (only the acquire side, no double count)",
+    ),
+    (
+        "go",
+        "package m\nfunc f(items []int, mu *M){ for _, x := range items { mu.Lock(); use(x) } }",
+        [("lock_in_loop", "")],
+        "mu.Lock per range iteration",
+    ),
+    (
+        "java",
+        "class A{ void m(java.util.List<String> ids, java.util.concurrent.locks.Lock lk){"
+        "for(String id:ids){ lk.lock(); } } }",
+        [("lock_in_loop", "")],
+        "lk.lock() per iteration",
+    ),
+    (
+        "java",
+        "class A{ void m(java.util.List<String> ids, Object gate){"
+        "for(String id:ids){ synchronized(gate){ use(id); } } } }",
+        [("lock_in_loop", "")],
+        "synchronized block per iteration",
+    ),
+    (
+        "csharp",
+        "class A{ void M(System.Collections.Generic.List<int> ids, object gate){"
+        "foreach(var id in ids){ lock(gate){ Use(id); } } } }",
+        [("lock_in_loop", "")],
+        "lock(gate){} per iteration",
+    ),
+]
+
+
+@pytest.mark.parametrize("lang,src,expected,note", _LOCK_CASES, ids=[c[3] for c in _LOCK_CASES])
+def test_lock_cases(lang, src, expected, note):
+    assert _hits(lang, src) == sorted(expected), note
+
+
+# ---------------------------------------------------------------------------
+# serial_await_in_loop — Py/TS/JS/C# (rides alongside io_in_loop)
+# ---------------------------------------------------------------------------
+
+_SERIAL_AWAIT_CASES = [
+    (
+        "python",
+        "import httpx\nasync def f(urls):\n    for u in urls:\n        await httpx.get(u)\n",
+        [("io_in_loop", "network"), ("serial_await_in_loop", "network")],
+        "awaited httpx.get in a loop -> io_in_loop + serial_await",
+    ),
+    (
+        "typescript",
+        "async function f(urls){ for (const u of urls){ await fetch(u); } }",
+        [("io_in_loop", "network"), ("serial_await_in_loop", "network")],
+        "awaited fetch in a loop",
+    ),
+    (
+        "python",
+        "import subprocess\ndef f(paths):\n    for p in paths:\n        subprocess.run(['ls'], cwd=p)\n",
+        [("io_in_loop", "subprocess")],
+        "a NON-awaited sink does not get the serial_await co-signal",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "lang,src,expected,note", _SERIAL_AWAIT_CASES, ids=[c[3] for c in _SERIAL_AWAIT_CASES]
+)
+def test_serial_await_cases(lang, src, expected, note):
+    assert _hits(lang, src) == sorted(expected), note
+
+
+# ---------------------------------------------------------------------------
+# membership_test_against_list_in_loop — Py/TS/JS (gated on a list-bound name)
+# ---------------------------------------------------------------------------
+
+_MEMBERSHIP_CASES = [
+    (
+        "python",
+        "def f(items):\n    big = [1, 2, 3]\n    for x in items:\n        if x in big:\n            use(x)\n",
+        [("membership_test_against_list_in_loop", "")],
+        "x in <list literal> in a loop",
+    ),
+    (
+        "python",
+        "def f(items):\n    big = [i for i in range(9)]\n    for x in items:\n        y = x not in big\n",
+        [("membership_test_against_list_in_loop", "")],
+        "x not in <list comprehension> also fires",
+    ),
+    (
+        "python",
+        "def f(items):\n    big = set()\n    for x in items:\n        if x in big:\n            use(x)\n",
+        [],
+        "membership against a set is O(1) -> not flagged",
+    ),
+    (
+        "python",
+        "def f(items, big):\n    for x in items:\n        if x in big:\n            use(x)\n",
+        [],
+        "an opaque (unproven) name is not flagged",
+    ),
+    (
+        "python",
+        # ``seen`` is a list in g() but a set in f(); the file-level gate must
+        # treat the collided name as ambiguous and NOT fire (real-corpus FP).
+        "def g(xs):\n    seen = []\n    for x in xs:\n        seen.append(x)\n"
+        "def f(items):\n    seen = set()\n    for x in items:\n        if x in seen:\n            use(x)\n",
+        [],
+        "a name bound to a set in any scope is excluded (list/set collision)",
+    ),
+    (
+        "typescript",
+        "function f(items){ const big = [1,2,3]; "
+        "for (const x of items){ if (big.includes(x)) use(x); } }",
+        [("membership_test_against_list_in_loop", "")],
+        "big.includes(x) where big is an array literal",
+    ),
+    (
+        "typescript",
+        "function f(items){ const big = new Set(); "
+        "for (const x of items){ if (big.includes(x)) use(x); } }",
+        [],
+        "includes on a non-array-bound name is not flagged",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "lang,src,expected,note", _MEMBERSHIP_CASES, ids=[c[3] for c in _MEMBERSHIP_CASES]
+)
+def test_membership_cases(lang, src, expected, note):
+    assert _hits(lang, src) == sorted(expected), note
+
+
+# ---------------------------------------------------------------------------
+# Biomarkers lift hits; scoring keeps them performance-only
+# ---------------------------------------------------------------------------
+
+_NEW_KINDS = [
+    "resource_construction_in_loop",
+    "lock_in_loop",
+    "serial_await_in_loop",
+    "membership_test_against_list_in_loop",
+]
+
+
+def _ctx(perf_hits: list[PerfHit]) -> FileContext:
+    return FileContext(
+        file_path="x.py",
+        language="python",
+        nloc=10,
+        has_test_file=False,
+        module="x",
+        perf_hits=perf_hits,
+    )
+
+
+@pytest.mark.parametrize("kind", _NEW_KINDS)
+def test_each_marker_is_performance_only(kind):
+    """Every Phase-7a marker maps to performance ONLY (defect golden intact)."""
+    assert dimensions_for(kind) == {"performance"}
+
+
+def test_detectors_only_consume_their_own_kind():
+    ctx = _ctx(
+        [
+            PerfHit("resource_construction_in_loop", 1, "f", ""),
+            PerfHit("lock_in_loop", 2, "f", ""),
+            PerfHit("serial_await_in_loop", 3, "f", "network"),
+            PerfHit("membership_test_against_list_in_loop", 4, "f", ""),
+        ]
+    )
+    assert len(ResourceConstructionInLoopDetector().detect(ctx)) == 1
+    assert len(LockInLoopDetector().detect(ctx)) == 1
+    assert len(SerialAwaitInLoopDetector().detect(ctx)) == 1
+    assert len(MembershipTestAgainstListInLoopDetector().detect(ctx)) == 1
+
+
+def test_new_markers_score_performance_not_defect():
+    ctx = _ctx([PerfHit(k, i + 1, "f", "") for i, k in enumerate(_NEW_KINDS)])
+    results = detect_all(ctx)
+    got = {r.biomarker_type for r in results}
+    assert set(_NEW_KINDS) <= got
+    scores, deductions = score_file(results)
+    assert scores["defect"] == 10.0
+    assert scores["maintainability"] == 10.0
+    assert scores["performance"] < 10.0
+    assert all(d == 0.0 for d in deductions)


### PR DESCRIPTION
## What

Adds four static performance-risk detectors to the per-language code-health walker. Each is a loop-scoped marker that contributes only to the bounded **performance** dimension; the surfaced defect score is unchanged (locked by the dimension golden test).

| Marker | Catches | Languages |
|--------|---------|-----------|
| `resource_construction_in_loop` | A heavy client/connection constructed every iteration (`sqlite3.connect`, `httpx.Client`, `boto3.client`, `new PrismaClient`, `new HttpClient`, `sql.Open`) instead of hoisted | Python, TS/JS, Java, Go, C# |
| `lock_in_loop` | A lock acquired every iteration (`lock.acquire`, `mu.Lock`, `synchronized`, `lock(x){}`, `Monitor.Enter`); activates the `lock` I/O-boundary kind | Python, Java, Go, C# |
| `serial_await_in_loop` | An awaited I/O sink run serially in a loop where a `gather` / `Promise.all` could fan it out (advisory) | Python, TS/JS, C# |
| `membership_test_against_list_in_loop` | `x in big_list` / `big_list.includes(x)` inside a loop (O(n·m)), gated on a name provably bound to a list | Python, TS/JS |

## How

- Markers are opt-in per dialect via the `loop_call_marker` / `loop_stmt_marker` hooks (now threaded with list-bound-name context for the membership gate) plus an inline awaited-sink path for `serial_await_in_loop`. A language without a dialect, or one that does not list a marker, emits nothing.
- New biomarker modules lift the walker hits into findings; scoring maps each to the `performance` dimension under the existing 1.0 perf cap (advisory weights). The defect dimension is untouched.
- UI glossary entries and user docs (`CODE_HEALTH.md`, `LANGUAGE_SUPPORT.md`) updated.

## Precision

Precision-first by design: each detector targets an unambiguous shape and degrades to "no signal" rather than guessing. Notable gates:
- `membership_*` fires only when the right operand is provably a list, and excludes any name ever bound to a set/dict in the file (avoids the `seen = []` / `seen = set()` cross-scope collision).
- `resource_construction_*` matches distinctive classified constructors only; the overloaded bare `HttpClient` name is excluded in Java (no import gate there).
- `serial_await_*` rides alongside `io_in_loop` as an advisory co-signal and hedges its suggestion (it cannot prove the iterations are independent).

Each marker was validated against the repo's own source tree before shipping.

## Tests

- New unit suite covering every marker across all dialects, positive and negative (precision-gate) cases.
- Updated the two existing cases where an awaited sink now also carries the advisory `serial_await` co-signal.
- Full health unit suite + perf-benchmark integration green; the defect dimension golden is byte-for-byte unchanged.
