### PR TITLE
README: drop the redundant prose tagline (already in the banner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 <a href="https://www.repowise.dev"><img src=".github/assets/banner.png" alt="repowise — the codebase intelligence layer for your AI coding agent" width="100%" /></a>
 
-<p align="center"><em>The codebase intelligence layer for the AI era. Context your AI agent can use, and the health, risk, and ownership signals your team can trust.</em></p>
-
 <p align="center"><strong>Five intelligence layers · Nine MCP tools · 15 languages · Multi-repo workspaces · One <code>pip install</code></strong></p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Remove the prose tagline line under the banner — it duplicates text already shown in the banner image.

Removed:
> *The codebase intelligence layer for the AI era. Context your AI agent can use, and the health, risk, and ownership signals your team can trust.*

The banner already carries the tagline, so the line was redundant. The "Five intelligence layers · Nine MCP tools · …" summary line directly below is kept. Docs-only, off the latest `main` (after #562 merged).
