### PR TITLE
feat(init): docs toggle in Advanced, configurable index-only, raise commit cap

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -46,6 +46,14 @@ repowise init .
 
 In workspace mode, adds: repo scanning, per-repo indexing, cross-repo analysis (co-changes, contracts, package deps), workspace CLAUDE.md generation.
 
+**Interactive modes.** Running a bare `repowise init` on a TTY (no `--provider`, `--index-only`, or `--yes`) opens a menu:
+
+1. **Everything** — index + AI docs. After picking a provider you can answer **"Customize?"** to tune any setting before the run.
+2. **Index only** — graph, git, code health, dead code; no LLM, no cost. Answer **"Customize indexing?"** to set exclude patterns, commit limit, skip-tests/infra, submodules, and fast mode.
+3. **Advanced** — full control. First choose **"Generate AI docs?"**; the prompts then split into an **Indexing** section (always) and a **Generation** section (provider, concurrency, embedder, wiki style, onboarding, decision harvesting, tiering — only when docs are on).
+
+All three reach the indexing knobs; the LLM-only knobs appear only when docs are enabled. Passing any of the flags below (or `--yes`) skips the menu and runs non-interactively.
+
 **Options:**
 
 | Flag | Description |
@@ -63,11 +71,14 @@ In workspace mode, adds: repo scanning, per-repo indexing, cross-repo analysis (
 | `--skip-infra` | Exclude infrastructure files (Dockerfiles, Makefiles, Terraform). |
 | `--exclude / -x` | Gitignore-style exclusion patterns. Repeatable. |
 | `--include-submodules` | Include git submodule directories. |
-| `--concurrency` | Max concurrent LLM calls (default: 5). |
+| `--concurrency` | Max concurrent LLM calls (default: 10). |
 | `--reasoning` | Reasoning mode for supported providers: `auto`, `off`/`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` (default: `auto`). |
+| `--coverage` | Documentation coverage as a fraction of repo files (e.g. `0.10`, `0.20`, `0.50`). Bypasses the interactive coverage chooser. |
+| `--onboarding / --no-onboarding` | Generate the curated Onboarding collection (up to 8 overview pages). Default: on; slots without enough signal are skipped. |
+| `--harvest-decisions / --no-harvest-decisions` | Harvest architectural decisions during page generation (verified against source before storage). Default: on. |
 | `--resume` | Resume from the last checkpoint if interrupted. |
 | `--force` | Regenerate all pages even if they exist. |
-| `--commit-limit` | Max commits to analyze per file (default: 500). |
+| `--commit-limit` | Max commits to analyze per file (default: 500, max: 10000). |
 | `--follow-renames` | Track file renames in git history. |
 | `--no-claude-md` | Don't generate `CLAUDE.md`. |
 | `--distill-hook / --no-distill-hook` | Install or skip the Distill command-rewrite hook (Claude Code PreToolUse). Strictly opt-in: interactive runs prompt (default No); `--no-distill-hook` also gates the repo off in config so a globally installed hook stays inert here. In workspace mode the verdict (prompt or flag) applies to every selected repo. See [DISTILL.md](DISTILL.md). |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -193,7 +193,7 @@ repowise init [PATH]
 | `--reasoning` | Reasoning mode for supported providers: `auto`, `off`/`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` (default: `auto`). |
 | `--resume` | Resume from the last checkpoint if a previous run was interrupted. |
 | `--force` | Regenerate all pages even if they already exist. |
-| `--commit-limit` | Max commits to analyze per file (default: 500, max: 5000). Saved to config. |
+| `--commit-limit` | Max commits to analyze per file (default: 500, max: 10000). Saved to config. |
 | `--follow-renames` | Track file renames in git history (slower but more accurate). |
 | `--no-claude-md` | Don't generate `CLAUDE.md` at the end. |
 | `--agents / --no-agents` | Generate or skip managed `AGENTS.md` for Codex. Persists the preference. |

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -52,7 +52,9 @@ from repowise.cli.ui import (
     MaybeCountColumn,
     RichProgressCallback,
     interactive_advanced_config,
+    interactive_customize_offer,
     interactive_fast_mode_offer,
+    interactive_generate_docs_toggle,
     interactive_mode_select,
     interactive_provider_config_select,
     load_dotenv,
@@ -60,6 +62,7 @@ from repowise.cli.ui import (
     print_index_only_intro,
     print_phase_header,
     print_scan_summary,
+    prompt_wiki_style,
     quick_repo_scan,
     should_offer_fast_mode,
 )
@@ -77,27 +80,6 @@ from .persistence import (
 )
 from .reporting import show_analysis_summary, show_completion
 from .workspace import _workspace_init
-
-
-def _prompt_wiki_style(console: Any) -> str:
-    """Interactive picker for the wiki documentation style (full-mode init only).
-
-    Returns the chosen style name. Defaults to the comprehensive baseline so a
-    bare Enter keeps today's behaviour.
-    """
-    styles = list_styles()
-    console.print("\n[bold]Documentation style[/bold]")
-    for idx, spec in enumerate(styles, 1):
-        marker = " [dim](default)[/dim]" if spec.name == DEFAULT_STYLE else ""
-        console.print(f"  {idx}. [cyan]{spec.name}[/cyan]{marker} — {spec.description}")
-    default_idx = next((i for i, s in enumerate(styles, 1) if s.name == DEFAULT_STYLE), 1)
-    choice = click.prompt(
-        "  Choose a style",
-        type=click.IntRange(1, len(styles)),
-        default=default_idx,
-        show_default=True,
-    )
-    return styles[choice - 1].name
 
 
 def _run_generation_phase(
@@ -296,7 +278,7 @@ def _run_generation_phase(
     "--commit-limit",
     type=int,
     default=None,
-    help="Max commits to analyze per file and for co-change detection (default: 500, max: 5000). Saved to config.",
+    help="Max commits to analyze per file and for co-change detection (default: 500, max: 10000). Saved to config.",
 )
 @click.option(
     "--follow-renames",
@@ -522,6 +504,13 @@ def init_command(
     # file page is a full-LLM tier-1 page (unchanged behaviour).
     tier1_top_n: int | None = None
 
+    # The two orthogonal axes the interactive menu resolves: whether docs are
+    # generated and whether we entered the advanced-config prompts. Initialized
+    # for the non-interactive path (where the menu never runs); the menu
+    # overrides them below. They gate the editor-files prompt further down.
+    generate_docs = not index_only
+    customize = False
+
     # Pre-scan for interactive mode — fast stats to inform choices
     scan_info = None
     if is_interactive:
@@ -531,18 +520,24 @@ def init_command(
         print_scan_summary(console, scan_info)
         mode = interactive_mode_select(console)
 
+        # Map the menu onto the two axes (docs on/off, customize yes/no):
+        #   full       -> docs on,  optional customize
+        #   index_only -> docs off, optional customize
+        #   advanced   -> docs toggle, always customize
         if mode == "index_only":
-            index_only = True
-            # On a large repo, an index-only run is exactly the case where the
-            # fast tier (essential git, no blame/co-change) pays off — offer it,
-            # defaulting to yes since docs are already opted out.
-            if (
-                run_mode != "fast"
-                and should_offer_fast_mode(scan_info)
-                and interactive_fast_mode_offer(console, scan_info, default_fast=True)
-            ):
-                run_mode = "fast"
+            generate_docs = False
+            customize = interactive_customize_offer(console, generate_docs=False)
         elif mode == "advanced":
+            generate_docs = interactive_generate_docs_toggle(console)
+            customize = True
+        else:  # full
+            generate_docs = True
+            customize = interactive_customize_offer(console, generate_docs=True)
+        index_only = not generate_docs
+
+        # Provider selection only when docs will be generated. Index-only runs
+        # auto-detect a decision-extraction provider later without prompting.
+        if generate_docs:
             selection = interactive_provider_config_select(
                 console,
                 model,
@@ -552,51 +547,60 @@ def init_command(
             provider_name = selection.provider_name
             model = selection.model
             reasoning = selection.reasoning
+
+        if customize:
             adv = interactive_advanced_config(
                 console,
                 scan=scan_info,
                 allow_fast=True,
                 prompt_reasoning=False,
+                generate_docs=generate_docs,
+                wiki_style=wiki_style,
             )
+            # Indexing knobs (always present).
             commit_limit = adv["commit_limit"]
             follow_renames = adv["follow_renames"]
             skip_tests = adv["skip_tests"]
             skip_infra = adv["skip_infra"]
-            concurrency = adv["concurrency"]
-            reasoning = adv.get("reasoning") or reasoning
             exclude = adv["exclude"]
-            test_run = adv["test_run"]
-            embedder_name = adv.get("embedder") or embedder_name
             include_submodules = adv.get("include_submodules", include_submodules)
             run_mode = adv.get("run_mode", run_mode)
-            tier1_top_n = adv.get("tier1_top_n")
+            # Generation knobs (only gathered when docs are on).
+            if generate_docs:
+                concurrency = adv["concurrency"]
+                reasoning = adv.get("reasoning") or reasoning
+                embedder_name = adv.get("embedder") or embedder_name
+                test_run = adv["test_run"]
+                tier1_top_n = adv.get("tier1_top_n")
+                onboarding = adv.get("onboarding", onboarding)
+                harvest_decisions = adv.get("harvest_decisions", harvest_decisions)
+                if adv.get("wiki_style"):
+                    wiki_style = adv["wiki_style"]
+            # Fast mode (picked in the indexing section) is a no-LLM index, so it
+            # forces index-only even if the user had asked for docs.
             if run_mode == "fast":
                 index_only = True
+                generate_docs = False
         else:
-            selection = interactive_provider_config_select(
-                console,
-                model,
-                reasoning,
-                repo_path=repo_path,
-            )
-            provider_name = selection.provider_name
-            model = selection.model
-            reasoning = selection.reasoning
-            # Full mode picked, but on a large repo offer the quick path too.
-            # Default no here — the user explicitly asked for docs.
+            # No customization: still offer the fast first-index on large repos.
+            # Default yes for an index-only run (docs already opted out), no for a
+            # full run (the user explicitly asked for docs).
             if (
                 run_mode != "fast"
                 and should_offer_fast_mode(scan_info)
-                and interactive_fast_mode_offer(console, scan_info, default_fast=False)
+                and interactive_fast_mode_offer(
+                    console, scan_info, default_fast=not generate_docs
+                )
             ):
                 run_mode = "fast"
                 index_only = True
+                generate_docs = False
 
-        # Wiki style: prompt in interactive full-mode runs when not set via flag.
-        # Index-only runs generate no pages, so the question is skipped (D7).
-        # --yes skips the prompt and uses the default style.
-        if wiki_style is None and not index_only and not yes:
-            wiki_style = _prompt_wiki_style(console)
+        # Wiki style: prompt for a docs run when not already chosen (via the
+        # --wiki-style flag or the advanced generation section). Index-only runs
+        # generate no pages, so the question is skipped. --yes uses the default.
+        if generate_docs and wiki_style is None and not yes:
+            wiki_style = prompt_wiki_style(console)
 
     # Resolve the effective style (CLI flag > interactive prompt > default) and
     # canonicalize it. Used by generation and persisted so update/restyle honor it.
@@ -613,7 +617,10 @@ def init_command(
         integration_overrides=get_default_integration_overrides(
             codex_setup=codex_setup,
         ),
-        prompt_for_project_files=is_interactive and not index_only,
+        # Prompt for CLAUDE.md / AGENTS.md / Codex setup whenever the user is
+        # engaging interactively — either generating docs or customizing an
+        # index-only run (the latter previously got no say).
+        prompt_for_project_files=is_interactive and (generate_docs or customize),
     )
 
     # Merge exclude_patterns from config.yaml and --exclude/-x flags
@@ -624,7 +631,7 @@ def init_command(
 
     # Resolve commit limit: CLI flag → config.yaml → default (500)
     resolved_commit_limit: int = commit_limit or config.get("commit_limit") or 500
-    resolved_commit_limit = max(1, min(resolved_commit_limit, 5000))
+    resolved_commit_limit = max(1, min(resolved_commit_limit, 10000))
     if commit_limit is not None:
         config["commit_limit"] = resolved_commit_limit
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
@@ -480,7 +480,12 @@ def _workspace_init(
             provider_name = selection.provider_name
             model = selection.model
             reasoning = selection.reasoning
-            adv = interactive_advanced_config(console, prompt_reasoning=False)
+            # Pass the resolved style so the advanced generation section doesn't
+            # add a per-workspace wiki-style prompt (the workspace flow applies
+            # one style uniformly); onboarding / decision harvesting still apply.
+            adv = interactive_advanced_config(
+                console, prompt_reasoning=False, wiki_style=wiki_style
+            )
             commit_limit = adv.get("commit_limit") or commit_limit
             follow_renames = adv.get("follow_renames", follow_renames)
             skip_tests = adv.get("skip_tests", skip_tests)
@@ -491,6 +496,10 @@ def _workspace_init(
             test_run = adv.get("test_run", test_run)
             reasoning = adv.get("reasoning") or reasoning
             embedder_name_resolved = resolve_embedder(adv.get("embedder") or embedder_name)
+            onboarding = adv.get("onboarding", onboarding)
+            harvest_decisions = adv.get("harvest_decisions", harvest_decisions)
+            if adv.get("wiki_style"):
+                wiki_style = adv["wiki_style"]
         elif not index_only:
             # "full" mode
             selection = interactive_provider_config_select(
@@ -545,7 +554,7 @@ def _workspace_init(
     console.print()
 
     # Step 4: Index each selected repo (always generate_docs=False; generation is separate)
-    resolved_commit_limit = max(1, min(commit_limit or 500, 5000))
+    resolved_commit_limit = max(1, min(commit_limit or 500, 10000))
     total_files = 0
     total_symbols = 0
     total_pages = 0

--- a/packages/cli/src/repowise/cli/ui/__init__.py
+++ b/packages/cli/src/repowise/cli/ui/__init__.py
@@ -28,9 +28,12 @@ from repowise.cli.ui.mascot import (
 from repowise.cli.ui.mode_selection import (
     LARGE_REPO_FILE_THRESHOLD,
     interactive_advanced_config,
+    interactive_customize_offer,
     interactive_fast_mode_offer,
+    interactive_generate_docs_toggle,
     interactive_mode_select,
     print_index_only_intro,
+    prompt_wiki_style,
     should_offer_fast_mode,
 )
 from repowise.cli.ui.progress import MaybeCountColumn, RichProgressCallback
@@ -74,7 +77,9 @@ __all__ = [
     "build_contextual_next_steps",
     "format_elapsed",
     "interactive_advanced_config",
+    "interactive_customize_offer",
     "interactive_fast_mode_offer",
+    "interactive_generate_docs_toggle",
     "interactive_mode_select",
     "interactive_primary_select",
     "interactive_provider_config_select",
@@ -86,6 +91,7 @@ __all__ = [
     "print_index_only_intro",
     "print_phase_header",
     "print_scan_summary",
+    "prompt_wiki_style",
     "quick_repo_scan",
     "should_offer_fast_mode",
 ]

--- a/packages/cli/src/repowise/cli/ui/mode_selection.py
+++ b/packages/cli/src/repowise/cli/ui/mode_selection.py
@@ -15,6 +15,7 @@ from rich.text import Text
 
 from repowise.cli.ui.brand import BRAND, BRAND_STYLE, DIM
 from repowise.cli.ui.repo_scanner import RepoScanInfo
+from repowise.core.generation.styles import DEFAULT_STYLE, list_styles
 from repowise.core.reasoning import REASONING_MODES
 
 # A repo at or above this many files is "large" — large enough that a quick
@@ -83,8 +84,8 @@ def interactive_mode_select(console: Console) -> str:
 
     body.append("  [3]", style=BRAND_STYLE)
     body.append("  Advanced\n", style="bold")
-    body.append("       Everything, with extra configuration\n")
-    body.append("       (commit limit, exclude patterns, concurrency …)")
+    body.append("       Full control — turn AI docs on or off, then tune indexing\n")
+    body.append("       and generation (commit limit, exclude patterns, concurrency …)")
 
     console.print(
         Panel(
@@ -102,6 +103,53 @@ def interactive_mode_select(console: Console) -> str:
         console=console,
     )
     return {"1": "full", "2": "index_only", "3": "advanced"}[choice]
+
+
+def interactive_generate_docs_toggle(console: Console) -> bool:
+    """Advanced-mode entry: ask whether to generate AI wiki docs.
+
+    Returns True for a full doc-generating run, False for an index-only run that
+    still flows through the indexing-configuration prompts. Indexing (graph, git,
+    code health, dead code) is free; only doc generation calls the LLM.
+    """
+    console.print()
+    console.print(
+        "  [dim]AI docs call the LLM (has a cost). Indexing — dependency graph, "
+        "git history,\n  code health, dead code — is always free.[/dim]"
+    )
+    return click.confirm("  Generate AI wiki docs?", default=True)
+
+
+def interactive_customize_offer(console: Console, *, generate_docs: bool) -> bool:
+    """Offer to drop into advanced configuration from full / index-only modes.
+
+    Returns True when the user wants to tune the defaults rather than accept
+    them. The label tracks whether generation knobs are in scope.
+    """
+    what = "indexing & generation" if generate_docs else "indexing"
+    console.print()
+    return click.confirm(f"  Customize {what} options?", default=False)
+
+
+def prompt_wiki_style(console: Console) -> str:
+    """Interactive picker for the wiki documentation style.
+
+    Returns the chosen style name. Defaults to the comprehensive baseline so a
+    bare Enter keeps today's behaviour.
+    """
+    styles = list_styles()
+    console.print("\n[bold]Documentation style[/bold]")
+    for idx, spec in enumerate(styles, 1):
+        marker = " [dim](default)[/dim]" if spec.name == DEFAULT_STYLE else ""
+        console.print(f"  {idx}. [cyan]{spec.name}[/cyan]{marker} — {spec.description}")
+    default_idx = next((i for i, s in enumerate(styles, 1) if s.name == DEFAULT_STYLE), 1)
+    choice = click.prompt(
+        "  Choose a style",
+        type=click.IntRange(1, len(styles)),
+        default=default_idx,
+        show_default=True,
+    )
+    return styles[choice - 1].name
 
 
 def _prompt_scope(console: Console, scan: RepoScanInfo | None, result: dict[str, Any]) -> None:
@@ -216,7 +264,7 @@ def _prompt_git(console: Console, scan: RepoScanInfo | None, result: dict[str, A
         default=default_limit,
         type=int,
     )
-    val = max(1, min(val, 5000))
+    val = max(1, min(val, 10000))
     result["commit_limit"] = val
 
     result["follow_renames"] = click.confirm(
@@ -233,8 +281,14 @@ def _prompt_generation(
     allow_fast: bool,
     is_large: bool,
     prompt_reasoning: bool = True,
+    wiki_style: str | None = None,
 ) -> None:
-    """Generation section: concurrency, reasoning, embedder, test run, tiering."""
+    """Generation section: concurrency, reasoning, embedder, test run, tiering,
+    onboarding, decision harvesting, and wiki style.
+
+    *wiki_style* carries an explicit ``--wiki-style`` value; when set the style
+    prompt is skipped so the flag wins.
+    """
     console.print()
     console.print(f"  [{BRAND}]Generation[/]")
     console.print("  [dim]LLM page generation settings[/dim]")
@@ -276,15 +330,34 @@ def _prompt_generation(
         default=False,
     )
 
+    # Curated onboarding collection (up to 8 overview pages) — extra LLM cost,
+    # slots without enough signal are skipped automatically.
+    result["onboarding"] = click.confirm(
+        "  Generate the curated Onboarding collection? (up to 8 overview pages)",
+        default=True,
+    )
+
+    # Decision harvesting rides along with file-page generation; the token cost
+    # lands only on files that actually carry a decision.
+    result["harvest_decisions"] = click.confirm(
+        "  Harvest architectural decisions during generation?",
+        default=True,
+    )
+
     # Tiered doc generation: cap the number of full-LLM (tier-1) file pages on
     # large repos. The long tail is rendered from a deterministic template +
     # embedded for search (no LLM). 0 = no cap (every selected page is tier-1).
-    # Only meaningful when docs actually generate (standard mode).
+    # Only meaningful when docs actually generate (standard mode). This caps the
+    # full-LLM pages; the coverage chooser (shown later) sets how many files are
+    # documented at all.
     result["tier1_top_n"] = None
     if allow_fast and result["run_mode"] == "standard":
         tier_default = 300 if is_large else 0
         console.print()
-        console.print("  [dim]Tiered docs: cap full-LLM file pages; rest are template-only.[/dim]")
+        console.print(
+            "  [dim]Tiered docs: cap full-LLM file pages; rest are template-only. "
+            "Coverage (how many files to document) is chosen just before generation.[/dim]"
+        )
         tier_val = click.prompt(
             "  Full-LLM file-page cap (tier-1, 0 = no cap)",
             default=tier_default,
@@ -292,33 +365,59 @@ def _prompt_generation(
         )
         result["tier1_top_n"] = tier_val if tier_val > 0 else None
 
+    # Documentation voice/density. An explicit --wiki-style wins; otherwise prompt
+    # here so the choice lands inside the section, before the summary panel.
+    result["wiki_style"] = wiki_style if wiki_style is not None else prompt_wiki_style(console)
 
-def _build_summary_table(result: dict[str, Any], patterns: list[str], *, allow_fast: bool) -> Table:
-    """Build the configuration-summary table from the gathered answers."""
+
+def _build_summary_table(
+    result: dict[str, Any],
+    patterns: list[str],
+    *,
+    allow_fast: bool,
+    generate_docs: bool = True,
+) -> Table:
+    """Build the configuration-summary table from the gathered answers.
+
+    Generation rows are shown only when *generate_docs* is True, so an
+    index-only advanced run doesn't list knobs that never apply.
+    """
     summary = Table(box=None, padding=(0, 2), show_header=False)
     summary.add_column("Option", style="dim")
     summary.add_column("Value", style="bold")
+
+    # ── Indexing (always) ──────────────────────────────────────────────────
+    summary.add_row("Generate docs", "yes" if generate_docs else "no (index only)")
     summary.add_row("Skip tests", "yes" if result["skip_tests"] else "no")
     summary.add_row("Skip infra", "yes" if result["skip_infra"] else "no")
     if result["include_submodules"]:
         summary.add_row("Include submodules", "yes")
     summary.add_row("Commit limit", str(result["commit_limit"]))
     summary.add_row("Follow renames", "yes" if result["follow_renames"] else "no")
-    summary.add_row("Concurrency", str(result["concurrency"]))
-    if result.get("reasoning"):
-        summary.add_row("Reasoning", result["reasoning"])
-    summary.add_row("Embedder", result["embedder"])
     if allow_fast:
         summary.add_row("Run mode", result["run_mode"])
-        if result.get("tier1_top_n"):
-            summary.add_row("Full-LLM page cap", str(result["tier1_top_n"]))
     if patterns:
         if len(patterns) <= 5:
             summary.add_row("Exclude", ", ".join(patterns))
         else:
             # Bullet-list when many patterns — comma-joined wraps unreadably.
             summary.add_row("Exclude", "\n".join(f"• {p}" for p in patterns))
-    summary.add_row("Test run", "yes" if result["test_run"] else "no")
+
+    # ── Generation (docs only) ─────────────────────────────────────────────
+    if generate_docs:
+        summary.add_row("Concurrency", str(result["concurrency"]))
+        if result.get("reasoning"):
+            summary.add_row("Reasoning", result["reasoning"])
+        summary.add_row("Embedder", result["embedder"])
+        if result.get("wiki_style"):
+            summary.add_row("Wiki style", result["wiki_style"])
+        if allow_fast and result.get("tier1_top_n"):
+            summary.add_row("Full-LLM page cap", str(result["tier1_top_n"]))
+        summary.add_row("Onboarding", "yes" if result.get("onboarding", True) else "no")
+        summary.add_row(
+            "Harvest decisions", "yes" if result.get("harvest_decisions", True) else "no"
+        )
+        summary.add_row("Test run", "yes" if result["test_run"] else "no")
     return summary
 
 
@@ -328,16 +427,26 @@ def interactive_advanced_config(
     *,
     allow_fast: bool = False,
     prompt_reasoning: bool = True,
+    generate_docs: bool = True,
+    wiki_style: str | None = None,
 ) -> dict[str, Any]:
     """Prompt for advanced init options, grouped into logical sections.
 
     When *scan* is provided, uses it for smart defaults and contextual hints
     (file counts, suggested exclude patterns, etc.).
 
+    The indexing section (scope, run mode, exclude, git) is always prompted.
+    The generation section (concurrency, reasoning, embedder, onboarding,
+    decision harvesting, tiering, wiki style, test run) is prompted only when
+    *generate_docs* is True, so an index-only advanced run skips knobs that have
+    no effect. ``generate_docs`` is echoed back in the result.
+
     Returns a dict with keys matching init_command kwargs:
     ``commit_limit``, ``follow_renames``, ``skip_tests``, ``skip_infra``,
-    ``concurrency``, ``exclude``, ``test_run``, ``embedder``,
-    ``include_submodules``.
+    ``exclude``, ``include_submodules``, ``run_mode``, ``generate_docs`` (always),
+    plus ``concurrency``, ``reasoning``, ``embedder``, ``test_run``,
+    ``tier1_top_n``, ``onboarding``, ``harvest_decisions``, ``wiki_style`` (docs
+    only).
 
     Editor integration prompts are intentionally not asked here so that full and
     advanced modes stay aligned. Editor setup owns those prompts after mode
@@ -358,18 +467,23 @@ def interactive_advanced_config(
     _prompt_run_mode(console, result, allow_fast=allow_fast, is_large=is_large)
     patterns = _prompt_exclude(console, scan, result)
     _prompt_git(console, scan, result)
-    _prompt_generation(
-        console,
-        scan,
-        result,
-        allow_fast=allow_fast,
-        is_large=is_large,
-        prompt_reasoning=prompt_reasoning,
-    )
+    if generate_docs:
+        _prompt_generation(
+            console,
+            scan,
+            result,
+            allow_fast=allow_fast,
+            is_large=is_large,
+            prompt_reasoning=prompt_reasoning,
+            wiki_style=wiki_style,
+        )
+    result["generate_docs"] = generate_docs
 
     # ── Summary ───────────────────────────────────────────────────────────
     console.print()
-    summary = _build_summary_table(result, patterns, allow_fast=allow_fast)
+    summary = _build_summary_table(
+        result, patterns, allow_fast=allow_fast, generate_docs=generate_docs
+    )
     console.print(
         Panel(
             summary,

--- a/packages/core/src/repowise/core/pipeline/orchestrator.py
+++ b/packages/core/src/repowise/core/pipeline/orchestrator.py
@@ -186,7 +186,7 @@ async def run_pipeline(
     repo_path:
         Path to an already-cloned repository on disk.
     commit_depth:
-        Maximum commits to analyse per file (1-5000). Default 500.
+        Maximum commits to analyse per file (1-10000). Default 500.
     follow_renames:
         Use ``git log --follow`` to track files across renames.
     skip_tests:
@@ -225,7 +225,7 @@ async def run_pipeline(
     repo_path = Path(repo_path).resolve()
     start = time.monotonic()
 
-    commit_depth = max(1, min(commit_depth, 5000))
+    commit_depth = max(1, min(commit_depth, 10000))
 
     # Mode policy: FAST forces ESSENTIAL git indexing and disables doc
     # generation (and therefore all LLM calls). STANDARD preserves the

--- a/plugins/claude-code/commands/init.md
+++ b/plugins/claude-code/commands/init.md
@@ -83,7 +83,7 @@ Exclusions:
   --skip-infra           Skip infrastructure files (Dockerfile, Makefile, Terraform, shell)
 
 Git:
-  --commit-limit N       Max commits to analyze per file (default: 500, max: 5000)
+  --commit-limit N       Max commits to analyze per file (default: 500, max: 10000)
   --follow-renames       Track files across renames (slower but more accurate history)
 
 Output:

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -156,7 +156,7 @@ class TestInitIndexOnly:
 
         cfg = load_config(work_repo)
         assert cfg["exclude_patterns"] == ["vendor/"]
-        assert cfg["commit_limit"] == 5000  # 99999 clamped to the 5000 max
+        assert cfg["commit_limit"] == 10000  # 99999 clamped to the 10000 max
 
     def test_index_only_omits_excludes_when_none_given(self, runner, work_repo):
         from repowise.cli.helpers import load_config

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -245,7 +245,7 @@ class TestInitYesFlag:
                 return_value=fake_scan,
             ),
             patch(
-                "repowise.cli.commands.init_cmd.command._prompt_wiki_style",
+                "repowise.cli.commands.init_cmd.command.prompt_wiki_style",
                 side_effect=_fake_prompt_wiki_style,
             ),
             patch(

--- a/tests/unit/cli/test_ui_package.py
+++ b/tests/unit/cli/test_ui_package.py
@@ -12,6 +12,7 @@ import pytest
 import repowise.cli.ui as ui
 from repowise.cli.ui import mode_selection
 from repowise.cli.ui.repo_scanner import RepoScanInfo
+from repowise.core.generation.styles import DEFAULT_STYLE
 
 
 def test_facade_reexports_public_surface() -> None:
@@ -66,6 +67,7 @@ def _drive_advanced_config(
     *,
     scan: RepoScanInfo | None,
     allow_fast: bool,
+    generate_docs: bool = True,
 ) -> dict:
     """Run interactive_advanced_config with all prompts answered by their defaults."""
 
@@ -84,13 +86,14 @@ def _drive_advanced_config(
             pass
 
     return mode_selection.interactive_advanced_config(
-        _NullConsole(), scan=scan, allow_fast=allow_fast
+        _NullConsole(), scan=scan, allow_fast=allow_fast, generate_docs=generate_docs
     )
 
 
 def test_advanced_config_default_keys_no_fast(monkeypatch: pytest.MonkeyPatch) -> None:
     result = _drive_advanced_config(monkeypatch, scan=None, allow_fast=False)
     assert result == {
+        "generate_docs": True,
         "skip_tests": False,
         "skip_infra": False,
         "include_submodules": False,
@@ -102,8 +105,31 @@ def test_advanced_config_default_keys_no_fast(monkeypatch: pytest.MonkeyPatch) -
         "reasoning": "auto",
         "embedder": "mock",
         "test_run": False,
+        "onboarding": True,
+        "harvest_decisions": True,
         "tier1_top_n": None,
+        "wiki_style": DEFAULT_STYLE,
     }
+
+
+def test_advanced_config_index_only_omits_generation_keys(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """generate_docs=False gathers indexing knobs only — no LLM-only keys."""
+    result = _drive_advanced_config(monkeypatch, scan=None, allow_fast=False, generate_docs=False)
+    assert result == {
+        "generate_docs": False,
+        "skip_tests": False,
+        "skip_infra": False,
+        "include_submodules": False,
+        "run_mode": "standard",
+        "exclude": (),
+        "commit_limit": 500,
+        "follow_renames": False,
+    }
+    # The generation-only knobs must not appear.
+    for key in ("concurrency", "embedder", "onboarding", "harvest_decisions", "wiki_style"):
+        assert key not in result
 
 
 def test_advanced_config_allow_fast_small_repo(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

Reworks the three interactive `repowise init` modes so they're orthogonal and every setting is reachable, plus raises the `--commit-limit` cap.

### Interactive modes
- **Advanced** now leads with a **"Generate AI docs?"** toggle and splits into an **Indexing** section (always) and a **Generation** section (only when docs are on). This makes a *configured-but-index-only* run possible for the first time.
- **Index only** gains a **"Customize indexing?"** path (exclude patterns, commit limit, skip-tests/infra, submodules, fast mode) and now prompts for editor project files (CLAUDE.md / AGENTS.md / Codex), which it previously skipped entirely.
- **Full** gains a **"Customize?"** path into the same sections, converging modes 1 and 3. Menu wording updated from "Everything, with extra configuration".

### Newly surfaced settings
- `--onboarding/--no-onboarding` and `--harvest-decisions/--no-harvest-decisions` (both LLM-cost knobs) are now offered in the interactive Generation section, not just as flags.
- The wiki-style prompt moved inside the Generation section so it no longer trails the configuration summary panel.
- Onboarding / decision-harvesting are wired through the workspace advanced flow (previously asked-but-ignored there).

### Commit-limit cap
- Raised from **5000 to 10000** (default stays **500**) across the CLI clamps, the workspace clamp, the orchestrator clamp, help text, and docs.

### Docs
- `CLI_REFERENCE.md` gains an "Interactive modes" section and rows for `--coverage`, `--onboarding`, `--harvest-decisions`.
- Corrected the stale `--concurrency` default (documented as 5; code is 10).

## Testing
- `tests/unit/cli` (614) pass; updated `test_ui_package` characterization for the new dict shape (added an index-only subset case) and re-targeted the moved `prompt_wiki_style` patch.
- `tests/integration/test_cli.py` commit-limit clamp test updated to assert the 10000 cap.
- `ruff check` clean on all touched files.