### PR TITLE
feat(cli): add --no-workspace to init and make --yes fully non-interactive

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -55,6 +55,7 @@ In workspace mode, adds: repo scanning, per-repo indexing, cross-repo analysis (
 | `--embedder` | Embedder for semantic search: `gemini`, `openai`, `mock` |
 | `--index-only` | Skip LLM generation. Only parse, build graph, and index git. Free. |
 | `--mode` | Pipeline depth: `standard` (default) or `fast` (graph + essential-git only — no per-file blame/co-change, no LLM — for very large repos; upgrade later with `update --full`). |
+| `--no-workspace` | Force single-repo mode even when invoked from a workspace root (indexes only the target PATH instead of fanning out across workspace repos). |
 | `--wiki-style` | Documentation voice/density: `comprehensive` (default), `caveman` (token-condensed, AI-first), `reference` (API-manual), `tutorial` (beginner-friendly). Interactive full runs prompt when omitted. Saved to config so `update` keeps the style. See [WIKI_STYLES.md](WIKI_STYLES.md). |
 | `--dry-run` | Show generation plan and cost estimate without running. |
 | `--test-run` | Generate docs for only the top 10 files (by PageRank). |
@@ -91,6 +92,7 @@ repowise init --include-submodules                    # include submodules
 repowise init --no-codex --no-agents                  # skip Codex project files
 repowise init .                                       # workspace mode
 repowise init . --index-only -x "node_modules/"      # workspace, no LLM
+repowise init . --no-workspace                        # force single-repo, even in a workspace root
 ```
 
 ---

--- a/packages/cli/src/repowise/cli/commands/init_cmd/_interactive.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/_interactive.py
@@ -13,6 +13,8 @@ def offer_distill_rewrite_hook(
     console_obj: Any,
     repo_paths: list[Path],
     flag: bool | None,
+    *,
+    yes: bool = False,
 ) -> None:
     """Opt-in install of the distill command-rewrite hook (Claude Code).
 
@@ -21,6 +23,9 @@ def offer_distill_rewrite_hook(
     config (so a hook installed globally from another repo stays inert
     there), None prompts when interactive (defaulting to yes) and does
     nothing otherwise.
+
+    When ``yes`` is True any prompt that would arise from ``flag=None`` is
+    skipped (no hook is installed silently).
 
     The hook itself is user-level (one install covers every repo), but the
     verdict is recorded per repo as ``distill.commands.enabled`` in each
@@ -39,6 +44,9 @@ def offer_distill_rewrite_hook(
         "false",
         "no",
     ):
+        return
+    # --yes with an undecided flag: skip the interactive prompt entirely.
+    if flag is None and yes:
         return
     if flag is None and not sys.stdin.isatty():
         return
@@ -86,12 +94,17 @@ def offer_hook_install(
     console_obj: Any,
     repo_paths: list[Path],
     aliases: list[str] | None = None,
+    *,
+    yes: bool = False,
 ) -> None:
     """Interactively offer to install post-commit hooks for auto-sync.
 
     For a single repo, asks yes/no.  For multiple repos (workspace), lets the
-    user pick which repos to install hooks for.
+    user pick which repos to install hooks for.  When ``yes`` is True all
+    interactive prompts are skipped (no hook is installed silently).
     """
+    if yes:
+        return  # --yes: skip all interactive prompts
     if not sys.stdin.isatty():
         return  # Non-interactive — skip
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -341,6 +341,16 @@ def _run_generation_phase(
     help="Include git submodule directories (excluded by default).",
 )
 @click.option(
+    "--no-workspace",
+    "no_workspace",
+    is_flag=True,
+    default=False,
+    help=(
+        "Force single-repo mode even when invoked from a workspace root. "
+        "Indexes only the target PATH and skips workspace detection."
+    ),
+)
+@click.option(
     "--all",
     "init_all",
     is_flag=True,
@@ -417,6 +427,7 @@ def init_command(
     codex_setup: bool | None,
     distill_hook: bool | None,
     include_submodules: bool,
+    no_workspace: bool,
     init_all: bool,
     onboarding: bool,
     coverage_pct: float | None,
@@ -442,11 +453,12 @@ def init_command(
 
     # ---- Workspace detection ----
     # If the path contains multiple git repos (and is not itself a single repo),
-    # branch into the multi-repo workspace flow.
+    # branch into the multi-repo workspace flow.  --no-workspace bypasses this
+    # entirely and forces single-repo mode regardless of what scan finds.
     from repowise.core.workspace import scan_for_repos
 
     scan = scan_for_repos(repo_path, include_submodules=include_submodules)
-    if len(scan.repos) > 1:
+    if len(scan.repos) > 1 and not no_workspace:
         _workspace_init(
             scan=scan,
             init_all=init_all,
@@ -500,7 +512,11 @@ def init_command(
         index_only = True
 
     # ---- Interactive mode (TTY, no explicit flags) ----
-    is_interactive = sys.stdin.isatty() and provider_name is None and not index_only
+    # --yes forces non-interactive even on a TTY (mirrors the workspace path),
+    # so a scripted `init -y` never blocks on the mode-selection menu.
+    is_interactive = (
+        sys.stdin.isatty() and provider_name is None and not index_only and not yes
+    )
 
     # Tiered doc generation cap (set in advanced mode); None = every selected
     # file page is a full-LLM tier-1 page (unchanged behaviour).
@@ -578,7 +594,8 @@ def init_command(
 
         # Wiki style: prompt in interactive full-mode runs when not set via flag.
         # Index-only runs generate no pages, so the question is skipped (D7).
-        if wiki_style is None and not index_only:
+        # --yes skips the prompt and uses the default style.
+        if wiki_style is None and not index_only and not yes:
             wiki_style = _prompt_wiki_style(console)
 
     # Resolve the effective style (CLI flag > interactive prompt > default) and
@@ -921,8 +938,8 @@ def init_command(
     )
 
     # Offer to install post-commit hook (both index-only and full modes)
-    offer_hook_install(console, [repo_path])
+    offer_hook_install(console, [repo_path], yes=yes)
 
     # Opt-in distill command-rewrite hook for Claude Code. The workspace flow
     # runs its own offer across all selected repos inside _workspace_init.
-    offer_distill_rewrite_hook(console, [repo_path], distill_hook)
+    offer_distill_rewrite_hook(console, [repo_path], distill_hook, yes=yes)

--- a/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
@@ -444,14 +444,19 @@ def _workspace_init(
     console.print(f"  Detected [bold]{len(scan.repos)}[/bold] repositories in {root}\n")
 
     # Step 1: Select repos to index
-    selected = list(scan.repos) if init_all else interactive_repo_select(console, scan.repos)
+    # --yes or --all: take every detected repo without prompting.
+    select_all = init_all or yes
+    selected = list(scan.repos) if select_all else interactive_repo_select(console, scan.repos)
 
     if not selected:
         console.print("[yellow]No repositories selected. Aborting.[/yellow]")
         return
 
     # Step 2: Select primary repo
-    primary_alias = selected[0].alias if init_all else interactive_primary_select(console, selected)
+    # --yes or --all: auto-pick the first repo as primary without prompting.
+    primary_alias = (
+        selected[0].alias if select_all else interactive_primary_select(console, selected)
+    )
 
     # Determine root path (for provider resolution + dotenv)
     primary_repo = next((r for r in selected if r.alias == primary_alias), selected[0])
@@ -459,7 +464,8 @@ def _workspace_init(
 
     # Step 2b: Mode selection + provider setup
     # When running interactively with no explicit flags, present the mode menu.
-    is_interactive = sys.stdin.isatty() and provider_name is None and not index_only
+    # --yes suppresses all interactive prompts: treat as non-interactive.
+    is_interactive = sys.stdin.isatty() and provider_name is None and not index_only and not yes
 
     embedder_name_resolved = resolve_embedder(embedder_name)
 
@@ -631,6 +637,7 @@ def _workspace_init(
             console,
             [r.path for r in indexed_repos],
             aliases=[r.alias for r in indexed_repos],
+            yes=yes,
         )
     # Opt-in distill command-rewrite hook for Claude Code: one user-level
     # install, with the verdict recorded per repo. Applied to *all* selected
@@ -638,5 +645,5 @@ def _workspace_init(
     # failed) because ensure_repowise_dir already created `.repowise/` in
     # each, and the hook treats any repo with `.repowise/` and no recorded
     # verdict as enabled — a decline must gate every one of them off.
-    offer_distill_rewrite_hook(console, [r.path for r in selected], distill_hook)
+    offer_distill_rewrite_hook(console, [r.path for r in selected], distill_hook, yes=yes)
     console.print()

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -41,6 +41,7 @@ class TestCliBasics:
         assert "xhigh" in result.output
         assert "--codex" in result.output
         assert "--agents" in result.output
+        assert "--no-workspace" in result.output
 
     def test_update_help(self, runner):
         result = runner.invoke(cli, ["update", "--help"])
@@ -132,6 +133,165 @@ class TestErrorCases:
         (tmp_path / ".repowise").mkdir()
         result = runner.invoke(cli, ["update", str(tmp_path)])
         assert result.exit_code != 0
+
+
+class TestInitNoWorkspaceFlag:
+    """Tests for ``repowise init --no-workspace``."""
+
+    def test_no_workspace_forces_single_repo(self, runner, tmp_path, monkeypatch):
+        """--no-workspace skips the workspace branch even when scan returns >1 repo."""
+        from unittest.mock import MagicMock, patch
+
+        # Simulate a workspace with two repos detected.
+        fake_repo = MagicMock()
+        fake_repo.path = tmp_path
+        fake_scan = MagicMock()
+        fake_scan.repos = [fake_repo, MagicMock()]  # 2 repos -> would trigger workspace
+
+        workspace_entered = []
+
+        def fake_workspace_init(**kwargs):
+            workspace_entered.append(True)
+
+        # Patch scan_for_repos so we control what it returns, and patch
+        # _workspace_init so we can detect if the workspace branch runs.
+        with (
+            patch(
+                "repowise.core.workspace.scan_for_repos",
+                return_value=fake_scan,
+            ),
+            patch(
+                "repowise.cli.commands.init_cmd.command._workspace_init",
+                side_effect=fake_workspace_init,
+            ),
+        ):
+            # Without --no-workspace the workspace branch should be entered.
+            result = runner.invoke(cli, ["init", str(tmp_path)])
+            assert workspace_entered, "expected workspace branch without --no-workspace"
+
+            workspace_entered.clear()
+
+            # With --no-workspace the workspace branch must NOT be entered.
+            result = runner.invoke(cli, ["init", "--no-workspace", str(tmp_path)])
+            assert not workspace_entered, (
+                f"--no-workspace should skip workspace branch, but it was entered. "
+                f"exit_code={result.exit_code}, output={result.output}"
+            )
+
+    def test_no_workspace_in_help(self, runner):
+        """--no-workspace flag is documented in init --help output."""
+        result = runner.invoke(cli, ["init", "--help"])
+        assert result.exit_code == 0
+        assert "--no-workspace" in result.output
+
+
+class TestInitYesFlag:
+    """Tests that -y/--yes makes init fully non-interactive."""
+
+    def test_yes_skips_offer_hook_install(self):
+        """offer_hook_install returns immediately when yes=True, never calling click.confirm."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from repowise.cli.commands.init_cmd._interactive import offer_hook_install
+
+        console_mock = type(
+            "C", (), {"print": lambda self, *a, **kw: None, "line": lambda self: None}
+        )()
+
+        with patch(
+            "click.confirm", side_effect=AssertionError("should not prompt")
+        ) as mock_confirm:
+            # With yes=True and a TTY-like stdin, confirm must never be called.
+            offer_hook_install(console_mock, [Path("/tmp/repo")], yes=True)
+            mock_confirm.assert_not_called()
+
+    def test_yes_skips_offer_distill_rewrite_hook_when_flag_is_none(self):
+        """offer_distill_rewrite_hook skips any prompt when yes=True and flag=None."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from repowise.cli.commands.init_cmd._interactive import offer_distill_rewrite_hook
+
+        console_mock = type(
+            "C", (), {"print": lambda self, *a, **kw: None, "line": lambda self: None}
+        )()
+
+        with patch(
+            "click.confirm", side_effect=AssertionError("should not prompt")
+        ) as mock_confirm:
+            offer_distill_rewrite_hook(console_mock, [Path("/tmp/repo")], flag=None, yes=True)
+            mock_confirm.assert_not_called()
+
+    def test_yes_skips_wiki_style_prompt(self, runner, tmp_path, monkeypatch):
+        """With -y, the wiki-style interactive prompt is never shown."""
+        from unittest.mock import MagicMock, patch
+
+        # Single-repo scan (no workspace branch).
+        fake_repo = MagicMock()
+        fake_repo.path = tmp_path
+        fake_scan = MagicMock()
+        fake_scan.repos = [fake_repo]
+
+        prompt_called = []
+
+        def _fake_prompt_wiki_style(_console):
+            prompt_called.append(True)
+            return "comprehensive"
+
+        with (
+            patch(
+                "repowise.core.workspace.scan_for_repos",
+                return_value=fake_scan,
+            ),
+            patch(
+                "repowise.cli.commands.init_cmd.command._prompt_wiki_style",
+                side_effect=_fake_prompt_wiki_style,
+            ),
+            patch(
+                "repowise.cli.commands.init_cmd.command.resolve_provider",
+                side_effect=Exception("stop early"),
+            ),
+        ):
+            runner.invoke(cli, ["init", "-y", "--index-only", str(tmp_path)])
+            assert not prompt_called, "-y should bypass the wiki-style interactive prompt"
+
+    def test_yes_skips_mode_select_on_tty(self, runner, tmp_path):
+        """With -y on a TTY, the interactive mode-selection menu is never shown.
+
+        Without the ``and not yes`` guard on ``is_interactive`` a scripted
+        ``init -y`` would still block on ``interactive_mode_select`` whenever
+        stdin happens to be a TTY.
+        """
+        from unittest.mock import MagicMock, patch
+
+        fake_repo = MagicMock()
+        fake_repo.path = tmp_path
+        fake_scan = MagicMock()
+        fake_scan.repos = [fake_repo]
+
+        mode_select_called = []
+
+        with (
+            patch(
+                "repowise.core.workspace.scan_for_repos",
+                return_value=fake_scan,
+            ),
+            patch("sys.stdin.isatty", return_value=True),
+            patch(
+                "repowise.cli.commands.init_cmd.command.interactive_mode_select",
+                side_effect=lambda *_a, **_kw: mode_select_called.append(True),
+            ),
+            # Stop before the real pipeline runs.
+            patch(
+                "repowise.cli.commands.init_cmd.command.resolve_provider",
+                side_effect=Exception("stop early"),
+            ),
+        ):
+            runner.invoke(cli, ["init", "-y", str(tmp_path)])
+            assert not mode_select_called, (
+                "-y must bypass the interactive mode-selection menu even on a TTY"
+            )
 
 
 class TestBuildFilteredChangedPaths:


### PR DESCRIPTION
## What

- Adds `--no-workspace` to `repowise init`, mirroring the existing flag on `update`. At a workspace root, `init` auto-detects workspace mode and fans out across every member repo; `--no-workspace` forces single-repo mode so it indexes only the target PATH.
- Hardens `--yes`/`-y` so a scripted `init` never blocks on an interactive prompt. Previously, on a TTY, `init -y` could still stop at the mode-selection menu (and a few other prompts). `--yes` now skips:
  - the interactive mode-selection menu (single-repo **and** workspace paths)
  - the wiki-style chooser
  - workspace repo / primary-repo selection
  - the hook-install and distill-rewrite confirmations

## Why

These two together make non-interactive, single-repo indexing scriptable from a workspace checkout (e.g. CI, automation, fast local iteration), which previously required either running outside the workspace or babysitting prompts.

## Tests

- `--no-workspace` routes to single-repo mode (and the default still enters the workspace branch).
- `-y` bypasses the hook-install confirm, the distill-rewrite confirm, the wiki-style prompt, and the mode-selection menu on a TTY.
- Full CLI suite: 28 passed; `ruff check` clean.

## Docs

- `docs/CLI_REFERENCE.md`: new `--no-workspace` row + example under `init`.