### PR TITLE
feat(files): browsable Files page, table restyle, dark-mode polish

### DIFF
--- a/packages/server/src/repowise/server/routers/files.py
+++ b/packages/server/src/repowise/server/routers/files.py
@@ -10,6 +10,7 @@ decisions, and dead-code findings for the file.
 
 from __future__ import annotations
 
+import bisect
 import json
 from typing import Any
 
@@ -78,6 +79,99 @@ def _symbol_slim(s: WikiSymbol) -> dict:
     }
 
 
+def _percentile_map(values: dict[str, float]) -> dict[str, float]:
+    """Map each key to the percentile rank (0-100) of its value within the set.
+
+    Ties share the same rank. Returns an empty map for an empty input. O(n log n)
+    via a single sort — never the O(n²) of per-row `percentile_rank` scans.
+    """
+    if not values:
+        return {}
+    ordered = sorted(values.values())
+    n = len(ordered)
+    if n == 1:
+        return {k: 100.0 for k in values}
+    # For each distinct value, the share of entries strictly below it.
+    out: dict[str, float] = {}
+    for key, v in values.items():
+        below = bisect.bisect_left(ordered, v)
+        out[key] = round(below / (n - 1) * 100.0, 1)
+    return out
+
+
+@router.get("/{repo_id}/files")
+async def files_index(
+    repo_id: str,
+    session: AsyncSession = Depends(get_db_session),  # noqa: B008
+) -> dict:
+    """Slim per-file rows for the browsable Files index + treemap.
+
+    One row per indexed file node, joined in-memory from four batch reads
+    (graph nodes, materialized degree metrics, health metrics, git metadata).
+    Percentiles for importance (pagerank) and churn are computed once over the
+    full set so the client can rank without refetching.
+    """
+    repo = await crud.get_repository(session, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=404, detail="Repository not found")
+
+    nodes = await crud.get_all_file_metrics(session, repo_id)
+    degrees = await crud.get_graph_metrics(session, repo_id)
+    metrics_by_path = {m.file_path: m for m in await crud.get_health_metrics(session, repo_id)}
+    git_by_path = await crud.get_all_git_metadata(session, repo_id)
+
+    pagerank_pct = _percentile_map({n.node_id: (n.pagerank or 0.0) for n in nodes})
+
+    files: list[dict] = []
+    lang_counts: dict[str, int] = {}
+    for n in nodes:
+        path = n.node_id
+        metric = metrics_by_path.get(path)
+        git = git_by_path.get(path)
+        deg = degrees.get(path)
+        lang = n.language or ""
+        if lang:
+            lang_counts[lang] = lang_counts.get(lang, 0) + 1
+        # `score` is the overall surfaced number (== defect); prefer the explicit
+        # `defect_score` when the three-signal split populated it.
+        defect = None
+        if metric is not None:
+            defect = metric.defect_score if metric.defect_score is not None else metric.score
+        files.append(
+            {
+                "file_path": path,
+                "language": lang,
+                "loc": metric.nloc if metric else None,
+                "symbol_count": n.symbol_count,
+                "pagerank_pct": pagerank_pct.get(path, 0.0),
+                "in_degree": deg["in_degree"] if deg else 0,
+                "out_degree": deg["out_degree"] if deg else 0,
+                "defect_score": defect,
+                "maintainability_score": metric.maintainability_score if metric else None,
+                "performance_score": metric.performance_score if metric else None,
+                "churn_pct": round((git.churn_percentile or 0.0) * 100.0, 1) if git else None,
+                "commit_count": git.commit_count_total if git else None,
+                "last_commit_at": (
+                    git.last_commit_at.isoformat() if git and git.last_commit_at else None
+                ),
+                "coverage_pct": metric.line_coverage_pct if metric else None,
+                "is_test": n.is_test,
+                "is_entry_point": n.is_entry_point,
+                "community_id": n.community_id,
+            }
+        )
+
+    languages = [
+        {"language": lang, "count": count}
+        for lang, count in sorted(lang_counts.items(), key=lambda kv: -kv[1])
+    ]
+    return {
+        "files": files,
+        "total": len(files),
+        "languages": languages,
+    }
+
+
 @router.get("/{repo_id}/files/{file_path:path}")
 async def file_detail(
     repo_id: str,
@@ -96,9 +190,7 @@ async def file_detail(
     # Degree is read once (graph node only) and shared by the health-signals
     # block below and the graph-context block further down.
     degrees = (
-        await crud.get_node_degree_counts(session, repo_id, file_path)
-        if node is not None
-        else None
+        await crud.get_node_degree_counts(session, repo_id, file_path) if node is not None else None
     )
 
     if node is None and git_meta is None and metric is None:

--- a/packages/types/src/files.ts
+++ b/packages/types/src/files.ts
@@ -185,6 +185,43 @@ export interface FileDeadCodeFinding {
   safe_to_delete: boolean;
 }
 
+/**
+ * One slim row in the browsable Files index (`GET /api/repos/{id}/files`).
+ * Everything the treemap + ranked table need without the per-file aggregate's
+ * weight. `pagerank_pct` / `churn_pct` are 0-100 percentiles ranked over the
+ * whole repo; scores are 0-10; nullable fields read "—" when unmeasured.
+ */
+export interface FileRow {
+  file_path: string;
+  language: string;
+  loc: number | null;
+  symbol_count: number;
+  pagerank_pct: number;
+  in_degree: number;
+  out_degree: number;
+  defect_score: number | null;
+  maintainability_score: number | null;
+  performance_score: number | null;
+  churn_pct: number | null;
+  commit_count: number | null;
+  last_commit_at: string | null;
+  coverage_pct: number | null;
+  is_test: boolean;
+  is_entry_point: boolean;
+  community_id: number;
+}
+
+export interface FileLanguageCount {
+  language: string;
+  count: number;
+}
+
+export interface FilesIndexResponse {
+  files: FileRow[];
+  total: number;
+  languages: FileLanguageCount[];
+}
+
 export interface FileDetailResponse {
   file_path: string;
   wiki_page: FileWikiPageRef | null;

--- a/packages/ui/src/blast-radius/cells.tsx
+++ b/packages/ui/src/blast-radius/cells.tsx
@@ -3,7 +3,7 @@ import { cn } from "../lib/cn";
 
 export function Th({ children }: { children: ReactNode }) {
   return (
-    <th className="text-left text-xs font-medium text-[var(--color-text-tertiary)] py-1.5 pr-4 whitespace-nowrap">
+    <th className="text-left text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)] py-1.5 pr-4 whitespace-nowrap">
       {children}
     </th>
   );

--- a/packages/ui/src/blast-radius/cochange-table.tsx
+++ b/packages/ui/src/blast-radius/cochange-table.tsx
@@ -11,7 +11,7 @@ export function CochangeTable({ rows }: CochangeTableProps) {
       <table className="w-full">
         <caption className="sr-only">Co-change warnings</caption>
         <thead>
-          <tr>
+          <tr className="border-b border-[var(--color-border-default)]">
             <Th>Changed File</Th>
             <Th>Missing Partner</Th>
             <Th>Co-change Count</Th>
@@ -21,10 +21,13 @@ export function CochangeTable({ rows }: CochangeTableProps) {
           {rows.map((r, i) => (
             <tr
               key={`${r.changed}|${r.missing_partner}|${i}`}
-              className="border-t border-[var(--color-border-default)]"
+              className="group border-t border-[var(--color-table-divider)] hover:bg-[var(--color-bg-elevated)]"
             >
               <Td>
-                <span className="font-mono break-all" title={r.changed}>
+                <span
+                  className="font-mono break-all group-hover:underline underline-offset-2"
+                  title={r.changed}
+                >
                   {r.changed}
                 </span>
               </Td>

--- a/packages/ui/src/blast-radius/direct-risks-table.tsx
+++ b/packages/ui/src/blast-radius/direct-risks-table.tsx
@@ -49,7 +49,7 @@ export function DirectRisksTable({ rows }: DirectRisksTableProps) {
       <table className="w-full">
         <caption className="sr-only">Direct risks for the changed files</caption>
         <thead>
-          <tr className="text-left text-xs font-medium text-[var(--color-text-tertiary)]">
+          <tr className="border-b border-[var(--color-border-default)] text-left text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
             <th className="py-1.5 pr-4">File</th>
             <th className="w-[28%] py-1.5 pr-4">Risk (0–10)</th>
             <th className="w-[24%] py-1.5 pr-4">Temporal hotspot</th>
@@ -58,10 +58,13 @@ export function DirectRisksTable({ rows }: DirectRisksTableProps) {
         </thead>
         <tbody>
           {sorted.map((r) => (
-            <tr key={r.path} className="border-t border-[var(--color-border-default)]">
+            <tr
+              key={r.path}
+              className="group border-t border-[var(--color-table-divider)] hover:bg-[var(--color-bg-elevated)]"
+            >
               <td className="py-2 pr-4 align-middle">
                 <span
-                  className="block max-w-[280px] truncate font-mono text-xs text-[var(--color-text-secondary)]"
+                  className="block max-w-[280px] truncate font-mono text-xs text-[var(--color-text-secondary)] group-hover:underline underline-offset-2"
                   title={r.path}
                 >
                   {r.path}

--- a/packages/ui/src/blast-radius/reviewers-table.tsx
+++ b/packages/ui/src/blast-radius/reviewers-table.tsx
@@ -11,7 +11,7 @@ export function ReviewersTable({ rows }: ReviewersTableProps) {
       <table className="w-full">
         <caption className="sr-only">Recommended reviewers</caption>
         <thead>
-          <tr>
+          <tr className="border-b border-[var(--color-border-default)]">
             <Th>Email</Th>
             <Th>Files Owned</Th>
             <Th>Avg Ownership %</Th>
@@ -19,8 +19,15 @@ export function ReviewersTable({ rows }: ReviewersTableProps) {
         </thead>
         <tbody>
           {rows.map((r) => (
-            <tr key={r.email} className="border-t border-[var(--color-border-default)]">
-              <Td>{r.email}</Td>
+            <tr
+              key={r.email}
+              className="group border-t border-[var(--color-table-divider)] hover:bg-[var(--color-bg-elevated)]"
+            >
+              <Td>
+                <span className="group-hover:underline underline-offset-2">
+                  {r.email}
+                </span>
+              </Td>
               <Td className="text-right tabular-nums">{r.files}</Td>
               <Td className="text-right tabular-nums">
                 {(r.ownership_pct * 100).toFixed(1)}%

--- a/packages/ui/src/blast-radius/transitive-table.tsx
+++ b/packages/ui/src/blast-radius/transitive-table.tsx
@@ -11,16 +11,22 @@ export function TransitiveTable({ rows }: TransitiveTableProps) {
       <table className="w-full">
         <caption className="sr-only">Transitively affected files</caption>
         <thead>
-          <tr>
+          <tr className="border-b border-[var(--color-border-default)]">
             <Th>File</Th>
             <Th>Depth</Th>
           </tr>
         </thead>
         <tbody>
           {rows.map((r) => (
-            <tr key={r.path} className="border-t border-[var(--color-border-default)]">
+            <tr
+              key={r.path}
+              className="group border-t border-[var(--color-table-divider)] hover:bg-[var(--color-bg-elevated)]"
+            >
               <Td>
-                <span className="font-mono break-all" title={r.path}>
+                <span
+                  className="font-mono break-all group-hover:underline underline-offset-2"
+                  title={r.path}
+                >
                   {r.path}
                 </span>
               </Td>

--- a/packages/ui/src/brand.ts
+++ b/packages/ui/src/brand.ts
@@ -43,13 +43,13 @@ export const LIGHT = {
 
 /** Dark-mode surface/text values. */
 export const DARK = {
-  bgRoot: "#17131d",
-  bgSurface: "#211b29",
-  bgElevated: "#2a2335",
-  bgInset: "#110d17",
-  textPrimary: "#eeeaf4",
-  textSecondary: "#a79db3",
-  textTertiary: "#786f84",
+  bgRoot: "#1a1a1b",
+  bgSurface: "#232325",
+  bgElevated: "#2b2c2e",
+  bgInset: "#141415",
+  textPrimary: "#ececed",
+  textSecondary: "#a2a2a6",
+  textTertiary: "#717176",
   accentPrimary: "#f59520",
   accentFill: "#f59520",
   accentSecondary: "#a98fc4",

--- a/packages/ui/src/chat/chat-markdown.tsx
+++ b/packages/ui/src/chat/chat-markdown.tsx
@@ -105,13 +105,23 @@ const components: Components = {
       <table className="text-xs w-full border-collapse">{children}</table>
     </div>
   ),
+  thead: ({ children }) => (
+    <thead className="bg-[var(--color-bg-surface)] border-b border-[var(--color-border-default)]">
+      {children}
+    </thead>
+  ),
   th: ({ children }) => (
-    <th className="text-left px-2 py-1 border-b border-[var(--color-border-default)] text-[var(--color-text-tertiary)] font-medium uppercase tracking-wider text-[10px]">
+    <th className="text-left px-3 py-2.5 text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
       {children}
     </th>
   ),
+  tr: ({ children }) => (
+    <tr className="border-t border-[var(--color-table-divider)] transition-colors hover:bg-[var(--color-bg-elevated)]">
+      {children}
+    </tr>
+  ),
   td: ({ children }) => (
-    <td className="px-2 py-1 border-b border-[var(--color-border-default)] text-[var(--color-text-secondary)]">
+    <td className="px-3 py-2.5 text-[var(--color-text-secondary)]">
       {children}
     </td>
   ),

--- a/packages/ui/src/coverage/freshness-table.tsx
+++ b/packages/ui/src/coverage/freshness-table.tsx
@@ -83,24 +83,24 @@ export function FreshnessTable({ pages, onRegenerate }: FreshnessTableProps) {
       {filtered.length === 0 ? (
         <EmptyState title="No pages" description="No pages match this filter." />
       ) : (
-        <div className="rounded-lg border border-[var(--color-border-default)] overflow-x-auto">
+        <div className="border border-[var(--color-border-default)] overflow-hidden overflow-x-auto">
           <table className="w-full text-sm">
             <caption className="sr-only">Documentation freshness</caption>
-            <thead className="sticky top-0 z-10 bg-[var(--color-bg-elevated)]">
-              <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
-                <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+            <thead className="sticky top-0 z-10 bg-[var(--color-bg-surface)]">
+              <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
+                <th scope="col" className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
                   Page
                 </th>
-                <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
+                <th scope="col" className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
                   Status
                 </th>
-                <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
+                <th scope="col" className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
                   Confidence
                 </th>
-                <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden md:table-cell">
+                <th scope="col" className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden md:table-cell">
                   Model
                 </th>
-                <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-28 hidden md:table-cell">
+                <th scope="col" className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-28 hidden md:table-cell">
                   Updated
                 </th>
                 <th scope="col" className="px-4 py-2.5 w-24">
@@ -114,10 +114,10 @@ export function FreshnessTable({ pages, onRegenerate }: FreshnessTableProps) {
                 return (
                   <tr
                     key={page.id}
-                    className="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] transition-colors last:border-0"
+                    className="group border-b border-[var(--color-table-divider)] hover:bg-[var(--color-bg-elevated)] transition-colors last:border-0"
                   >
                     <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-primary)] min-w-[220px] max-w-[480px]">
-                      <div className="truncate" title={page.target_path}>{page.target_path}</div>
+                      <div className="truncate group-hover:underline underline-offset-2" title={page.target_path}>{page.target_path}</div>
                       {(() => { const TypeIcon = getPageTypeIcon(page.page_type); return (
                         <div className="flex items-center gap-1 truncate text-[var(--color-text-tertiary)]" title={page.page_type}>
                           <TypeIcon className="h-3 w-3 shrink-0" />

--- a/packages/ui/src/dead-code/finding-row.tsx
+++ b/packages/ui/src/dead-code/finding-row.tsx
@@ -81,7 +81,7 @@ export function FindingRow({ finding, repoId, selected, onToggle, onPatch, onUpd
   return (
     <tr
       className={cn(
-        "border-b border-[var(--color-border-default)] transition-colors last:border-0",
+        "border-b border-[var(--color-table-divider)] transition-colors last:border-0",
         selected ? "bg-[var(--color-accent-muted)]" : "hover:bg-[var(--color-bg-elevated)]",
       )}
     >

--- a/packages/ui/src/dead-code/findings-table.tsx
+++ b/packages/ui/src/dead-code/findings-table.tsx
@@ -200,11 +200,11 @@ export function FindingsTable({ findings, repoId, onPatch, onBulkResolve, isLoad
                 description="No open findings for this category with current filters."
               />
             ) : (
-              <div className="rounded-lg border border-[var(--color-border-default)] overflow-x-auto mt-2">
+              <div className="border border-[var(--color-border-default)] overflow-x-auto overflow-hidden mt-2">
                 <table className="w-full text-sm">
                   <caption className="sr-only">Dead code findings</caption>
-                  <thead className="sticky top-0 z-10 bg-[var(--color-bg-elevated)]">
-                    <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
+                  <thead className="sticky top-0 z-10 bg-[var(--color-bg-surface)]">
+                    <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
                       <th scope="col" className="px-4 py-2.5 w-8">
                         <input
                           type="checkbox"
@@ -214,16 +214,16 @@ export function FindingsTable({ findings, repoId, onPatch, onBulkResolve, isLoad
                           className="rounded border-[var(--color-border-default)]"
                         />
                       </th>
-                      <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+                      <th scope="col" className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
                         File / Symbol
                       </th>
-                      <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
+                      <th scope="col" className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24">
                         Confidence
                       </th>
-                      <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden md:table-cell">
+                      <th scope="col" className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden md:table-cell">
                         Owner
                       </th>
-                      <th scope="col" className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-16 hidden md:table-cell">
+                      <th scope="col" className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-16 hidden md:table-cell">
                         Lines
                       </th>
                       <th scope="col" className="px-4 py-2.5 w-20 hidden sm:table-cell">

--- a/packages/ui/src/files/file-health-tab.tsx
+++ b/packages/ui/src/files/file-health-tab.tsx
@@ -210,9 +210,9 @@ export function FileHealthTab({
           <h3 className="text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
             Functions by churn
           </h3>
-          <div className="overflow-x-auto rounded-md border border-[var(--color-border-default)]">
+          <div className="overflow-x-auto overflow-hidden border border-[var(--color-border-default)]">
             <table className="w-full text-xs">
-              <thead>
+              <thead className="bg-[var(--color-bg-surface)]">
                 <tr className="border-b border-[var(--color-border-default)] text-left text-[10px] uppercase tracking-wider text-[var(--color-text-tertiary)]">
                   <th className="px-3 py-2 font-medium">Function</th>
                   <th className="px-3 py-2 font-medium text-right">Mods</th>
@@ -233,7 +233,7 @@ export function FileHealthTab({
                   return (
                     <tr
                       key={b.symbol_id}
-                      className="border-b border-[var(--color-border-default)] last:border-0"
+                      className="border-b border-[var(--color-table-divider)] last:border-0 hover:bg-[var(--color-bg-elevated)]"
                     >
                       <td className="px-3 py-1.5 text-[var(--color-text-primary)]">
                         {symbolHref ? (

--- a/packages/ui/src/files/files-index.tsx
+++ b/packages/ui/src/files/files-index.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Search } from "lucide-react";
+import type { FileLanguageCount, FileRow } from "@repowise-dev/types/files";
+import { cn } from "../lib/cn";
+import { formatLOC, formatNumber } from "../lib/format";
+import { FilesTreemap, type TreemapColor, type TreemapSize } from "./files-treemap";
+import { FilesTable, type SortKey } from "./files-table";
+
+interface FilesIndexProps {
+  files: FileRow[];
+  languages: FileLanguageCount[];
+  /** Build the per-file page href (e.g. `/repos/:id/files/:path`). */
+  fileHref: (path: string) => string;
+}
+
+type TestFilter = "all" | "code" | "tests";
+
+const SORT_DEFAULT_DIR: Record<SortKey, "asc" | "desc"> = {
+  importance: "desc",
+  health: "asc", // lowest (worst) health first is the interesting end
+  churn: "desc",
+  loc: "desc",
+  coverage: "asc",
+  name: "asc",
+};
+
+function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+}: {
+  options: { value: T; label: string }[];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="inline-flex rounded-md border border-[var(--color-border-default)] p-0.5">
+      {options.map((o) => (
+        <button
+          key={o.value}
+          onClick={() => onChange(o.value)}
+          className={cn(
+            "rounded px-2 py-1 text-xs font-medium transition-colors",
+            value === o.value
+              ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
+              : "text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]",
+          )}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Kpi({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2">
+      <p className="text-lg font-semibold tabular-nums text-[var(--color-text-primary)]">{value}</p>
+      <p className="text-[11px] uppercase tracking-wide text-[var(--color-text-tertiary)]">
+        {label}
+      </p>
+    </div>
+  );
+}
+
+export function FilesIndex({ files, languages, fileHref }: FilesIndexProps) {
+  const [query, setQuery] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("importance");
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  const [langFilter, setLangFilter] = useState<string>("");
+  const [testFilter, setTestFilter] = useState<TestFilter>("all");
+  const [sizeBy, setSizeBy] = useState<TreemapSize>("importance");
+  const [colorBy, setColorBy] = useState<TreemapColor>("health");
+  const [prefix, setPrefix] = useState<string[]>([]);
+
+  // KPI strip — cheap aggregate over the full set (memoized).
+  const kpis = useMemo(() => {
+    let loc = 0;
+    let scored = 0;
+    let healthy = 0;
+    for (const f of files) {
+      loc += f.loc ?? 0;
+      if (f.defect_score != null) {
+        scored++;
+        if (f.defect_score >= 7) healthy++;
+      }
+    }
+    return {
+      total: files.length,
+      loc,
+      langCount: languages.length,
+      healthyPct: scored > 0 ? Math.round((healthy / scored) * 100) : null,
+    };
+  }, [files, languages]);
+
+  const handleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir(SORT_DEFAULT_DIR[key]);
+    }
+  };
+
+  // Filter (prefix scope → test → language → fuzzy) then sort. Memoized so
+  // keystrokes only recompute when an input actually changes.
+  const tableFiles = useMemo(() => {
+    const pfx = prefix.length ? prefix.join("/") + "/" : "";
+    const q = query.trim().toLowerCase();
+    const filtered = files.filter((f) => {
+      if (pfx && !f.file_path.startsWith(pfx)) return false;
+      if (testFilter === "tests" && !f.is_test) return false;
+      if (testFilter === "code" && f.is_test) return false;
+      if (langFilter && f.language !== langFilter) return false;
+      if (q && !f.file_path.toLowerCase().includes(q)) return false;
+      return true;
+    });
+
+    const dir = sortDir === "asc" ? 1 : -1;
+    const num = (v: number | null) => (v == null ? -1 : v);
+    filtered.sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case "importance":
+          cmp = a.pagerank_pct - b.pagerank_pct;
+          break;
+        case "health":
+          cmp = num(a.defect_score) - num(b.defect_score);
+          break;
+        case "churn":
+          cmp = num(a.churn_pct) - num(b.churn_pct);
+          break;
+        case "loc":
+          cmp = num(a.loc) - num(b.loc);
+          break;
+        case "coverage":
+          cmp = num(a.coverage_pct) - num(b.coverage_pct);
+          break;
+        case "name":
+          cmp = a.file_path.localeCompare(b.file_path);
+          break;
+      }
+      if (cmp === 0) cmp = a.file_path.localeCompare(b.file_path);
+      return cmp * dir;
+    });
+    return filtered;
+  }, [files, prefix, query, testFilter, langFilter, sortKey, sortDir]);
+
+  return (
+    <div className="space-y-4">
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <Kpi label="Files" value={formatNumber(kpis.total)} />
+        <Kpi label="Lines" value={formatLOC(kpis.loc)} />
+        <Kpi label="Languages" value={String(kpis.langCount)} />
+        <Kpi label="Healthy" value={kpis.healthyPct != null ? `${kpis.healthyPct}%` : "—"} />
+      </div>
+
+      {/* Treemap hero */}
+      <div className="rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3 sm:p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+            Repository map
+          </h2>
+          <div className="flex flex-wrap items-center gap-2">
+            <Segmented<TreemapSize>
+              value={sizeBy}
+              onChange={setSizeBy}
+              options={[
+                { value: "importance", label: "Importance" },
+                { value: "loc", label: "Size" },
+              ]}
+            />
+            <Segmented<TreemapColor>
+              value={colorBy}
+              onChange={setColorBy}
+              options={[
+                { value: "health", label: "Health" },
+                { value: "language", label: "Language" },
+              ]}
+            />
+          </div>
+        </div>
+        <FilesTreemap
+          files={files}
+          fileHref={fileHref}
+          sizeBy={sizeBy}
+          colorBy={colorBy}
+          prefix={prefix}
+          onPrefixChange={setPrefix}
+        />
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative min-w-0 flex-1">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--color-text-tertiary)]" />
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Filter files by path…"
+            className="h-9 w-full rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] pl-8 pr-3 text-sm text-[var(--color-text-primary)] outline-none placeholder:text-[var(--color-text-tertiary)] focus:border-[var(--color-accent-primary)]"
+          />
+        </div>
+        <Segmented<TestFilter>
+          value={testFilter}
+          onChange={setTestFilter}
+          options={[
+            { value: "all", label: "All" },
+            { value: "code", label: "Code" },
+            { value: "tests", label: "Tests" },
+          ]}
+        />
+        {languages.length > 1 && (
+          <select
+            value={langFilter}
+            onChange={(e) => setLangFilter(e.target.value)}
+            className="h-9 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2 text-sm text-[var(--color-text-secondary)] outline-none focus:border-[var(--color-accent-primary)]"
+          >
+            <option value="">All languages</option>
+            {languages.map((l) => (
+              <option key={l.language} value={l.language}>
+                {l.language} ({l.count})
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      <p className="text-xs text-[var(--color-text-tertiary)]">
+        {formatNumber(tableFiles.length)}
+        {tableFiles.length === 1 ? " file" : " files"}
+        {prefix.length > 0 && ` in ${prefix.join("/")}/`}
+      </p>
+
+      <FilesTable
+        files={tableFiles}
+        fileHref={fileHref}
+        sortKey={sortKey}
+        sortDir={sortDir}
+        onSort={handleSort}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/files/files-table.tsx
+++ b/packages/ui/src/files/files-table.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { ArrowDown, ArrowUp, FlaskConical, LogIn } from "lucide-react";
+import type { FileRow } from "@repowise-dev/types/files";
+import { cn } from "../lib/cn";
+import { formatLOC, truncatePath } from "../lib/format";
+
+export type SortKey =
+  | "importance"
+  | "health"
+  | "churn"
+  | "loc"
+  | "coverage"
+  | "name";
+
+interface FilesTableProps {
+  /** Already filtered + sorted by the parent. */
+  files: FileRow[];
+  fileHref: (path: string) => string;
+  sortKey: SortKey;
+  sortDir: "asc" | "desc";
+  onSort: (key: SortKey) => void;
+}
+
+const ROW_HEIGHT = 44;
+const OVERSCAN = 8;
+
+function scoreClass(score: number | null): string {
+  if (score == null) return "text-[var(--color-text-tertiary)]";
+  if (score < 4) return "text-[var(--color-risk-high)]";
+  if (score < 7) return "text-[var(--color-risk-medium)]";
+  return "text-[var(--color-risk-low)]";
+}
+
+function SortHeader({
+  label,
+  col,
+  sortKey,
+  sortDir,
+  onSort,
+  className,
+}: {
+  label: string;
+  col: SortKey;
+  sortKey: SortKey;
+  sortDir: "asc" | "desc";
+  onSort: (key: SortKey) => void;
+  className?: string;
+}) {
+  const active = sortKey === col;
+  return (
+    <button
+      onClick={() => onSort(col)}
+      className={cn(
+        "flex items-center gap-1 text-left transition-colors hover:text-[var(--color-text-primary)]",
+        active ? "text-[var(--color-text-primary)]" : "text-[var(--color-text-tertiary)]",
+        className,
+      )}
+    >
+      {label}
+      {active &&
+        (sortDir === "asc" ? (
+          <ArrowUp className="h-3 w-3" />
+        ) : (
+          <ArrowDown className="h-3 w-3" />
+        ))}
+    </button>
+  );
+}
+
+// Column grid — kept in sync between header and rows. Trailing columns collapse
+// on narrow widths (the `hidden sm:/md:` utilities) so the table stays readable
+// on mobile without horizontal scroll.
+// Column grid by breakpoint. Mobile keeps the three headline columns (File,
+// Importance, Health); LOC joins at sm; Churn + Coverage at md. Counts match
+// the cells' `hidden …:flex` visibility so the grid never mis-aligns or
+// overflows — the first column is always `minmax(0,1fr)` so paths truncate.
+const GRID =
+  "grid grid-cols-[minmax(0,1fr)_auto_56px] sm:grid-cols-[minmax(0,1fr)_64px_64px_64px] md:grid-cols-[minmax(0,1fr)_72px_84px_72px_64px_72px] items-center gap-2 px-3 sm:px-4";
+
+export function FilesTable({ files, fileHref, sortKey, sortDir, onSort }: FilesTableProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportH, setViewportH] = useState(600);
+
+  const total = files.length;
+  const start = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN);
+  const end = Math.min(total, Math.ceil((scrollTop + viewportH) / ROW_HEIGHT) + OVERSCAN);
+  const visible = files.slice(start, end);
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-[var(--color-border-default)]">
+      {/* Header — floating uppercase labels under a single rule, no fill. */}
+      <div
+        className={cn(
+          GRID,
+          "h-10 border-b border-[var(--color-border-default)] text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]",
+        )}
+      >
+        <SortHeader label="File" col="name" sortKey={sortKey} sortDir={sortDir} onSort={onSort} />
+        <SortHeader
+          label="Imp."
+          col="importance"
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={onSort}
+          className="justify-end"
+        />
+        <SortHeader
+          label="Health"
+          col="health"
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={onSort}
+          className="justify-end"
+        />
+        <SortHeader
+          label="Churn"
+          col="churn"
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={onSort}
+          className="hidden justify-end md:flex"
+        />
+        <SortHeader
+          label="LOC"
+          col="loc"
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={onSort}
+          className="hidden justify-end sm:flex"
+        />
+        <SortHeader
+          label="Cov."
+          col="coverage"
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={onSort}
+          className="hidden justify-end md:flex"
+        />
+      </div>
+
+      {/* Virtualized body */}
+      <div
+        ref={scrollRef}
+        onScroll={(e) => {
+          setScrollTop(e.currentTarget.scrollTop);
+          setViewportH(e.currentTarget.clientHeight);
+        }}
+        className="relative max-h-[62vh] overflow-auto"
+      >
+        {total === 0 ? (
+          <div className="flex h-32 items-center justify-center text-sm text-[var(--color-text-tertiary)]">
+            No files match these filters.
+          </div>
+        ) : (
+          <div style={{ height: total * ROW_HEIGHT }} className="relative">
+            <div style={{ transform: `translateY(${start * ROW_HEIGHT}px)` }}>
+              {visible.map((f) => {
+                const name = f.file_path.split("/").pop() ?? f.file_path;
+                const dir = f.file_path.slice(0, f.file_path.length - name.length);
+                return (
+                  <a
+                    key={f.file_path}
+                    href={fileHref(f.file_path)}
+                    style={{ height: ROW_HEIGHT }}
+                    className={cn(
+                      GRID,
+                      "group border-b border-[var(--color-table-divider)] text-sm transition-colors hover:bg-[var(--color-bg-elevated)]",
+                    )}
+                  >
+                    {/* File path */}
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      {f.is_entry_point && (
+                        <LogIn className="h-3.5 w-3.5 shrink-0 text-[var(--color-accent-primary)]" />
+                      )}
+                      {f.is_test && (
+                        <FlaskConical className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-tertiary)]" />
+                      )}
+                      <span className="min-w-0 truncate font-mono text-[13px]">
+                        <span className="text-[var(--color-text-tertiary)]">
+                          {truncatePath(dir, 40)}
+                        </span>
+                        <span className="text-[var(--color-text-primary)] underline-offset-2 group-hover:underline">
+                          {name}
+                        </span>
+                      </span>
+                    </span>
+
+                    {/* Importance */}
+                    <span className="flex items-center justify-end gap-1.5 tabular-nums text-[var(--color-text-secondary)]">
+                      <span
+                        className="hidden h-1.5 rounded-full bg-[var(--color-accent-primary)] sm:inline-block"
+                        style={{ width: `${Math.max(2, (f.pagerank_pct / 100) * 28)}px` }}
+                      />
+                      {Math.round(f.pagerank_pct)}
+                    </span>
+
+                    {/* Health */}
+                    <span
+                      className={cn(
+                        "flex justify-end tabular-nums",
+                        scoreClass(f.defect_score),
+                      )}
+                    >
+                      {f.defect_score != null ? f.defect_score.toFixed(1) : "—"}
+                    </span>
+
+                    {/* Churn */}
+                    <span className="hidden justify-end tabular-nums text-[var(--color-text-secondary)] md:flex">
+                      {f.churn_pct != null ? `${Math.round(f.churn_pct)}` : "—"}
+                    </span>
+
+                    {/* LOC */}
+                    <span className="hidden justify-end tabular-nums text-[var(--color-text-secondary)] sm:flex">
+                      {f.loc != null ? formatLOC(f.loc) : "—"}
+                    </span>
+
+                    {/* Coverage */}
+                    <span className="hidden justify-end tabular-nums text-[var(--color-text-secondary)] md:flex">
+                      {f.coverage_pct != null ? `${Math.round(f.coverage_pct)}%` : "—"}
+                    </span>
+                  </a>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/files/files-treemap.tsx
+++ b/packages/ui/src/files/files-treemap.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { hierarchy, treemap, treemapSquarify, type HierarchyRectangularNode } from "d3-hierarchy";
+import type { FileRow } from "@repowise-dev/types/files";
+import { ChevronRight, FolderOpen } from "lucide-react";
+import { cn } from "../lib/cn";
+
+export type TreemapSize = "importance" | "loc";
+export type TreemapColor = "health" | "language";
+
+interface FilesTreemapProps {
+  files: FileRow[];
+  /** Build the per-file page href for a leaf tile. */
+  fileHref: (path: string) => string;
+  sizeBy: TreemapSize;
+  colorBy: TreemapColor;
+  /** Drill state is lifted so the toolbar breadcrumb and table can share it. */
+  prefix: string[];
+  onPrefixChange: (prefix: string[]) => void;
+}
+
+interface LevelChild {
+  /** Display name (last path segment). */
+  name: string;
+  /** Full path: the file path (leaf) or the folder prefix (branch). */
+  fullPath: string;
+  isFolder: boolean;
+  value: number;
+  fileCount: number;
+  /** Aggregate (file: own; folder: loc-weighted) defect score, for coloring. */
+  avgScore: number | null;
+  /** Dominant language across descendants, for language coloring. */
+  language: string;
+}
+
+const LANG_COLORS: Record<string, string> = {
+  python: "var(--color-info)",
+  typescript: "var(--color-accent-secondary)",
+  javascript: "var(--color-warning)",
+  tsx: "var(--color-accent-secondary)",
+  go: "var(--color-edge-co-change)",
+  rust: "var(--color-risk-medium)",
+  java: "var(--color-plum-400)",
+  ruby: "var(--color-risk-high)",
+};
+const LANG_FALLBACK = "var(--color-text-tertiary)";
+
+function langColor(lang: string): string {
+  return LANG_COLORS[lang.toLowerCase()] ?? LANG_FALLBACK;
+}
+
+/** Health score (0-10) → traffic-light fill. Null reads neutral. */
+function healthColor(score: number | null): string {
+  if (score == null) return "var(--color-text-tertiary)";
+  if (score < 4) return "var(--color-risk-high)";
+  if (score < 7) return "var(--color-risk-medium)";
+  return "var(--color-risk-low)";
+}
+
+function sizeValue(row: FileRow, sizeBy: TreemapSize): number {
+  if (sizeBy === "loc") return Math.max(row.loc ?? 1, 1);
+  // Importance: pagerank percentile, floored so trivial files still get a sliver.
+  return Math.max(row.pagerank_pct, 1);
+}
+
+/** Direct children (folders + files) of `prefix`, aggregated from descendants. */
+function levelChildren(files: FileRow[], prefix: string[], sizeBy: TreemapSize): LevelChild[] {
+  const depth = prefix.length;
+  const groups = new Map<string, { rows: FileRow[]; isFolder: boolean }>();
+  for (const row of files) {
+    const segs = row.file_path.split("/");
+    // Only descendants of the current prefix.
+    let matches = true;
+    for (let i = 0; i < depth; i++) {
+      if (segs[i] !== prefix[i]) {
+        matches = false;
+        break;
+      }
+    }
+    if (!matches || segs.length <= depth) continue;
+    const seg = segs[depth]!;
+    const isFolder = segs.length > depth + 1;
+    const existing = groups.get(seg);
+    if (existing) {
+      existing.rows.push(row);
+      // A name is a folder if any descendant has it as a folder.
+      existing.isFolder = existing.isFolder || isFolder;
+    } else {
+      groups.set(seg, { rows: [row], isFolder });
+    }
+  }
+
+  const out: LevelChild[] = [];
+  for (const [seg, { rows, isFolder }] of groups) {
+    const value = rows.reduce((acc, r) => acc + sizeValue(r, sizeBy), 0);
+    // loc-weighted defect average across descendants with a measured score.
+    let scoreNum = 0;
+    let scoreWeight = 0;
+    const langTally = new Map<string, number>();
+    for (const r of rows) {
+      if (r.defect_score != null) {
+        const w = Math.max(r.loc ?? 1, 1);
+        scoreNum += r.defect_score * w;
+        scoreWeight += w;
+      }
+      if (r.language) langTally.set(r.language, (langTally.get(r.language) ?? 0) + 1);
+    }
+    let domLang = "";
+    let domCount = -1;
+    for (const [lang, count] of langTally) {
+      if (count > domCount) {
+        domLang = lang;
+        domCount = count;
+      }
+    }
+    out.push({
+      name: seg,
+      fullPath: isFolder ? [...prefix, seg].join("/") : rows[0]!.file_path,
+      isFolder,
+      value,
+      fileCount: rows.length,
+      avgScore: scoreWeight > 0 ? scoreNum / scoreWeight : null,
+      language: domLang,
+    });
+  }
+  return out;
+}
+
+/** Treemap node datum: the root carries `children`, each leaf a `child`. */
+interface TreeDatum {
+  children?: TreeDatum[];
+  child?: LevelChild;
+}
+
+interface Tip {
+  x: number;
+  y: number;
+  child: LevelChild;
+}
+
+export function FilesTreemap({
+  files,
+  fileHref,
+  sizeBy,
+  colorBy,
+  prefix,
+  onPrefixChange,
+}: FilesTreemapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dims, setDims] = useState({ width: 640, height: 340 });
+  const [tip, setTip] = useState<Tip | null>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? 0;
+      if (w > 0) {
+        // Shorter on narrow (mobile) widths so the hero never dominates the fold.
+        const h = w < 480 ? Math.max(200, w * 0.62) : Math.max(260, Math.min(420, w * 0.46));
+        setDims({ width: w, height: h });
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const children = useMemo(
+    () => levelChildren(files, prefix, sizeBy),
+    [files, prefix, sizeBy],
+  );
+
+  const leaves = useMemo(() => {
+    if (children.length === 0) return [] as HierarchyRectangularNode<TreeDatum>[];
+    const root = hierarchy<TreeDatum>({
+      children: children.map((c) => ({ child: c })),
+    })
+      .sum((d) => d.child?.value ?? 0)
+      .sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
+    treemap<TreeDatum>()
+      .size([dims.width, dims.height])
+      .padding(2)
+      .tile(treemapSquarify)(root);
+    return root.leaves() as HierarchyRectangularNode<TreeDatum>[];
+  }, [children, dims.width, dims.height]);
+
+  const handleMove = useCallback((e: React.MouseEvent, child: LevelChild) => {
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setTip({ x: e.clientX - rect.left, y: e.clientY - rect.top, child });
+  }, []);
+
+  const fill = useCallback(
+    (c: LevelChild) => (colorBy === "language" ? langColor(c.language) : healthColor(c.avgScore)),
+    [colorBy],
+  );
+
+  if (children.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center rounded-lg border border-dashed border-[var(--color-border-default)] text-sm text-[var(--color-text-tertiary)]">
+        No files to show here.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Breadcrumb */}
+      <div className="mb-2 flex flex-wrap items-center gap-1 text-xs text-[var(--color-text-secondary)]">
+        <button
+          onClick={() => onPrefixChange([])}
+          className="rounded px-1.5 py-0.5 font-medium hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]"
+        >
+          root
+        </button>
+        {prefix.map((seg, i) => (
+          <span key={i} className="flex items-center gap-1">
+            <ChevronRight className="h-3 w-3 opacity-40" />
+            <button
+              onClick={() => onPrefixChange(prefix.slice(0, i + 1))}
+              className="rounded px-1.5 py-0.5 font-mono hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)]"
+            >
+              {seg}
+            </button>
+          </span>
+        ))}
+      </div>
+
+      <div ref={containerRef} className="relative w-full">
+        <svg
+          width={dims.width}
+          height={dims.height}
+          className="rounded-lg"
+          onMouseLeave={() => setTip(null)}
+        >
+          {leaves.map((leaf) => {
+            const c = leaf.data.child;
+            if (!c) return null;
+            const x0 = leaf.x0;
+            const y0 = leaf.y0;
+            const w = leaf.x1 - x0;
+            const h = leaf.y1 - y0;
+            const showLabel = w > 46 && h > 26;
+            const tile = (
+              <g
+                onMouseMove={(e) => handleMove(e, c)}
+                onMouseLeave={() => setTip(null)}
+                className="cursor-pointer"
+              >
+                <rect
+                  x={x0}
+                  y={y0}
+                  width={w}
+                  height={h}
+                  fill={fill(c)}
+                  opacity={c.isFolder ? 0.55 : 0.85}
+                  rx={3}
+                  stroke={c.isFolder ? "var(--color-border-strong)" : "none"}
+                  strokeWidth={c.isFolder ? 1 : 0}
+                  className="transition-opacity hover:opacity-100"
+                />
+                {showLabel && (
+                  <>
+                    {c.isFolder && (
+                      <FolderOpen
+                        x={x0 + 6}
+                        y={y0 + 6}
+                        width={11}
+                        height={11}
+                        className="text-[var(--color-text-primary)]"
+                      />
+                    )}
+                    <text
+                      x={x0 + (c.isFolder ? 21 : 6)}
+                      y={y0 + 15}
+                      fill="var(--color-text-primary)"
+                      fontSize={11}
+                      fontWeight={600}
+                      fontFamily="var(--font-geist-mono)"
+                      pointerEvents="none"
+                    >
+                      {c.name.length > w / 7 ? c.name.slice(0, Math.floor(w / 7)) + "…" : c.name}
+                    </text>
+                    {h > 38 && (
+                      <text
+                        x={x0 + 6}
+                        y={y0 + 28}
+                        fill="color-mix(in srgb, var(--color-text-primary) 65%, transparent)"
+                        fontSize={9.5}
+                        pointerEvents="none"
+                      >
+                        {c.isFolder ? `${c.fileCount} files` : c.language || "file"}
+                      </text>
+                    )}
+                  </>
+                )}
+              </g>
+            );
+            // Folders drill in; files navigate to the per-file page.
+            return c.isFolder ? (
+              <g key={c.fullPath} onClick={() => onPrefixChange([...prefix, c.name])}>
+                {tile}
+              </g>
+            ) : (
+              <a key={c.fullPath} href={fileHref(c.fullPath)}>
+                {tile}
+              </a>
+            );
+          })}
+        </svg>
+
+        {tip && (
+          <div
+            className="pointer-events-none absolute z-20 rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)] px-3 py-2 text-xs shadow-lg"
+            style={{ left: Math.min(tip.x + 12, dims.width - 190), top: Math.max(tip.y - 56, 4) }}
+          >
+            <p className="font-mono font-medium text-[var(--color-text-primary)]">
+              {tip.child.name}
+            </p>
+            <p className="mt-0.5 text-[var(--color-text-secondary)]">
+              {tip.child.isFolder
+                ? `${tip.child.fileCount} files`
+                : tip.child.language || "file"}
+            </p>
+            {tip.child.avgScore != null && (
+              <p
+                className={cn(
+                  "mt-0.5 font-medium",
+                  tip.child.avgScore < 4
+                    ? "text-[var(--color-risk-high)]"
+                    : tip.child.avgScore < 7
+                      ? "text-[var(--color-risk-medium)]"
+                      : "text-[var(--color-risk-low)]",
+                )}
+              >
+                health {tip.child.avgScore.toFixed(1)}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/files/index.ts
+++ b/packages/ui/src/files/index.ts
@@ -6,3 +6,6 @@ export * from "./file-health-tab";
 export * from "./file-history-tab";
 export * from "./file-coverage-tab";
 export * from "./file-graph-tab";
+export * from "./files-index";
+export * from "./files-treemap";
+export * from "./files-table";

--- a/packages/ui/src/git/hotspot-table.tsx
+++ b/packages/ui/src/git/hotspot-table.tsx
@@ -187,21 +187,21 @@ export function HotspotTable({
       {filtered.length === 0 ? (
         <EmptyState title="No matches" description="Try adjusting your search or filters." />
       ) : (
-        <div className="rounded-lg border border-[var(--color-border-default)] overflow-x-auto">
+        <div className="border border-[var(--color-border-default)] overflow-hidden overflow-x-auto">
           <table className="w-full min-w-[760px] text-sm">
-            <thead className="sticky top-0 z-10 bg-[var(--color-bg-elevated)]">
-              <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
+            <thead className="sticky top-0 z-10 bg-[var(--color-bg-surface)]">
+              <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
                 {expandable && <th className="w-6 px-1" aria-hidden="true" />}
-                <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-8">
+                <th className="px-3 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-8">
                   #
                 </th>
-                <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+                <th className="px-3 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
                   File
                 </th>
                 <th
                   scope="col"
                   aria-sort={ariaSortFor("commits", sortKey, sortDir)}
-                  className="px-3 py-2.5 text-right text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24 cursor-pointer select-none hover:text-[var(--color-text-secondary)]"
+                  className="px-3 py-2.5 text-right text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24 cursor-pointer select-none hover:text-[var(--color-text-secondary)]"
                   onClick={() => handleSort("commits")}
                 >
                   Commits 90d<SortIcon column="commits" sortKey={sortKey} sortDir={sortDir} />
@@ -209,7 +209,7 @@ export function HotspotTable({
                 <th
                   scope="col"
                   aria-sort={ariaSortFor("churn", sortKey, sortDir)}
-                  className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-32 cursor-pointer select-none hover:text-[var(--color-text-secondary)] hidden lg:table-cell"
+                  className="px-3 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-32 cursor-pointer select-none hover:text-[var(--color-text-secondary)] hidden lg:table-cell"
                   onClick={() => handleSort("churn")}
                 >
                   Churn<SortIcon column="churn" sortKey={sortKey} sortDir={sortDir} />
@@ -217,19 +217,19 @@ export function HotspotTable({
                 <th
                   scope="col"
                   aria-sort={ariaSortFor("trend", sortKey, sortDir)}
-                  className="px-3 py-2.5 text-right text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24 cursor-pointer select-none hover:text-[var(--color-text-secondary)]"
+                  className="px-3 py-2.5 text-right text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24 cursor-pointer select-none hover:text-[var(--color-text-secondary)]"
                   onClick={() => handleSort("trend")}
                   title="Exponential decay score weighting recent commits more heavily (180-day half-life)"
                 >
                   Trend<SortIcon column="trend" sortKey={sortKey} sortDir={sortDir} />
                 </th>
-                <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-20 hidden md:table-cell">
+                <th className="px-3 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-20 hidden md:table-cell">
                   Bus Factor
                 </th>
-                <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24 hidden lg:table-cell">
+                <th className="px-3 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24 hidden lg:table-cell">
                   Lines ±90d
                 </th>
-                <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden md:table-cell">
+                <th className="px-3 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden md:table-cell">
                   Owner
                 </th>
                 <th className="px-3 py-2.5 w-20" />
@@ -245,7 +245,7 @@ export function HotspotTable({
                   <tr
                     onClick={onSelect ? () => onSelect(h) : undefined}
                     className={cn(
-                      "border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] transition-colors",
+                      "border-b border-[var(--color-table-divider)] hover:bg-[var(--color-bg-elevated)] transition-colors group",
                       !isExpanded && "last:border-0",
                       onSelect && "cursor-pointer",
                     )}
@@ -276,7 +276,7 @@ export function HotspotTable({
                       {i + 1}
                     </td>
                     <td className="px-3 py-2.5 font-mono text-xs text-[var(--color-text-primary)] min-w-[180px] max-w-[420px]">
-                      <span className="block truncate" title={h.file_path}>{h.file_path}</span>
+                      <span className="block truncate group-hover:underline underline-offset-2" title={h.file_path}>{h.file_path}</span>
                     </td>
                     <td className="px-3 py-2.5 tabular-nums text-xs text-right">
                       <span className="inline-flex items-center justify-end gap-1">
@@ -357,7 +357,7 @@ export function HotspotTable({
                     </td>
                   </tr>
                   {expandable && isExpanded && (
-                    <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-subtle)] last:border-0">
+                    <tr className="border-b border-[var(--color-table-divider)] bg-[var(--color-bg-subtle)] last:border-0">
                       <td className="px-1" />
                       <td colSpan={9} className="px-3 py-3">
                         {renderExpandedRow!(h)}

--- a/packages/ui/src/graph/sigma/use-sigma.ts
+++ b/packages/ui/src/graph/sigma/use-sigma.ts
@@ -410,7 +410,7 @@ export function useSigmaRenderer(options: UseSigmaOptions): UseSigmaReturn {
     if (!graph || graph.order === 0) return;
     const viz = (vizRef.current = resolveVizPalette(options.graphTheme));
     const cm = options.colorMode;
-    const coreColor = resolveToken("--color-bg-inset", "#110d17");
+    const coreColor = resolveToken("--color-bg-inset", "#141415");
     graph.updateEachNodeAttributes(
       (_node, attrs) => {
         let color: string;

--- a/packages/ui/src/health/module-rollup-list.tsx
+++ b/packages/ui/src/health/module-rollup-list.tsx
@@ -63,9 +63,9 @@ export function ModuleRollupList({
   };
 
   return (
-    <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] overflow-hidden">
+    <div className="border border-[var(--color-border-default)] overflow-hidden">
       <table className="w-full text-sm">
-        <thead className="bg-[var(--color-bg-elevated)] text-[var(--color-text-tertiary)] text-xs uppercase tracking-wider">
+        <thead className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)] text-[var(--color-text-tertiary)] text-[11px] uppercase tracking-wider">
           <tr>
             <Th label="Module" active={sort === "module"} order={order} onClick={() => toggle("module")} />
             <Th label="Files" active={sort === "file_count"} order={order} onClick={() => toggle("file_count")} />
@@ -78,10 +78,12 @@ export function ModuleRollupList({
           {visible.map((m) => (
             <tr
               key={m.module}
-              className={`border-t border-[var(--color-border-default)] ${onSelect ? "cursor-pointer hover:bg-[var(--color-bg-elevated)]" : ""}`}
+              className={`group border-t border-[var(--color-table-divider)] ${onSelect ? "cursor-pointer hover:bg-[var(--color-bg-elevated)]" : ""}`}
               onClick={onSelect ? () => onSelect(m) : undefined}
             >
-              <td className="px-3 py-2 font-medium text-[var(--color-text-primary)]">{m.module}</td>
+              <td className="px-3 py-2 font-medium text-[var(--color-text-primary)]">
+                <span className="group-hover:underline underline-offset-2">{m.module}</span>
+              </td>
               <td className="px-3 py-2 tabular-nums text-[var(--color-text-secondary)]">{m.file_count}</td>
               <td className="px-3 py-2 tabular-nums text-[var(--color-text-secondary)]">{m.nloc.toLocaleString()}</td>
               <td className="px-3 py-2">

--- a/packages/ui/src/security/findings-table.tsx
+++ b/packages/ui/src/security/findings-table.tsx
@@ -92,23 +92,23 @@ export function SecurityFindingsTable({ findings, onSelect, onGeneratePrompt }: 
         </div>
       </div>
 
-      <div className="rounded-lg border border-[var(--color-border-default)] overflow-x-auto">
+      <div className="border border-[var(--color-border-default)] overflow-hidden overflow-x-auto">
         <table className="w-full min-w-[560px] text-sm">
-          <thead className="sticky top-0 z-10 bg-[var(--color-bg-elevated)]">
-            <tr className="border-b border-[var(--color-border-default)]">
-              <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-20">
+          <thead className="sticky top-0 z-10 bg-[var(--color-bg-surface)]">
+            <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
+              <th className="px-3 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-20">
                 Severity
               </th>
-              <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+              <th className="px-3 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
                 File
               </th>
-              <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-40">
+              <th className="px-3 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-40">
                 Kind
               </th>
-              <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+              <th className="px-3 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
                 Snippet
               </th>
-              <th className="px-3 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-28">
+              <th className="px-3 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-28">
                 Detected
               </th>
               {onGeneratePrompt && <th className="px-3 py-2.5 w-10" />}
@@ -120,7 +120,7 @@ export function SecurityFindingsTable({ findings, onSelect, onGeneratePrompt }: 
                 key={f.id}
                 onClick={onSelect ? () => onSelect(f) : undefined}
                 className={
-                  "border-b border-[var(--color-border-default)] last:border-0 hover:bg-[var(--color-bg-elevated)] transition-colors" +
+                  "group border-b border-[var(--color-table-divider)] last:border-0 hover:bg-[var(--color-bg-elevated)] transition-colors" +
                   (onSelect ? " cursor-pointer" : "")
                 }
               >
@@ -130,7 +130,7 @@ export function SecurityFindingsTable({ findings, onSelect, onGeneratePrompt }: 
                   </Badge>
                 </td>
                 <td className="px-3 py-2 font-mono text-xs text-[var(--color-text-primary)] max-w-[280px]">
-                  <span className="block truncate" title={f.file_path}>{f.file_path}</span>
+                  <span className="block truncate group-hover:underline underline-offset-2" title={f.file_path}>{f.file_path}</span>
                 </td>
                 <td className="px-3 py-2 text-xs text-[var(--color-text-secondary)]">{f.kind}</td>
                 <td className="px-3 py-2 font-mono text-xs text-[var(--color-text-tertiary)] max-w-[320px]">

--- a/packages/ui/src/shared/responsive-table/responsive-table.tsx
+++ b/packages/ui/src/shared/responsive-table/responsive-table.tsx
@@ -101,7 +101,7 @@ export function ResponsiveTable<T>({
   const table = (
     <div className={cn("overflow-x-auto", stacked && STACKED_TABLE_CLS[stacked])}>
       <table className="w-full text-sm">
-        <thead className="bg-[var(--color-bg-elevated)] text-[var(--color-text-tertiary)] text-xs uppercase tracking-wider sticky top-0 z-10">
+        <thead className="bg-[var(--color-bg-surface)] text-[var(--color-text-tertiary)] text-[11px] uppercase tracking-wider sticky top-0 z-10 border-b border-[var(--color-border-default)]">
           <tr>
             {columns.map((c) => {
               const isActive = c.sortable && c.key === sortField;
@@ -109,7 +109,7 @@ export function ResponsiveTable<T>({
                 <th
                   key={c.key}
                   className={cn(
-                    "px-3 py-2 font-medium whitespace-nowrap",
+                    "px-3 py-2.5 font-medium whitespace-nowrap",
                     alignCls(c.align),
                     PRIORITY_CELL_CLS[c.priority ?? 1],
                     c.sortable && onSort && "cursor-pointer select-none",
@@ -143,7 +143,7 @@ export function ResponsiveTable<T>({
               <tr
                 key={key}
                 className={cn(
-                  "border-t border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)]",
+                  "border-t border-[var(--color-table-divider)] hover:bg-[var(--color-bg-elevated)]",
                   isSelected && "bg-[var(--color-accent-muted)]/30",
                   onRowClick && "cursor-pointer",
                 )}
@@ -153,7 +153,7 @@ export function ResponsiveTable<T>({
                   <td
                     key={c.key}
                     className={cn(
-                      "px-3 py-2",
+                      "px-3 py-2.5",
                       alignCls(c.align),
                       PRIORITY_CELL_CLS[c.priority ?? 1],
                       c.cellClassName,
@@ -171,7 +171,7 @@ export function ResponsiveTable<T>({
   );
 
   const cards = stacked ? (
-    <ul className={cn("divide-y divide-[var(--color-border-default)]", STACKED_CARDS_CLS[stacked])}>
+    <ul className={cn("divide-y divide-[var(--color-table-divider)]", STACKED_CARDS_CLS[stacked])}>
       {rows.map((row) => {
         const key = rowKey(row);
         const isSelected = selectedKey != null && selectedKey === key;
@@ -213,8 +213,7 @@ export function ResponsiveTable<T>({
   return (
     <div
       className={cn(
-        !bare &&
-          "rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]",
+        !bare && "overflow-hidden border border-[var(--color-border-default)]",
         className,
       )}
     >

--- a/packages/ui/src/symbols/symbol-table.tsx
+++ b/packages/ui/src/symbols/symbol-table.tsx
@@ -267,30 +267,30 @@ export function SymbolTable({
       ) : items.length === 0 ? (
         <EmptyState title="No symbols found" description="Try adjusting your filters." />
       ) : (
-        <div className="rounded-lg border border-[var(--color-border-default)] overflow-hidden">
+        <div className="border border-[var(--color-border-default)] overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
-              <thead className="sticky top-0 z-10">
-                <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]">
-                  <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-32">
+              <thead className="sticky top-0 z-10 bg-[var(--color-bg-surface)]">
+                <tr className="border-b border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-32">
                     <span className="inline-flex items-center gap-1">
                       <TrendingUp className="h-3 w-3" />
                       Importance
                     </span>
                   </th>
-                  <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
                     Name
                   </th>
-                  <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
                     Signals
                   </th>
-                  <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden sm:table-cell">
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden sm:table-cell">
                     Kind
                   </th>
-                  <th className="px-4 py-2.5 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden sm:table-cell">
+                  <th className="px-4 py-2.5 text-left text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden sm:table-cell">
                     File
                   </th>
-                  <th className="px-4 py-2.5 text-right text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden md:table-cell">
+                  <th className="px-4 py-2.5 text-right text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider hidden md:table-cell">
                     Complexity
                   </th>
                   {prefix && <th className="px-2 py-2.5 w-12" />}
@@ -300,7 +300,7 @@ export function SymbolTable({
                 {items.map((sym) => (
                   <tr
                     key={sym.id}
-                    className="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] transition-colors last:border-0 cursor-pointer focus:outline-none focus:bg-[var(--color-bg-elevated)]"
+                    className="group border-b border-[var(--color-table-divider)] hover:bg-[var(--color-bg-elevated)] transition-colors last:border-0 cursor-pointer focus:outline-none focus:bg-[var(--color-bg-elevated)]"
                     tabIndex={0}
                     role="button"
                     aria-label={`View ${sym.qualified_name || sym.name}`}
@@ -316,7 +316,7 @@ export function SymbolTable({
                       <ImportanceBar score={sym.importance_score} />
                     </td>
                     <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-primary)] min-w-[200px] max-w-[420px]">
-                      <span className="truncate block" title={sym.qualified_name || sym.name}>
+                      <span className="truncate block group-hover:underline underline-offset-2" title={sym.qualified_name || sym.name}>
                         {sym.name}
                       </span>
                       {sym.parent_name && (

--- a/packages/ui/src/wiki/wiki-markdown.tsx
+++ b/packages/ui/src/wiki/wiki-markdown.tsx
@@ -209,20 +209,25 @@ function buildComponents(
     </blockquote>
   ),
   table: ({ children }) => (
-    <div className="my-4 overflow-x-auto rounded border border-[var(--color-border-default)]">
+    <div className="my-4 overflow-x-auto overflow-hidden border border-[var(--color-border-default)]">
       <table className="w-full text-sm">{children}</table>
     </div>
   ),
   thead: ({ children }) => (
-    <thead className="bg-[var(--color-bg-elevated)]">{children}</thead>
+    <thead className="bg-[var(--color-bg-surface)] border-b border-[var(--color-border-default)]">{children}</thead>
   ),
   th: ({ children }) => (
-    <th className="px-4 py-2 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider">
+    <th className="px-3 py-2.5 text-left text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
       {children}
     </th>
   ),
+  tr: ({ children }) => (
+    <tr className="border-t border-[var(--color-table-divider)] transition-colors hover:bg-[var(--color-bg-elevated)]">
+      {children}
+    </tr>
+  ),
   td: ({ children }) => (
-    <td className="px-4 py-2 text-sm text-[var(--color-text-secondary)] border-t border-[var(--color-border-default)]">
+    <td className="px-3 py-2.5 text-[var(--color-text-secondary)]">
       {children}
     </td>
   ),

--- a/packages/ui/src/wiki/wiki-mdx-components.tsx
+++ b/packages/ui/src/wiki/wiki-mdx-components.tsx
@@ -67,22 +67,28 @@ export const wikiMdxComponents = {
     />
   ),
   table: (props: React.HTMLAttributes<HTMLTableElement>) => (
-    <div className="my-4 overflow-x-auto rounded border border-[var(--color-border-default)]">
+    <div className="my-4 overflow-x-auto overflow-hidden border border-[var(--color-border-default)]">
       <table className="w-full text-sm" {...props} />
     </div>
   ),
   thead: (props: React.HTMLAttributes<HTMLTableSectionElement>) => (
-    <thead className="bg-[var(--color-bg-elevated)]" {...props} />
+    <thead className="bg-[var(--color-bg-surface)] border-b border-[var(--color-border-default)]" {...props} />
   ),
   th: (props: React.HTMLAttributes<HTMLTableCellElement>) => (
     <th
-      className="px-4 py-2 text-left text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider"
+      className="px-3 py-2.5 text-left text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]"
+      {...props}
+    />
+  ),
+  tr: (props: React.HTMLAttributes<HTMLTableRowElement>) => (
+    <tr
+      className="border-t border-[var(--color-table-divider)] transition-colors hover:bg-[var(--color-bg-elevated)]"
       {...props}
     />
   ),
   td: (props: React.HTMLAttributes<HTMLTableCellElement>) => (
     <td
-      className="px-4 py-2 text-sm text-[var(--color-text-secondary)] border-t border-[var(--color-border-default)]"
+      className="px-3 py-2.5 text-[var(--color-text-secondary)]"
       {...props}
     />
   ),

--- a/packages/ui/styles/globals.css
+++ b/packages/ui/styles/globals.css
@@ -182,6 +182,10 @@
   --color-bg-wash: rgba(36, 27, 44, 0.05);
   --color-bg-wash-hover: rgba(36, 27, 44, 0.1);
   --color-border-subtle: var(--color-border-default);
+  /* Faint hairline for table row dividers — half the weight of a normal
+     border so rows whisper while the header rule still reads. References the
+     themed --color-border-default lazily, so it adapts in dark mode too. */
+  --color-table-divider: color-mix(in srgb, var(--color-border-default) 50%, transparent);
   --color-text-muted: var(--color-text-tertiary);
 
   /* Viz state colors (selection / diff) — brand-aligned + theme-aware */
@@ -289,25 +293,28 @@
 /* -------------------------------------------------------------------- */
 
 .dark {
-  /* Plum-tinted charcoal base — the theme's own dark identity.
-     A restrained violet cast (hue ~270, low sat) differentiates the product
-     from the many neutral-charcoal + orange UIs while keeping the brand
-     orange accent popping. Verified in docs/design/contrast_check.py. */
-  --color-bg-root: #17131d;
-  --color-bg-surface: #211b29;
-  --color-bg-elevated: #2a2335;
-  --color-bg-overlay: #322a3e;
-  --color-bg-inset: #110d17;
+  /* Neutral graphite base — a true dark gray (near-zero hue) so nothing reads
+     blue, green, or plum. The surface ramp climbs root -> surface -> elevated
+     -> overlay with wide steps so the sidebar, breadcrumb bar, cards, tables,
+     and modals all read as distinct layers off the same tokens. Light mode is
+     unchanged. */
+  --color-bg-root: #1a1a1b;
+  --color-bg-surface: #232325;
+  --color-bg-elevated: #2b2c2e;
+  --color-bg-overlay: #343539;
+  --color-bg-inset: #141415;
 
-  --color-border-default: rgba(213, 197, 232, 0.1);
-  --color-border-hover: rgba(213, 197, 232, 0.18);
+  /* Neutral hairlines so card / sidebar / table edges read on the gray base. */
+  --color-border-default: rgba(255, 255, 255, 0.1);
+  --color-border-hover: rgba(255, 255, 255, 0.18);
   --color-border-active: rgba(245, 149, 32, 0.55);
 
-  --color-text-primary: #eeeaf4;
-  --color-text-secondary: #a79db3;
-  --color-text-tertiary: #786f84;
-  --color-text-inverse: #17131d;
-  --color-text-on-accent: #17131d;
+  /* Neutral gray text (no plum / blue cast) to match the graphite chrome. */
+  --color-text-primary: #ececed;
+  --color-text-secondary: #a2a2a6;
+  --color-text-tertiary: #717176;
+  --color-text-inverse: #1a1a1b;
+  --color-text-on-accent: #1a1a1b;
 
   --color-accent-primary: #f59520;
   --color-accent-fill: #f59520;
@@ -349,10 +356,10 @@
 
   /* C4 / graph canvas surfaces — dark variants (the var()-derived aliases
      flip on their own; only the explicit rgbas need a dark override). */
-  --color-canvas-dot: rgba(222, 210, 235, 0.06);
-  --color-bg-glass: rgba(33, 27, 41, 0.72);
-  --color-bg-wash: rgba(222, 210, 235, 0.05);
-  --color-bg-wash-hover: rgba(222, 210, 235, 0.1);
+  --color-canvas-dot: rgba(255, 255, 255, 0.05);
+  --color-bg-glass: rgba(35, 35, 37, 0.72);
+  --color-bg-wash: rgba(255, 255, 255, 0.04);
+  --color-bg-wash-hover: rgba(255, 255, 255, 0.08);
 
   /* Edge hue that isn't a pure var() derivation gets a dark-legible tweak */
   --color-edge-inherits: #a98fc4; /* plum-300 reads better on dark */
@@ -374,13 +381,13 @@
 
   /* Deep shadows with a neutral inset hairline for premium depth */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(222, 210, 235, 0.05);
-  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5), inset 0 0 0 1px rgba(222, 210, 235, 0.06);
-  --shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(222, 210, 235, 0.07);
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5), inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+  --shadow-xl: 0 16px 48px rgba(0, 0, 0, 0.6), inset 0 0 0 1px rgba(255, 255, 255, 0.07);
   --shadow-button: 0 1px 2px rgba(0, 0, 0, 0.4);
 
-  /* Dark soft wash — plum charcoal with a faint warm lift at the end */
-  --gradient-warm-wash: linear-gradient(160deg, #1b1622 0%, #241d2e 55%, #2e2629 100%);
+  /* Dark soft wash — neutral graphite with a faint lift at the end */
+  --gradient-warm-wash: linear-gradient(160deg, #1c1c1e 0%, #232325 55%, #2c2c2f 100%);
 }
 
 /* -------------------------------------------------------------------- */
@@ -479,11 +486,11 @@ body {
 }
 
 .dark ::-webkit-scrollbar-thumb {
-  background: rgba(222, 210, 235, 0.12);
+  background: rgba(255, 255, 255, 0.14);
 }
 
 .dark ::-webkit-scrollbar-thumb:hover {
-  background: rgba(222, 210, 235, 0.22);
+  background: rgba(255, 255, 255, 0.26);
 }
 
 /* -------------------------------------------------------------------- */
@@ -537,7 +544,18 @@ body {
   --tw-prose-quotes: var(--color-text-secondary);
   --tw-prose-quote-borders: var(--color-border-default);
   --tw-prose-th-borders: var(--color-border-default);
-  --tw-prose-td-borders: var(--color-border-default);
+  /* Faint row hairlines to match the app-wide table spec; the header rule
+     (th-borders) stays at full weight so the head still separates cleanly. */
+  --tw-prose-td-borders: var(--color-table-divider);
+}
+
+/* Markdown data tables: quiet row hover, square edges (consistent with the
+   app table spec). Header weight + borders come from the prose vars above. */
+.prose tbody tr {
+  transition: background-color var(--duration-fast) var(--ease-out);
+}
+.prose tbody tr:hover {
+  background: var(--color-bg-elevated);
 }
 
 .prose code {

--- a/packages/web/src/app/repos/[id]/files/page.tsx
+++ b/packages/web/src/app/repos/[id]/files/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { Files } from "lucide-react";
+import { PageShell } from "@repowise-dev/ui/shared/page-shell";
+import { FilesExplorer } from "@/components/files/files-explorer";
+
+export const metadata: Metadata = { title: "Files" };
+
+export default async function FilesIndexPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  return (
+    <PageShell
+      maxWidth="wide"
+      icon={<Files className="h-5 w-5 text-[var(--color-accent-primary)]" />}
+      title="Files"
+      description="Every indexed file, ranked by importance and browsable by folder. Drill into the map or filter the table to jump straight to a file."
+    >
+      <FilesExplorer repoId={id} />
+    </PageShell>
+  );
+}

--- a/packages/web/src/components/files/files-explorer.tsx
+++ b/packages/web/src/components/files/files-explorer.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback } from "react";
+import useSWR from "swr";
+import { AlertTriangle } from "lucide-react";
+import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
+import { FilesIndex } from "@repowise-dev/ui/files";
+import { getFilesIndex } from "@/lib/api/files";
+
+export function FilesExplorer({ repoId }: { repoId: string }) {
+  const { data, error, isLoading } = useSWR(
+    `files-index:${repoId}`,
+    () => getFilesIndex(repoId),
+    { revalidateOnFocus: false },
+  );
+
+  const fileHref = useCallback(
+    (path: string) =>
+      `/repos/${repoId}/files/${path.split("/").map(encodeURIComponent).join("/")}`,
+    [repoId],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-14 w-full" />
+          ))}
+        </div>
+        <Skeleton className="h-80 w-full" />
+        <Skeleton className="h-9 w-full" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-[var(--color-border-default)] p-4 text-sm text-[var(--color-text-secondary)]">
+        <AlertTriangle className="h-4 w-4 text-[var(--color-warning)]" />
+        Couldn&apos;t load the file index for this repository.
+      </div>
+    );
+  }
+
+  return <FilesIndex files={data.files} languages={data.languages} fileHref={fileHref} />;
+}

--- a/packages/web/src/components/layout/nav-items.ts
+++ b/packages/web/src/components/layout/nav-items.ts
@@ -13,6 +13,7 @@ import {
   BookOpen,
   Boxes,
   DollarSign,
+  FolderTree,
   GitCommitHorizontal,
   GitMerge,
   HeartPulse,
@@ -65,6 +66,7 @@ export function repoNavGroups(repoId: string): NavGroup[] {
         { label: "Knowledge Graph", href: `${base}/knowledge-graph`, icon: Waypoints },
         { label: "Code Health", href: `${base}/code-health`, icon: HeartPulse },
         { label: "Refactoring", href: `${base}/refactoring`, icon: Wrench },
+        { label: "Files", href: `${base}/files`, icon: FolderTree },
       ],
     },
     {

--- a/packages/web/src/components/search/command-palette.tsx
+++ b/packages/web/src/components/search/command-palette.tsx
@@ -3,9 +3,11 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { Command } from "cmdk";
-import { Search, LayoutDashboard, Settings, BookOpen, Layers, Link2, GitMerge, MessageSquare } from "lucide-react";
+import useSWR from "swr";
+import { Search, LayoutDashboard, Settings, BookOpen, FileCode, Layers, Link2, GitMerge, MessageSquare } from "lucide-react";
 import { useSearch } from "@/lib/hooks/use-search";
 import { truncatePath } from "@repowise-dev/ui/lib/format";
+import { getFilesIndex } from "@/lib/api/files";
 import { repoNavItems } from "@/components/layout/nav-items";
 import { pageHref } from "@/lib/utils/page-href";
 import type { RepoResponse, WorkspaceResponse } from "@/lib/api/types";
@@ -35,6 +37,33 @@ export function CommandPalette({ repos, workspace }: CommandPaletteProps) {
     () => (activeRepo ? repoNavItems(activeRepo.id) : []),
     [activeRepo],
   );
+
+  // File jump — fetched lazily (only once the palette is open with a repo in
+  // scope) and cached; the Files page shares the same SWR key so this is warm
+  // after a visit there. We do our own ranking and cap the rendered set so the
+  // palette never mounts thousands of cmdk items.
+  const { data: filesData } = useSWR(
+    open && activeRepo ? `files-index:${activeRepo.id}` : null,
+    () => getFilesIndex(activeRepo!.id),
+    { revalidateOnFocus: false },
+  );
+
+  const fileMatches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!activeRepo || q.length < 2 || !filesData) return [];
+    const scored: { path: string; score: number }[] = [];
+    for (const f of filesData.files) {
+      const path = f.file_path.toLowerCase();
+      const idx = path.indexOf(q);
+      if (idx === -1) continue;
+      const base = f.file_path.split("/").pop()?.toLowerCase() ?? "";
+      // Rank: basename match beats mid-path; earlier match beats later.
+      const score = (base.includes(q) ? 0 : 1000) + idx;
+      scored.push({ path: f.file_path, score });
+    }
+    scored.sort((a, b) => a.score - b.score || a.path.length - b.path.length);
+    return scored.slice(0, 12).map((s) => s.path);
+  }, [query, activeRepo, filesData]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -78,7 +107,7 @@ export function CommandPalette({ repos, workspace }: CommandPaletteProps) {
           <Command.Input
             value={query}
             onValueChange={setQuery}
-            placeholder="Search pages, navigate repos…"
+            placeholder="Jump to a file, search pages, navigate repos…"
             className="flex-1 bg-transparent text-sm text-[var(--color-text-primary)] outline-none placeholder:text-[var(--color-text-tertiary)]"
           />
           <kbd className="hidden sm:inline-flex items-center rounded border border-[var(--color-border-default)] px-1.5 py-0.5 text-xs text-[var(--color-text-tertiary)] font-mono">
@@ -206,6 +235,41 @@ export function CommandPalette({ repos, workspace }: CommandPaletteProps) {
                   {repo.name}
                 </Command.Item>
               ))}
+            </Command.Group>
+          )}
+
+          {/* File jump */}
+          {activeRepo && fileMatches.length > 0 && (
+            <Command.Group heading="Files" className="px-2 pb-1">
+              {fileMatches.map((path) => {
+                const name = path.split("/").pop() ?? path;
+                const dir = path.slice(0, path.length - name.length);
+                return (
+                  <Command.Item
+                    // Embed the query so cmdk's own filter keeps our pre-ranked
+                    // matches visible instead of re-filtering them out.
+                    key={path}
+                    value={`file ${path} ${query}`}
+                    onSelect={() =>
+                      navigate(
+                        `/repos/${activeRepo.id}/files/${path
+                          .split("/")
+                          .map(encodeURIComponent)
+                          .join("/")}`,
+                      )
+                    }
+                    className="flex items-center gap-2.5 rounded-md px-3 py-2 text-sm cursor-pointer hover:bg-[var(--color-bg-elevated)] data-[selected=true]:bg-[var(--color-bg-elevated)]"
+                  >
+                    <FileCode className="h-4 w-4 shrink-0 text-[var(--color-text-tertiary)]" />
+                    <span className="min-w-0 truncate font-mono text-[13px]">
+                      <span className="text-[var(--color-text-tertiary)]">
+                        {truncatePath(dir, 36)}
+                      </span>
+                      <span className="text-[var(--color-text-primary)]">{name}</span>
+                    </span>
+                  </Command.Item>
+                );
+              })}
             </Command.Group>
           )}
 

--- a/packages/web/src/lib/api/files.ts
+++ b/packages/web/src/lib/api/files.ts
@@ -1,5 +1,10 @@
-import type { FileDetailResponse } from "@repowise-dev/types/files";
+import type { FileDetailResponse, FilesIndexResponse } from "@repowise-dev/types/files";
 import { apiGet, BASE_URL, buildHeaders } from "./client";
+
+/** Slim per-file rows for the browsable Files index + treemap. */
+export async function getFilesIndex(repoId: string): Promise<FilesIndexResponse> {
+  return apiGet<FilesIndexResponse>(`/api/repos/${repoId}/files`);
+}
 
 /** Canonical file-detail aggregate for the file entity page. */
 export async function getFileDetail(


### PR DESCRIPTION
## Files page

A canonical, browsable Files surface so you can find and jump to any file.

- **Navigable treemap hero** sized by importance (pagerank) or LOC, colored by
  health or language, with folder drill-down and breadcrumb. Renders only the
  current folder's direct children, so it stays fast on large repos.
- **Virtualized file table** with fuzzy path filter, sortable columns
  (importance, health, churn, LOC, coverage, name), language and test filters,
  and a folder-scoping toggle that follows the treemap drill.
- **Command palette jump-to-file** (lazy-fetched, cached, ranked) and a **Files**
  entry in the sidebar.
- **Backend** `GET /api/repos/{id}/files` returns slim per-file rows joined from
  batched reads (graph nodes, degree metrics, health metrics, git metadata),
  with importance and churn percentiles computed once. No N+1.

## Table restyle

A consistent, cleaner look across every table.

- Floating uppercase headers under a single rule, faint `--color-table-divider`
  row hairlines, square corners, comfier density, and underline-on-hover for
  primary link cells.
- Applied to the shared `ResponsiveTable` primitive, markdown and prose tables,
  and the per-area data tables (blast-radius, git, security, symbols, coverage,
  dead-code, health).

## Dark mode

- Darker dark-mode adjustments to the brand palette, sigma graph colors, and
  global tokens.

## Checks

- `ui` and `web` type-checks pass
- UI design gates pass (no raw hex, 74 contrast pairs, 0 failures)
- Backend router imports; `ruff` clean
