### PR TITLE
fix(kg): guard matchMedia in the knowledge-graph panel mount effect

### DIFF
--- a/packages/ui/src/c4/panels/Sidebar.tsx
+++ b/packages/ui/src/c4/panels/Sidebar.tsx
@@ -56,9 +56,11 @@ export function Sidebar(props: SidebarProps) {
 
   // Collapse on small screens at first mount — a 320px overlay swallows the
   // whole graph on a phone. Runs once; the user's manual toggle wins after.
+  // `matchMedia` is absent in SSR and in the jsdom test env, so guard it.
   useEffect(() => {
     if (
       typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
       window.matchMedia("(max-width: 767px)").matches
     ) {
       setSidebarOpen(false);


### PR DESCRIPTION
## What

The mobile auto-collapse effect added in #579 called `window.matchMedia` unconditionally. That throws `TypeError: window.matchMedia is not a function` in the jsdom test environment (and would on any SSR pass), which broke the `packages/ui` test suite and, in turn, the internal package publish (`publish-internal.yml`).

Guard on `typeof window.matchMedia === "function"` before calling it.

## Test

- `npm run test --workspace @repowise-dev/ui` — 489 passed.