### PR TITLE
fix(graph): make GraphBuilder picklable across a process boundary

### DIFF
--- a/packages/core/src/repowise/core/ingestion/graph/_centrality_cache.py
+++ b/packages/core/src/repowise/core/ingestion/graph/_centrality_cache.py
@@ -67,6 +67,20 @@ class CentralityCache:
         self._lock = threading.Lock()
         self._loaded = False
 
+    def __getstate__(self) -> dict:
+        # A ``threading.Lock`` is not picklable, and the GraphBuilder that owns
+        # this cache is pickled to hand graph state across a process boundary
+        # (e.g. the hosted static-state bundle). Drop the lock here; the entries
+        # are the only state worth carrying. ``__setstate__`` restores a fresh
+        # lock.
+        state = self.__dict__.copy()
+        state["_lock"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._lock = threading.Lock()
+
     def _ensure_loaded(self) -> None:
         if self._loaded:
             return

--- a/packages/core/src/repowise/core/ingestion/graph/builder.py
+++ b/packages/core/src/repowise/core/ingestion/graph/builder.py
@@ -100,6 +100,24 @@ class GraphBuilder(MetricsMixin, ResolveMixin, EdgesMixin, SerializeMixin, Rehyd
         # call + heritage resolvers; reset whenever files change).
         self._import_name_maps: Any | None = None
 
+    def __getstate__(self) -> dict:
+        # GraphBuilder is pickled to hand a fully-built graph (structure +
+        # materialized metric caches) across a process boundary without a
+        # re-clone + re-run of the pipeline — e.g. the hosted static-state
+        # bundle that feeds doc generation. ``threading.Lock`` is not
+        # picklable, so drop it; every other member (the NetworkX graph,
+        # ParsedFiles, metric caches, the resolvers) pickles fine.
+        # ``__setstate__`` recreates the lock.
+        state = self.__dict__.copy()
+        state["_subgraph_lock"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        import threading
+
+        self.__dict__.update(state)
+        self._subgraph_lock = threading.Lock()
+
     def set_tsconfig_resolver(self, resolver: Any) -> None:
         """Attach a :class:`TsconfigResolver` for TS/JS path-alias resolution."""
         self._tsconfig_resolver = resolver

--- a/tests/unit/ingestion/test_centrality_cache.py
+++ b/tests/unit/ingestion/test_centrality_cache.py
@@ -131,3 +131,37 @@ async def test_compute_metrics_parallel_with_cache(tmp_path):
     sym_sig = subgraph_signature(gb.symbol_subgraph())
     assert cache.get("file", file_sig) == gb.betweenness_centrality()
     assert cache.get("symbol", sym_sig) == gb.symbol_betweenness_centrality()
+
+
+def test_centrality_cache_is_picklable(tmp_path):
+    """The cache's ``threading.Lock`` must not block pickling (it's dropped
+    and recreated), and entries survive the round trip."""
+    import pickle
+
+    cache = CentralityCache(tmp_path)
+    cache.put("file", "sig-1", {"n": 0.25})
+
+    restored = pickle.loads(pickle.dumps(cache))
+    assert restored.get("file", "sig-1") == {"n": 0.25}
+    # The lock is recreated (not None) so the restored cache is usable.
+    assert restored.get("file", "sig-2") is None
+
+
+def test_graph_builder_round_trips_through_pickle(tmp_path):
+    """GraphBuilder is pickled to hand built graph state across a process
+    boundary (e.g. the hosted static-state bundle). A ``threading.Lock`` member
+    used to make that raise ``TypeError: cannot pickle '_thread.lock'``; this
+    locks in that a fully-built, cache-backed builder serializes and the
+    reloaded object is still usable (the lock is recreated)."""
+    import pickle
+
+    gb = _build(tmp_path, _FILES)
+    file_bc = gb.betweenness_centrality()
+    pr = gb.pagerank()
+
+    reloaded = pickle.loads(pickle.dumps(gb, protocol=pickle.HIGHEST_PROTOCOL))
+
+    assert set(reloaded._parsed_files) == set(gb._parsed_files)
+    assert reloaded.pagerank() == pr
+    # The lock-guarded subgraph path must work after restore (lock recreated).
+    assert reloaded.betweenness_centrality() == file_bc


### PR DESCRIPTION
## Summary

`GraphBuilder` holds two `threading.Lock` members (its subgraph lock, and the centrality cache's lock), so pickling a fully-built builder raised `TypeError: cannot pickle '_thread.lock' object`. That blocks any path that hands a built graph (structure + materialized metric caches) across a process boundary without re-running the pipeline.

## Change

Add `__getstate__`/`__setstate__` to `GraphBuilder` and `CentralityCache` that drop the lock when pickling and recreate a fresh one on unpickle. Every other member (the NetworkX graph, `ParsedFile`s, metric caches, resolvers) already pickles cleanly.

## Verification

- New tests: `GraphBuilder` round-trips through pickle and the reloaded object is still usable (the lock-guarded subgraph/betweenness path works after restore); `CentralityCache` round-trips and entries survive.
- Reproduced locally on a real TypeScript graph (tsconfig resolver + centrality cache attached): pickles and reloads, restored builder recomputes metrics. The two locks were the only offenders.
- Full graph + centrality test suites pass; lint clean.