### PR TITLE
fix(health): skip for...of over constant collections in TS/JS perf detector

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
+++ b/packages/core/src/repowise/core/analysis/health/perf/dialects/ts_js.py
@@ -120,6 +120,27 @@ class TsJsPerfDialect(BasePerfDialect):
             return self._dotted_path(right)
         return None
 
+    def is_constant_loop(self, node: Node) -> bool:
+        """True if a ``for...of`` / ``for...in`` iterates a compile-time-constant
+        bound: an inline **array literal** (``for (const p of ["/a", "/b"])`` —
+        the author enumerated a fixed set, so there is no data-dependent N+1
+        blow-up) or an **ALL_CAPS** named constant (``for (const f of
+        DREAMS_FILENAMES)``). Mirrors the Python dialect's literal-collection
+        skip. C-style ``for (;;)`` / ``while`` / ``do`` are cursors — never
+        constant here (they are pagination / polling)."""
+        if node.type not in self._ITERATION_LOOP_KINDS:
+            return False
+        right = node.child_by_field_name("right")
+        if right is None:
+            return False
+        if right.type == "array":
+            return True
+        if right.type == "identifier" and right.text is not None:
+            name = right.text.decode("utf-8", "replace")
+            if name.isupper() and len(name) > 1:
+                return True
+        return False
+
     def sink_kind(
         self,
         root: str,

--- a/tests/unit/health/test_perf_io_in_loop.py
+++ b/tests/unit/health/test_perf_io_in_loop.py
@@ -151,6 +151,28 @@ _CASES = [
     ),
     (
         "typescript",
+        b"import fs from 'fs';\n"
+        b'function f() {\n  for (const p of ["/proc/net/tcp", "/proc/net/tcp6"]) {\n'
+        b'    fs.readFileSync(p, "utf8");\n  }\n}\n',
+        [],
+        "for-of over an inline array literal is constant-bounded -> skipped",
+    ),
+    (
+        "typescript",
+        b"import fs from 'fs';\nconst NAMES = ['DREAMS.md', 'dreams.md'];\n"
+        b"function f() {\n  for (const n of NAMES) {\n    fs.readFileSync(n);\n  }\n}\n",
+        [],
+        "for-of over an ALL_CAPS named constant is constant-bounded -> skipped",
+    ),
+    (
+        "typescript",
+        b"import fs from 'fs';\n"
+        b'function f(paths) {\n  for (const p of paths) {\n    fs.readFileSync(p, "utf8");\n  }\n}\n',
+        [("io_in_loop", "filesystem")],
+        "for-of over a data-dependent variable still fires (contrast to constant)",
+    ),
+    (
+        "typescript",
         b"import axios from 'axios';\n"
         b"function f(items) {\n"
         b"  for (const u of items) {\n"


### PR DESCRIPTION
## What

The TS/JS perf dialect inherited the base no-op `is_constant_loop`, so `io_in_loop` (and the other per-iteration loop markers) fired on `for...of` loops whose iterable is an **inline array literal** (`for (const p of ["/proc/net/tcp", "/proc/net/tcp6"])`) or an **ALL_CAPS named constant** (`for (const f of DREAMS_FILENAMES)`). These loops are bounded by construction, not a data-dependent N+1. The Python dialect already skips the equivalent `for x in [literal]` / `for x in ALL_CAPS`; this ports the same logic to `ts_js.py`.

## Why

Validating the performance markers against a large, fast-moving TypeScript monorepo surfaced this as the dominant false-positive class in a stratified precision sample: `for...of` over a fixed inline collection read as a per-iteration I/O-in-loop when the iteration count is a small compile-time constant.

## Impact (measured)

Re-running the detector over the same ~20k-file TS monorepo:

| marker | before | after | delta |
|--------|------:|-----:|------:|
| `io_in_loop` | 1805 | 1615 | **-190** |
| `serial_await_in_loop` | 422 | 357 | -65 |
| `nested_loop_with_io` | 45 | 35 | -10 |

No true-positive loss: a `for...of` over a lowercase variable iterable still fires (we cannot prove it bounded without data flow, matching the Python dialect's conservative limit).

## Tests

Regression cases added to `test_perf_io_in_loop.py`:
- `for...of` over an inline array literal -> skipped
- `for...of` over an ALL_CAPS named constant -> skipped
- `for...of` over a data-dependent variable -> still fires (contrast)

Full `tests/unit/health` suite passes (512). The defect golden is byte-for-byte unchanged - every perf marker stays `performance`-only and the change only removes constant-bounded false positives from the performance dimension.