### PR TITLE
docs: document enriched get_health MCP surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ diverges from live `.git/HEAD`.
 | `get_risk(targets, changed_files?)` | Hotspot scores, dependents, co-change partners, ownership, test gaps, security signals. Pass `changed_files` for PR mode → a `directive` block (`will_break`, `missing_cochanges`, `missing_tests`, `governance_risk`). |
 | `get_why(query?, targets?)` | Architectural decision records, status, evidence spans, and the supersession **lineage chain**. Falls back to git archaeology when no ADRs exist. |
 | `get_dead_code(...)` | Unreachable code by confidence tier with cleanup-impact estimates; cross-repo consumer detection in workspace mode. |
-| `get_health(targets?, include?)` | 25-biomarker scores per file across three signals (defect · maintainability · performance). Dashboard mode → KPIs + lowest-scoring files + module rollup; targeted mode → per-file findings. `include`: coverage, refactoring, trend. |
+| `get_health(targets?, include?)` | Biomarker scores per file across three signals (defect · maintainability · performance). Dashboard mode → KPIs + lowest-scoring files + module rollup; targeted mode → per-file findings. Self-check before a PR via `include`: `accuracy` (does the score find the bugs), `signals` (per-file churn / owners / prior defects), `churn_complexity`, a dimension name to filter findings, plus `coverage`, `refactoring`, `trend`. |
 
 Worked example (*"Add rate limiting to all API endpoints"* in 5 calls instead of
 ~30 greps+reads) and the full reference: **[docs/MCP_TOOLS.md →](docs/MCP_TOOLS.md)**

--- a/docs/CODE_HEALTH.md
+++ b/docs/CODE_HEALTH.md
@@ -351,6 +351,14 @@ dashboards, where it expands into a per-K table (worst 10/20/30), a
 concentration stat (what share of recently-fixed files fall in the
 least-healthy 20%), and the exact flagged files.
 
+Agents can read the same stat over MCP, so a coding agent can confirm the score
+is trustworthy on this repo before acting on it:
+
+```python
+# MCP — dashboard mode, the same precision@K / lift block
+get_health(include=["accuracy"])
+```
+
 It stays silent on repos without enough history to be honest (fewer than 25
 scored files, or fewer than 5 recently-fixed files). One caveat it discloses:
 `prior_defect` is itself one (down-weighted) input to the score, so this is an
@@ -631,6 +639,9 @@ GET /api/repos/{repo_id}/health/files/breakdown?file_path=path/to/file.py
 ```python
 # MCP — attached to the get_context health block (null fields dropped)
 get_context(targets=["path/to/file.py"], include=["health"])
+
+# MCP — also on get_health targeted mode, one `signals` object per metric
+get_health(targets=["path/to/file.py"], include=["signals"])
 ```
 
 ## Hotspot anatomy
@@ -652,6 +663,11 @@ dashboard tab, toggleable with the churn × bus-factor view.
 ```bash
 # REST — repo-level point list (one point per churned file)
 GET /api/repos/{repo_id}/health/churn-complexity
+```
+
+```python
+# MCP — the same point list, dashboard mode
+get_health(include=["churn_complexity"])
 ```
 
 Files with no recent churn are omitted (they have nothing to say on the churn

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -425,33 +425,59 @@ get_dead_code(min_confidence=0.8, include_internals=true)
 
 ## `get_health`
 
-Code-health biomarker scores — the same 25 deterministic biomarkers the
-`repowise health` CLI computes, exposed for agentic workflows. Zero LLM calls.
+Code-health biomarker scores — the same deterministic biomarkers the
+`repowise health` CLI computes, across three signals (defect risk ·
+maintainability · performance), exposed for agentic workflows. Zero LLM calls.
+Use it to **self-check a change before opening a PR** — the same signals a
+code-health merge-gate judges it on.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `targets` | list[string] | No | File paths, or `module:foo` to expand a module's file set. Empty → dashboard mode. |
-| `include` | list[string] | No | `"refactoring"` (rule-based suggestions), `"trend"` (snapshot diff + declining / predicted-decline alerts), `"coverage"` |
+| `include` | list[string] | No | Opt-in blocks (default response stays lean): `"biomarkers"` (findings in dashboard mode), `"refactoring"` (rule-based suggestions per finding), `"trend"` (snapshot diff + declining / predicted-decline alerts), `"coverage"`, `"accuracy"` (the "does the score find the bugs?" stat, dashboard mode), `"signals"` (per-file process / people / topology signals, targeted mode), `"churn_complexity"` (churn × complexity quadrant points, dashboard mode), and a dimension name — `"performance"` / `"defect"` / `"maintainability"` — to filter findings to that pillar. |
 | `repo` | string | No | *(workspace only)* Target repo alias |
 | `limit` | int | No | Max rows in the lowest-scoring file list (default 20, capped at 50) |
 
 **Returns:** Dashboard mode (no `targets`) returns repo-level KPIs (hotspot
-health, average health, worst performer), the lowest-scoring files, and a
-per-module NLOC-weighted rollup. Targeted mode returns per-file biomarker
-findings with severity and the score breakdown.
+health, average health, worst performer, maintainability / performance pillar
+averages), the lowest-scoring files, and a per-module NLOC-weighted rollup.
+Targeted mode returns per-file biomarker findings with severity, per-dimension
+scores, and the score breakdown. Each finding carries a `dimension`
+(`defect` / `maintainability` / `performance`).
 
-**When to use:** Before refactoring — find the worst-scoring files and what to
-fix first. Pair with `get_risk` on hotspots.
+The opt-in enrichments:
+
+- **`accuracy`** → a `defect_accuracy` block: of the K least-healthy files, how
+  many were recently bug-fixed vs the repo-wide base rate (precision@K + `lift`),
+  with a per-K table and the flagged files. Silent (`null`) on repos with too
+  little history to be honest (< 25 scored files or < 5 recently-fixed files).
+- **`signals`** → a `signals` object on each targeted metric: prior-defect count,
+  change scatter, 90-day churn, primary / recent owner, and graph in / out
+  degree. Honest `null` per field when the underlying row is absent (never an
+  imputed zero).
+- **`churn_complexity`** → `churn_complexity` points (one per recently-changed
+  file: 90-day commit count, max CCN, NLOC, score, churn percentile) — the
+  refactor zone where volatility and tangle collide.
+- **dimension filter** → narrows the returned findings to one pillar. Pair with
+  `"biomarkers"` for the full (uncapped) finding set, e.g.
+  `include=["biomarkers", "performance"]`.
+
+**When to use:** Before opening a PR, to self-check the files you changed
+(`targets=[...], include=["signals"]`) and confirm you are not regressing the
+worst files. Before refactoring — find the worst-scoring files and what to fix
+first (`include=["accuracy", "churn_complexity"]`). Pair with `get_risk` on
+hotspots.
 
 **Example calls:**
 
 ```
 get_health()
-get_health(include=["refactoring"])
-get_health(targets=["src/api/server.py"])
-get_health(targets=["module:src.api"], include=["trend"])
+get_health(include=["accuracy", "churn_complexity"])
+get_health(include=["biomarkers", "performance"])     # only performance findings
+get_health(targets=["src/api/server.py"], include=["signals"])
+get_health(targets=["module:src.api"], include=["trend", "refactoring"])
 ```
 
 ---


### PR DESCRIPTION
## What

Documents the four new opt-in `get_health` MCP `include` flags shipped in #571 (accuracy, signals, churn_complexity, and the `performance` / `defect` / `maintainability` finding filter) plus the pre-PR self-check use case.

- **docs/MCP_TOOLS.md** — rewrote the `get_health` section: the new flags in the parameter table, an enrichment-returns breakdown, and self-check examples. Dropped the brittle hard-coded biomarker count in favor of the three-signal description (defect risk / maintainability / performance).
- **README.md** — extended the `get_health` row in the MCP tool table with the self-check flags.
- **docs/CODE_HEALTH.md** — added the MCP path next to the existing REST/CLI snippets in three sections: the "does the score find the bugs?" stat (`include=["accuracy"]`), file signals (`include=["signals"]`), and the churn x complexity points (`include=["churn_complexity"]`).

## Why

The enriched tool surface in #571 was undocumented in the user-facing references. This brings the MCP reference, the README tool table, and the code-health guide in line with what the tool now exposes.

## Notes

Docs only, no code changes. Best read after #571 (the implementation PR).