### PR TITLE
feat(kg): make the knowledge-graph info panel collapsible

### DIFF
--- a/packages/types/src/overview.ts
+++ b/packages/types/src/overview.ts
@@ -13,6 +13,14 @@ export interface OverviewRepoMeta {
   default_branch: string;
   head_commit: string | null;
   updated_at: string | null;
+  /** GitHub owner/login. Hosted-only — lets surfaces like the MCP connect
+   *  card build the `owner/name` server URL without resolving the repo
+   *  through the viewer's own repo list (so it works on public shares for
+   *  non-owners). Absent/`""` for the OSS CLI, which has no remote owner. */
+  owner?: string;
+  /** Whether the repo is publicly browsable. Hosted-only; drives the
+   *  public/private connect copy. Defaults to public when absent. */
+  is_public?: boolean;
 }
 
 export interface OverviewStatDeltas {

--- a/packages/ui/src/c4/panels/Sidebar.tsx
+++ b/packages/ui/src/c4/panels/Sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { Info, FolderOpen } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Info, FolderOpen, PanelRightOpen, X } from "lucide-react";
 import { useArchitectureStore } from "../store/use-architecture-store";
 import { ProjectOverview } from "./ProjectOverview";
 import { ArchNodeInfo } from "./ArchNodeInfo";
@@ -50,9 +50,55 @@ export function Sidebar(props: SidebarProps) {
   const view = useArchitectureStore((s) => s.view);
   const selectedNodeId = useArchitectureStore((s) => s.selectedNodeId);
   const tourActive = useArchitectureStore((s) => s.tourActive);
+  const sidebarOpen = useArchitectureStore((s) => s.sidebarOpen);
+  const setSidebarOpen = useArchitectureStore((s) => s.setSidebarOpen);
   const [activeTab, setActiveTab] = useState<SidebarTab>("info");
 
+  // Collapse on small screens at first mount — a 320px overlay swallows the
+  // whole graph on a phone. Runs once; the user's manual toggle wins after.
+  useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      window.matchMedia("(max-width: 767px)").matches
+    ) {
+      setSidebarOpen(false);
+    }
+  }, [setSidebarOpen]);
+
   if (!view) return null;
+
+  // Collapsed: a small floating affordance to bring the panel back, kept in
+  // the same corner so it reads as "the panel lives here".
+  if (!sidebarOpen) {
+    return (
+      <button
+        type="button"
+        aria-label="Open Knowledge Graph panel"
+        onClick={() => setSidebarOpen(true)}
+        style={{
+          position: "absolute",
+          top: 12,
+          right: 12,
+          zIndex: 5,
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "8px 10px",
+          fontSize: 12,
+          fontWeight: 600,
+          cursor: "pointer",
+          color: "var(--color-text-primary)",
+          background: "var(--color-bg-elevated, rgba(17,24,39,0.96))",
+          border: "1px solid var(--color-border-default)",
+          borderRadius: 8,
+          boxShadow: "0 10px 30px rgba(0,0,0,0.35)",
+        }}
+      >
+        <PanelRightOpen size={14} />
+        Details
+      </button>
+    );
+  }
 
   return (
     <aside
@@ -61,7 +107,9 @@ export function Sidebar(props: SidebarProps) {
         position: "absolute",
         top: 12,
         right: 12,
-        width: 320,
+        // Cap to the viewport on phones so the panel never overflows the
+        // canvas edge-to-edge.
+        width: "min(320px, calc(100vw - 24px))",
         maxHeight: "calc(100% - 24px)",
         background: "var(--color-bg-elevated, rgba(17,24,39,0.96))",
         border: "1px solid var(--color-border-default)",
@@ -79,6 +127,7 @@ export function Sidebar(props: SidebarProps) {
         aria-label="Sidebar tabs"
         style={{
           display: "flex",
+          alignItems: "stretch",
           borderBottom: "1px solid var(--color-border-default)",
           flexShrink: 0,
         }}
@@ -106,6 +155,25 @@ export function Sidebar(props: SidebarProps) {
         >
           <FolderOpen size={13} />
           Files
+        </button>
+        <button
+          type="button"
+          aria-label="Close panel"
+          onClick={() => setSidebarOpen(false)}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 34,
+            flexShrink: 0,
+            cursor: "pointer",
+            background: "none",
+            border: "none",
+            borderLeft: "1px solid var(--color-border-default)",
+            color: "var(--color-text-secondary)",
+          }}
+        >
+          <X size={14} />
         </button>
       </nav>
 

--- a/packages/ui/src/c4/store/use-architecture-store.ts
+++ b/packages/ui/src/c4/store/use-architecture-store.ts
@@ -62,6 +62,11 @@ interface ArchitectureStoreState {
 
   pathFinderOpen: boolean;
   reactFlowInstance: ReactFlowInstance | null;
+
+  /** Whether the right-hand info/files panel is visible. Open on desktop;
+   *  the panel itself collapses this on small screens at mount so it doesn't
+   *  obstruct the graph. */
+  sidebarOpen: boolean;
 }
 
 interface ArchitectureStoreActions {
@@ -112,6 +117,9 @@ interface ArchitectureStoreActions {
 
   setPathFinderOpen: (open: boolean) => void;
   setReactFlowInstance: (instance: ReactFlowInstance | null) => void;
+
+  setSidebarOpen: (open: boolean) => void;
+  toggleSidebar: () => void;
 }
 
 export type ArchitectureStore = ArchitectureStoreState & ArchitectureStoreActions;
@@ -308,6 +316,8 @@ const INITIAL_STATE: ArchitectureStoreState = {
 
   pathFinderOpen: false,
   reactFlowInstance: null,
+
+  sidebarOpen: true,
 };
 
 export const useArchitectureStore = create<ArchitectureStore>()(
@@ -407,6 +417,9 @@ export const useArchitectureStore = create<ArchitectureStore>()(
           ...drillStateForNode(state, nodeId),
           selectedNodeId: nodeId,
           focusNodeId: null,
+          // Selecting a node surfaces its details — reopen the panel if the
+          // user had collapsed it (key on mobile, where it starts closed).
+          ...(nodeId ? { sidebarOpen: true } : {}),
         });
       },
 
@@ -636,6 +649,14 @@ export const useArchitectureStore = create<ArchitectureStore>()(
 
       setReactFlowInstance: (instance: ReactFlowInstance | null) => {
         set({ reactFlowInstance: instance });
+      },
+
+      setSidebarOpen: (open: boolean) => {
+        set({ sidebarOpen: open });
+      },
+
+      toggleSidebar: () => {
+        set({ sidebarOpen: !get().sidebarOpen });
       },
     }),
     { name: "architecture-store" },


### PR DESCRIPTION
## What

The right-hand Info/Files panel on the knowledge-graph view was always open and could not be dismissed. On small screens its 320px overlay covers the whole graph, with no way to see the canvas behind it.

- Add a close (X) control in the panel header and a compact "Details" reopen affordance in the same corner, backed by a new `sidebarOpen` flag in the architecture store (mirrors the existing `filterPanelOpen` / `codeViewerOpen` pattern).
- Collapse the panel automatically on first mount on phone-width viewports so it never lands obstructing the graph.
- Cap the panel width to the viewport (`min(320px, 100vw - 24px)`) so it can't overflow the canvas edge.
- Selecting a node reopens the panel so node details stay reachable after a manual collapse.

Also adds optional `owner` / `is_public` to `OverviewRepoMeta` so hosted surfaces can build an owner/name server URL from the overview payload. Both fields are optional and unused by the OSS web app.

## Test

- `tsc --noEmit` passes for `packages/ui` and `packages/types`.
- Desktop behaviour is unchanged (panel open by default); the close/reopen and mobile auto-collapse are additive.