### PR TITLE
feat(health): language-specific perf markers + precision refinements

### DIFF
--- a/docs/CODE_HEALTH.md
+++ b/docs/CODE_HEALTH.md
@@ -188,10 +188,29 @@ below) rather than the shared core:
 
 - **`regex_compile_in_loop`** (Java, Go): a `Pattern.compile` /
   `regexp.MustCompile` recompiled every iteration instead of hoisted. Skipped on
-  Python / .NET, which cache compiled patterns.
+  Python / .NET, which cache compiled patterns; on Go it fires only for a
+  **string-literal pattern** (a dynamic argument may legitimately vary per
+  iteration and cannot be hoisted).
 - **`defer_in_loop`** (Go): a `defer` inside a loop holds the deferred handle
   until the enclosing function returns, not the iteration: the classic Go file /
   row-handle leak. A pure syntactic shape, very high precision.
+- **`goroutine_in_unbounded_loop`** (Go): a `go …()` spawned per element of a
+  `for k, v := range coll` loop, with no concurrency bound — a spawn explosion
+  (use a worker pool / bounded `errgroup`). Restricted to the two-variable
+  `range` form, which is only legal over a collection (a single-variable
+  `for i := range n` is a bounded count loop). Advisory.
+- **`list_insert_zero_in_loop`** (Python): `lst.insert(0, x)` each iteration
+  shifts the whole list (O(n²)); use `collections.deque.appendleft`. Gated to a
+  literal `0` index and to a list not re-created each iteration.
+- **`pd_concat_in_loop`** (Python): `pd.concat([acc, chunk])` inside a loop
+  copies the whole frame each pass (O(n²)); collect chunks and concat once.
+- **`json_parse_in_loop`** (JS/TS): the `JSON.parse(JSON.stringify(x))`
+  deep-clone idiom in a loop (use `structuredClone`). Restricted to that idiom —
+  parsing a *distinct* payload each iteration is necessary work, not waste.
+  Advisory.
+- **`array_spread_in_reduce`** (JS/TS): `arr.reduce((a, x) => [...a, x], [])`
+  rebuilds the accumulator every step (O(n²)); push-and-return instead. The
+  `.reduce` is itself the loop, so this fires regardless of an enclosing loop.
 - **sync-over-async** (C#, via `blocking_sync_in_async`): `.Result` / `.Wait()`
   / `.GetAwaiter().GetResult()` inside an `async` method blocks a thread-pool
   thread. C# is the one non-Python language with real `async`/`await`.
@@ -215,10 +234,14 @@ gated for precision: distinctive sinks (EF `*Async`, Spring-Data `findBy*`, JDBC
 db-import evidence. **`io_in_loop` is validated across languages** on an 11-repo
 OSS corpus: Go 96.7%, TypeScript 100%, Python 96.2% hand-labeled precision; the
 `blocking_sync_in_async` C# `.Result`/Result-pattern collision and the Go
-`*sql.Rows.Scan` cursor FP were caught and fixed by that validation. `nested_loop_quadratic`
-measured below the bar in every language (centrality gates volume, not shape) and
-stays advisory-only, as does `blocking_io_under_lock` (rare-by-good-practice: zero
-corpus instances even on concurrency-heavy Java).
+`*sql.Rows.Scan` cursor FP were caught and fixed by that validation.
+`string_concat_in_loop` is validated at 100% (26/26) after a reset-per-iteration
+guard (an accumulator re-initialized each iteration is bounded, not O(n²)).
+`nested_loop_quadratic` now fires only on a **same-collection** shape (two nested
+loops over the same collection = all-pairs O(n²)) instead of raw nesting depth;
+that makes it precision-safe-by-construction but rare, so it stays advisory-only,
+as do `blocking_io_under_lock`, `pd_concat_in_loop`, `json_parse_in_loop`, and
+`goroutine_in_unbounded_loop` (high-precision by construction, low corpus recall).
 
 **Soundness limits (honest, by design).** Performance is a *static* signal, so
 it under-reports rather than over-reports (these cap recall, not precision):

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/array_spread_in_reduce.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/array_spread_in_reduce.py
@@ -1,0 +1,46 @@
+"""Array-spread-in-reduce — ``arr.reduce((a, x) => [...a, x], [])``.
+
+Spreading the accumulator into a fresh array / object on every reduce step
+rebuilds the whole accumulator each iteration, turning an O(n) fold into O(n^2).
+The fix is to mutate-and-return the accumulator (``a.push(x); return a``) or use
+``Object.assign``. A ``performance`` dimension signal. Detected by the TS/JS
+dialect only when the reduce callback spreads its OWN accumulator parameter, so
+it fires regardless of an enclosing loop (the ``.reduce`` is itself the loop).
+This detector lifts the hits into findings.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "array_spread_in_reduce"
+
+
+class ArraySpreadInReduceDetector:
+    name = _KIND
+    category = "performance"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        out: list[BiomarkerResult] = []
+        for hit in ctx.perf_hits:
+            if hit.kind != _KIND:
+                continue
+            out.append(
+                BiomarkerResult(
+                    biomarker_type=self.name,
+                    severity=Severity.MEDIUM,
+                    function_name=hit.function,
+                    line_start=hit.line,
+                    line_end=hit.line,
+                    details={},
+                    reason=(
+                        "spreading the accumulator into a new array/object each reduce "
+                        "step rebuilds it every pass (O(n^2)); push-and-return instead"
+                    ),
+                )
+            )
+        return out
+
+
+BIOMARKER = ArraySpreadInReduceDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/goroutine_in_unbounded_loop.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/goroutine_in_unbounded_loop.py
@@ -1,0 +1,45 @@
+"""Goroutine-in-unbounded-loop — a ``go`` spawn per element of a range loop.
+
+``for _, item := range items { go process(item) }`` fans out one goroutine per
+item with no concurrency bound — the Go spawn-explosion anti-pattern (the fix is
+a worker pool / bounded semaphore / ``errgroup`` with a limit). A ``performance``
+dimension signal. Gated by the Go dialect to a ``range`` loop (a data-dependent
+iteration count); a bare ``for {}`` accept loop or a ``for cond`` cursor is
+excluded. This detector lifts the pre-collected hits into findings.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "goroutine_in_unbounded_loop"
+
+
+class GoroutineInUnboundedLoopDetector:
+    name = _KIND
+    category = "performance"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        out: list[BiomarkerResult] = []
+        for hit in ctx.perf_hits:
+            if hit.kind != _KIND:
+                continue
+            out.append(
+                BiomarkerResult(
+                    biomarker_type=self.name,
+                    severity=Severity.MEDIUM,
+                    function_name=hit.function,
+                    line_start=hit.line,
+                    line_end=hit.line,
+                    details={},
+                    reason=(
+                        "a goroutine is spawned per loop element with no concurrency "
+                        "bound; use a worker pool or a bounded errgroup/semaphore"
+                    ),
+                )
+            )
+        return out
+
+
+BIOMARKER = GoroutineInUnboundedLoopDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/json_parse_in_loop.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/json_parse_in_loop.py
@@ -1,0 +1,45 @@
+"""JSON-parse/stringify-in-loop — serialize/deserialize every iteration.
+
+``JSON.parse`` / ``JSON.stringify`` inside a loop re-serializes each pass; the
+``JSON.parse(JSON.stringify(x))`` deep-clone in a loop is the canonical waste
+(use ``structuredClone`` or hoist the parse). A ``performance`` dimension signal,
+shipped advisory: per-iteration parsing of *distinct* payloads is sometimes
+necessary work, so the centrality ranker downranks the cold sites. This detector
+lifts the hits into findings.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "json_parse_in_loop"
+
+
+class JsonParseInLoopDetector:
+    name = _KIND
+    category = "performance"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        out: list[BiomarkerResult] = []
+        for hit in ctx.perf_hits:
+            if hit.kind != _KIND:
+                continue
+            out.append(
+                BiomarkerResult(
+                    biomarker_type=self.name,
+                    severity=Severity.LOW,
+                    function_name=hit.function,
+                    line_start=hit.line,
+                    line_end=hit.line,
+                    details={},
+                    reason=(
+                        "JSON.parse/stringify runs every loop iteration; hoist the "
+                        "serialization or use structuredClone for deep copies"
+                    ),
+                )
+            )
+        return out
+
+
+BIOMARKER = JsonParseInLoopDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/list_insert_zero_in_loop.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/list_insert_zero_in_loop.py
@@ -1,0 +1,44 @@
+"""List-insert-at-zero-in-loop — ``lst.insert(0, x)`` every iteration.
+
+Inserting at the front of a Python list shifts every existing element, so doing
+it per iteration is O(n^2). The fix is ``collections.deque.appendleft`` (O(1)) or
+appending then reversing once. A ``performance`` dimension signal. Gated by the
+Python dialect to a literal ``0`` first argument (a variable index is not the
+front-insertion anti-pattern). This detector lifts the hits into findings.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "list_insert_zero_in_loop"
+
+
+class ListInsertZeroInLoopDetector:
+    name = _KIND
+    category = "performance"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        out: list[BiomarkerResult] = []
+        for hit in ctx.perf_hits:
+            if hit.kind != _KIND:
+                continue
+            out.append(
+                BiomarkerResult(
+                    biomarker_type=self.name,
+                    severity=Severity.MEDIUM,
+                    function_name=hit.function,
+                    line_start=hit.line,
+                    line_end=hit.line,
+                    details={},
+                    reason=(
+                        "insert(0, ...) in a loop shifts the whole list each pass (O(n^2)); "
+                        "use collections.deque.appendleft or append-then-reverse"
+                    ),
+                )
+            )
+        return out
+
+
+BIOMARKER = ListInsertZeroInLoopDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/pd_concat_in_loop.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/pd_concat_in_loop.py
@@ -1,0 +1,45 @@
+"""Pandas-concat-in-loop — ``pd.concat([acc, chunk])`` every iteration.
+
+Concatenating a DataFrame inside a loop copies the entire accumulated frame each
+pass, turning an O(n) build into O(n^2) (the documented pandas anti-pattern). The
+fix is to collect the chunks in a list and ``pd.concat`` them once after the
+loop. A ``performance`` dimension signal. Gated by the Python dialect to the
+distinctive ``pd``/``pandas`` ``concat`` root. This detector lifts the hits into
+findings.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "pd_concat_in_loop"
+
+
+class PdConcatInLoopDetector:
+    name = _KIND
+    category = "performance"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        out: list[BiomarkerResult] = []
+        for hit in ctx.perf_hits:
+            if hit.kind != _KIND:
+                continue
+            out.append(
+                BiomarkerResult(
+                    biomarker_type=self.name,
+                    severity=Severity.MEDIUM,
+                    function_name=hit.function,
+                    line_start=hit.line,
+                    line_end=hit.line,
+                    details={},
+                    reason=(
+                        "pd.concat in a loop copies the whole frame each pass (O(n^2)); "
+                        "collect the chunks in a list and concat once after the loop"
+                    ),
+                )
+            )
+        return out
+
+
+BIOMARKER = PdConcatInLoopDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/registry.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/registry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from .array_spread_in_reduce import ArraySpreadInReduceDetector
 from .base import Biomarker, BiomarkerResult, FileContext
 from .blocking_io_under_lock import BlockingIoUnderLockDetector
 from .blocking_sync_in_async import BlockingSyncInAsyncDetector
@@ -30,12 +31,15 @@ from .duplicated_assertion_block import DuplicatedAssertionBlockDetector
 from .error_handling import ErrorHandlingDetector
 from .function_hotspot import FunctionHotspotDetector
 from .god_class import GodClassDetector
+from .goroutine_in_unbounded_loop import GoroutineInUnboundedLoopDetector
 from .hidden_coupling import HiddenCouplingDetector
 from .hot_path_sync_io import HotPathSyncIoDetector
 from .io_in_loop import IoInLoopDetector
+from .json_parse_in_loop import JsonParseInLoopDetector
 from .knowledge_loss import KnowledgeLossDetector
 from .large_assertion_block import LargeAssertionBlockDetector
 from .large_method import LargeMethodDetector
+from .list_insert_zero_in_loop import ListInsertZeroInLoopDetector
 from .lock_in_loop import LockInLoopDetector
 from .low_cohesion import LowCohesionDetector
 from .membership_test_against_list_in_loop import MembershipTestAgainstListInLoopDetector
@@ -43,6 +47,7 @@ from .nested_complexity import NestedComplexityDetector
 from .nested_loop_quadratic import NestedLoopQuadraticDetector
 from .nested_loop_with_io import NestedLoopWithIoDetector
 from .ownership_risk import OwnershipRiskDetector
+from .pd_concat_in_loop import PdConcatInLoopDetector
 from .primitive_obsession import PrimitiveObsessionDetector
 from .prior_defect import PriorDefectDetector
 from .resource_construction_in_loop import ResourceConstructionInLoopDetector
@@ -91,6 +96,12 @@ _DETECTOR_FACTORIES: list[type[Biomarker]] = [
     NestedLoopQuadraticDetector,  # type: ignore[list-item]
     HotPathSyncIoDetector,  # type: ignore[list-item]
     BlockingIoUnderLockDetector,  # type: ignore[list-item]
+    # Phase 7d — language-specific markers (advisory weight; bounded by the cap).
+    ListInsertZeroInLoopDetector,  # type: ignore[list-item]
+    PdConcatInLoopDetector,  # type: ignore[list-item]
+    JsonParseInLoopDetector,  # type: ignore[list-item]
+    ArraySpreadInReduceDetector,  # type: ignore[list-item]
+    GoroutineInUnboundedLoopDetector,  # type: ignore[list-item]
 ]
 
 

--- a/packages/core/src/repowise/core/analysis/health/complexity/walker.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/walker.py
@@ -33,6 +33,8 @@ from .languages import LanguageNodeMap, get_language_map
 if TYPE_CHECKING:
     from tree_sitter import Node
 
+    from ..perf.dialects.base import BasePerfDialect
+
 log = structlog.get_logger(__name__)
 
 
@@ -1010,6 +1012,10 @@ _LOOP_CALL_MARKER_KINDS = frozenset(
         "resource_construction_in_loop",
         "lock_in_loop",
         "membership_test_against_list_in_loop",
+        # Phase 7d — language-specific call markers.
+        "list_insert_zero_in_loop",
+        "pd_concat_in_loop",
+        "json_parse_in_loop",
     }
 )
 _LOOP_STMT_MARKER_KINDS = frozenset(
@@ -1018,8 +1024,13 @@ _LOOP_STMT_MARKER_KINDS = frozenset(
         "resource_construction_in_loop",
         "lock_in_loop",
         "membership_test_against_list_in_loop",
+        # Phase 7d — language-specific statement markers.
+        "goroutine_in_unbounded_loop",
     }
 )
+# Markers for a call that is its OWN iteration construct (``.reduce``), a perf
+# smell at any loop depth — emitted via ``dialect.bare_call_marker``.
+_BARE_CALL_MARKER_KINDS = frozenset({"array_spread_in_reduce"})
 
 # Boundary kinds that are *unambiguously blocking* when called synchronously, so
 # a loop_depth-0 occurrence in a hot function is a ``hot_path_sync_io`` candidate.
@@ -1052,6 +1063,25 @@ def _perf_func_name(node: Node) -> str | None:
     return None
 
 
+def _enclosing_loop_iterables(
+    node: Node, dialect: BasePerfDialect, loop_kinds: frozenset[str], fn_kinds: frozenset[str]
+) -> set[str]:
+    """Names of the collections every enclosing loop (up to the function bound)
+    iterates over — the lookup the same-collection ``nested_loop_quadratic``
+    shape gate compares the inner loop's iterable against."""
+    names: set[str] = set()
+    cur = node.parent
+    for _ in range(64):
+        if cur is None or cur.type in fn_kinds:
+            break
+        if cur.type in loop_kinds:
+            nm = dialect.loop_iterable_name(cur)
+            if nm:
+                names.add(nm)
+        cur = cur.parent
+    return names
+
+
 def _collect_perf_hits(
     root: Node, language: str, lmap: LanguageNodeMap
 ) -> tuple[list[PerfHit], dict[str, str], list[PerfFnFacts]]:
@@ -1081,6 +1111,7 @@ def _collect_perf_hits(
     do_blocking = "blocking_sync_in_async" in markers
     do_loop_call_marker = bool(markers & _LOOP_CALL_MARKER_KINDS)
     do_loop_stmt_marker = bool(markers & _LOOP_STMT_MARKER_KINDS)
+    do_bare_call_marker = bool(markers & _BARE_CALL_MARKER_KINDS)
     do_serial_await = "serial_await_in_loop" in markers
     # Phase 7b markers.
     do_nested_io = "nested_loop_with_io" in markers
@@ -1124,10 +1155,14 @@ def _collect_perf_hits(
             fn_acc[func_start] = entry
         return entry[1], entry[2], entry[3], entry[4]
 
-    # (node, loop_depth, in_async, func_name, func_start, lock_depth)
-    stack: list[tuple[Node, int, bool, str | None, int, int]] = [(root, 0, False, None, 0, 0)]
+    # (node, loop_depth, in_async, func_name, func_start, lock_depth, outer_iter)
+    # ``outer_iter`` is whether the OUTERMOST enclosing loop iterates a collection
+    # (vs a ``while``/cursor) — the precision gate for ``nested_loop_with_io``.
+    stack: list[tuple[Node, int, bool, str | None, int, int, bool]] = [
+        (root, 0, False, None, 0, 0, True)
+    ]
     while stack:
-        node, loop_depth, in_async, func_name, func_start, lock_depth = stack.pop()
+        node, loop_depth, in_async, func_name, func_start, lock_depth, outer_iter = stack.pop()
         t = node.type
 
         is_loop = t in loop_kinds
@@ -1148,9 +1183,15 @@ def _collect_perf_hits(
         # engine emits ``nested_loop_quadratic`` only when the function is hot
         # (centrality gate), so the noisy-everywhere shape never ships ungated.
         if is_loop and loop_depth >= 1 and do_nested_quadratic:
-            misc = _acc(next_start, next_func)[3]
-            if misc[0] == 0:
-                misc[0] = node.start_point[0] + 1
+            # Shape gate (Phase-7d): raw nesting depth was ~3-20% precision in
+            # every language. Fire only on the SAME-COLLECTION shape — the inner
+            # loop iterates the same named collection as an enclosing loop
+            # (all-pairs O(n^2)) — which all four Phase-7c labelers converged on.
+            nm = dialect.loop_iterable_name(node)
+            if nm and nm in _enclosing_loop_iterables(node, dialect, loop_kinds, fn_kinds):
+                misc = _acc(next_start, next_func)[3]
+                if misc[0] == 0:
+                    misc[0] = node.start_point[0] + 1
 
         if t in call_kinds:
             method = dialect.callee_method_name(node) or ""
@@ -1158,6 +1199,12 @@ def _collect_perf_hits(
             parent = node.parent
             awaited = parent is not None and "await" in parent.type
             line = node.start_point[0] + 1
+            if do_bare_call_marker:
+                # A call that is its own iteration construct (``.reduce`` with an
+                # accumulator spread) — a perf smell at any loop depth.
+                bare = dialect.bare_call_marker(root_name, method, node)
+                if bare is not None:
+                    hits.append(PerfHit(bare, line, next_func, "", func_start=next_start))
             kind = dialect.sink_kind(
                 root_name,
                 method,
@@ -1180,10 +1227,14 @@ def _collect_perf_hits(
                                 "serial_await_in_loop", line, next_func, kind, func_start=next_start
                             )
                         )
-                    if do_nested_io and loop_depth >= 2:
+                    if do_nested_io and loop_depth >= 2 and outer_iter:
                         # A sink in the inner body of a NESTED loop -> O(n·m)
                         # round-trips. Nesting raises confidence, so it ships
-                        # un-gated alongside ``io_in_loop``.
+                        # un-gated alongside ``io_in_loop`` — but only when the
+                        # OUTER loop iterates a collection (``outer_iter``): a
+                        # ``while`` pagination cursor wrapping an inner ``for ...
+                        # of chunk`` is ``io_in_loop``, not a nested explosion
+                        # (Phase-7c TS while-cursor FP).
                         hits.append(
                             PerfHit(
                                 "nested_loop_with_io", line, next_func, kind, func_start=next_start
@@ -1293,6 +1344,9 @@ def _collect_perf_hits(
         entering_lock = do_lock_io and dialect.is_lock_scope(node)
 
         if is_loop:
+            # The outermost loop in a nest fixes ``outer_iter``; deeper loops
+            # inherit it. Set when entering the first loop (loop_depth 0 -> 1).
+            next_outer_iter = outer_iter if loop_depth >= 1 else dialect.is_iteration_loop(node)
             # Only the loop BODY runs per-iteration; the ``for x in <iterable>``
             # header / ``while <cond>`` condition runs once.
             body = node.child_by_field_name("body")
@@ -1301,18 +1355,32 @@ def _collect_perf_hits(
                 # with ``==`` (identity by tree + byte range), never ``is``.
                 for c in node.children:
                     cd = loop_depth + 1 if c == body else loop_depth
-                    stack.append((c, cd, next_async, next_func, next_start, lock_depth))
+                    stack.append(
+                        (c, cd, next_async, next_func, next_start, lock_depth, next_outer_iter)
+                    )
             else:
                 for c in node.children:
-                    stack.append((c, loop_depth + 1, next_async, next_func, next_start, lock_depth))
+                    stack.append(
+                        (
+                            c,
+                            loop_depth + 1,
+                            next_async,
+                            next_func,
+                            next_start,
+                            lock_depth,
+                            next_outer_iter,
+                        )
+                    )
         elif entering_lock:
             # Raise lock_depth for the body block only (not the lock-object expr).
             for c in node.children:
                 cl = lock_depth + 1 if c.type in _LOCK_BODY_KINDS else lock_depth
-                stack.append((c, loop_depth, next_async, next_func, next_start, cl))
+                stack.append((c, loop_depth, next_async, next_func, next_start, cl, outer_iter))
         else:
             for c in node.children:
-                stack.append((c, loop_depth, next_async, next_func, next_start, lock_depth))
+                stack.append(
+                    (c, loop_depth, next_async, next_func, next_start, lock_depth, outer_iter)
+                )
 
     # Dedup chained sinks: ``result.scalars().all()`` parses as two call nodes
     # on one line (the ``.scalars()`` sink and the ``.all()`` materializer) —

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/base.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/base.py
@@ -181,6 +181,47 @@ class BasePerfDialect:
         """True if this loop's bound is a compile-time constant (not N+1)."""
         return False
 
+    def is_iteration_loop(self, node: Node) -> bool:
+        """True if this loop iterates a *collection* (a data multiplier), rather
+        than spinning a cursor (``while (hasMore)`` / ``for (;;)``).
+
+        The precision lever for the nested-loop markers: only when the OUTER
+        loop multiplies over a collection is an inner I/O sink genuinely O(n*m).
+        A pagination ``while`` cursor wrapping an inner ``for ... of chunk`` is
+        ``io_in_loop``, not a nested round-trip explosion (Phase-7c TS corpus).
+        Default ``True`` — a language that does not distinguish keeps today's
+        behavior byte-for-byte; TS/JS overrides this to exclude ``while`` /
+        C-style ``for`` cursors.
+        """
+        return True
+
+    @staticmethod
+    def _dotted_path(node: Node | None) -> str | None:
+        """The text of *node* if it is a stable dotted path (``items`` /
+        ``self.items`` / ``a.b.c``) with no call / subscript / index, else None.
+
+        Lets the same-collection ``nested_loop_quadratic`` gate compare two
+        loops iterating ``self.items`` — not only bare locals — while excluding
+        ``get_items()`` / ``rows[i]`` which are not stable identities."""
+        if node is None or node.text is None:
+            return None
+        txt = node.text.decode("utf-8", "replace")
+        if not txt or not (txt[0].isalpha() or txt[0] == "_"):
+            return None
+        return txt if all(c.isalnum() or c in "_." for c in txt) else None
+
+    def loop_iterable_name(self, node: Node) -> str | None:
+        """Bare identifier this loop iterates over (``for x in items`` -> 'items'),
+        or ``None`` when it is not a simple name.
+
+        The gate for the same-collection ``nested_loop_quadratic`` shape: two
+        nested loops over the SAME named collection are an all-pairs O(n^2) site
+        (the high-precision shape that replaces raw nesting depth). Default
+        ``None`` so a language that does not override it never fires the shaped
+        marker. Precision-first by construction.
+        """
+        return None
+
     def is_string_concat(self, node: Node) -> bool:
         """True if *node* is a ``+=`` accumulation onto a string."""
         if not self.aug_assign_kinds or node.type not in self.aug_assign_kinds:
@@ -237,6 +278,18 @@ class BasePerfDialect:
         ``lock_in_loop`` (``lock.acquire`` / ``mu.Lock``), and the JS/TS
         ``arr.includes`` form of ``membership_test_against_list_in_loop`` (gated
         on ``root in list_names``). Default ``None``.
+        """
+        return None
+
+    def bare_call_marker(self, root: str, method: str, node: Node) -> str | None:
+        """Marker kind for a *call* that is its own iteration construct, so it is
+        a perf smell at ANY loop depth (not only inside an outer loop).
+
+        Used for ``array_spread_in_reduce`` (``arr.reduce((a,x)=>[...a,x], [])``
+        rebuilds the accumulator every step -> O(n^2)): the ``.reduce`` IS the
+        loop, so unlike :meth:`loop_call_marker` this fires without an enclosing
+        loop. Default ``None`` so a language that does not override it is
+        byte-for-byte unchanged.
         """
         return None
 

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/go.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/go.py
@@ -114,6 +114,8 @@ class GoPerfDialect(BasePerfDialect):
             "nested_loop_with_io",
             "nested_loop_quadratic",
             "hot_path_sync_io",
+            # Phase 7d — Go-specific spawn explosion.
+            "goroutine_in_unbounded_loop",
         }
     )
 
@@ -186,7 +188,12 @@ class GoPerfDialect(BasePerfDialect):
     def loop_call_marker(
         self, root: str, method: str, node: Node, list_names: frozenset[str]
     ) -> str | None:
-        if root == "regexp" and method in GO_REGEX_COMPILE:
+        if root == "regexp" and method in GO_REGEX_COMPILE and self._has_static_pattern_arg(node):
+            # Only a *string-literal* pattern is unambiguously hoistable: a
+            # dynamic argument (``regexp.MustCompile(pat)`` / a concatenation with
+            # a per-iteration variable) may legitimately vary each iteration and
+            # cannot be lifted out of the loop. Phase-7c Go corpus: the 10
+            # dynamic-arg cases were all UNSURE; gating on a literal removes them.
             return "regex_compile_in_loop"
         if (root, method) in GO_RESOURCE_CTORS:
             return "resource_construction_in_loop"
@@ -196,10 +203,77 @@ class GoPerfDialect(BasePerfDialect):
             return "lock_in_loop"
         return None
 
+    def loop_iterable_name(self, node: Node) -> str | None:
+        """The collection a ``for _, x := range coll`` loop iterates (``coll``)."""
+        if node.type != "for_statement":
+            return None
+        clause = next((c for c in node.children if c.type == "range_clause"), None)
+        if clause is None:
+            return None
+        # ``range_clause`` ends with the iterated expression after the ``range``
+        # keyword; take the last named child when it is a bare identifier.
+        named = [c for c in clause.children if c.is_named]
+        if named and named[-1].type in ("identifier", "selector_expression"):
+            return self._dotted_path(named[-1])
+        return None
+
+    @staticmethod
+    def _has_static_pattern_arg(node: Node) -> bool:
+        """True if the call's first argument is a compile-time string literal.
+
+        ``regexp.MustCompile("^foo$")`` is hoistable; ``regexp.MustCompile(pat)``
+        or ``regexp.MustCompile("^"+x)`` may vary per iteration and is excluded.
+        """
+        args = node.child_by_field_name("arguments")
+        if args is None:
+            return False
+        first = next((c for c in args.children if c.is_named), None)
+        return first is not None and first.type in _GO_STRING_KINDS
+
     def loop_stmt_marker(self, node: Node, list_names: frozenset[str]) -> str | None:
         if node.type == "defer_statement":
             return "defer_in_loop"
+        # ``go func(){…}()`` spawned per element of a ``for … range`` loop fans
+        # out one goroutine per item with no concurrency bound (the spawn-
+        # explosion anti-pattern: should use a worker pool / semaphore). Gated to
+        # a RANGE loop — a bare ``for {}`` accept loop or a ``for cond`` cursor
+        # spawns one-per-event (idiomatic), so it is excluded.
+        if node.type == "go_statement" and self._nearest_for_is_range(node):
+            return "goroutine_in_unbounded_loop"
         return None
+
+    @staticmethod
+    def _nearest_for_is_range(node: Node) -> bool:
+        """True if the nearest enclosing ``for`` loop ranges over a COLLECTION.
+
+        Phase-7d gate: a single-variable ``for i := range n`` (Go 1.22
+        range-over-int, or a count constant) is a bounded count loop, NOT a
+        per-element fan-out — both 0%-precision FPs were ``for i := range
+        <const>`` in tests. The two-variable ``for k, v := range coll`` form is
+        only legal over a slice / map / string / channel, so requiring a value
+        variable isolates the genuine per-element spawn. Stops at the function
+        boundary.
+        """
+        cur = node.parent
+        for _ in range(64):
+            if cur is None or cur.type in (
+                "function_declaration",
+                "method_declaration",
+                "func_literal",
+            ):
+                return False
+            if cur.type == "for_statement":
+                clause = next((c for c in cur.children if c.type == "range_clause"), None)
+                if clause is None:
+                    return False
+                left = clause.child_by_field_name("left")
+                if left is None:
+                    return False
+                # ``left`` is an expression_list of the range variables; a value
+                # variable (>= 2) proves iteration over a collection.
+                return sum(1 for c in left.children if c.is_named) >= 2
+            cur = cur.parent
+        return False
 
 
 DIALECT = GoPerfDialect()

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/python.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/python.py
@@ -108,6 +108,9 @@ class PythonPerfDialect(BasePerfDialect):
             "nested_loop_with_io",
             "nested_loop_quadratic",
             "hot_path_sync_io",
+            # Phase 7d — Python-specific quadratic anti-patterns.
+            "list_insert_zero_in_loop",
+            "pd_concat_in_loop",
         }
     )
 
@@ -199,6 +202,80 @@ class PythonPerfDialect(BasePerfDialect):
             return True
         return False
 
+    # Builtins that wrap a collection without changing what is iterated, so the
+    # same-collection O(n^2) shape sees through them: ``for x in enumerate(items)``
+    # iterates ``items``.
+    _ITER_WRAPPERS: frozenset[str] = frozenset({"enumerate", "sorted", "reversed", "list", "set"})
+
+    def loop_iterable_name(self, node: Node) -> str | None:
+        if node.type != "for_statement":
+            return None
+        right = node.child_by_field_name("right")
+        if right is None:
+            return None
+        if right.type in ("identifier", "attribute"):
+            return self._dotted_path(right)
+        if right.type == "call":
+            fn = right.child_by_field_name("function")
+            if fn is None or fn.text is None:
+                return None
+            if fn.text.decode("utf-8", "replace") not in self._ITER_WRAPPERS:
+                return None
+            args = right.child_by_field_name("arguments")
+            if args is None:
+                return None
+            first = next((c for c in args.children if c.is_named), None)
+            if first is not None and first.type == "identifier" and first.text is not None:
+                return first.text.decode("utf-8", "replace")
+        return None
+
+    def is_string_concat(self, node: Node) -> bool:
+        """``s += "x"`` accumulation — but skip an accumulator that is *reset*
+        each iteration of an enclosing loop.
+
+        ``buf = base[:N]; ... buf += part`` inside a loop builds a fresh, bounded
+        string per iteration (not the O(n^2) cross-iteration accumulation the
+        marker targets), so it is a false positive. Phase-7c headroom corpus:
+        the reset-per-iteration shape was the dominant FP class (Py 77.8%). When
+        the same name is plainly re-assigned inside an enclosing loop body, the
+        ``+=`` cannot accumulate across iterations, so do not flag it.
+        """
+        if not super().is_string_concat(node):
+            return False
+        left = node.child_by_field_name("left")
+        if left is None or left.type != "identifier" or left.text is None:
+            return True  # opaque target -> keep the (precision-first) flag
+        name = left.text.decode("utf-8", "replace")
+        cur = node.parent
+        while cur is not None:
+            if cur.type in ("for_statement", "while_statement"):
+                body = cur.child_by_field_name("body")
+                if body is not None and self._resets_name(body, name, node):
+                    return False
+            cur = cur.parent
+        return True
+
+    @staticmethod
+    def _resets_name(body: Node, name: str, exclude: Node) -> bool:
+        """True if *body* contains a plain ``name = ...`` assignment (not the
+        ``+=`` node *exclude* itself) — i.e. the accumulator is reset here."""
+        stack: list[Node] = [body]
+        while stack:
+            n = stack.pop()
+            if n.type == "assignment" and not (
+                n.start_byte == exclude.start_byte and n.end_byte == exclude.end_byte
+            ):
+                lhs = n.child_by_field_name("left")
+                if (
+                    lhs is not None
+                    and lhs.type == "identifier"
+                    and lhs.text is not None
+                    and lhs.text.decode("utf-8", "replace") == name
+                ):
+                    return True
+            stack.extend(n.children)
+        return False
+
     def blocking_sync_api(self, root: str, method: str) -> str | None:
         """The offending API name if ``root.method`` is a known blocking sync call.
 
@@ -228,7 +305,52 @@ class PythonPerfDialect(BasePerfDialect):
         # extra guard against a bare-name collision).
         if method in _PY_LOCK_METHODS and self.callee_is_attribute(node):
             return "lock_in_loop"
+        # ``lst.insert(0, x)`` each iteration shifts the whole list -> O(n^2);
+        # ``collections.deque.appendleft`` / build-then-reverse is O(n). Gated to
+        # a literal ``0`` first arg (``insert(i, x)`` at a variable index is not
+        # the front-insertion anti-pattern) AND to a list that is not re-created
+        # each iteration (a fresh ``buf = [...]; buf.insert(0, x)`` is bounded,
+        # not O(n^2) — the same reset-per-iteration FP class as string_concat;
+        # Phase-7d headroom corpus).
+        if (
+            method == "insert"
+            and self.callee_is_attribute(node)
+            and self._first_arg_is_zero(node)
+            and not self._receiver_reset_in_loop(node, root)
+        ):
+            return "list_insert_zero_in_loop"
+        # ``pd.concat([acc, chunk])`` / ``pandas.concat(...)`` in a loop copies
+        # the whole frame each pass -> O(n^2); collect a list and concat once.
+        if root in ("pd", "pandas") and method == "concat":
+            return "pd_concat_in_loop"
         return None
+
+    def _receiver_reset_in_loop(self, node: Node, name: str) -> bool:
+        """True if the call's receiver ``name`` is re-assigned (reset to a fresh
+        list) inside an enclosing loop body — so the per-front-insert is bounded
+        per iteration, not an O(n^2) accumulation."""
+        if not name:
+            return False
+        cur = node.parent
+        while cur is not None:
+            if cur.type in ("for_statement", "while_statement"):
+                body = cur.child_by_field_name("body")
+                if body is not None and self._resets_name(body, name, node):
+                    return True
+            cur = cur.parent
+        return False
+
+    @staticmethod
+    def _first_arg_is_zero(node: Node) -> bool:
+        args = node.child_by_field_name("arguments")
+        if args is None:
+            return False
+        first = next((c for c in args.children if c.is_named), None)
+        return (
+            first is not None
+            and first.type == "integer"
+            and (first.text or b"").decode("utf-8", "replace") == "0"
+        )
 
     def loop_stmt_marker(self, node: Node, list_names: frozenset[str]) -> str | None:
         # ``x in big_list`` / ``x not in big_list`` where ``big_list`` is a

--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
@@ -95,11 +95,30 @@ class TsJsPerfDialect(BasePerfDialect):
             "nested_loop_with_io",
             "nested_loop_quadratic",
             "hot_path_sync_io",
+            # Phase 7d — JS/TS-specific anti-patterns.
+            "json_parse_in_loop",
+            "array_spread_in_reduce",
         }
     )
 
     string_literal_kinds = _TS_STRING_KINDS
     aug_assign_kinds = _TS_AUG_ASSIGN_KINDS
+
+    # Only ``for ... of`` / ``for ... in`` multiply over a collection. C-style
+    # ``for (;;)``, ``while`` and ``do`` are cursors (pagination / polling), so
+    # they do not make an inner sink a nested O(n*m) round-trip.
+    _ITERATION_LOOP_KINDS: frozenset[str] = frozenset({"for_in_statement", "for_of_statement"})
+
+    def is_iteration_loop(self, node: Node) -> bool:
+        return node.type in self._ITERATION_LOOP_KINDS
+
+    def loop_iterable_name(self, node: Node) -> str | None:
+        if node.type not in self._ITERATION_LOOP_KINDS:
+            return None
+        right = node.child_by_field_name("right")
+        if right is not None and right.type in ("identifier", "member_expression"):
+            return self._dotted_path(right)
+        return None
 
     def sink_kind(
         self,
@@ -135,7 +154,94 @@ class TsJsPerfDialect(BasePerfDialect):
         # ``arr.includes(x)`` where ``arr`` is a known array -> O(n) membership.
         if method == "includes" and root in list_names:
             return "membership_test_against_list_in_loop"
+        # ``JSON.parse(JSON.stringify(x))`` deep-clone in a loop is the canonical
+        # waste (use ``structuredClone``). Phase-7d gate: a BARE ``JSON.parse`` /
+        # ``JSON.stringify`` per iteration was 0% precision (30/30 were
+        # format-conversion loops serializing a DISTINCT payload each pass —
+        # necessary work, not waste), so the marker is restricted to the
+        # deep-clone idiom, which is unconditionally hoistable.
+        if root == "JSON" and method == "parse" and self._arg_is_json_stringify(node):
+            return "json_parse_in_loop"
         return None
+
+    @staticmethod
+    def _arg_is_json_stringify(node: Node) -> bool:
+        """True if the call's first argument is itself a ``JSON.stringify(...)``
+        call — the ``JSON.parse(JSON.stringify(x))`` deep-clone idiom."""
+        args = node.child_by_field_name("arguments")
+        if args is None:
+            return False
+        first = next((c for c in args.children if c.is_named), None)
+        if first is None or first.type != "call_expression":
+            return False
+        fn = first.child_by_field_name("function")
+        return (
+            fn is not None
+            and fn.text is not None
+            and fn.text.decode("utf-8", "replace") == "JSON.stringify"
+        )
+
+    def bare_call_marker(self, root: str, method: str, node: Node) -> str | None:
+        # ``arr.reduce((acc, x) => [...acc, x], [])`` rebuilds the accumulator
+        # every step -> O(n^2). The ``.reduce`` IS the loop, so this fires at any
+        # depth. Precision-first: only when the callback spreads its OWN
+        # accumulator param into a fresh array / object literal.
+        if method != "reduce":
+            return None
+        args = node.child_by_field_name("arguments")
+        if args is None:
+            return None
+        cb = next((c for c in args.children if c.is_named), None)
+        if cb is None or cb.type not in ("arrow_function", "function", "function_expression"):
+            return None
+        acc = self._first_param_name(cb)
+        body = cb.child_by_field_name("body")
+        if acc is None or body is None:
+            return None
+        return "array_spread_in_reduce" if self._spreads_name_in_collection(body, acc) else None
+
+    @staticmethod
+    def _first_param_name(cb: Node) -> str | None:
+        """First parameter identifier of an arrow/function (the reduce accumulator)."""
+        params = cb.child_by_field_name("parameters")
+        if params is not None:
+            for c in params.children:
+                ident = c if c.type == "identifier" else c.child_by_field_name("pattern")
+                if ident is not None and ident.type == "identifier" and ident.text is not None:
+                    return ident.text.decode("utf-8", "replace")
+            return None
+        # ``x => …`` single unparenthesized param.
+        first = next((c for c in cb.children if c.is_named), None)
+        if first is not None and first.type == "identifier" and first.text is not None:
+            return first.text.decode("utf-8", "replace")
+        return None
+
+    @staticmethod
+    def _spreads_name_in_collection(body: Node, name: str) -> bool:
+        """True if *body* spreads ``name`` into an array / object literal
+        (``[...name, x]`` / ``{...name}``) — the O(n^2) accumulator rebuild."""
+        stack: list[Node] = [body]
+        while stack:
+            n = stack.pop()
+            if (
+                n.type == "spread_element"
+                and n.parent is not None
+                and n.parent.type
+                in (
+                    "array",
+                    "object",
+                )
+            ):
+                arg = next((c for c in n.children if c.is_named), None)
+                if (
+                    arg is not None
+                    and arg.type == "identifier"
+                    and arg.text is not None
+                    and arg.text.decode("utf-8", "replace") == name
+                ):
+                    return True
+            stack.extend(n.children)
+        return False
 
     def loop_stmt_marker(self, node: Node, list_names: frozenset[str]) -> str | None:
         # ``new PrismaClient(...)`` etc. is a ``new_expression`` (not a

--- a/packages/core/src/repowise/core/analysis/health/scoring.py
+++ b/packages/core/src/repowise/core/analysis/health/scoring.py
@@ -222,6 +222,12 @@ _BIOMARKER_DIMENSIONS: dict[str, set[str]] = {
     "nested_loop_quadratic": {"performance"},
     "hot_path_sync_io": {"performance"},
     "blocking_io_under_lock": {"performance"},
+    # Phase 7d language-specific markers - performance-only.
+    "list_insert_zero_in_loop": {"performance"},
+    "pd_concat_in_loop": {"performance"},
+    "json_parse_in_loop": {"performance"},
+    "array_spread_in_reduce": {"performance"},
+    "goroutine_in_unbounded_loop": {"performance"},
 }
 
 # Maintainability per-biomarker weight multipliers. Expert-set by definition -
@@ -288,7 +294,11 @@ _MAINTAINABILITY_HOME: frozenset[str] = frozenset(
 _PERFORMANCE_WEIGHT_MULTIPLIER: dict[str, float] = {
     "io_in_loop": 1.0,
     "blocking_sync_in_async": 0.7,
-    "string_concat_in_loop": 0.5,
+    # PROMOTED 0.5 -> 0.7 (Phase-7d): the reset-per-iteration guard lifted Python
+    # precision to 100% (26/26 on the headroom corpus) by dropping the dominant
+    # FP class (an accumulator re-initialized each iteration is bounded, not
+    # O(n^2)). Clears the 70% bar with comfortable n.
+    "string_concat_in_loop": 0.7,
     # Phase 7a markers. Ship at advisory weight pending each one's Phase-0 gate
     # (MARKER_BACKLOG.md); promote to full weight where corpus precision >= 70%.
     # resource_construction is the highest-confidence (classified constructor),
@@ -308,6 +318,15 @@ _PERFORMANCE_WEIGHT_MULTIPLIER: dict[str, float] = {
     "blocking_io_under_lock": 0.6,
     "hot_path_sync_io": 0.5,
     "nested_loop_quadratic": 0.4,
+    # Phase 7d language-specific markers. Ship advisory pending each one's gate
+    # (MARKER_BACKLOG.md / PHASE7D); the two O(n^2)-by-construction Python ones
+    # (front-insert / pd.concat) carry slightly more weight than the moderate-
+    # precision json_parse / goroutine-spawn ones.
+    "list_insert_zero_in_loop": 0.6,
+    "pd_concat_in_loop": 0.6,
+    "array_spread_in_reduce": 0.5,
+    "json_parse_in_loop": 0.4,
+    "goroutine_in_unbounded_loop": 0.4,
 }
 
 # All perf biomarkers share one ``performance`` category, so the single cap
@@ -324,6 +343,11 @@ _PERFORMANCE_CATEGORY: dict[str, str] = {
     "nested_loop_quadratic": "performance",
     "hot_path_sync_io": "performance",
     "blocking_io_under_lock": "performance",
+    "list_insert_zero_in_loop": "performance",
+    "pd_concat_in_loop": "performance",
+    "json_parse_in_loop": "performance",
+    "array_spread_in_reduce": "performance",
+    "goroutine_in_unbounded_loop": "performance",
 }
 
 # One bounded performance category cap. ~1.0 keeps performance advisory.
@@ -345,6 +369,11 @@ _PERFORMANCE_HOME: frozenset[str] = frozenset(
         "nested_loop_quadratic",
         "hot_path_sync_io",
         "blocking_io_under_lock",
+        "list_insert_zero_in_loop",
+        "pd_concat_in_loop",
+        "json_parse_in_loop",
+        "array_spread_in_reduce",
+        "goroutine_in_unbounded_loop",
     }
 )
 

--- a/tests/fixtures/lang_samples/go/perf_io_in_loop.go
+++ b/tests/fixtures/lang_samples/go/perf_io_in_loop.go
@@ -42,7 +42,8 @@ func deferInLoop(paths []string) {
 
 func regexpCompileInRange(ids []string) {
 	for _, id := range ids {
-		regexp.MustCompile(id) // POSITIVE: recompiled per iteration
+		regexp.MustCompile(`^[a-z]+$`) // POSITIVE: a static literal pattern, hoistable
+		regexp.MustCompile(id)         // NEGATIVE: a dynamic per-iteration arg cannot be hoisted
 	}
 }
 

--- a/tests/unit/health/test_perf_dialects.py
+++ b/tests/unit/health/test_perf_dialects.py
@@ -280,3 +280,115 @@ def test_python_asyncio_sleep_not_a_sink():
     kinds = {k for k, _ in _hits("python", src)}
     assert "io_in_loop" not in kinds
     assert "serial_await_in_loop" not in kinds
+
+
+# ---------------------------------------------------------------------------
+# Phase-7d marker refinements (precision lifts surfaced by the 7c corpus)
+# ---------------------------------------------------------------------------
+
+
+def test_go_regex_dynamic_pattern_not_flagged():
+    """``regexp.MustCompile(pat)`` with a dynamic arg is not hoistable.
+
+    Phase-7c Go corpus: 10 dynamic-arg cases were UNSURE (the pattern may vary
+    per iteration). Only a string-literal pattern is unambiguously hoistable.
+    """
+    dyn = 'package p\nimport "regexp"\nfunc f(ids []string){ for _, id := range ids { regexp.MustCompile(id) } }\n'
+    lit = 'package p\nimport "regexp"\nfunc f(ids []string){ for _, id := range ids { regexp.MustCompile(`^x$`) } }\n'
+    assert not any(k == "regex_compile_in_loop" for k, _ in _hits("go", dyn))
+    assert ("regex_compile_in_loop", "") in _hits("go", lit)
+
+
+def test_python_string_concat_reset_per_iteration_not_flagged():
+    """``buf = seed; ... buf += part`` reset each iteration is bounded, not O(n^2).
+
+    Phase-7c headroom corpus: reset-per-iteration was the dominant Py FP (77.8%).
+    """
+    reset = (
+        "def f(rows):\n"
+        "    for r in rows:\n"
+        "        buf = 'x'\n"
+        "        for c in r:\n"
+        "            buf += 'y'\n"
+    )
+    accum = (
+        "def g(rows):\n    out = ''\n    for r in rows:\n        out += 'line'\n    return out\n"
+    )
+    assert not any(k == "string_concat_in_loop" for k, _ in _hits("python", reset))
+    assert ("string_concat_in_loop", "") in _hits("python", accum)
+
+
+def test_ts_nested_io_requires_collection_outer_loop():
+    """A ``while`` cursor wrapping an inner ``for ... of`` is io_in_loop, not nested.
+
+    Phase-7c dub corpus: pagination ``while (hasMore) { for (row of chunk) … }``
+    miscounted as ``nested_loop_with_io``; the outer loop must iterate a
+    collection for the O(n*m) round-trip claim to hold.
+    """
+    cursor = (
+        "async function f(prisma){ while (hasMore) { for (const r of chunk) {"
+        " await prisma.user.findMany(); } } }"
+    )
+    nested = (
+        "async function g(prisma, xs, ys){ for (const x of xs) { for (const y of ys) {"
+        " await prisma.user.findMany(); } } }"
+    )
+    assert not any(k == "nested_loop_with_io" for k, _ in _hits("typescript", cursor))
+    assert ("nested_loop_with_io", "db") in _hits("typescript", nested)
+
+
+# ---------------------------------------------------------------------------
+# Phase-7d language-specific markers
+# ---------------------------------------------------------------------------
+
+
+def test_go_goroutine_in_range_loop_but_not_accept_loop():
+    spawn = "package m\nfunc f(items []int){ for _, it := range items { go work(it) } }"
+    accept = "package m\nfunc f(){ for { go handle() } }"
+    # Single-variable ``for i := range n`` is a bounded count loop (Go 1.22
+    # range-over-int / a count constant), not a per-element fan-out (Phase-7d).
+    count = "package m\nfunc f(){ for i := range numG { go work(i) } }"
+    assert ("goroutine_in_unbounded_loop", "") in _hits("go", spawn)
+    assert not any(k == "goroutine_in_unbounded_loop" for k, _ in _hits("go", accept))
+    assert not any(k == "goroutine_in_unbounded_loop" for k, _ in _hits("go", count))
+
+
+def test_python_list_insert_zero_vs_variable_index():
+    front = "def f(xs):\n    out = []\n    for x in xs:\n        out.insert(0, x)\n"
+    idx = "def f(xs):\n    out = []\n    for i, x in enumerate(xs):\n        out.insert(i, x)\n"
+    # A list re-created fresh each iteration is bounded, not O(n^2) (Phase-7d
+    # reset guard — the same FP class as string_concat).
+    reset = "def f(xs):\n    for x in xs:\n        cand = [x]\n        cand.insert(0, prev)\n"
+    assert ("list_insert_zero_in_loop", "") in _hits("python", front)
+    assert not any(k == "list_insert_zero_in_loop" for k, _ in _hits("python", idx))
+    assert not any(k == "list_insert_zero_in_loop" for k, _ in _hits("python", reset))
+
+
+def test_ts_json_parse_only_deep_clone_idiom():
+    """Bare ``JSON.parse(x.payload)`` of a distinct per-iteration payload is
+    necessary work (Phase-7d: bare parse/stringify was 0% precision)."""
+    bare = "function f(xs){ for (const x of xs) { const c = JSON.parse(x.payload); } }"
+    assert not any(k == "json_parse_in_loop" for k, _ in _hits("typescript", bare))
+
+
+def test_python_pd_concat_in_loop():
+    src = (
+        "import pandas as pd\n"
+        "def f(chunks):\n"
+        "    df = pd.DataFrame()\n"
+        "    for c in chunks:\n"
+        "        df = pd.concat([df, c])\n"
+    )
+    assert ("pd_concat_in_loop", "") in _hits("python", src)
+
+
+def test_ts_json_parse_in_loop():
+    src = "function f(xs){ for (const x of xs) { const c = JSON.parse(JSON.stringify(x)); } }"
+    assert ("json_parse_in_loop", "") in _hits("typescript", src)
+
+
+def test_ts_array_spread_in_reduce_vs_push():
+    spread = "function f(xs){ return xs.reduce((acc, x) => [...acc, x], []); }"
+    push = "function f(xs){ return xs.reduce((acc, x) => { acc.push(x); return acc; }, []); }"
+    assert ("array_spread_in_reduce", "") in _hits("typescript", spread)
+    assert not any(k == "array_spread_in_reduce" for k, _ in _hits("typescript", push))

--- a/tests/unit/health/test_perf_phase7b.py
+++ b/tests/unit/health/test_perf_phase7b.py
@@ -145,12 +145,23 @@ def test_blocking_io_under_lock_same_function(lang, src, expected, note):
 
 
 def test_walker_records_nested_loop_fact_not_a_hit():
-    src = "def f(xs, ys):\n    for x in xs:\n        for y in ys:\n            use(x, y)\n"
+    # SAME-collection nested iteration (all-pairs O(n^2)) — the Phase-7d shape
+    # gate. The fact is recorded for the centrality gate, but no hit is emitted.
+    src = "def f(items):\n    for x in items:\n        for y in items:\n            use(x, y)\n"
     fc = walk_file("t.py", "python", src.encode())
-    # No I/O, no nested_loop_with_io hit — but the fact is recorded for the gate.
     assert all(h.kind != "nested_loop_quadratic" for h in fc.perf_hits)
     fact = {f.function: f for f in fc.perf_fn_facts}["f"]
     assert fact.nested_loop_line == 3  # the inner ``for``
+
+
+def test_walker_skips_different_collection_nested_loops():
+    # Two nested loops over DIFFERENT collections are not an all-pairs O(n^2)
+    # site (it is O(n*m) over independent inputs) — the Phase-7d shape gate drops
+    # this raw-nesting case that previously FP'd nested_loop_quadratic ~3-20%.
+    src = "def f(xs, ys):\n    for x in xs:\n        for y in ys:\n            use(x, y)\n"
+    fc = walk_file("t.py", "python", src.encode())
+    fact = {f.function: f for f in fc.perf_fn_facts}.get("f")
+    assert fact is None or fact.nested_loop_line == 0
 
 
 def test_walker_records_blocking_sink_fact_not_a_hit():
@@ -199,10 +210,10 @@ def _walked(path: str, src: str):
 
 _HOT_SRC = (
     "import subprocess\n"
-    "def hot(xs, ys):\n"
+    "def hot(items):\n"
     "    subprocess.run(['git', 'status'])\n"  # a blocking loop_depth-0 sink (hot_path)
-    "    for x in xs:\n"
-    "        for y in ys:\n"  # nested loop (quadratic)
+    "    for x in items:\n"
+    "        for y in items:\n"  # same-collection nested loop (all-pairs O(n^2))
     "            use(x, y)\n"
 )
 

--- a/tests/unit/health/test_scoring_dimensions.py
+++ b/tests/unit/health/test_scoring_dimensions.py
@@ -248,11 +248,12 @@ def test_perf_category_cap_bounds_dimension():
 
 
 def test_perf_bonus_markers_advisory_weight():
-    """string_concat (0.5) and blocking_sync (0.7) ride at reduced weight."""
+    """string_concat (0.7, Phase-7d promoted) and blocking_sync (0.7) ride at
+    reduced weight."""
     assert dimensions_for("string_concat_in_loop") == {"performance"}
     assert dimensions_for("blocking_sync_in_async") == {"performance"}
-    s1, _ = score_file([_r("string_concat_in_loop", Severity.LOW)])  # 0.3 * 0.5
-    assert s1["performance"] == round(10.0 - 0.15, 2)
+    s1, _ = score_file([_r("string_concat_in_loop", Severity.LOW)])  # 0.3 * 0.7
+    assert s1["performance"] == round(10.0 - 0.21, 2)
     s2, _ = score_file([_r("blocking_sync_in_async", Severity.MEDIUM)])  # 0.7 * 0.7
     assert s2["performance"] == round(10.0 - 0.49, 2)
 


### PR DESCRIPTION
## What

Adds five language-specific performance-risk markers and refines four existing ones to lift precision. Every marker is performance-only and bounded by the performance cap, so the defect score is unchanged.

### New markers (each gated on an OSS corpus, shipped advisory)

| Marker | Lang | Catches |
|--------|------|---------|
| `array_spread_in_reduce` | JS/TS | `reduce((a, x) => [...a, x], [])` rebuilding the accumulator each step (O(n^2)) |
| `json_parse_in_loop` | JS/TS | the `JSON.parse(JSON.stringify(x))` deep-clone idiom in a loop |
| `list_insert_zero_in_loop` | Python | `lst.insert(0, x)` in a loop (O(n^2)) |
| `pd_concat_in_loop` | Python | `pd.concat` in a loop copying the frame each pass (O(n^2)) |
| `goroutine_in_unbounded_loop` | Go | a goroutine spawned per element of a `range` loop with no bound |

### Refinements

- **`string_concat_in_loop`**: skip an accumulator that is re-initialized each iteration (bounded, not O(n^2)). Reached 100% precision on the validation corpus and is promoted to full advisory weight.
- **`nested_loop_quadratic`**: fire on a same-collection shape (two nested loops over the same collection) instead of raw nesting depth, which eliminates the dominant false-positive class.
- **`nested_loop_with_io`**: require the outer loop to iterate a collection, so a `while` pagination cursor wrapping an inner `for ... of` is reported as `io_in_loop` rather than a nested round-trip.
- **`regex_compile_in_loop`** (Go): restrict to a string-literal pattern argument (a dynamic pattern may legitimately vary per iteration).

### Mechanism

Adds a `bare_call_marker` dialect hook so a call that is itself an iteration construct (`reduce`) can be flagged regardless of an enclosing loop. The same-collection and outer-collection gates are threaded through the perf walker without changing behavior for languages that do not opt in.

## Testing

- New unit coverage for all five markers and all four refinements.
- Full health suite green (511 tests); ruff clean.
- Defect-dimension snapshot/golden tests unchanged.