### PR TITLE
feat(commits): Code Evolution timeline as the headline

### DIFF
--- a/packages/core/src/repowise/core/ingestion/git_indexer/_constants.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/_constants.py
@@ -212,6 +212,112 @@ def is_fix_commit(subject: str) -> bool:
     return any(p.search(subject) for p in _FIX_COMMIT_INCLUDE)
 
 
+# ---------------------------------------------------------------------------
+# Single-label commit-category classification (powers the "Code Evolution"
+# timeline on the commits page). Unlike ``_COMMIT_CATEGORIES`` — which is
+# *multi-label* and tuned for per-file category *ratios* — this assigns each
+# commit exactly ONE category so a stacked timeline sums cleanly to 100%.
+#
+# Resolution order: an explicit conventional-commit prefix (``feat:``,
+# ``fix(scope):`` …) wins outright; otherwise the keyword patterns below are
+# tried in priority order and the first match decides. Anything unmatched
+# falls through to "other". The labels are the seven that read as a story arc
+# (feature-born → fix/refactor/docs as a repo matures) plus deps/chore/test.
+# ---------------------------------------------------------------------------
+
+# Ordered: more specific / higher-signal intents first so a "fix typo in docs"
+# resolves the way a human would skim it.
+EVOLUTION_CATEGORIES: tuple[str, ...] = (
+    "feature",
+    "fix",
+    "refactor",
+    "docs",
+    "test",
+    "deps",
+    "chore",
+    "other",
+)
+
+# Conventional-commit type -> our category. The prefix is authoritative when
+# present (``type(scope)!: subject``), so this short-circuits the keyword pass.
+_CONVENTIONAL_PREFIX = re.compile(
+    r"^\s*(?P<type>[a-z]+)(?:\([^)]*\))?!?:",
+    re.IGNORECASE,
+)
+_CONVENTIONAL_MAP: dict[str, str] = {
+    "feat": "feature",
+    "feature": "feature",
+    "fix": "fix",
+    "bugfix": "fix",
+    "hotfix": "fix",
+    "perf": "refactor",
+    "refactor": "refactor",
+    "style": "refactor",
+    "docs": "docs",
+    "doc": "docs",
+    "test": "test",
+    "tests": "test",
+    "build": "deps",
+    "deps": "deps",
+    "ci": "chore",
+    "chore": "chore",
+    "revert": "fix",
+}
+
+# Keyword fallback, tried in this exact order; first hit wins.
+_EVOLUTION_KEYWORDS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("docs", re.compile(r"\b(docs?|documentation|readme|changelog|comment)\b", re.IGNORECASE)),
+    ("test", re.compile(r"\b(test|tests|testing|spec|coverage|fixture)\b", re.IGNORECASE)),
+    (
+        "deps",
+        re.compile(
+            r"\b(bump|upgrade|downgrade|depend|dependency|dependencies|lockfile|"
+            r"requirements|vendor|pin)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    ("fix", re.compile(r"\b(fix|fixes|fixed|bug|patch|hotfix|regression|crash|revert)\b", re.IGNORECASE)),
+    (
+        "refactor",
+        re.compile(
+            r"\b(refactor|restructure|cleanup|clean.up|rename|reorganize|extract|"
+            r"simplify|move|tidy|dedupe|perf|optimi[sz]e)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "feature",
+        re.compile(
+            r"\b(add|adds|added|implement|introduce|create|new|feat|feature|support|enable)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "chore",
+        re.compile(r"\b(chore|lint|format|style|ci|build|release|merge|config|tooling)\b", re.IGNORECASE),
+    ),
+)
+
+
+def classify_commit_category(subject: str) -> str:
+    """Assign a commit *subject* exactly one :data:`EVOLUTION_CATEGORIES` label.
+
+    A leading conventional-commit prefix is authoritative; otherwise the first
+    matching keyword pattern (in priority order) wins. Unmatched -> ``"other"``.
+    """
+    if not subject:
+        return "other"
+    m = _CONVENTIONAL_PREFIX.match(subject)
+    if m:
+        mapped = _CONVENTIONAL_MAP.get(m.group("type").lower())
+        if mapped:
+            return mapped
+    for label, pattern in _EVOLUTION_KEYWORDS:
+        if pattern.search(subject):
+            return label
+    return "other"
+
+
 # Co-change temporal decay: half-life ~125 days (lambda for exp(-t/tau)).
 _CO_CHANGE_DECAY_TAU: float = 180.0
 

--- a/packages/server/src/repowise/server/routers/git.py
+++ b/packages/server/src/repowise/server/routers/git.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+from collections import Counter
+from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, select
@@ -13,6 +15,10 @@ from repowise.core.analysis.change_risk import (
     RiskNormalizer,
     score_change,
 )
+from repowise.core.ingestion.git_indexer._constants import (
+    EVOLUTION_CATEGORIES,
+    classify_commit_category,
+)
 from repowise.core.persistence import crud
 from repowise.core.persistence.models import GitCommit, GitMetadata
 from repowise.server.deps import get_db_session, verify_api_key
@@ -21,6 +27,8 @@ from repowise.server.schemas import (
     AgentTrendBucket,
     AgentTrendResponse,
     CommitDetailResponse,
+    CommitEvolutionBucket,
+    CommitEvolutionResponse,
     CommitResponse,
     GitMetadataResponse,
     GitSummaryResponse,
@@ -248,6 +256,85 @@ async def get_agent_trend(
             key=lambda x: x["count"],
             reverse=True,
         ),
+    )
+
+
+@router.get("/{repo_id}/commits/evolution", response_model=CommitEvolutionResponse)
+async def get_commit_evolution(
+    repo_id: str,
+    granularity: str = Query("auto", pattern="^(auto|month|week)$"),
+    session: AsyncSession = Depends(get_db_session),  # noqa: B008
+) -> CommitEvolutionResponse:
+    """The repo's development "story arc" — commit-category mix over time.
+
+    Each commit is classified into exactly one category (feature / fix /
+    refactor / docs / test / deps / chore / other) from its subject and bucketed
+    by month (or week on short-history repos). Classification is pure and runs
+    off the already-stored subject, so this needs no reindex. The UI stacks the
+    buckets to show how the development emphasis shifts as the repo matures.
+    """
+    result = await session.execute(
+        select(GitCommit.committed_at, GitCommit.subject).where(
+            GitCommit.repository_id == repo_id
+        )
+    )
+    rows = [(ts, subj) for ts, subj in result.all() if ts is not None]
+
+    if not rows:
+        return CommitEvolutionResponse(
+            buckets=[],
+            categories=[],
+            totals={},
+            total_commits=0,
+            granularity="month",
+        )
+
+    rows.sort(key=lambda r: r[0])
+    first, last = rows[0][0], rows[-1][0]
+
+    # Auto: weekly resolution keeps short-lived repos from collapsing into one
+    # or two fat monthly columns; anything spanning more than ~26 weeks reads
+    # better monthly.
+    if granularity == "auto":
+        span_days = (last - first).days
+        granularity = "week" if span_days <= 26 * 7 else "month"
+
+    def _bucket_key(ts: datetime) -> tuple[str, str]:
+        if granularity == "week":
+            iso_year, iso_week, _ = ts.isocalendar()
+            monday = (ts - timedelta(days=ts.isoweekday() - 1)).date()
+            return f"{iso_year}-W{iso_week:02d}", monday.isoformat()
+        return ts.strftime("%Y-%m"), ts.replace(day=1).date().isoformat()
+
+    buckets: dict[str, dict] = {}
+    totals: Counter[str] = Counter()
+    for ts, subject in rows:
+        period, start = _bucket_key(ts)
+        cat = classify_commit_category(subject or "")
+        b = buckets.setdefault(period, {"start": start, "total": 0, "counts": Counter()})
+        b["total"] += 1
+        b["counts"][cat] += 1
+        totals[cat] += 1
+
+    # Canonical category order, restricted to those that actually appear.
+    present = [c for c in EVOLUTION_CATEGORIES if totals.get(c)]
+
+    return CommitEvolutionResponse(
+        buckets=[
+            CommitEvolutionBucket(
+                period=period,
+                start=b["start"],
+                total=b["total"],
+                counts=dict(b["counts"]),
+            )
+            for period, b in sorted(buckets.items(), key=lambda kv: kv[1]["start"])
+        ],
+        categories=present,
+        totals=dict(totals),
+        total_commits=len(rows),
+        granularity=granularity,
+        first_commit_at=first.isoformat(),
+        last_commit_at=last.isoformat(),
     )
 
 

--- a/packages/server/src/repowise/server/schemas/__init__.py
+++ b/packages/server/src/repowise/server/schemas/__init__.py
@@ -65,6 +65,8 @@ from .git import (
     AgentTrendBucket,
     AgentTrendResponse,
     CommitDetailResponse,
+    CommitEvolutionBucket,
+    CommitEvolutionResponse,
     CommitResponse,
     GitMetadataResponse,
     GitSummaryResponse,
@@ -195,6 +197,8 @@ from .workspace import (
 __all__ = [
     "AgentTrendBucket",
     "AgentTrendResponse",
+    "CommitEvolutionBucket",
+    "CommitEvolutionResponse",
     "ArchEdgeResponse",
     "ArchLayerResponse",
     "ArchNodeResponse",

--- a/packages/server/src/repowise/server/schemas/git.py
+++ b/packages/server/src/repowise/server/schemas/git.py
@@ -218,3 +218,34 @@ class AgentTrendResponse(BaseModel):
     agent_commits: int
     agent_pct: float  # 0-100 across the whole window
     agent_names: list[dict] = []  # [{name, count}] descending
+
+
+class CommitEvolutionBucket(BaseModel):
+    """One time bucket of commit-category counts for the Code Evolution timeline.
+
+    ``counts`` keys are drawn from
+    :data:`repowise.core.ingestion.git_indexer._constants.EVOLUTION_CATEGORIES`;
+    a category is omitted when its count is zero in this bucket.
+    """
+
+    period: str  # "YYYY-MM" (monthly) or "YYYY-Wnn" (weekly)
+    start: str  # ISO date of the bucket's first day, for axis ordering/tooltips
+    total: int
+    counts: dict[str, int] = {}
+
+
+class CommitEvolutionResponse(BaseModel):
+    """Commit-category mix over time — the repo's development "story arc".
+
+    Each commit is classified into exactly one category (feature/fix/refactor/
+    docs/test/deps/chore/other) from its subject and bucketed by ``granularity``.
+    The UI renders ``buckets`` as a stacked area (share or volume).
+    """
+
+    buckets: list[CommitEvolutionBucket]
+    categories: list[str]  # categories present across the window, in canonical order
+    totals: dict[str, int] = {}  # window-wide count per category
+    total_commits: int
+    granularity: str  # "month" | "week"
+    first_commit_at: str | None = None
+    last_commit_at: str | None = None

--- a/packages/types/src/git.ts
+++ b/packages/types/src/git.ts
@@ -178,6 +178,36 @@ export interface AgentTrend {
   agent_names: { name: string; count: number }[];
 }
 
+/** Canonical commit-category labels for the Code Evolution timeline. */
+export type CommitCategory =
+  | "feature"
+  | "fix"
+  | "refactor"
+  | "docs"
+  | "test"
+  | "deps"
+  | "chore"
+  | "other";
+
+/** One time bucket of commit-category counts. */
+export interface CommitEvolutionBucket {
+  period: string; // "YYYY-MM" (monthly) or "YYYY-Wnn" (weekly)
+  start: string; // ISO date of the bucket's first day
+  total: number;
+  counts: Partial<Record<CommitCategory, number>>;
+}
+
+/** Commit-category mix over time — the repo's development "story arc". */
+export interface CommitEvolution {
+  buckets: CommitEvolutionBucket[];
+  categories: CommitCategory[]; // present across the window, canonical order
+  totals: Partial<Record<CommitCategory, number>>;
+  total_commits: number;
+  granularity: "month" | "week";
+  first_commit_at: string | null;
+  last_commit_at: string | null;
+}
+
 export interface OwnershipEntry {
   module_path: string;
   primary_owner: string | null;

--- a/packages/ui/src/commits/code-evolution-chart.tsx
+++ b/packages/ui/src/commits/code-evolution-chart.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { GitBranch, Info } from "lucide-react";
+import type {
+  CommitCategory,
+  CommitEvolution,
+} from "@repowise-dev/types/git";
+import {
+  Tooltip as UiTooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../ui/tooltip";
+import { cn } from "../lib/cn";
+
+/**
+ * The repo's development "story arc" — a stacked-area timeline of how the
+ * commit mix (feature / fix / refactor / docs / …) shifts over its history.
+ * Each commit is classified into exactly one category from its subject, so the
+ * bands stack cleanly; the share/volume toggle flips between proportion and
+ * raw throughput. The narrative line up top reads the arc for the user (e.g.
+ * "feature-led early, fix-and-docs heavy lately").
+ */
+
+interface CategoryMeta {
+  label: string;
+  color: string;
+  blurb: string;
+}
+
+// Drawn bottom-to-top in this order; "feature" anchors the base so the growth
+// band reads as the foundation the rest of the work sits on. Colours route
+// through semantic design tokens (theme-aware, no raw hex) and are picked so
+// the mapping reads intuitively: green = new capability, red = fixes, etc.
+const CATEGORY_META: Record<CommitCategory, CategoryMeta> = {
+  feature: { label: "Feature", color: "var(--color-success)", blurb: "new capability" },
+  fix: { label: "Fix", color: "var(--color-error)", blurb: "bug / regression" },
+  refactor: { label: "Refactor", color: "var(--color-accent-primary)", blurb: "reshape / perf" },
+  docs: { label: "Docs", color: "var(--color-info)", blurb: "documentation" },
+  test: { label: "Test", color: "var(--color-amber)", blurb: "tests / coverage" },
+  deps: { label: "Deps", color: "var(--color-caution)", blurb: "dependency bumps" },
+  chore: { label: "Chore", color: "var(--color-text-tertiary)", blurb: "tooling / CI / release" },
+  other: { label: "Other", color: "var(--color-border-active)", blurb: "unclassified" },
+};
+
+const STACK_ORDER: CommitCategory[] = [
+  "feature",
+  "fix",
+  "refactor",
+  "docs",
+  "test",
+  "deps",
+  "chore",
+  "other",
+];
+
+type Mode = "share" | "volume";
+
+function formatBucketLabel(startIso: string, granularity: string): string {
+  const d = new Date(startIso);
+  if (Number.isNaN(d.getTime())) return startIso;
+  const month = d.toLocaleString("en-US", { month: "short" });
+  if (granularity === "week") {
+    return `${month} ${d.getDate()}`;
+  }
+  return `${month} ${String(d.getFullYear()).slice(2)}`;
+}
+
+/** Dominant category across a slice of buckets (by summed count). */
+function dominant(
+  buckets: CommitEvolution["buckets"],
+  cats: CommitCategory[],
+): CommitCategory | null {
+  const sums = new Map<CommitCategory, number>();
+  for (const b of buckets) {
+    for (const c of cats) sums.set(c, (sums.get(c) ?? 0) + (b.counts[c] ?? 0));
+  }
+  let best: CommitCategory | null = null;
+  let bestN = 0;
+  for (const [c, n] of sums) {
+    if (n > bestN) {
+      best = c;
+      bestN = n;
+    }
+  }
+  return best;
+}
+
+function buildNarrative(data: CommitEvolution): string | null {
+  const { buckets, categories } = data;
+  if (buckets.length < 3 || categories.length === 0) return null;
+  const slice = Math.max(1, Math.floor(buckets.length / 4));
+  const early = dominant(buckets.slice(0, slice), categories);
+  const late = dominant(buckets.slice(-slice), categories);
+  if (!early || !late) return null;
+  if (early === late) {
+    return `Consistently ${CATEGORY_META[early].label.toLowerCase()}-driven across its history.`;
+  }
+  return `Began ${CATEGORY_META[early].label.toLowerCase()}-led, now leaning ${CATEGORY_META[late].label.toLowerCase()}.`;
+}
+
+interface TooltipPayloadItem {
+  dataKey: CommitCategory;
+  value: number;
+  payload: { _label: string; _total: number };
+}
+
+function ChartTooltip({
+  active,
+  payload,
+  mode,
+}: {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+  mode: Mode;
+}) {
+  if (!active || !payload || payload.length === 0) return null;
+  const total = payload[0]?.payload?._total ?? 0;
+  const rows = payload
+    .filter((p) => (p.value ?? 0) > 0)
+    .sort((a, b) => b.value - a.value);
+  return (
+    <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)] px-3 py-2 text-xs shadow-md">
+      <div className="mb-1.5 flex items-baseline justify-between gap-4">
+        <span className="font-medium text-[var(--color-text-primary)]">
+          {payload[0]?.payload?._label}
+        </span>
+        <span className="tabular-nums text-[var(--color-text-tertiary)]">
+          {total} commit{total === 1 ? "" : "s"}
+        </span>
+      </div>
+      <div className="space-y-1">
+        {rows.map((p) => {
+          const meta = CATEGORY_META[p.dataKey];
+          const pct = total > 0 ? Math.round((p.value / total) * 100) : 0;
+          return (
+            <div key={p.dataKey} className="flex items-center gap-2">
+              <span
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{ background: meta.color }}
+              />
+              <span className="text-[var(--color-text-secondary)]">{meta.label}</span>
+              <span className="ml-auto tabular-nums text-[var(--color-text-primary)]">
+                {mode === "share" ? `${pct}%` : p.value}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function CodeEvolutionChart({
+  evolution,
+  className,
+}: {
+  evolution: CommitEvolution;
+  className?: string;
+}) {
+  const [mode, setMode] = useState<Mode>("share");
+
+  const cats = useMemo(
+    () => STACK_ORDER.filter((c) => evolution.categories.includes(c)),
+    [evolution.categories],
+  );
+
+  const chartData = useMemo(() => {
+    return evolution.buckets.map((b) => {
+      const row: Record<string, number | string> = {
+        _label: formatBucketLabel(b.start, evolution.granularity),
+        _total: b.total,
+      };
+      for (const c of cats) {
+        const raw = b.counts[c] ?? 0;
+        row[c] =
+          mode === "share" && b.total > 0
+            ? Math.round((raw / b.total) * 1000) / 10
+            : raw;
+      }
+      return row;
+    });
+  }, [evolution.buckets, evolution.granularity, cats, mode]);
+
+  const narrative = useMemo(() => buildNarrative(evolution), [evolution]);
+  const grandTotal = evolution.total_commits || 1;
+
+  if (evolution.buckets.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 sm:p-5",
+        className,
+      )}
+    >
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <GitBranch className="h-4 w-4 text-[var(--color-accent-primary)]" />
+            <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+              Code Evolution
+            </h3>
+            <TooltipProvider delayDuration={150}>
+              <UiTooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="How categories are derived"
+                    className="text-[var(--color-text-tertiary)] transition-colors hover:text-[var(--color-text-secondary)]"
+                  >
+                    <Info className="h-3.5 w-3.5" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-[260px] text-xs leading-relaxed">
+                  Every indexed commit is classified into one category from its
+                  subject (conventional-commit prefix when present, else
+                  keywords). Bands stack to 100% in share mode.
+                </TooltipContent>
+              </UiTooltip>
+            </TooltipProvider>
+          </div>
+          <p className="mt-1 text-xs text-[var(--color-text-secondary)]">
+            {narrative ??
+              "How this repo's commit mix shifts over time."}
+          </p>
+        </div>
+
+        <div className="flex items-center rounded-lg border border-[var(--color-border-default)] p-0.5 text-xs">
+          {(["share", "volume"] as Mode[]).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={cn(
+                "rounded-md px-2.5 py-1 font-medium capitalize transition-colors",
+                mode === m
+                  ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
+                  : "text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)]",
+              )}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <ResponsiveContainer width="100%" height={260}>
+        <AreaChart
+          data={chartData}
+          margin={{ top: 4, right: 8, bottom: 0, left: -16 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            vertical={false}
+            stroke="var(--color-border-subtle, var(--color-border-default))"
+            opacity={0.4}
+          />
+          <XAxis
+            dataKey="_label"
+            tick={{ fontSize: 10, fill: "var(--color-text-tertiary)" }}
+            axisLine={false}
+            tickLine={false}
+            minTickGap={24}
+          />
+          <YAxis
+            tick={{ fontSize: 10, fill: "var(--color-text-tertiary)" }}
+            axisLine={false}
+            tickLine={false}
+            width={36}
+            domain={mode === "share" ? [0, 100] : [0, "auto"]}
+            tickFormatter={(v) => (mode === "share" ? `${v}%` : `${v}`)}
+          />
+          <Tooltip
+            content={<ChartTooltip mode={mode} />}
+            cursor={{ stroke: "var(--color-text-tertiary)", strokeWidth: 1, strokeDasharray: "3 3" }}
+          />
+          {cats.map((c) => (
+            <Area
+              key={c}
+              type="monotone"
+              dataKey={c}
+              stackId="1"
+              stroke={CATEGORY_META[c].color}
+              strokeWidth={1}
+              fill={CATEGORY_META[c].color}
+              fillOpacity={0.7}
+              isAnimationActive={false}
+            />
+          ))}
+        </AreaChart>
+      </ResponsiveContainer>
+
+      {/* Legend doubles as a window-wide breakdown: each category's lifetime share. */}
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1.5">
+        {cats.map((c) => {
+          const n = evolution.totals[c] ?? 0;
+          const pct = Math.round((n / grandTotal) * 100);
+          return (
+            <div key={c} className="flex items-center gap-1.5 text-xs">
+              <span
+                className="h-2.5 w-2.5 shrink-0 rounded-[3px]"
+                style={{ background: CATEGORY_META[c].color }}
+              />
+              <span className="text-[var(--color-text-secondary)]">
+                {CATEGORY_META[c].label}
+              </span>
+              <span className="tabular-nums text-[var(--color-text-tertiary)]">
+                {pct}%
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/commits/credibility-strip.tsx
+++ b/packages/ui/src/commits/credibility-strip.tsx
@@ -1,5 +1,11 @@
-import { ShieldCheck } from "lucide-react";
+import { Info, ShieldCheck } from "lucide-react";
 import { cn } from "../lib/cn";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../ui/tooltip";
 
 /**
  * Honest credibility note for the change-risk model. The numbers are the
@@ -7,6 +13,23 @@ import { cn } from "../lib/cn";
  * them rather than imply the score is infallible. The model edges churn-only
  * on average and is stronger on some repos; it is a ranking aid, not a verdict.
  */
+
+/** Shared copy so the strip and the compact info button never drift. */
+function CredibilityCopy() {
+  return (
+    <>
+      Change-risk is a calibrated linear model over each commit&apos;s diff shape
+      (size, diffusion, author experience). Backtested leave-one-repo-out it scores{" "}
+      <span className="font-medium text-[var(--color-text-primary)] tabular-nums">
+        0.772 AUC
+      </span>{" "}
+      vs <span className="tabular-nums">0.766</span> for a churn-only baseline — a
+      ranking aid for review order, not a verdict. Priority is{" "}
+      <span className="font-medium">relative to this repo&apos;s own distribution</span>.
+    </>
+  );
+}
+
 export function CredibilityStrip({ className }: { className?: string }) {
   return (
     <div
@@ -17,16 +40,43 @@ export function CredibilityStrip({ className }: { className?: string }) {
     >
       <ShieldCheck className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[var(--color-text-tertiary)]" />
       <p>
-        Change-risk is a calibrated linear model over each commit&apos;s diff shape
-        (size, diffusion, author experience). Backtested leave-one-repo-out it scores{" "}
-        <span className="font-medium text-[var(--color-text-primary)] tabular-nums">
-          0.772 AUC
-        </span>{" "}
-        vs{" "}
-        <span className="tabular-nums">0.766</span> for a churn-only baseline — a
-        ranking aid for review order, not a verdict. Priority is{" "}
-        <span className="font-medium">relative to this repo&apos;s own distribution</span>.
+        <CredibilityCopy />
       </p>
     </div>
+  );
+}
+
+/**
+ * Compact affordance for the same note — an info icon that reveals the model's
+ * provenance on hover/focus. Used where the queue shouldn't spend prime real
+ * estate on a full strip (e.g. inline beside the review-priority table header).
+ */
+export function CredibilityInfoButton({
+  label = "How change-risk is scored",
+  className,
+}: {
+  label?: string;
+  className?: string;
+}) {
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={label}
+            className={cn(
+              "inline-flex items-center text-[var(--color-text-tertiary)] transition-colors hover:text-[var(--color-text-secondary)]",
+              className,
+            )}
+          >
+            <Info className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-[300px] text-xs leading-relaxed text-[var(--color-text-secondary)]">
+          <CredibilityCopy />
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/packages/ui/src/commits/index.ts
+++ b/packages/ui/src/commits/index.ts
@@ -1,3 +1,4 @@
+export * from "./code-evolution-chart";
 export * from "./commit-table";
 export * from "./commit-detail-card";
 export * from "./risk-driver-breakdown";

--- a/packages/web/src/components/commits/commits-explorer.tsx
+++ b/packages/web/src/components/commits/commits-explorer.tsx
@@ -19,10 +19,17 @@ import {
 } from "@repowise-dev/ui/commits/commit-table";
 import { CommitDetailCard } from "@repowise-dev/ui/commits/commit-detail-card";
 import { AiPromptButton, AiPromptModal, buildCommitAiPrompt } from "@repowise-dev/ui/health";
-import { CredibilityStrip } from "@repowise-dev/ui/commits/credibility-strip";
+import { CredibilityInfoButton } from "@repowise-dev/ui/commits/credibility-strip";
+import { CodeEvolutionChart } from "@repowise-dev/ui/commits/code-evolution-chart";
 import { AgentTrendStrip } from "@repowise-dev/ui/commits/agent-trend-strip";
 import { RiskDistributionChart } from "@repowise-dev/ui/git/risk-distribution-chart";
-import { getAgentTrend, getCommit, getCommitsPage, getHotspots } from "@/lib/api/git";
+import {
+  getAgentTrend,
+  getCommit,
+  getCommitEvolution,
+  getCommitsPage,
+  getHotspots,
+} from "@/lib/api/git";
 import type { CommitResponse, Paginated } from "@/lib/api/types";
 
 const PAGE_SIZE = 50;
@@ -45,6 +52,13 @@ export function CommitsExplorer({ repoId }: { repoId: string }) {
   const { data: trend } = useSWR(
     `agent-trend:${repoId}`,
     () => getAgentTrend(repoId),
+    { revalidateOnFocus: false },
+  );
+
+  // Headline: the repo's development "story arc" — commit-category mix over time.
+  const { data: evolution } = useSWR(
+    `commit-evolution:${repoId}`,
+    () => getCommitEvolution(repoId),
     { revalidateOnFocus: false },
   );
 
@@ -93,18 +107,9 @@ export function CommitsExplorer({ repoId }: { repoId: string }) {
 
   return (
     <div className="space-y-6">
-      <CredibilityStrip />
-
-      {hotspots && hotspots.length > 0 && (
-        <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
-          <p className="mb-2 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
-            Risk distribution across the riskiest files
-          </p>
-          <RiskDistributionChart hotspots={hotspots} maxBars={25} />
-        </div>
+      {evolution && evolution.total_commits > 0 && (
+        <CodeEvolutionChart evolution={evolution} />
       )}
-
-      {trend && <AgentTrendStrip trend={trend} />}
 
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <StatCard
@@ -132,24 +137,48 @@ export function CommitsExplorer({ repoId }: { repoId: string }) {
         />
       </div>
 
-      <CommitTable
-        commits={list}
-        sort={sort}
-        onSortChange={(s) => {
-          setSort(s);
-          setLimit(PAGE_SIZE);
-        }}
-        authorship={authorship}
-        onAuthorshipChange={(a) => {
-          setAuthorship(a);
-          setLimit(PAGE_SIZE);
-        }}
-        onSelect={(c) => void setSelectedSha(c.sha)}
-        total={total}
-        hasMore={hasMore}
-        loadingMore={isValidating && !isLoading}
-        onLoadMore={() => setLimit((n) => Math.min(n + PAGE_SIZE, 200))}
-      />
+      {/* Secondary signals — smaller than the headline. Risk distribution
+          turns the queue's "relative to this repo" claim into a picture; the
+          agent-trend strip sits alongside it. */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        {hotspots && hotspots.length > 0 && (
+          <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
+            <p className="mb-2 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+              Risk distribution across the riskiest files
+            </p>
+            <RiskDistributionChart hotspots={hotspots} maxBars={12} />
+          </div>
+        )}
+        {trend && trend.agent_commits > 0 && (
+          <AgentTrendStrip trend={trend} />
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
+          <span>Review-priority queue</span>
+          <CredibilityInfoButton />
+        </div>
+
+        <CommitTable
+          commits={list}
+          sort={sort}
+          onSortChange={(s) => {
+            setSort(s);
+            setLimit(PAGE_SIZE);
+          }}
+          authorship={authorship}
+          onAuthorshipChange={(a) => {
+            setAuthorship(a);
+            setLimit(PAGE_SIZE);
+          }}
+          onSelect={(c) => void setSelectedSha(c.sha)}
+          total={total}
+          hasMore={hasMore}
+          loadingMore={isValidating && !isLoading}
+          onLoadMore={() => setLimit((n) => Math.min(n + PAGE_SIZE, 200))}
+        />
+      </div>
 
       <Sheet
         open={selectedSha !== null}

--- a/packages/web/src/lib/api/git.ts
+++ b/packages/web/src/lib/api/git.ts
@@ -1,6 +1,7 @@
 import { apiGet } from "./client";
 import type {
   AgentTrend,
+  CommitEvolution,
   CommitDetailResponse,
   CommitResponse,
   GitMetadataResponse,
@@ -135,6 +136,15 @@ export async function getCommitsPage(
 /** Monthly agent-vs-human commit volume across the indexed window. */
 export async function getAgentTrend(repoId: string): Promise<AgentTrend> {
   return apiGet<AgentTrend>(`/api/repos/${repoId}/commits/agent-trend`);
+}
+
+export async function getCommitEvolution(
+  repoId: string,
+  granularity: "auto" | "month" | "week" = "auto",
+): Promise<CommitEvolution> {
+  return apiGet<CommitEvolution>(
+    `/api/repos/${repoId}/commits/evolution?granularity=${granularity}`,
+  );
 }
 
 export async function getCommit(

--- a/packages/web/src/lib/api/types/git.ts
+++ b/packages/web/src/lib/api/types/git.ts
@@ -145,3 +145,30 @@ export interface AgentTrend {
   agent_pct: number;
   agent_names: { name: string; count: number }[];
 }
+
+export type CommitCategory =
+  | "feature"
+  | "fix"
+  | "refactor"
+  | "docs"
+  | "test"
+  | "deps"
+  | "chore"
+  | "other";
+
+export interface CommitEvolutionBucket {
+  period: string;
+  start: string;
+  total: number;
+  counts: Partial<Record<CommitCategory, number>>;
+}
+
+export interface CommitEvolution {
+  buckets: CommitEvolutionBucket[];
+  categories: CommitCategory[];
+  totals: Partial<Record<CommitCategory, number>>;
+  total_commits: number;
+  granularity: "month" | "week";
+  first_commit_at: string | null;
+  last_commit_at: string | null;
+}


### PR DESCRIPTION
## What

Reframes the commits page around the repo's **development story** instead of a risk table.

### Headline — Code Evolution timeline
A stacked-area chart of how the commit mix (feature / fix / refactor / docs / test / deps / chore / other) shifts over the repo's history. It auto-generates a one-line narrative ("began feature-led, now leaning fix") and a legend that doubles as a lifetime category breakdown. Toggle between **share %** and **volume**.

### Demotions
- The **risk distribution across the riskiest files** moves from a full-width block to a smaller secondary card.
- The **change-risk credibility note** (0.772 AUC vs 0.766 baseline) moves from a full-width strip into an **info button** beside the review-priority queue header, freeing the prime real estate.

## How it works
- `classify_commit_category()` (core) assigns each commit subject exactly one category, conventional-commit-prefix aware with a keyword fallback. Single-label so the stack sums to 100%.
- `GET /api/repos/{id}/commits/evolution` buckets `git_commits` by month (or week on short-history repos). Classification runs over the already-stored subject, so **no reindex is required**.
- `CodeEvolutionChart` (shared UI) renders the stack; colours route through semantic design tokens (passes the no-raw-hex gate).

## Validation
- Classifier unit-checked across prefix + keyword cases.
- Ran the bucketing over this repo's real history: feature 32% / fix 30% / refactor 10% / chore 13% / docs 7%, only 6% unclassified — a meaningful, varied timeline.
- `tsc --noEmit` clean for `ui` + `web`; `py_compile` clean; no-raw-hex gate passes; eslint clean.