### PR TITLE
test(ui): fix stale Code Health lens-switch test

### DIFF
--- a/packages/ui/__tests__/health/code-health-map.test.tsx
+++ b/packages/ui/__tests__/health/code-health-map.test.tsx
@@ -114,8 +114,8 @@ describe("CodeHealthMap", () => {
         onOverlayChange={onOverlayChange}
       />,
     );
-    // The lens switcher renders one toggle button per lens; click "Churn".
-    fireEvent.click(getByRole("button", { name: "Churn" }));
-    expect(onOverlayChange).toHaveBeenCalledWith("churn");
+    // The lens switcher renders one toggle button per lens; click "Maintainability".
+    fireEvent.click(getByRole("button", { name: "Maintainability" }));
+    expect(onOverlayChange).toHaveBeenCalledWith("maintainability");
   });
 });


### PR DESCRIPTION
@
## What

The `Publish internal prereleases` workflow was failing on the `@repowise-dev/ui` test suite:

```
packages/ui/__tests__/health/code-health-map.test.tsx > CodeHealthMap >
  fires onOverlayChange when a lens-switch button is clicked
TestingLibraryElementError: Unable to find an accessible element with the role "button" and name "Churn"
```

## Why

The Code Health overview lens switcher was narrowed to the three co-equal health signals (`OVERLAY_ORDER = ["health", "maintainability", "performance"]`). The churn lens keeps its `OVERLAY_SPECS` entry for other tabs but is no longer rendered in this switcher, so the test was clicking a button that no longer exists.

## Fix

Update the test to click the "Maintainability" lens (which is rendered) and assert `onOverlayChange("maintainability")`. All 8 tests in the file pass locally.
@