### PR TITLE
fix(web): reflect CLI auto-syncs in overview "Last synced"

### DIFF
--- a/packages/server/src/repowise/server/routers/overview.py
+++ b/packages/server/src/repowise/server/routers/overview.py
@@ -345,6 +345,7 @@ async def overview_summary(
     )
     last_sync_at: str | None = None
     last_resync_at: str | None = None
+    last_resync_dt = None
     last_sync_model: str | None = None
     active_job_id: str | None = None
     for j in job_rows:
@@ -357,9 +358,24 @@ async def overview_summary(
         if j.status == "completed" and j.finished_at:
             if mode == "full_resync" and last_resync_at is None:
                 last_resync_at = j.finished_at.isoformat()
+                last_resync_dt = j.finished_at
             elif mode != "full_resync" and last_sync_at is None:
                 last_sync_at = j.finished_at.isoformat()
                 last_sync_model = j.model_name or None
+
+    # Fall back to the repository's own ``updated_at`` when no completed
+    # server-side sync job exists. CLI / git-hook auto-syncs (``repowise
+    # update``) refresh the index and bump ``repositories.updated_at`` via
+    # ``upsert_repository``, but never create a GenerationJob row, so a
+    # job-only derivation reports "never synced" even though the index is
+    # current. Only adopt it when it is newer than the last full re-index so a
+    # re-index is not relabelled as a sync.
+    if (
+        last_sync_at is None
+        and repo.updated_at is not None
+        and (last_resync_dt is None or repo.updated_at > last_resync_dt)
+    ):
+        last_sync_at = repo.updated_at.isoformat()
 
     savings = await _savings_headline(repo.local_path)
 

--- a/tests/unit/server/conftest.py
+++ b/tests/unit/server/conftest.py
@@ -39,6 +39,7 @@ def _create_test_app():
         jobs,
         meta,
         modules,
+        overview,
         owners,
         pages,
         repos,
@@ -84,6 +85,7 @@ def _create_test_app():
     app.include_router(modules.router)
     app.include_router(decisions.router)
     app.include_router(external_systems.router)
+    app.include_router(overview.router)
 
     return app
 

--- a/tests/unit/server/test_overview_sync.py
+++ b/tests/unit/server/test_overview_sync.py
@@ -1,0 +1,79 @@
+"""Tests for the ``sync`` block of /api/repos/{id}/overview-summary.
+
+The "Last synced" timestamp must reflect CLI / git-hook auto-syncs
+(``repowise update``), which refresh the index and bump
+``repositories.updated_at`` but never create a GenerationJob row. A
+job-only derivation reported "never synced" even when the index was current.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from repowise.core.persistence import crud
+from repowise.core.persistence.database import get_session
+from repowise.core.persistence.models import GenerationJob
+from tests.unit.server.conftest import create_test_repo
+
+
+async def _complete_job(app, repo_id: str, *, mode: str, finished_at: datetime) -> None:
+    async with get_session(app.state.session_factory) as session:
+        job = await crud.upsert_generation_job(
+            session,
+            repository_id=repo_id,
+            status="completed",
+            config={"mode": mode},
+        )
+        row = (
+            await session.execute(select(GenerationJob).where(GenerationJob.id == job.id))
+        ).scalar_one()
+        row.status = "completed"
+        row.finished_at = finished_at
+
+
+@pytest.mark.asyncio
+async def test_last_sync_falls_back_to_repo_updated_at(client: AsyncClient) -> None:
+    """No completed sync job: last_sync_at uses repositories.updated_at."""
+    repo = await create_test_repo(client)
+
+    resp = await client.get(f"/api/repos/{repo['id']}/overview-summary")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["sync"]["last_sync_at"] is not None
+    assert body["sync"]["last_sync_at"] == body["repo"]["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_fallback_supersedes_older_full_resync(client: AsyncClient, app) -> None:
+    """An auto-sync after a full re-index shows as the latest sync, not the resync."""
+    repo = await create_test_repo(client)
+    await _complete_job(app, repo["id"], mode="full_resync", finished_at=datetime(2020, 1, 1))
+
+    resp = await client.get(f"/api/repos/{repo['id']}/overview-summary")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # repo.updated_at (now) is newer than the 2020 resync -> fallback wins.
+    assert body["sync"]["last_resync_at"] is not None
+    assert body["sync"]["last_sync_at"] == body["repo"]["updated_at"]
+    assert body["sync"]["last_sync_at"] != body["sync"]["last_resync_at"]
+
+
+@pytest.mark.asyncio
+async def test_completed_sync_job_wins_over_fallback(client: AsyncClient, app) -> None:
+    """A real completed sync job is preferred over the updated_at fallback."""
+    repo = await create_test_repo(client)
+    finished = datetime(2030, 1, 1)
+    await _complete_job(app, repo["id"], mode="sync", finished_at=finished)
+
+    resp = await client.get(f"/api/repos/{repo['id']}/overview-summary")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["sync"]["last_sync_at"] == finished.isoformat()
+    assert body["sync"]["last_sync_at"] != body["repo"]["updated_at"]


### PR DESCRIPTION
## Problem

The repo overview always showed **"Last synced: never"**, even though the index was current and being refreshed on every commit.

Root cause: `overview-summary` derived `sync.last_sync_at` *only* from completed server-side `GenerationJob` rows. CLI and git-hook auto-syncs (`repowise update`) refresh the index and bump `repositories.updated_at` via `upsert_repository`, but never create a `GenerationJob` row, so the job-only derivation reported "never" whenever syncing was driven by the CLI rather than the server's job pipeline.

## Fix

Fall back to `repositories.updated_at` when no completed sync job exists, but only when it is newer than the last full re-index, so a re-index is not relabelled as a sync. `repositories.updated_at` is the authoritative "index last refreshed" timestamp that every index path writes.

## Notes

- Server-only change. No schema change, no migration, no API shape change (`sync.last_sync_at` is unchanged in type).
- `repo.head_commit` was already correct in the DB and is unaffected by this change.

## Tests

- Adds `tests/unit/server/test_overview_sync.py` covering: fallback to `updated_at` with no jobs; fallback superseding an older full re-index; and a real completed sync job winning over the fallback.
- Mounts the `overview` router in the server test app (was previously not registered).