### PR TITLE
release: v0.22.0 — three-signal code health, reindex-free upgrades, hybrid search

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.22.0] — 2026-06-22
+
+### Added
+- **Three-signal code health.** The single code-health score is now split into three co-equal signals: **defect risk** (the headline score), **maintainability** (smells that raise change-cost without predicting bugs), and **performance risk** (static I/O-in-loop / N+1 shapes). Maintainability and performance are surfaced as their own pillars across the dashboard and the `get_health` MCP tool rather than being blended into the defect headline. (#528, #531, #533, #544)
+- **Performance-risk detection across languages.** A new performance detector finds I/O-in-loop and N+1 shapes, including cross-function cases resolved through call-graph reachability, with language-specific markers and dialects for Python, Java, Go, and C# (loop-level markers, `pandas_iterrows_in_loop`, centrality gating, and a reusable severity ranker). Detection runs through a `PerfDialect` plugin registry. (#530, #532, #536, #537, #538, #539, #541, #542)
+- **Dependencies classified by I/O boundary.** External systems are now classified by the kind of I/O boundary they sit on, feeding the performance and architecture views. (#529)
+- **Reindex-free upgrades.** The on-disk store now carries a format version separate from the package version, so upgrading repowise no longer forces a reindex. Upgrades show a release advisory and a "what's new" panel on the CLI, and the dashboard surfaces available upgrades with release info shared through core. (#553, #554, #556)
+- **Hybrid symbol and path search in `search_codebase`.** `search_codebase` now searches repowise's own structural index for identifier- and path-shaped queries instead of only running wiki-semantic search. A new `mode` parameter (`auto`/`concept`/`symbol`/`path`/`hybrid`) controls routing; `auto` picks by query shape and returns symbol IDs, file/line bounds, and signatures for identifier queries. (#558)
+- **Anonymous, opt-out CLI telemetry.** The CLI now collects anonymous usage telemetry behind a central platform layer; it is opt-out and collects no source code. (#555)
+- **AI prompt actions across the dashboard.** Health findings now carry MCP-native "fix this" AI prompt actions, rolled across the dashboard, with a finding-count cap to keep output bounded. (#546, #547)
+- **Commits and stats redesigns.** The commits page leads with a Code Evolution timeline, the blast-radius impact tab was redesigned, the owners view leads with a knowledge-distribution headline, and a new repo Stats "By the Numbers" page was added. Co-changes gained a repo-pair summary drill-down. (#543, #548, #549, #550, #551)
+
+### Changed
+- **Distill: seamless rewrite permissions + re-read savings.** `repowise distill` gained smoother rewrite-permission handling and additional re-read token savings. (#559)
+
+### Fixed
+- **Overview "Last synced" reflects CLI auto-syncs.** The overview page now reflects auto-syncs triggered by the CLI in its "Last synced" timestamp. (#564)
+- **Dead-code analyzer keeps same-file Python symbols.** Python symbols referenced only within their own file (callable-as-argument, annotation-only) are no longer flagged as dead code. (#563)
+- **Index freshness stays current.** Updates now keep the `CLAUDE.md` stamp and the indexed commit current so agents don't distrust a fresh index. (#524)
+- **Commits-page follow-ups.** Full-width agent strip, collapsible risk panel, and repo-wide stat cards on the commits page. (#552)
+- **Fewer performance false positives.** Eliminated three perf-detector false-positive classes across C#/Go/Python and now skips `for...of` over constant collections in the TS/JS detector. (#540, #545)
+
+### Documentation
+- README refreshed: banner, numbers-first lead, combined demo GIF, three-signal code-health framing, and star CTAs. (#534, #535, #562)
+- Plugin: version bump to 0.22.0; `search_codebase` skill docs updated for hybrid symbol/path search.
+
+---
+
 ## [0.21.0] — 2026-06-19
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.22.0] — 2026-06-22
+
+### Added
+- **Three-signal code health.** The single code-health score is now split into three co-equal signals: **defect risk** (the headline score), **maintainability** (smells that raise change-cost without predicting bugs), and **performance risk** (static I/O-in-loop / N+1 shapes). Maintainability and performance are surfaced as their own pillars across the dashboard and the `get_health` MCP tool rather than being blended into the defect headline. (#528, #531, #533, #544)
+- **Performance-risk detection across languages.** A new performance detector finds I/O-in-loop and N+1 shapes, including cross-function cases resolved through call-graph reachability, with language-specific markers and dialects for Python, Java, Go, and C# (loop-level markers, `pandas_iterrows_in_loop`, centrality gating, and a reusable severity ranker). Detection runs through a `PerfDialect` plugin registry. (#530, #532, #536, #537, #538, #539, #541, #542)
+- **Dependencies classified by I/O boundary.** External systems are now classified by the kind of I/O boundary they sit on, feeding the performance and architecture views. (#529)
+- **Reindex-free upgrades.** The on-disk store now carries a format version separate from the package version, so upgrading repowise no longer forces a reindex. Upgrades show a release advisory and a "what's new" panel on the CLI, and the dashboard surfaces available upgrades with release info shared through core. (#553, #554, #556)
+- **Hybrid symbol and path search in `search_codebase`.** `search_codebase` now searches repowise's own structural index for identifier- and path-shaped queries instead of only running wiki-semantic search. A new `mode` parameter (`auto`/`concept`/`symbol`/`path`/`hybrid`) controls routing; `auto` picks by query shape and returns symbol IDs, file/line bounds, and signatures for identifier queries. (#558)
+- **Anonymous, opt-out CLI telemetry.** The CLI now collects anonymous usage telemetry behind a central platform layer; it is opt-out and collects no source code. (#555)
+- **AI prompt actions across the dashboard.** Health findings now carry MCP-native "fix this" AI prompt actions, rolled across the dashboard, with a finding-count cap to keep output bounded. (#546, #547)
+- **Commits and stats redesigns.** The commits page leads with a Code Evolution timeline, the blast-radius impact tab was redesigned, the owners view leads with a knowledge-distribution headline, and a new repo Stats "By the Numbers" page was added. Co-changes gained a repo-pair summary drill-down. (#543, #548, #549, #550, #551)
+
+### Changed
+- **Distill: seamless rewrite permissions + re-read savings.** `repowise distill` gained smoother rewrite-permission handling and additional re-read token savings. (#559)
+
+### Fixed
+- **Overview "Last synced" reflects CLI auto-syncs.** The overview page now reflects auto-syncs triggered by the CLI in its "Last synced" timestamp. (#564)
+- **Dead-code analyzer keeps same-file Python symbols.** Python symbols referenced only within their own file (callable-as-argument, annotation-only) are no longer flagged as dead code. (#563)
+- **Index freshness stays current.** Updates now keep the `CLAUDE.md` stamp and the indexed commit current so agents don't distrust a fresh index. (#524)
+- **Commits-page follow-ups.** Full-width agent strip, collapsible risk panel, and repo-wide stat cards on the commits page. (#552)
+- **Fewer performance false positives.** Eliminated three perf-detector false-positive classes across C#/Go/Python and now skips `for...of` over constant collections in the TS/JS detector. (#540, #545)
+
+### Documentation
+- README refreshed: banner, numbers-first lead, combined demo GIF, three-signal code-health framing, and star CTAs. (#534, #535, #562)
+- Plugin: version bump to 0.22.0; `search_codebase` skill docs updated for hybrid symbol/path search.
+
+---
+
 ## [0.21.0] — 2026-06-19
 
 ### Added

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.22.0
+
+### Changed
+- Updated the `search_codebase` skill docs to describe hybrid symbol/path search:
+  the new `mode` parameter (`auto`/`concept`/`symbol`/`path`/`hybrid`) and
+  identifier/path query routing into structural-index results.
+
 ## 0.21.0
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Repowise codebase intelligence for Codex.",
   "author": {
     "name": "Repowise",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.21.0"
+version = "0.22.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## release: v0.22.0

The big theme this cycle is **three-signal code health**: the single score is split into **defect risk** (the headline), **maintainability**, and **performance risk**, each surfaced as its own pillar across the dashboard and `get_health`. Alongside that: reindex-free upgrades, hybrid symbol/path `search_codebase`, anonymous opt-out CLI telemetry, and several web redesigns (commits, blast-radius, owners, stats).

See `docs/CHANGELOG.md` for the full entry.

### Version bump
- `pyproject.toml`, the three package `__init__.py` files, `uv.lock` self-entry
- Plugin manifests: `.claude-plugin/marketplace.json` + `plugins/claude-code/.claude-plugin/plugin.json` -> 0.22.0; `plugins/codex/.codex-plugin/plugin.json` -> 0.1.1
- Changelogs: `docs/CHANGELOG.md` (+ bundled copy resynced), `plugins/claude-code/CHANGELOG.md`

### Test plan
- [x] `uv build --wheel` -> `dist/repowise-0.22.0-py3-none-any.whl` (commands + `.scm`/`.j2` package-data present)
- [x] `uv lock` regenerated (self-entry 0.21.0 -> 0.22.0)
- [x] `npm ci && npm run build --workspace packages/web` -> standalone `server.js` + workspace-package code in chunks
- [x] bundled-changelog sync guard passes
- [x] version-drift grep clean (no 0.21.0 left)
- [ ] post-merge: tag `v0.22.0` on main + push -> publish.yml
- [ ] post-merge: verify GitHub release assets + PyPI

### Merge convention
Use a **regular merge commit** (not squash) so the tag points at a real merge of the bump-only diff.
