### PR TITLE
feat(impact): redesign the blast-radius impact tab

### DIFF
--- a/packages/ui/__tests__/blast-radius/blast-radius.test.tsx
+++ b/packages/ui/__tests__/blast-radius/blast-radius.test.tsx
@@ -61,8 +61,8 @@ describe("TableSection", () => {
 describe("DirectRisksTable", () => {
   it("scales risk_score 0–1 → 0–10", () => {
     render(<DirectRisksTable rows={fixture.direct_risks} />);
-    expect(screen.getByText("8.20")).toBeTruthy();
-    expect(screen.getByText("7.40")).toBeTruthy();
+    expect(screen.getByText("8.2")).toBeTruthy();
+    expect(screen.getByText("7.4")).toBeTruthy();
   });
 });
 
@@ -106,17 +106,18 @@ describe("BlastRadiusSummary", () => {
 });
 
 describe("BlastRadiusResults", () => {
-  it("composes the risk gauge, summary, impact map, and collapsible sections", () => {
+  it("composes the risk header, impact map, and collapsible sections", () => {
     render(<BlastRadiusResults result={fixture} changedFiles={["src/auth/login.py"]} />);
-    expect(screen.getByText("High Risk")).toBeTruthy();
-    // Summary stat label (capitalized) is distinct from the collapsible toggle
-    // title (sentence case), so each appears once.
-    expect(screen.getByText("Direct Risks")).toBeTruthy();
-    expect(screen.getByText("Direct risks")).toBeTruthy();
+    // Header band label + gauge score.
+    expect(screen.getByText("High risk")).toBeTruthy();
+    expect(screen.getByText("7.6")).toBeTruthy();
+    // The header tile and the collapsible toggle share the "Direct risks" /
+    // "Test gaps" copy, so each appears more than once.
+    expect(screen.getAllByText("Direct risks").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Transitive affected files")).toBeTruthy();
     expect(screen.getByText("Co-change warnings")).toBeTruthy();
     expect(screen.getByText("Recommended reviewers")).toBeTruthy();
-    expect(screen.getByText("Test gaps")).toBeTruthy();
+    expect(screen.getAllByText("Test gaps").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Impact map")).toBeTruthy();
   });
 
@@ -131,6 +132,6 @@ describe("BlastRadiusResults", () => {
     };
     render(<BlastRadiusResults result={empty} />);
     expect(screen.getByText("No downstream impact found")).toBeTruthy();
-    expect(screen.getByText("Low Risk")).toBeTruthy();
+    expect(screen.getByText("Low risk")).toBeTruthy();
   });
 });

--- a/packages/ui/src/blast-radius/blast-radius-header.tsx
+++ b/packages/ui/src/blast-radius/blast-radius-header.tsx
@@ -1,0 +1,221 @@
+import {
+  AlertTriangle,
+  FlaskConical,
+  GitCompareArrows,
+  Network,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import type { BlastRadiusResponse } from "@repowise-dev/types/blast-radius";
+import { cn } from "../lib/cn";
+
+interface BlastRadiusHeaderProps {
+  result: BlastRadiusResponse;
+  changedFiles?: string[];
+}
+
+interface Band {
+  label: string;
+  color: string; // CSS var
+  text: string;
+  ring: string;
+}
+
+function band(score: number): Band {
+  if (score >= 7)
+    return {
+      label: "High risk",
+      color: "var(--color-error)",
+      text: "text-[var(--color-error)]",
+      ring: "border-[var(--color-error)]/30 bg-[var(--color-error)]/5",
+    };
+  if (score >= 4)
+    return {
+      label: "Medium risk",
+      color: "var(--color-warning)",
+      text: "text-[var(--color-warning)]",
+      ring: "border-[var(--color-warning)]/30 bg-[var(--color-warning)]/5",
+    };
+  return {
+    label: "Low risk",
+    color: "var(--color-success)",
+    text: "text-[var(--color-success)]",
+    ring: "border-[var(--color-success)]/30 bg-[var(--color-success)]/5",
+  };
+}
+
+// --- Half-donut gauge geometry -------------------------------------------
+const GW = 200;
+const GH = 116;
+const GCX = GW / 2;
+const GCY = GH - 8;
+const GR = 84;
+const GSTROKE = 14;
+
+function polar(cx: number, cy: number, r: number, angleDeg: number) {
+  const rad = (angleDeg * Math.PI) / 180;
+  return { x: cx + r * Math.cos(rad), y: cy + r * Math.sin(rad) };
+}
+
+function arcPath(
+  cx: number,
+  cy: number,
+  r: number,
+  startAngle: number,
+  endAngle: number,
+): string {
+  const start = polar(cx, cy, r, startAngle);
+  const end = polar(cx, cy, r, endAngle);
+  const largeArc = endAngle - startAngle <= 180 ? 0 : 1;
+  return `M ${start.x} ${start.y} A ${r} ${r} 0 ${largeArc} 1 ${end.x} ${end.y}`;
+}
+
+/** A 180° gauge that fills proportionally to the 0–10 score. */
+function RiskGauge({ score }: { score: number }) {
+  const b = band(score);
+  const frac = Math.max(0, Math.min(1, score / 10));
+  const valueEnd = 180 + frac * 180;
+  return (
+    <div className="relative shrink-0" style={{ width: GW, height: GH }}>
+      <svg viewBox={`0 0 ${GW} ${GH}`} className="h-auto w-full" aria-hidden="true">
+        <path
+          d={arcPath(GCX, GCY, GR, 180, 360)}
+          fill="none"
+          stroke="var(--color-bg-wash)"
+          strokeWidth={GSTROKE}
+          strokeLinecap="round"
+        />
+        {frac > 0 && (
+          <path
+            d={arcPath(GCX, GCY, GR, 180, valueEnd)}
+            fill="none"
+            stroke={b.color}
+            strokeWidth={GSTROKE}
+            strokeLinecap="round"
+          />
+        )}
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-end pb-1">
+        <span className={cn("text-4xl font-bold leading-none tabular-nums", b.text)}>
+          {score.toFixed(1)}
+        </span>
+        <span className="mt-1 text-[10px] uppercase tracking-wider text-[var(--color-text-tertiary)]">
+          risk / 10
+        </span>
+      </div>
+    </div>
+  );
+}
+
+interface Tile {
+  label: string;
+  value: number;
+  icon: ReactNode;
+  tone: string; // text color token class
+  active: boolean;
+}
+
+function StatTile({ tile }: { tile: Tile }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2.5",
+        tile.active ? "" : "opacity-60",
+      )}
+    >
+      <span className={cn("shrink-0", tile.value > 0 ? tile.tone : "text-[var(--color-text-tertiary)]")}>
+        {tile.icon}
+      </span>
+      <div className="min-w-0">
+        <p className="text-xl font-bold leading-none tabular-nums text-[var(--color-text-primary)]">
+          {tile.value}
+        </p>
+        <p className="mt-0.5 truncate text-[11px] text-[var(--color-text-tertiary)]">
+          {tile.label}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/** Plain-English read of the blast radius, built from the counts. */
+function verdict(result: BlastRadiusResponse, changedCount: number): string {
+  const direct = result.direct_risks.length;
+  const transitive = result.transitive_affected.length;
+  const gaps = result.test_gaps.length;
+  const reach = direct + transitive;
+  const filesWord = changedCount === 1 ? "file" : "files";
+  if (reach === 0) {
+    return `Changing ${changedCount} ${filesWord} looks self-contained — nothing downstream depends on it within this depth.`;
+  }
+  const gapClause =
+    gaps > 0
+      ? ` ${gaps} affected ${gaps === 1 ? "file lacks" : "files lack"} tests.`
+      : " Affected files have tests.";
+  return `Changing ${changedCount} ${filesWord} puts ${reach} downstream ${
+    reach === 1 ? "file" : "files"
+  } in scope (${direct} direct, ${transitive} transitive).${gapClause}`;
+}
+
+/**
+ * The blast-radius headline: a risk gauge, four signal tiles, and a one-line
+ * plain-English verdict — replacing the old centred-number card + flat stat
+ * grid so the result reads as a conclusion, not a row of figures.
+ */
+export function BlastRadiusHeader({ result, changedFiles = [] }: BlastRadiusHeaderProps) {
+  const b = band(result.overall_risk_score);
+  const tiles: Tile[] = [
+    {
+      label: "Direct risks",
+      value: result.direct_risks.length,
+      icon: <AlertTriangle className="h-5 w-5" />,
+      tone: "text-[var(--color-error)]",
+      active: result.direct_risks.length > 0,
+    },
+    {
+      label: "Transitive files",
+      value: result.transitive_affected.length,
+      icon: <Network className="h-5 w-5" />,
+      tone: "text-[var(--color-warning)]",
+      active: result.transitive_affected.length > 0,
+    },
+    {
+      label: "Co-change gaps",
+      value: result.cochange_warnings.length,
+      icon: <GitCompareArrows className="h-5 w-5" />,
+      tone: "text-[var(--color-caution)]",
+      active: result.cochange_warnings.length > 0,
+    },
+    {
+      label: "Test gaps",
+      value: result.test_gaps.length,
+      icon: <FlaskConical className="h-5 w-5" />,
+      tone: "text-[var(--color-info)]",
+      active: result.test_gaps.length > 0,
+    },
+  ];
+
+  return (
+    <div className={cn("rounded-xl border p-4 sm:p-5", b.ring)}>
+      <div className="flex flex-col gap-5 sm:flex-row sm:items-center">
+        <RiskGauge score={result.overall_risk_score} />
+
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={cn("text-sm font-semibold", b.text)}>{b.label}</span>
+            <span className="text-xs text-[var(--color-text-tertiary)]">
+              · blast radius of this change
+            </span>
+          </div>
+          <p className="text-sm leading-relaxed text-[var(--color-text-secondary)]">
+            {verdict(result, changedFiles.length)}
+          </p>
+          <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+            {tiles.map((t) => (
+              <StatTile key={t.label} tile={t} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/blast-radius/blast-radius-results.tsx
+++ b/packages/ui/src/blast-radius/blast-radius-results.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import type { BlastRadiusResponse } from "@repowise-dev/types/blast-radius";
-import { RiskScoreCard } from "./risk-score-card";
-import { BlastRadiusSummary } from "./blast-radius-summary";
+import { BlastRadiusHeader } from "./blast-radius-header";
 import { ImpactGraph } from "./impact-graph";
 import { DirectRisksTable } from "./direct-risks-table";
 import { TransitiveTable } from "./transitive-table";
@@ -32,10 +31,7 @@ export function BlastRadiusResults({
 }: BlastRadiusResultsProps) {
   return (
     <div className="space-y-6">
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
-        <RiskScoreCard score={result.overall_risk_score} />
-        <BlastRadiusSummary result={result} />
-      </div>
+      <BlastRadiusHeader result={result} changedFiles={changedFiles} />
 
       {/* One picture: changed files → direct → transitive. */}
       <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">

--- a/packages/ui/src/blast-radius/direct-risks-table.tsx
+++ b/packages/ui/src/blast-radius/direct-risks-table.tsx
@@ -1,37 +1,93 @@
 import type { DirectRiskEntry } from "@repowise-dev/types/blast-radius";
-import { Th, Td } from "./cells";
 
 interface DirectRisksTableProps {
   rows: DirectRiskEntry[];
 }
 
+/** Health-band ink, matching the impact-graph node colours. */
+function riskInk(risk01: number): string {
+  if (risk01 >= 0.66) return "var(--color-error)";
+  if (risk01 >= 0.33) return "var(--color-warning)";
+  return "var(--color-success)";
+}
+
+/** A 0–1 value rendered as a labelled mini-bar so rows scan visually. */
+function MiniBar({
+  value01,
+  color,
+  display,
+}: {
+  value01: number;
+  color: string;
+  display: string;
+}) {
+  const pct = Math.max(0, Math.min(100, value01 * 100));
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-full min-w-[48px] overflow-hidden rounded-full bg-[var(--color-bg-wash)]">
+        <div
+          className="h-full rounded-full"
+          style={{ width: `${pct}%`, background: color }}
+        />
+      </div>
+      <span className="w-10 shrink-0 text-right tabular-nums text-[var(--color-text-secondary)]">
+        {display}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Direct dependents of the changed files, sorted by risk. Each numeric column
+ * is an inline mini-bar (risk health-banded, hotspot/centrality neutral) so the
+ * heaviest rows pop without reading every figure.
+ */
 export function DirectRisksTable({ rows }: DirectRisksTableProps) {
-  // Backend risk_score / temporal_hotspot are 0–1; render 0–10 to match the gauge.
-  const fmt10 = (v: number) => (v * 10).toFixed(2);
-  const fmtPct = (v: number) => `${(v * 100).toFixed(2)}%`;
+  const sorted = [...rows].sort((a, b) => b.risk_score - a.risk_score);
   return (
     <div className="overflow-x-auto">
       <table className="w-full">
         <caption className="sr-only">Direct risks for the changed files</caption>
         <thead>
-          <tr>
-            <Th>File</Th>
-            <Th>Risk Score</Th>
-            <Th>Temporal Hotspot</Th>
-            <Th>Centrality</Th>
+          <tr className="text-left text-xs font-medium text-[var(--color-text-tertiary)]">
+            <th className="py-1.5 pr-4">File</th>
+            <th className="w-[28%] py-1.5 pr-4">Risk (0–10)</th>
+            <th className="w-[24%] py-1.5 pr-4">Temporal hotspot</th>
+            <th className="w-[24%] py-1.5">Centrality</th>
           </tr>
         </thead>
         <tbody>
-          {rows.map((r) => (
+          {sorted.map((r) => (
             <tr key={r.path} className="border-t border-[var(--color-border-default)]">
-              <Td>
-                <span className="font-mono break-all" title={r.path}>
+              <td className="py-2 pr-4 align-middle">
+                <span
+                  className="block max-w-[280px] truncate font-mono text-xs text-[var(--color-text-secondary)]"
+                  title={r.path}
+                >
                   {r.path}
                 </span>
-              </Td>
-              <Td className="text-right tabular-nums">{fmt10(r.risk_score)}</Td>
-              <Td className="text-right tabular-nums">{fmt10(r.temporal_hotspot)}</Td>
-              <Td className="text-right tabular-nums">{fmtPct(r.centrality)}</Td>
+              </td>
+              <td className="py-2 pr-4 align-middle">
+                <MiniBar
+                  value01={r.risk_score}
+                  color={riskInk(r.risk_score)}
+                  display={(r.risk_score * 10).toFixed(1)}
+                />
+              </td>
+              <td className="py-2 pr-4 align-middle">
+                <MiniBar
+                  value01={r.temporal_hotspot}
+                  color="var(--color-accent-secondary)"
+                  display={(r.temporal_hotspot * 10).toFixed(1)}
+                />
+              </td>
+              <td className="py-2 align-middle">
+                <MiniBar
+                  value01={r.centrality}
+                  color="var(--color-info)"
+                  display={`${(r.centrality * 100).toFixed(0)}%`}
+                />
+              </td>
             </tr>
           ))}
         </tbody>

--- a/packages/ui/src/blast-radius/impact-graph.tsx
+++ b/packages/ui/src/blast-radius/impact-graph.tsx
@@ -9,12 +9,14 @@ interface ImpactGraphProps {
   changedFiles: string[];
 }
 
-const WIDTH = 520;
-const HEIGHT = 320;
+const WIDTH = 640;
+const HEIGHT = 440;
 const CX = WIDTH / 2;
 const CY = HEIGHT / 2;
-const INNER_R = 96;
-const OUTER_R = 144;
+const INNER_R = 132;
+const OUTER_R = 196;
+const MAX_DIRECT = 12;
+const MAX_TRANSITIVE = 18;
 
 function basename(path: string): string {
   return path.split("/").pop() || path;
@@ -35,126 +37,197 @@ interface PlacedNode {
   y: number;
   r: number;
   fill: string;
+  glow?: string;
+  opacity?: number;
 }
 
 /**
- * A compact impact graph: the changed files at the centre, direct risks on an
- * inner ring (health-banded), and transitive-affected files on an outer ring.
- * Edges are quiet hairlines, reusing the coupling diagram's dot/edge idiom so
- * the blast radius reads as a picture before the detail tables.
+ * The impact map: changed files at the hub, direct risks on an inner ring
+ * (sized by centrality, health-banded, high-risk nodes haloed), and transitive
+ * dependents on an outer ring graded by reach depth. Curved hairline edges and
+ * faint ring guides give the blast radius a readable shape before the tables.
  */
 export function ImpactGraph({ result, changedFiles }: ImpactGraphProps) {
-  const { centre, direct, transitive } = useMemo(() => {
-    const directRows = result.direct_risks.slice(0, 10);
-    const transitiveRows = result.transitive_affected.slice(0, 14);
+  const { centre, direct, transitive, maxDepth, truncDirect, truncTrans } = useMemo(() => {
+    const directRows = result.direct_risks.slice(0, MAX_DIRECT);
+    const transitiveRows = result.transitive_affected.slice(0, MAX_TRANSITIVE);
+    const depthCeil = Math.max(
+      1,
+      ...result.transitive_affected.map((t) => t.depth || 1),
+    );
 
     const centreNodes: PlacedNode[] = changedFiles.slice(0, 6).map((path, i, arr) => {
-      const angle = arr.length === 1 ? -Math.PI / 2 : (i / arr.length) * 2 * Math.PI - Math.PI / 2;
-      const spread = arr.length === 1 ? 0 : 26;
+      const angle =
+        arr.length === 1 ? -Math.PI / 2 : (i / arr.length) * 2 * Math.PI - Math.PI / 2;
+      const spread = arr.length === 1 ? 0 : 30;
       return {
         key: `c-${path}`,
         label: basename(path),
         full: path,
         x: CX + Math.cos(angle) * spread,
         y: CY + Math.sin(angle) * spread,
-        r: 7,
+        r: 8,
         fill: "var(--color-accent-primary)",
+        glow: "var(--color-accent-primary)",
       };
     });
 
     const directNodes: PlacedNode[] = directRows.map((d, i) => {
       const angle = (i / Math.max(1, directRows.length)) * 2 * Math.PI - Math.PI / 2;
-      return {
+      const node: PlacedNode = {
         key: `d-${d.path}`,
         label: basename(d.path),
-        full: d.path,
+        full: `${d.path} · risk ${(d.risk_score * 10).toFixed(1)} · centrality ${(d.centrality * 100).toFixed(0)}%`,
         x: CX + Math.cos(angle) * INNER_R,
         y: CY + Math.sin(angle) * INNER_R,
-        r: 4 + d.centrality * 4,
+        r: 5 + d.centrality * 6,
         fill: riskInk(d.risk_score),
       };
+      if (d.risk_score >= 0.66) node.glow = "var(--color-error)";
+      return node;
     });
 
     const transitiveNodes: PlacedNode[] = transitiveRows.map((t, i) => {
-      const angle = (i / Math.max(1, transitiveRows.length)) * 2 * Math.PI - Math.PI / 2 + 0.2;
+      const angle = (i / Math.max(1, transitiveRows.length)) * 2 * Math.PI - Math.PI / 2 + 0.18;
+      // Closer dependents read warmer/stronger; distant ones fade out.
+      const depthFrac = (t.depth || 1) / depthCeil;
       return {
         key: `t-${t.path}`,
         label: basename(t.path),
-        full: t.path,
+        full: `${t.path} · depth ${t.depth}`,
         x: CX + Math.cos(angle) * OUTER_R,
         y: CY + Math.sin(angle) * OUTER_R,
-        r: 3,
-        fill: "var(--color-text-tertiary)",
+        r: 3.5,
+        fill: "var(--color-text-secondary)",
+        opacity: 0.85 - depthFrac * 0.5,
       };
     });
 
-    return { centre: centreNodes, direct: directNodes, transitive: transitiveNodes };
+    return {
+      centre: centreNodes,
+      direct: directNodes,
+      transitive: transitiveNodes,
+      maxDepth: depthCeil,
+      truncDirect: result.direct_risks.length - directRows.length,
+      truncTrans: result.transitive_affected.length - transitiveRows.length,
+    };
   }, [result, changedFiles]);
 
   const hasNodes = centre.length > 0 || direct.length > 0 || transitive.length > 0;
   if (!hasNodes) return null;
 
   return (
-    <svg
-      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-      className="mx-auto h-auto w-full max-w-[560px]"
-      role="img"
-      aria-label="Impact graph: changed files at centre, direct and transitive affected files around them"
-    >
-      {/* Edges: centre → direct (quiet), direct ring → transitive (quieter) */}
-      {direct.map((d) => (
-        <line
-          key={`e-${d.key}`}
-          x1={CX}
-          y1={CY}
-          x2={d.x}
-          y2={d.y}
-          stroke="var(--color-text-tertiary)"
+    <div>
+      <svg
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        className="mx-auto h-auto w-full max-w-[680px]"
+        role="img"
+        aria-label="Impact graph: changed files at centre, direct and transitive affected files around them"
+      >
+        {/* Faint concentric guides for the two rings. */}
+        <circle
+          cx={CX}
+          cy={CY}
+          r={INNER_R}
+          fill="none"
+          stroke="var(--color-border-default)"
+          strokeOpacity={0.4}
+          strokeDasharray="2 5"
+        />
+        <circle
+          cx={CX}
+          cy={CY}
+          r={OUTER_R}
+          fill="none"
+          stroke="var(--color-border-default)"
           strokeOpacity={0.25}
-          strokeWidth={1}
+          strokeDasharray="2 5"
         />
-      ))}
-      {transitive.map((t) => (
-        <line
-          key={`e-${t.key}`}
-          x1={CX}
-          y1={CY}
-          x2={t.x}
-          y2={t.y}
-          stroke="var(--color-text-tertiary)"
-          strokeOpacity={0.1}
-          strokeWidth={0.75}
-        />
-      ))}
 
-      {[...transitive, ...direct, ...centre].map((n) => (
-        <g key={n.key}>
-          <circle
-            cx={n.x}
-            cy={n.y}
-            r={n.r}
-            fill={n.fill}
-            stroke="var(--color-bg-surface)"
+        {/* Edges: hub → direct (curved hairlines), hub → transitive (quieter). */}
+        {direct.map((d) => (
+          <path
+            key={`e-${d.key}`}
+            d={`M ${CX} ${CY} Q ${(CX + d.x) / 2} ${(CY + d.y) / 2 - 14} ${d.x} ${d.y}`}
+            fill="none"
+            stroke={d.fill}
+            strokeOpacity={0.28}
             strokeWidth={1}
-          >
-            <title>{n.full}</title>
-          </circle>
-        </g>
-      ))}
+          />
+        ))}
+        {transitive.map((t) => (
+          <line
+            key={`e-${t.key}`}
+            x1={CX}
+            y1={CY}
+            x2={t.x}
+            y2={t.y}
+            stroke="var(--color-text-tertiary)"
+            strokeOpacity={0.08}
+            strokeWidth={0.75}
+          />
+        ))}
 
-      {/* Label only the centre + direct nodes to keep the canvas legible. */}
-      {[...centre, ...direct].map((n) => (
-        <text
-          key={`l-${n.key}`}
-          x={n.x}
-          y={n.y - n.r - 3}
-          textAnchor="middle"
-          className="fill-[var(--color-text-secondary)]"
-          style={{ fontSize: 10 }}
-        >
-          {n.label.length > 18 ? `${n.label.slice(0, 17)}…` : n.label}
-        </text>
-      ))}
-    </svg>
+        {[...transitive, ...direct, ...centre].map((n) => (
+          <g key={n.key} opacity={n.opacity ?? 1}>
+            {n.glow && (
+              <circle cx={n.x} cy={n.y} r={n.r + 4} fill={n.glow} fillOpacity={0.18} />
+            )}
+            <circle
+              cx={n.x}
+              cy={n.y}
+              r={n.r}
+              fill={n.fill}
+              stroke="var(--color-bg-surface)"
+              strokeWidth={1.5}
+            >
+              <title>{n.full}</title>
+            </circle>
+          </g>
+        ))}
+
+        {/* Label only the centre + direct nodes to keep the canvas legible. */}
+        {[...centre, ...direct].map((n) => (
+          <text
+            key={`l-${n.key}`}
+            x={n.x}
+            y={n.y - n.r - 4}
+            textAnchor="middle"
+            className="fill-[var(--color-text-secondary)]"
+            style={{ fontSize: 10 }}
+          >
+            {n.label.length > 20 ? `${n.label.slice(0, 19)}…` : n.label}
+          </text>
+        ))}
+      </svg>
+
+      {/* Legend + truncation notes. */}
+      <div className="mt-2 flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5 text-[11px] text-[var(--color-text-tertiary)]">
+        <span className="flex items-center gap-1.5">
+          <span className="h-2.5 w-2.5 rounded-full bg-[var(--color-accent-primary)]" />
+          Changed
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="h-2.5 w-2.5 rounded-full bg-[var(--color-error)]" />
+          Direct, high risk
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="h-2.5 w-2.5 rounded-full bg-[var(--color-success)]" />
+          Direct, lower risk
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="h-2.5 w-2.5 rounded-full bg-[var(--color-text-secondary)]" />
+          Transitive {maxDepth > 1 ? `(to depth ${maxDepth})` : ""}
+        </span>
+        <span className="text-[var(--color-text-tertiary)]">· node size = centrality</span>
+      </div>
+      {(truncDirect > 0 || truncTrans > 0) && (
+        <p className="mt-1 text-center text-[10px] text-[var(--color-text-tertiary)]">
+          {truncDirect > 0 && `+${truncDirect} more direct`}
+          {truncDirect > 0 && truncTrans > 0 && " · "}
+          {truncTrans > 0 && `+${truncTrans} more transitive`} not drawn (see tables below)
+        </p>
+      )}
+    </div>
   );
 }

--- a/packages/ui/src/blast-radius/index.ts
+++ b/packages/ui/src/blast-radius/index.ts
@@ -1,4 +1,5 @@
 export * from "./risk-score-card";
+export * from "./blast-radius-header";
 export * from "./impact-graph";
 export * from "./table-section";
 export * from "./direct-risks-table";


### PR DESCRIPTION
## What

The code-health **Impact** tab (`?tab=impact`) read as a centred number plus five stacked tables. This makes the results a visual readout of the blast radius.

### Risk header (new)
- A **180° gauge** that fills proportionally to the 0–10 risk score, banded green/amber/red.
- Four **icon-coded signal tiles** — direct risks, transitive files, co-change gaps, test gaps — dimmed when zero.
- A **plain-English verdict** built from the counts: *"Changing 6 files puts 23 downstream files in scope (4 direct, 19 transitive). 4 affected files lack tests."*

### Impact graph (redesigned)
- Bigger canvas, faint concentric **ring guides**, curved hairline edges.
- Direct-risk nodes **sized by centrality** and **haloed** when high-risk; transitive nodes **graded by reach depth**.
- A **legend** and explicit truncation notes ("+N more … not drawn").

### Direct-risks table (redesigned)
- Each numeric column is an **inline mini-bar** (risk health-banded; hotspot/centrality neutral); rows sort by risk.

## Scope
Pure UI in the shared `@repowise-dev/ui` package. The analyzer input and the `blast-radius` endpoint are unchanged — no backend work. Colours route through design tokens (passes the no-raw-hex gate).

## Validation
- `tsc --noEmit` clean for `ui` + `web`.
- `vitest` blast-radius suite green (12/12; updated for the new copy).
- no-raw-hex gate passes.