### PR TITLE
feat: aggregate cross-repo co-changes by repo pair with drill-down (Resolves #482)

### DIFF
--- a/packages/ui/src/workspace/index.ts
+++ b/packages/ui/src/workspace/index.ts
@@ -5,5 +5,6 @@ export * from "./cross-repo-summary";
 export * from "./package-deps-table";
 export * from "./repo-card";
 export * from "./repo-card-compact";
+export * from "./repo-pair-table";
 export * from "./workspace-graph";
 export * from "./workspace-graph-node";

--- a/packages/ui/src/workspace/repo-pair-table.tsx
+++ b/packages/ui/src/workspace/repo-pair-table.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { Badge } from "../ui/badge";
+import { EmptyState } from "../shared/empty-state";
+import {
+  ResponsiveTable,
+  type ResponsiveColumn,
+} from "../shared/responsive-table";
+import { ChevronRight } from "lucide-react";
+
+export interface RepoPairSummary {
+  id: string; // "repo1↔repo2"
+  repo1: string;
+  repo2: string;
+  filePairCount: number;
+  maxStrength: number;
+  lastDate: string;
+}
+
+interface RepoPairTableProps {
+  repoPairs: RepoPairSummary[];
+  onSelectPair?: (id: string) => void;
+  selectedPairId?: string | null;
+}
+
+export function RepoPairTable({ repoPairs, onSelectPair, selectedPairId }: RepoPairTableProps) {
+  const columns: ResponsiveColumn<RepoPairSummary>[] = [
+    {
+      key: "pair",
+      header: "Repository Pair",
+      priority: 1,
+      render: (p) => (
+        <div className="flex items-center gap-2">
+          <Badge variant="default" className="text-xs">{p.repo1}</Badge>
+          <span className="text-[var(--color-text-tertiary)] text-xs">↔</span>
+          <Badge variant="default" className="text-xs">{p.repo2}</Badge>
+        </div>
+      ),
+    },
+    {
+      key: "count",
+      header: "File Pairs",
+      priority: 2,
+      align: "right",
+      cellClassName: "text-xs text-[var(--color-text-secondary)] tabular-nums",
+      render: (p) => p.filePairCount,
+    },
+    {
+      key: "strength",
+      header: "Max Strength",
+      priority: 1,
+      headerClassName: "w-32",
+      render: (p) => (
+        <div className="flex items-center gap-2 min-w-[90px]">
+          <div className="h-1.5 flex-1 rounded-full bg-[var(--color-bg-inset)] overflow-hidden">
+            <div
+              className="h-full rounded-full bg-[var(--color-accent-primary)] transition-all"
+              style={{ width: `${Math.min(Math.round(p.maxStrength * 10), 100)}%` }}
+            />
+          </div>
+          <span className="text-xs text-[var(--color-text-tertiary)] tabular-nums w-8 text-right">
+            {Math.round(p.maxStrength * 10) / 10}
+          </span>
+        </div>
+      ),
+      mobileRender: (p) => Math.round(p.maxStrength * 10) / 10,
+    },
+    {
+      key: "last",
+      header: "Latest Activity",
+      priority: 3,
+      align: "right",
+      cellClassName: "text-xs text-[var(--color-text-tertiary)]",
+      render: (p) => (
+        <span title={p.lastDate ? new Date(p.lastDate).toLocaleString() : undefined}>
+          {p.lastDate ? new Date(p.lastDate).toLocaleDateString() : "—"}
+        </span>
+      ),
+    },
+    ...(onSelectPair
+      ? [
+          {
+            key: "action",
+            header: "",
+            priority: 1 as const,
+            align: "right" as const,
+            render: () => <ChevronRight className="h-4 w-4 text-[var(--color-text-tertiary)] inline-block" />,
+            hideInCard: true,
+          },
+        ]
+      : []),
+  ];
+
+  return (
+    <ResponsiveTable
+      columns={columns}
+      rows={repoPairs}
+      rowKey={(p) => p.id}
+      selectedKey={selectedPairId}
+      onRowClick={onSelectPair ? (p) => onSelectPair(p.id) : undefined}
+      bare
+      empty={
+        <EmptyState
+          title="No repository pairs"
+          description="No cross-repository co-changes found."
+        />
+      }
+    />
+  );
+}

--- a/packages/web/src/app/workspace/co-changes/page.tsx
+++ b/packages/web/src/app/workspace/co-changes/page.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import { useState } from "react";
-import { GitMerge, Filter } from "lucide-react";
+import { useState, useMemo } from "react";
+import { GitMerge, Filter, ArrowLeft, LayoutList, Columns } from "lucide-react";
 import { useWorkspaceCoChanges, useWorkspace } from "@/lib/hooks/use-workspace";
 import { CoChangeTable } from "@repowise-dev/ui/workspace/co-change-table";
+import { RepoPairTable, type RepoPairSummary } from "@repowise-dev/ui/workspace/repo-pair-table";
 import { Card, CardContent, CardHeader, CardTitle } from "@repowise-dev/ui/ui/card";
 import { StatCard } from "@repowise-dev/ui/shared/stat-card";
 import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
+import { Button } from "@repowise-dev/ui/ui/button";
 
 export default function CoChangesPage() {
   const { workspace } = useWorkspace();
   const [repo, setRepo] = useState("");
+  const [viewMode, setViewMode] = useState<"pairs" | "flat">("pairs");
+  const [selectedPairId, setSelectedPairId] = useState<string | null>(null);
 
   const { data, isLoading } = useWorkspaceCoChanges({
     repo: repo || undefined,
@@ -22,17 +26,83 @@ export default function CoChangesPage() {
   const selectClass =
     "rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1.5 text-sm text-[var(--color-text-primary)] outline-none focus:border-[var(--color-accent-primary)]";
 
+  const repoPairs = useMemo(() => {
+    if (!data?.co_changes) return [];
+    const map = new Map<string, RepoPairSummary>();
+    for (const cc of data.co_changes) {
+      const sorted = [cc.source_repo, cc.target_repo].sort();
+      const id = `${sorted[0]}↔${sorted[1]}`;
+      
+      if (!map.has(id)) {
+        map.set(id, {
+          id,
+          repo1: sorted[0],
+          repo2: sorted[1],
+          filePairCount: 0,
+          maxStrength: 0,
+          lastDate: "",
+        });
+      }
+      const summary = map.get(id)!;
+      summary.filePairCount += 1;
+      if (cc.strength > summary.maxStrength) {
+        summary.maxStrength = cc.strength;
+      }
+      if (!summary.lastDate || cc.last_date > summary.lastDate) {
+        summary.lastDate = cc.last_date;
+      }
+    }
+    return Array.from(map.values()).sort((a, b) => b.maxStrength - a.maxStrength);
+  }, [data?.co_changes]);
+
+  const displayedCoChanges = useMemo(() => {
+    if (!data?.co_changes) return [];
+    if (viewMode === "pairs" && selectedPairId) {
+      return data.co_changes.filter((cc) => {
+        const sorted = [cc.source_repo, cc.target_repo].sort();
+        return `${sorted[0]}↔${sorted[1]}` === selectedPairId;
+      });
+    }
+    return data.co_changes;
+  }, [data?.co_changes, viewMode, selectedPairId]);
+
   return (
     <div className="p-5 sm:p-8 space-y-6 max-w-[1200px]">
       {/* Header */}
       <div>
-        <div className="flex items-center gap-2.5 mb-1">
-          <GitMerge className="h-6 w-6 text-[var(--color-accent-primary)]" />
-          <h1 className="text-2xl font-semibold text-[var(--color-text-primary)]">
-            Co-Changes
-          </h1>
+        <div className="flex items-center justify-between mb-1">
+          <div className="flex items-center gap-2.5">
+            <GitMerge className="h-6 w-6 text-[var(--color-accent-primary)]" />
+            <h1 className="text-2xl font-semibold text-[var(--color-text-primary)]">
+              Co-Changes
+            </h1>
+          </div>
+          <div className="flex items-center rounded-md border border-[var(--color-border-default)] p-1 bg-[var(--color-bg-surface)]">
+            <button
+              onClick={() => { setViewMode("pairs"); setSelectedPairId(null); }}
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded transition-colors ${
+                viewMode === "pairs"
+                  ? "bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] shadow-sm"
+                  : "text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+              }`}
+            >
+              <Columns className="h-4 w-4" />
+              Repo Pairs
+            </button>
+            <button
+              onClick={() => { setViewMode("flat"); setSelectedPairId(null); }}
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded transition-colors ${
+                viewMode === "flat"
+                  ? "bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] shadow-sm"
+                  : "text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
+              }`}
+            >
+              <LayoutList className="h-4 w-4" />
+              Flat List
+            </button>
+          </div>
         </div>
-        <p className="text-sm text-[var(--color-text-secondary)]">
+        <p className="text-sm text-[var(--color-text-secondary)] mt-2">
           Files the same author committed across repositories within a short time
           window. This is a temporal work-pattern hint from git history, not a
           verified technical dependency, so treat it as a starting point for
@@ -49,15 +119,7 @@ export default function CoChangesPage() {
         />
         <StatCard
           label="Repo Pairs"
-          value={
-            data?.co_changes
-              ? new Set(
-                  data.co_changes.map((cc) =>
-                    [cc.source_repo, cc.target_repo].sort().join("↔"),
-                  ),
-                ).size
-              : "—"
-          }
+          value={data?.co_changes ? repoPairs.length : "—"}
           icon={<GitMerge className="h-4 w-4 text-[var(--color-accent-secondary)]" />}
         />
         <StatCard
@@ -76,30 +138,46 @@ export default function CoChangesPage() {
       </div>
 
       {/* Filters */}
-      <div className="flex items-center gap-3">
-        <Filter className="h-4 w-4 text-[var(--color-text-tertiary)]" />
-        <span className="text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
-          Filter
-        </span>
-        <select
-          value={repo}
-          onChange={(e) => setRepo(e.target.value)}
-          className={selectClass}
-        >
-          <option value="">All Repos</option>
-          {repos.map((r) => (
-            <option key={r.alias} value={r.alias}>
-              {r.alias}
-            </option>
-          ))}
-        </select>
+      <div className="flex items-center justify-between">
+        {viewMode === "pairs" && selectedPairId ? (
+          <Button 
+            variant="outline" 
+            size="sm" 
+            onClick={() => setSelectedPairId(null)}
+            className="flex items-center gap-1.5"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Repo Pairs
+          </Button>
+        ) : (
+          <div className="flex items-center gap-3">
+            <Filter className="h-4 w-4 text-[var(--color-text-tertiary)]" />
+            <span className="text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+              Filter
+            </span>
+            <select
+              value={repo}
+              onChange={(e) => setRepo(e.target.value)}
+              className={selectClass}
+            >
+              <option value="">All Repos</option>
+              {repos.map((r) => (
+                <option key={r.alias} value={r.alias}>
+                  {r.alias}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
       </div>
 
       {/* Table */}
       <Card>
         <CardHeader className="pb-2">
           <CardTitle className="text-sm font-medium">
-            Co-Change Pairs ({data?.co_changes?.length ?? 0})
+            {viewMode === "pairs" && !selectedPairId 
+              ? `Repo Pairs (${repoPairs.length})` 
+              : `Co-Change Pairs (${displayedCoChanges.length})`}
           </CardTitle>
         </CardHeader>
         <CardContent className="pt-0">
@@ -109,8 +187,14 @@ export default function CoChangesPage() {
                 <Skeleton key={i} className="h-10 w-full" />
               ))}
             </div>
+          ) : viewMode === "pairs" && !selectedPairId ? (
+            <RepoPairTable 
+              repoPairs={repoPairs} 
+              onSelectPair={setSelectedPairId} 
+              selectedPairId={selectedPairId}
+            />
           ) : (
-            <CoChangeTable coChanges={data?.co_changes ?? []} />
+            <CoChangeTable coChanges={displayedCoChanges} />
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
### Background
Follow-up to #475. This PR addresses the missing piece of the co-changes page improvement: aggregating co-changes by repo-pair before drilling into the specific file pairs. 

Previously, the page displayed a flat list of file-to-file pairs which made it hard to scan and see the top-level relationship of "which repos move together."

### Proposed Changes
- **New `RepoPairTable` Component**: Added a new summary layer table displaying the unordered repo pairs (e.g., `backend ↔ frontend`), alongside the aggregate max strength, the number of file pairs involved, and the most recent activity date.
- **Drill-down Functionality**: You can now click on a specific repo pair in the summary table to filter the detailed `CoChangeTable` to only show file pairs for that specific repo pair.
- **View Toggle**: Added a toggle in the UI to easily switch between the new "Repo Pairs" grouped view and the classic "Flat List" view.
- No backend/schema changes were required, as all data existed inside the `WorkspaceCoChangeEntry`.

### Acceptance Criteria Met
- [x] A repo-pair summary is shown above (or instead of) the flat list.
- [x] Selecting a repo pair filters the file-pair detail to that pair.
- [x] `npm run type-check`, `npm run lint`, and `npm run build` all pass successfully.

Resolves #482
