### PR TITLE
feat(health): surface performance as a co-equal pillar in the web UI

### DIFF
--- a/packages/core/src/repowise/core/persistence/crud/analysis.py
+++ b/packages/core/src/repowise/core/persistence/crud/analysis.py
@@ -10,7 +10,7 @@ import json
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from repowise.core.analysis.dead_code.risk_factors import effective_safe_to_delete
@@ -426,6 +426,7 @@ async def get_health_findings(
     biomarker_type: str | None = None,
     min_severity: str | None = None,
     file_path: str | None = None,
+    dimension: str | None = None,
     status: str = "open",
 ) -> list[HealthFinding]:
     q = select(HealthFinding).where(
@@ -436,6 +437,15 @@ async def get_health_findings(
         q = q.where(HealthFinding.biomarker_type == biomarker_type)
     if file_path is not None:
         q = q.where(HealthFinding.file_path == file_path)
+    if dimension is not None:
+        # Older rows predate the split and carry a NULL dimension that homes
+        # under "defect"; fold those in so a defect filter never drops them.
+        if dimension == "defect":
+            q = q.where(
+                or_(HealthFinding.dimension == "defect", HealthFinding.dimension.is_(None))
+            )
+        else:
+            q = q.where(HealthFinding.dimension == dimension)
     if min_severity is not None:
         # Severity order: low < medium < high < critical
         order = {"low": 0, "medium": 1, "high": 2, "critical": 3}
@@ -473,6 +483,10 @@ async def get_health_summary(session: AsyncSession, repository_id: str) -> dict:
             "open_findings": 0,
             "maintainability_average": None,
             "performance_average": None,
+            "maintainability_findings": 0,
+            "performance_findings": 0,
+            "worst_performance_path": None,
+            "worst_performance_score": None,
         }
     total_nloc = sum(max(m.nloc, 1) for m in metrics)
     if total_nloc:
@@ -512,26 +526,48 @@ async def get_health_summary(session: AsyncSession, repository_id: str) -> dict:
         else:
             performance_average = sum(m.performance_score for m in perf_scored) / len(perf_scored)
 
-    findings_count = await session.execute(
-        select(func.count())
-        .select_from(HealthFinding)
+    # Worst-performance file: the lowest per-file performance score, surfaced only
+    # when there is genuine risk (score < 10) so a clean repo shows no actionable
+    # target rather than a misleading "worst" at a perfect 10.0.
+    worst_performance_path: str | None = None
+    worst_performance_score: float | None = None
+    if perf_scored:
+        perf_worst = min(perf_scored, key=lambda r: r.performance_score)
+        if perf_worst.performance_score < 10.0:
+            worst_performance_path = perf_worst.file_path
+            worst_performance_score = round(perf_worst.performance_score, 2)
+
+    # Open-finding counts split by home dimension (NULL homes under "defect"),
+    # so each pillar can show its own actionable count.
+    dim_rows = await session.execute(
+        select(HealthFinding.dimension, func.count())
         .where(
             HealthFinding.repository_id == repository_id,
             HealthFinding.status == "open",
         )
+        .group_by(HealthFinding.dimension)
     )
+    by_dim: dict[str, int] = {}
+    for dim, count in dim_rows.all():
+        by_dim[dim or "defect"] = by_dim.get(dim or "defect", 0) + int(count)
+    open_findings = sum(by_dim.values())
+
     return {
         "file_count": len(metrics),
         "average_health": round(avg, 2),
         "worst_performer_path": worst.file_path,
         "worst_performer_score": round(worst.score, 2),
-        "open_findings": findings_count.scalar() or 0,
+        "open_findings": open_findings,
         "maintainability_average": (
             round(maintainability_average, 2) if maintainability_average is not None else None
         ),
         "performance_average": (
             round(performance_average, 2) if performance_average is not None else None
         ),
+        "maintainability_findings": by_dim.get("maintainability", 0),
+        "performance_findings": by_dim.get("performance", 0),
+        "worst_performance_path": worst_performance_path,
+        "worst_performance_score": worst_performance_score,
     }
 
 

--- a/packages/server/src/repowise/server/routers/code_health.py
+++ b/packages/server/src/repowise/server/routers/code_health.py
@@ -460,6 +460,7 @@ async def list_health_findings(
     biomarker_type: str | None = Query(None),
     file_path: str | None = Query(None),
     min_severity: str | None = Query(None),
+    dimension: str | None = Query(None),
     limit: int = Query(100, ge=1, le=1000),
     session: AsyncSession = Depends(get_db_session),  # noqa: B008
 ) -> list[dict]:
@@ -469,6 +470,7 @@ async def list_health_findings(
         biomarker_type=biomarker_type,
         file_path=file_path,
         min_severity=min_severity,
+        dimension=dimension,
     )
     return await _attach_symbol_ids(
         session, repo_id, [_finding_to_dict(f) for f in findings[:limit]]

--- a/packages/server/src/repowise/server/routers/overview.py
+++ b/packages/server/src/repowise/server/routers/overview.py
@@ -390,6 +390,12 @@ async def overview_summary(
             "worst_performer_path": health_summary.get("worst_performer_path"),
             "worst_performer_score": health_summary.get("worst_performer_score"),
             "open_findings": health_summary.get("open_findings", 0),
+            # The two co-equal pillars surfaced alongside the defect headline.
+            "maintainability_average": health_summary.get("maintainability_average"),
+            "performance_average": health_summary.get("performance_average"),
+            "performance_findings": health_summary.get("performance_findings", 0),
+            "worst_performance_path": health_summary.get("worst_performance_path"),
+            "worst_performance_score": health_summary.get("worst_performance_score"),
             "severity_breakdown": severity_breakdown,
             "last_indexed_at": last_indexed_at,
             "snapshot_count": len(snapshots),

--- a/packages/types/src/health.ts
+++ b/packages/types/src/health.ts
@@ -250,6 +250,14 @@ export interface HealthOverviewSummary {
    */
   performance_average?: number | null;
   performance_hotspot?: number | null;
+  /** Open findings homing under the maintainability / performance pillars — the
+   *  per-pillar actionable counts. Absent on payloads predating the split. */
+  maintainability_findings?: number;
+  performance_findings?: number;
+  /** Lowest-scoring file by performance risk, surfaced only when score < 10
+   *  (a clean repo returns `null` rather than a misleading "worst" at 10.0). */
+  worst_performance_path?: string | null;
+  worst_performance_score?: number | null;
 }
 
 export interface HealthOverviewResponse {

--- a/packages/types/src/overview.ts
+++ b/packages/types/src/overview.ts
@@ -46,6 +46,17 @@ export interface OverviewHealth {
   worst_performer_path: string | null;
   worst_performer_score: number | null;
   open_findings: number;
+  /** Co-equal maintainability pillar headline (NLOC-weighted). `null` when no
+   *  file carries a maintainability score yet. */
+  maintainability_average?: number | null;
+  /** Co-equal performance pillar headline: static performance RISK (I/O-in-loop
+   *  / N+1). `null` when not yet measured. */
+  performance_average?: number | null;
+  /** Open findings homing under the performance pillar — the actionable count. */
+  performance_findings?: number;
+  /** Lowest-scoring file by performance risk, surfaced only when score < 10. */
+  worst_performance_path?: string | null;
+  worst_performance_score?: number | null;
   severity_breakdown: Record<string, number>;
   last_indexed_at: string | null;
   snapshot_count: number;

--- a/packages/ui/src/dashboard/health-overview-card.tsx
+++ b/packages/ui/src/dashboard/health-overview-card.tsx
@@ -5,6 +5,8 @@ import {
   TrendingDown,
   ShieldAlert,
   ArrowRight,
+  Wrench,
+  Gauge,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { fileEntityPath } from "../shared/entity/routes";
@@ -27,6 +29,12 @@ export interface HealthOverviewData {
   /** Open biomarker findings, with a severity rollup. */
   open_findings: number;
   severity_breakdown: Record<string, number>;
+  /** Co-equal maintainability pillar headline (1–10), null until measured. */
+  maintainability_average?: number | null;
+  /** Co-equal performance pillar headline (1–10, static risk), null until measured. */
+  performance_average?: number | null;
+  /** Open findings homing under the performance pillar — the actionable count. */
+  performance_findings?: number;
   /** Snapshot history, oldest→newest, for the trend sparkline. */
   history: HealthOverviewPoint[];
   snapshot_count: number;
@@ -351,9 +359,118 @@ export function HealthOverviewCard({
                 </a>
               )}
             </div>
+
+            {/* The two co-equal pillars beside the defect headline above —
+                maintainability and performance, each a jump into its findings. */}
+            {(data.maintainability_average != null || data.performance_average != null) && (
+              <div className="grid grid-cols-2 divide-x divide-[var(--color-border-default)] border-t border-[var(--color-border-default)]">
+                <PillarStat
+                  href={`${reportHref}?pillar=maintainability`}
+                  icon={<Wrench className="h-3 w-3" />}
+                  label="Maintainability"
+                  score={data.maintainability_average ?? null}
+                />
+                <PerformancePillarStat
+                  href={`${reportHref}?pillar=performance`}
+                  score={data.performance_average ?? null}
+                  findings={data.performance_findings ?? 0}
+                />
+              </div>
+            )}
           </>
         )}
       </CardContent>
     </Card>
+  );
+}
+
+/** A compact pillar cell in the Overview health card — label + score/10 + band,
+ *  the whole cell a link into that pillar's filtered findings. */
+function PillarStat({
+  href,
+  icon,
+  label,
+  score,
+}: {
+  href: string;
+  icon: React.ReactNode;
+  label: string;
+  score: number | null;
+}) {
+  const b = score != null ? band(score) : null;
+  return (
+    <a
+      href={href}
+      className="flex flex-col gap-1 px-4 py-3 transition-colors hover:bg-[var(--color-bg-elevated)]"
+    >
+      <span className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+        {icon}
+        {label}
+      </span>
+      {score == null ? (
+        <span className="text-sm text-[var(--color-text-tertiary)]">Not measured</span>
+      ) : (
+        <span className="flex items-baseline gap-1.5">
+          <span className="text-xl font-bold tabular-nums leading-none" style={{ color: b?.color }}>
+            {score.toFixed(1)}
+          </span>
+          <span className="text-xs text-[var(--color-text-tertiary)]">/10</span>
+          {b ? (
+            <span className="text-[10px] font-medium uppercase tracking-wide" style={{ color: b.color }}>
+              {b.label}
+            </span>
+          ) : null}
+        </span>
+      )}
+    </a>
+  );
+}
+
+/** Performance is a risk pillar, so its cell leads with the count of open risks
+ *  (the actionable read) and keeps the /10 score as a quiet secondary line. */
+function PerformancePillarStat({
+  href,
+  score,
+  findings,
+}: {
+  href: string;
+  score: number | null;
+  findings: number;
+}) {
+  const clear = score != null && findings === 0;
+  return (
+    <a
+      href={href}
+      className="flex flex-col gap-1 px-4 py-3 transition-colors hover:bg-[var(--color-bg-elevated)]"
+    >
+      <span className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+        <Gauge className="h-3 w-3" />
+        Performance
+      </span>
+      {score == null ? (
+        <span className="text-sm text-[var(--color-text-tertiary)]">Not measured</span>
+      ) : clear ? (
+        <span className="flex items-baseline gap-1.5">
+          <span className="text-xl font-bold tabular-nums leading-none text-[var(--color-success)]">
+            0
+          </span>
+          <span className="text-[10px] font-medium uppercase tracking-wide text-[var(--color-success)]">
+            All clear
+          </span>
+        </span>
+      ) : (
+        <span className="flex items-baseline gap-1.5">
+          <span className="text-xl font-bold tabular-nums leading-none text-[var(--color-text-primary)]">
+            {findings.toLocaleString()}
+          </span>
+          <span className="text-xs text-[var(--color-text-secondary)]">
+            {findings === 1 ? "risk" : "risks"}
+          </span>
+          <span className="text-[10px] tabular-nums text-[var(--color-text-tertiary)]">
+            · {score.toFixed(1)}/10
+          </span>
+        </span>
+      )}
+    </a>
   );
 }

--- a/packages/ui/src/health/kpi-cards.tsx
+++ b/packages/ui/src/health/kpi-cards.tsx
@@ -1,8 +1,15 @@
 import type { HealthBand, HealthDistribution } from "@repowise-dev/types/health";
 import { bandForScore, HEALTH_BAND_LABEL } from "@repowise-dev/types";
+import { HeartPulse, Wrench, Gauge } from "lucide-react";
 import { formatNumber } from "../lib/format";
 import { InfoTip } from "../shared/info-tip";
-import { scoreTextColor, healthBandTextColor, formatDelta, deltaColor } from "./tokens";
+import {
+  scoreTextColor,
+  healthBandTextColor,
+  healthBandSoftBadgeClass,
+  formatDelta,
+  deltaColor,
+} from "./tokens";
 import { Sparkline } from "./sparkline";
 import { SeverityDistribution, type SeverityBreakdown } from "./severity-distribution";
 import { HealthDistributionBar } from "./health-distribution-bar";
@@ -23,6 +30,9 @@ export interface HealthSummary {
   /** Performance pillar headline (the co-surfaced third signal: static
    *  performance RISK). `null` when no file carries a performance score yet. */
   performance_average?: number | null;
+  /** Open findings homing under each pillar — the actionable counts. */
+  maintainability_findings?: number;
+  performance_findings?: number;
 }
 
 export interface HealthKpiCardsProps {
@@ -35,7 +45,17 @@ export interface HealthKpiCardsProps {
   worstHistory?: number[];
   averageDelta?: number | null;
   hotspotDelta?: number | null;
+  /** Jump to the pillar-filtered findings view. When provided, the
+   *  Maintainability + Performance signal tiles become interactive. */
+  onSelectPillar?: (pillar: "defect" | "maintainability" | "performance") => void;
 }
+
+const DEFECT_HINT =
+  "The overall health headline: the defect-risk signal, calibrated against real bugs from complexity, duplication, coverage, churn, and ownership. NLOC-weighted across the repo.";
+const MAINT_HINT =
+  "A co-equal second signal: the smells that hurt readability and change-cost (low cohesion, brain methods, primitive obsession, duplication, error handling), scored on their own and never blended into the defect score.";
+const PERF_HINT =
+  "A co-equal third signal: static performance RISK — I/O-in-loop / N+1 shapes (a DB, network, filesystem, or subprocess call per loop iteration), detected across function boundaries via the call graph. High precision, low recall; never blended into the defect score.";
 
 export function HealthKpiCards({
   summary,
@@ -45,129 +65,271 @@ export function HealthKpiCards({
   worstHistory,
   averageDelta,
   hotspotDelta,
+  onSelectPillar,
 }: HealthKpiCardsProps) {
   const band = summary.band ?? bandForScore(summary.average_health);
   const maint = summary.maintainability_average;
   const perf = summary.performance_average;
+  const perfFindings = summary.performance_findings ?? 0;
+  const maintFindings = summary.maintainability_findings ?? 0;
+
   return (
-    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-7">
-      <Card label="Files Analyzed">
-        <p className="text-2xl font-bold text-[var(--color-text-primary)] tabular-nums">
-          {formatNumber(summary.file_count)}
-        </p>
-      </Card>
-      <Card label="Average Health" sparkline={averageHistory} delta={averageDelta}>
-        <p
-          className={`flex items-baseline gap-2 text-2xl font-bold tabular-nums ${scoreTextColor(summary.average_health)}`}
+    <div className="space-y-3">
+      {/* ── The three signals: the product's health model, given top billing ── */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <SignalTile
+          icon={<HeartPulse className="h-4 w-4" />}
+          label="Defect risk"
+          hint={DEFECT_HINT}
+          score={summary.average_health}
+          band={band}
+          delta={averageDelta}
+          sparkline={averageHistory}
         >
-          <span>
-            {summary.average_health.toFixed(1)}
-            <span className="text-base font-normal text-[var(--color-text-secondary)]">/10</span>
-          </span>
-          <span className={`text-xs font-semibold uppercase tracking-wide ${healthBandTextColor(band)}`}>
-            {HEALTH_BAND_LABEL[band]}
-          </span>
-        </p>
-        {distribution ? (
-          <div className="mt-2">
-            <HealthDistributionBar distribution={distribution} showCounts={false} height="sm" />
-          </div>
-        ) : null}
-      </Card>
-      <Card
-        label="Maintainability"
-        hint="A second, parallel health signal: the smells that hurt readability and change-cost (low cohesion, brain methods, primitive obsession, duplication, error handling) scored on their own, separate from the defect-backed score, which they don't predict. NLOC-weighted across the repo."
-      >
-        {maint == null ? (
-          <p className="text-2xl font-bold tabular-nums text-[var(--color-text-tertiary)]">
-            —
-            <span className="ml-1 align-middle text-xs font-normal text-[var(--color-text-tertiary)]">
-              not measured
-            </span>
+          {distribution ? (
+            <div className="mt-3">
+              <HealthDistributionBar distribution={distribution} showCounts={false} height="sm" />
+            </div>
+          ) : null}
+        </SignalTile>
+
+        <SignalTile
+          icon={<Wrench className="h-4 w-4" />}
+          label="Maintainability"
+          hint={MAINT_HINT}
+          score={maint ?? null}
+          band={maint != null ? bandForScore(maint) : null}
+          footnote={
+            maint != null && maintFindings > 0
+              ? `${formatNumber(maintFindings)} ${maintFindings === 1 ? "finding" : "findings"}`
+              : maint != null
+                ? "No open findings"
+                : undefined
+          }
+          onClick={maint != null && onSelectPillar ? () => onSelectPillar("maintainability") : undefined}
+        />
+
+        <PerformanceTile
+          score={perf ?? null}
+          findings={perfFindings}
+          onClick={perf != null && onSelectPillar ? () => onSelectPillar("performance") : undefined}
+        />
+      </div>
+
+      {/* ── Operational stats: the supporting strip, visually quieter ── */}
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <StatCard label="Files Analyzed">
+          <p className="text-xl font-semibold text-[var(--color-text-primary)] tabular-nums">
+            {formatNumber(summary.file_count)}
           </p>
-        ) : (
-          <p
-            className={`flex items-baseline gap-2 text-2xl font-bold tabular-nums ${scoreTextColor(maint)}`}
-          >
-            <span>
-              {maint.toFixed(1)}
-              <span className="text-base font-normal text-[var(--color-text-secondary)]">/10</span>
-            </span>
-            <span className={`text-xs font-semibold uppercase tracking-wide ${healthBandTextColor(bandForScore(maint))}`}>
-              {HEALTH_BAND_LABEL[bandForScore(maint)]}
-            </span>
-          </p>
-        )}
-      </Card>
-      <Card
-        label="Performance"
-        hint="A third, parallel health signal: static performance RISK — I/O-in-loop / N+1 shapes (a DB, network, filesystem, or subprocess call per loop iteration), detected across function boundaries via the call graph and resolved to a classified I/O boundary. High precision, low recall; never blended into the defect score. NLOC-weighted across the repo."
-      >
-        {perf == null ? (
-          <p className="text-2xl font-bold tabular-nums text-[var(--color-text-tertiary)]">
-            —
-            <span className="ml-1 align-middle text-xs font-normal text-[var(--color-text-tertiary)]">
-              not measured
-            </span>
-          </p>
-        ) : (
-          <p
-            className={`flex items-baseline gap-2 text-2xl font-bold tabular-nums ${scoreTextColor(perf)}`}
-          >
-            <span>
-              {perf.toFixed(1)}
-              <span className="text-base font-normal text-[var(--color-text-secondary)]">/10</span>
-            </span>
-            <span className={`text-xs font-semibold uppercase tracking-wide ${healthBandTextColor(bandForScore(perf))}`}>
-              {HEALTH_BAND_LABEL[bandForScore(perf)]}
-            </span>
-          </p>
-        )}
-      </Card>
-      <Card
-        label="Hotspot Health"
-        sparkline={hotspotHistory}
-        delta={hotspotDelta}
-        hint="The health score averaged over the repo's churn hotspots only (NLOC-weighted). Not a hotspot count — it answers “how healthy is the code you touch most?”"
-      >
-        <p
-          className={`text-2xl font-bold tabular-nums ${scoreTextColor(summary.hotspot_health ?? null)}`}
+        </StatCard>
+        <StatCard
+          label="Hotspot Health"
+          sparkline={hotspotHistory}
+          delta={hotspotDelta}
+          hint="The health score averaged over the repo's churn hotspots only (NLOC-weighted) — how healthy is the code you touch most?"
         >
-          {summary.hotspot_health == null ? "—" : summary.hotspot_health.toFixed(1)}
-          {summary.hotspot_health == null ? null : (
-            <span className="text-base font-normal text-[var(--color-text-secondary)]">/10</span>
-          )}
-        </p>
-      </Card>
-      <Card label="Worst Performer" sparkline={worstHistory}>
-        <p
-          className={`text-2xl font-bold tabular-nums ${scoreTextColor(summary.worst_performer_score)}`}
-        >
-          {summary.worst_performer_score?.toFixed(1) ?? "—"}
-          <span className="text-base font-normal text-[var(--color-text-secondary)]">/10</span>
-        </p>
-        <p className="text-xs text-[var(--color-text-tertiary)] mt-1 truncate font-mono">
-          {summary.worst_performer_path ?? "no data"}
-        </p>
-      </Card>
-      <Card label="Open Findings">
-        <p className="text-2xl font-bold text-[var(--color-text-primary)] tabular-nums">
-          {formatNumber(summary.open_findings)}
-        </p>
-        {summary.severity_breakdown ? (
-          <div className="mt-2">
-            <SeverityDistribution
-              breakdown={summary.severity_breakdown}
-              showCounts={false}
-            />
-          </div>
-        ) : null}
-      </Card>
+          <p className={`text-xl font-semibold tabular-nums ${scoreTextColor(summary.hotspot_health ?? null)}`}>
+            {summary.hotspot_health == null ? "—" : summary.hotspot_health.toFixed(1)}
+            {summary.hotspot_health == null ? null : (
+              <span className="text-sm font-normal text-[var(--color-text-secondary)]">/10</span>
+            )}
+          </p>
+        </StatCard>
+        <StatCard label="Worst Performer" sparkline={worstHistory}>
+          <p className={`text-xl font-semibold tabular-nums ${scoreTextColor(summary.worst_performer_score)}`}>
+            {summary.worst_performer_score?.toFixed(1) ?? "—"}
+            <span className="text-sm font-normal text-[var(--color-text-secondary)]">/10</span>
+          </p>
+          <p className="text-xs text-[var(--color-text-tertiary)] mt-1 truncate font-mono">
+            {summary.worst_performer_path ?? "no data"}
+          </p>
+        </StatCard>
+        <StatCard label="Open Findings">
+          <p className="text-xl font-semibold text-[var(--color-text-primary)] tabular-nums">
+            {formatNumber(summary.open_findings)}
+          </p>
+          {summary.severity_breakdown ? (
+            <div className="mt-2">
+              <SeverityDistribution breakdown={summary.severity_breakdown} showCounts={false} />
+            </div>
+          ) : null}
+        </StatCard>
+      </div>
     </div>
   );
 }
 
-function Card({
+/** A hero signal tile: icon + label, a large score/10 with band badge, and an
+ *  optional supporting line. Becomes a button when `onClick` is provided. */
+function SignalTile({
+  icon,
+  label,
+  hint,
+  score,
+  band,
+  delta,
+  sparkline,
+  footnote,
+  onClick,
+  children,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  hint: string;
+  score: number | null;
+  band: HealthBand | null;
+  delta?: number | null | undefined;
+  sparkline?: number[] | undefined;
+  footnote?: string | undefined;
+  onClick?: (() => void) | undefined;
+  children?: React.ReactNode;
+}) {
+  const inner = (
+    <>
+      <div className="flex items-center justify-between gap-2">
+        <span className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+          <span className="text-[var(--color-text-secondary)]">{icon}</span>
+          {label}
+          <InfoTip content={hint} label={`About ${label}`} />
+        </span>
+        {sparkline && sparkline.length > 1 ? (
+          <span className="text-[var(--color-text-tertiary)]">
+            <Sparkline values={sparkline} width={56} height={16} />
+          </span>
+        ) : null}
+      </div>
+
+      {score == null ? (
+        <p className="mt-3 text-3xl font-bold tabular-nums text-[var(--color-text-tertiary)]">
+          —
+          <span className="ml-2 align-middle text-xs font-normal">not measured</span>
+        </p>
+      ) : (
+        <div className="mt-3 flex items-baseline gap-2.5">
+          <span className={`text-3xl font-bold leading-none tabular-nums ${scoreTextColor(score)}`}>
+            {score.toFixed(1)}
+            <span className="text-base font-normal text-[var(--color-text-secondary)]">/10</span>
+          </span>
+          {band ? (
+            <span
+              className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${healthBandSoftBadgeClass(band)}`}
+            >
+              {HEALTH_BAND_LABEL[band]}
+            </span>
+          ) : null}
+        </div>
+      )}
+
+      {delta != null && Math.abs(delta) >= 0.005 ? (
+        <p className={`mt-1.5 text-xs tabular-nums ${deltaColor(delta)}`}>
+          {formatDelta(delta)} vs. prior
+        </p>
+      ) : footnote ? (
+        <p className="mt-1.5 text-xs text-[var(--color-text-tertiary)]">{footnote}</p>
+      ) : null}
+
+      {children}
+    </>
+  );
+  return <TileShell onClick={onClick}>{inner}</TileShell>;
+}
+
+/** Shared chrome for a hero signal tile — a static card, or a button when an
+ *  `onClick` makes it a jump into the pillar-filtered view. */
+function TileShell({
+  onClick,
+  children,
+}: {
+  onClick?: (() => void) | undefined;
+  children: React.ReactNode;
+}) {
+  const cls =
+    "flex w-full flex-col rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-5 text-left transition-colors";
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={`${cls} cursor-pointer hover:border-[var(--color-border-strong)]`}
+      >
+        {children}
+      </button>
+    );
+  }
+  return <div className={cls}>{children}</div>;
+}
+
+/** Performance is a RISK pillar — so it leads with the count of open risks, with
+ *  the /10 score as a calm secondary read. Clean repos show "0 · all clear". */
+function PerformanceTile({
+  score,
+  findings,
+  onClick,
+}: {
+  score: number | null;
+  findings: number;
+  onClick?: (() => void) | undefined;
+}) {
+  const interactive = !!onClick && (findings > 0 || score != null);
+  const band = score != null ? bandForScore(score) : null;
+  const clear = score != null && findings === 0;
+
+  const inner = (
+    <>
+      <span className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+        <span className="text-[var(--color-text-secondary)]">
+          <Gauge className="h-4 w-4" />
+        </span>
+        Performance
+        <InfoTip content={PERF_HINT} label="About Performance" />
+      </span>
+
+      {score == null ? (
+        <p className="mt-3 text-3xl font-bold tabular-nums text-[var(--color-text-tertiary)]">
+          —
+          <span className="ml-2 align-middle text-xs font-normal">not measured</span>
+        </p>
+      ) : clear ? (
+        <>
+          <div className="mt-3 flex items-baseline gap-2.5">
+            <span className="text-3xl font-bold leading-none tabular-nums text-[var(--color-success)]">
+              0
+            </span>
+            <span className="rounded-full bg-[var(--color-success)]/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--color-success)]">
+              All clear
+            </span>
+          </div>
+          <p className="mt-1.5 text-xs text-[var(--color-text-tertiary)] tabular-nums">
+            Risk score {score.toFixed(1)}/10
+          </p>
+        </>
+      ) : (
+        <>
+          <div className="mt-3 flex items-baseline gap-1.5">
+            <span className="text-3xl font-bold leading-none tabular-nums text-[var(--color-text-primary)]">
+              {formatNumber(findings)}
+            </span>
+            <span className="text-sm font-medium text-[var(--color-text-secondary)]">
+              {findings === 1 ? "risk" : "risks"}
+            </span>
+          </div>
+          <p className="mt-1.5 inline-flex items-center gap-1.5 text-xs tabular-nums text-[var(--color-text-tertiary)]">
+            Risk score {score.toFixed(1)}/10
+            {band ? (
+              <span className={`font-semibold uppercase tracking-wide ${healthBandTextColor(band)}`}>
+                {HEALTH_BAND_LABEL[band]}
+              </span>
+            ) : null}
+          </p>
+        </>
+      )}
+    </>
+  );
+  return <TileShell onClick={interactive ? onClick : undefined}>{inner}</TileShell>;
+}
+
+function StatCard({
   label,
   children,
   sparkline,

--- a/packages/web/src/components/code-health/triage-tab.tsx
+++ b/packages/web/src/components/code-health/triage-tab.tsx
@@ -7,7 +7,8 @@
  * function-level panels.
  */
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
 import { Button } from "@repowise-dev/ui/ui/button";
@@ -39,7 +40,7 @@ import {
   type Severity,
 } from "@repowise-dev/ui/health";
 import { CollapsibleSection } from "@repowise-dev/ui/shared/collapsible-section";
-import { Search } from "lucide-react";
+import { Gauge, Search } from "lucide-react";
 import {
   getHealthOverview,
   getRefactoringTargets,
@@ -123,9 +124,19 @@ export function TriageTab({
     { revalidateOnFocus: false },
   );
 
+  // Every open performance-pillar finding (the cross-function N+1 / I/O-in-loop
+  // moat), for the dedicated Performance risks panel.
+  const { data: perfFindings } = useSWR<HealthFinding[]>(
+    `code-health-perf-findings:${id}`,
+    () =>
+      listHealthFindings(id, { dimension: "performance", limit: 200 }).catch(
+        () => [] as HealthFinding[],
+      ),
+    { revalidateOnFocus: false },
+  );
+
   // ---- One filter set coordinates the queue AND the findings sidebar ----
   const [minSeverity, setMinSeverity] = useState<Severity | "all">("all");
-  const [pillar, setPillar] = useState<"all" | "defect" | "maintainability" | "performance">("all");
   const [biomarker, setBiomarker] = useState<string>("all");
   const [maxEffort, setMaxEffort] = useState<string>("all");
   const [sort, setSort] = useState<RefactoringQuery["sort"]>("impact_per_effort");
@@ -138,6 +149,36 @@ export function TriageTab({
   // ---- Map-driven UI: rail spotlight + filename dim + collapsible list ----
   const [hoverFile, setHoverFile] = useState<CodeHealthMapFile | null>(null);
   const [mapQuery, setMapQuery] = useState("");
+
+  // ---- Pillar filter is URL-synced (?pillar=) so the Overview + KPI tiles can
+  //      deep-link straight into a single dimension's findings. ----
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const rawPillar = searchParams.get("pillar");
+  const pillar: "all" | "defect" | "maintainability" | "performance" =
+    rawPillar === "defect" ||
+    rawPillar === "maintainability" ||
+    rawPillar === "performance"
+      ? rawPillar
+      : "all";
+  const findingsRef = useRef<HTMLDivElement | null>(null);
+  const setPillar = useCallback(
+    (next: "all" | "defect" | "maintainability" | "performance") => {
+      const sp = new URLSearchParams(searchParams.toString());
+      if (next === "all") sp.delete("pillar");
+      else sp.set("pillar", next);
+      const qs = sp.toString();
+      router.replace(qs ? `?${qs}` : "?", { scroll: false });
+    },
+    [router, searchParams],
+  );
+  const focusPillar = useCallback(
+    (next: "defect" | "maintainability" | "performance") => {
+      setPillar(next);
+      findingsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    },
+    [setPillar],
+  );
 
   const queueKey = useMemo(
     () => JSON.stringify({ id, biomarker, minSeverity, maxEffort, sort, queueLimit }),
@@ -250,10 +291,17 @@ export function TriageTab({
   return (
     <div className="space-y-6">
       {isLoading ? (
-        <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-7 gap-3">
-          {Array.from({ length: 7 }).map((_, i) => (
-            <Skeleton key={i} className="h-24 w-full rounded-lg" />
-          ))}
+        <div className="space-y-3">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-28 w-full rounded-xl" />
+            ))}
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-20 w-full rounded-lg" />
+            ))}
+          </div>
         </div>
       ) : error ? (
         <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4 text-sm text-[var(--color-text-secondary)] flex items-center justify-between gap-2">
@@ -271,6 +319,7 @@ export function TriageTab({
             worstHistory={worstSeries}
             averageDelta={trend?.summary?.average_delta ?? undefined}
             hotspotDelta={trend?.summary?.hotspot_delta ?? undefined}
+            onSelectPillar={focusPillar}
           />
 
           {overview.defect_accuracy ? (
@@ -323,7 +372,7 @@ export function TriageTab({
 
               <FileSpotlight file={hoverFile} onOpen={(p) => setSelectedFile(p)} />
 
-              <div className="flex items-center gap-2">
+              <div ref={findingsRef} className="flex items-center gap-2 scroll-mt-4">
                 <h2 className="text-sm font-medium uppercase tracking-wider text-[var(--color-text-tertiary)] mr-auto">
                   Findings
                 </h2>
@@ -370,6 +419,35 @@ export function TriageTab({
               </div>
             </aside>
           </div>
+
+          {/* Performance risks — the cross-function N+1 / I/O-in-loop moat,
+              given a dedicated home. Only rendered when risks actually exist
+              (high precision, low recall), so a clean repo stays uncluttered. */}
+          {perfFindings && perfFindings.length > 0 ? (
+            <CollapsibleSection
+              title={
+                <span className="inline-flex items-center gap-2">
+                  <Gauge className="h-4 w-4 text-[var(--color-info)]" />
+                  Performance risks
+                </span>
+              }
+              hint={`${perfFindings.length} ${perfFindings.length === 1 ? "risk" : "risks"}`}
+              defaultOpen
+            >
+              <div className="space-y-3">
+                <p className="text-xs text-[var(--color-text-secondary)]">
+                  Static performance risk: a DB, network, filesystem, or subprocess call
+                  per loop iteration, detected across function boundaries via the call
+                  graph. High precision, low recall, never blended into the defect score.
+                </p>
+                <BiomarkerList
+                  findings={perfFindings}
+                  grouped
+                  onSelect={(f) => setSelectedFile(f.file_path)}
+                />
+              </div>
+            </CollapsibleSection>
+          ) : null}
 
           {/* Collapsible: the full ranked queue + file inventory. The severity
               filter is shared with the rail above (one control, no duplicate). */}

--- a/packages/web/src/lib/api/code-health.ts
+++ b/packages/web/src/lib/api/code-health.ts
@@ -60,6 +60,7 @@ export async function listHealthFindings(
     biomarker_type?: string;
     file_path?: string;
     min_severity?: string;
+    dimension?: string;
     limit?: number;
   },
 ): Promise<HealthFinding[]> {


### PR DESCRIPTION
## What

Makes the **performance** health signal prominent in the web UI and brings it to the Overview page as an actionable surface. Performance was already computed and scored end to end, but in the UI it was only one of seven equal KPI cards on the Code Health page and absent from the Overview entirely.

## Changes

**Code Health page**
- The three health signals (defect risk, maintainability, performance) now lead the page as a prominent, airy three-tile band. The operational stats (files, hotspot health, worst performer, open findings) move into a quieter supporting strip below.
- Performance is a *risk* pillar, so its tile leads with the open-risk count instead of a near-perfect /10 that reads as "nothing to do" on clean repos. Clean repos show "All clear".
- New dedicated **Performance risks** panel listing the cross-function N+1 / I/O-in-loop findings, only rendered when risks exist.
- The pillar filter is now URL-synced (`?pillar=`), so the KPI tiles and the Overview card can deep-link straight into a single dimension's findings.

**Overview page**
- The Code Health card gains a compact two-cell pillar strip (maintainability + performance) beside the existing defect headline, with a findings-led performance cell. Each cell deep-links into the matching filtered findings.

**Backend / types**
- `get_health_summary` now also returns the per-pillar open-finding counts and the worst-performance file (surfaced only when there is genuine risk). These flow through both the health-overview and overview-summary endpoints.
- New `dimension` filter on the findings endpoint backs the performance panel.

## Notes

The surfaced overall score is unchanged: the defect golden stays byte-for-byte. Maintainability and performance remain co-equal *visible* signals that never feed back into the defect headline.

## Testing
- `npm run type-check`, `npm run lint` clean
- `ruff check` clean
- `pytest tests/unit/health` (512), `tests/unit/server` (633), `tests/unit/persistence/test_health_dimensions_crud.py` (3) all pass