### PR TITLE
release: v0.23.0 — repo-understanding overhaul, enriched get_health, contract-matching improvements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.23.0] — 2026-06-23
+
+### Added
+- **Repo-understanding overhaul: knowledge graph, C4, and guided tour.** The C4 model now derives real actors, true coupling, and accurate containers instead of approximations (#576). The guided tour ranks orientation entry points by execution-start order and surfaces churn hotspots (#574), and docs/tooling files are routed out of the layer catch-all with an invariant reviewer gate to keep the layering honest (#575). The knowledge-graph info panel is now collapsible (#579).
+- **Enriched `get_health` for pre-PR self-check.** The `get_health` MCP tool returns a richer payload so an agent can read the same signals the merge gate judges a change on before opening a PR. (#571, #572)
+- **`init --no-workspace` and a fully non-interactive `--yes`.** `repowise init` can skip workspace setup, and `--yes` is now fully non-interactive for scripted/CI use. (#573)
+- **Rust performance dialect.** Performance-risk detection gained a Rust dialect for I/O-in-loop / N+1 shapes. (#581)
+- **Configurable health rules.** `health-rules.json` now supports severity overrides and a small-team profile. (#569)
+- **Better cross-repo contract matching.** HTTP contract extraction resolves router mount prefixes (#567), and consumer-side matching gained hygiene filtering and base-URL service resolution (#568).
+
+### Fixed
+- **`GraphBuilder` is picklable across a process boundary.** Fixes a failure when the graph builder is handed to a worker process. (#583)
+- **Parse cache versioned by `ParsedFile` schema shape.** The parse cache now keys on the parsed-file schema rather than the package version, so unrelated releases keep the cache warm and a schema change invalidates it automatically. (#582)
+- **Knowledge-graph panel guards `matchMedia`.** The KG panel mount effect no longer assumes `matchMedia` is present, fixing a crash in environments without it. (#580)
+
+### Documentation
+- Plugin: version bump to 0.23.0.
+
+---
+
 ## [0.22.0] — 2026-06-22
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.23.0] — 2026-06-23
+
+### Added
+- **Repo-understanding overhaul: knowledge graph, C4, and guided tour.** The C4 model now derives real actors, true coupling, and accurate containers instead of approximations (#576). The guided tour ranks orientation entry points by execution-start order and surfaces churn hotspots (#574), and docs/tooling files are routed out of the layer catch-all with an invariant reviewer gate to keep the layering honest (#575). The knowledge-graph info panel is now collapsible (#579).
+- **Enriched `get_health` for pre-PR self-check.** The `get_health` MCP tool returns a richer payload so an agent can read the same signals the merge gate judges a change on before opening a PR. (#571, #572)
+- **`init --no-workspace` and a fully non-interactive `--yes`.** `repowise init` can skip workspace setup, and `--yes` is now fully non-interactive for scripted/CI use. (#573)
+- **Rust performance dialect.** Performance-risk detection gained a Rust dialect for I/O-in-loop / N+1 shapes. (#581)
+- **Configurable health rules.** `health-rules.json` now supports severity overrides and a small-team profile. (#569)
+- **Better cross-repo contract matching.** HTTP contract extraction resolves router mount prefixes (#567), and consumer-side matching gained hygiene filtering and base-URL service resolution (#568).
+
+### Fixed
+- **`GraphBuilder` is picklable across a process boundary.** Fixes a failure when the graph builder is handed to a worker process. (#583)
+- **Parse cache versioned by `ParsedFile` schema shape.** The parse cache now keys on the parsed-file schema rather than the package version, so unrelated releases keep the cache warm and a schema change invalidates it automatically. (#582)
+- **Knowledge-graph panel guards `matchMedia`.** The KG panel mount effect no longer assumes `matchMedia` is present, fixing a crash in environments without it. (#580)
+
+### Documentation
+- Plugin: version bump to 0.23.0.
+
+---
+
 ## [0.22.0] — 2026-06-22
 
 ### Added

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.23.0
+
+### Changed
+- Version bump to track the repowise 0.23.0 release. No command, skill, or MCP
+  tool-surface changes this cycle.
+
 ## 0.22.0
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.22.0"
+version = "0.23.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.22.0"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## release: v0.23.0

Bump-only release branch off `main`: version bump (4 Python files + `uv.lock` + both plugin manifests) and changelog.

### Highlights
- **Repo-understanding overhaul** across the knowledge graph, C4 model, and guided tour: real C4 actors/coupling/containers, execution-start-ordered entry points, churn hotspots in the tour, docs/tooling routed out of the layer catch-all, and a collapsible KG info panel.
- **Enriched `get_health` MCP tool** for pre-PR self-check.
- **`init --no-workspace`** and a fully non-interactive `--yes`.
- **Rust performance dialect** and configurable health rules (severity overrides + small-team profile).
- **Better cross-repo contract matching** (router mount prefixes, consumer hygiene, base-URL service resolution).
- Fixes: picklable `GraphBuilder`, parse cache versioned by `ParsedFile` schema shape, KG panel `matchMedia` guard.

No store-format / parser-schema bump this release. MCP tool surface unchanged (15 tools).

### Test plan
- [x] Version drift grep clean (only remaining `0.22.0` is the `respx` dep)
- [x] `uv build --wheel` — `repowise-0.23.0-py3-none-any.whl` (28 commands, 16 `.scm` queries, `.j2` templates present)
- [x] `npm ci && npm run build --workspace packages/web` — all routes built, standalone `server.js` present, workspace-package code compiled into bundle
- [x] `test_bundled_changelog_sync.py` passes
- [ ] End-to-end smoke (`repowise serve` + browser click-through)
- [ ] Tag merge commit on `main` + push (post-merge)

**Merge convention: regular merge commit, NOT squash** — the tag must point at a real merge commit so artifact provenance is traceable.
