### PR TITLE
release: v0.24.0 — refactoring intelligence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.24.0] — 2026-06-25
+
+### Added
+- **Refactoring intelligence: deterministic, graph-aware refactoring plans.** Code Health now derives concrete refactoring suggestions from the dependency graph and health biomarkers, with detectors for **Extract Class**, **Extract Helper**, **Move Method**, and **Break Cycle** (#586, #587, #588). Each suggestion is a ranked plan card carrying impact, effort, blast radius, and evidence, browsable in a new web Refactoring tab with file-first cards, a visual plan modal, and one-click agent export (#589, #590). Plans can optionally be turned into real code: opt-in LLM code generation produces a change from a deterministic plan, viewable in a side-by-side diff viewer (#592, #594).
+- **Airy Code Health overview with a Findings workbench.** The Code Health page was redesigned around a calmer overview and a dedicated Findings workbench for triaging biomarkers. (#593)
+- **Browsable Files page.** A new Files page lets you browse the repo's files directly, with a restyled table and dark-mode polish. (#591)
+- **`init` Advanced options.** `repowise init` gained an Advanced section with a docs toggle and a configurable index-only mode, and raised the commit-history cap. (#599)
+
+### Changed
+- **Large tables are virtualized.** A shared windowing primitive virtualizes large tables across the dashboard, keeping big repos responsive. (#598)
+
+### Fixed
+- **Execution-flow entry-point scores survive updates.** Incremental updates no longer wipe entry-point scores on the execution-flow graph. (#585)
+
+### Documentation
+- README and docs now lead with code health as a measure-locate-fix loop and document refactoring intelligence. (#595)
+- Plugin: version bump to 0.24.0.
+
+---
+
 ## [0.23.0] — 2026-06-23
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.24.0] — 2026-06-25
+
+### Added
+- **Refactoring intelligence: deterministic, graph-aware refactoring plans.** Code Health now derives concrete refactoring suggestions from the dependency graph and health biomarkers, with detectors for **Extract Class**, **Extract Helper**, **Move Method**, and **Break Cycle** (#586, #587, #588). Each suggestion is a ranked plan card carrying impact, effort, blast radius, and evidence, browsable in a new web Refactoring tab with file-first cards, a visual plan modal, and one-click agent export (#589, #590). Plans can optionally be turned into real code: opt-in LLM code generation produces a change from a deterministic plan, viewable in a side-by-side diff viewer (#592, #594).
+- **Airy Code Health overview with a Findings workbench.** The Code Health page was redesigned around a calmer overview and a dedicated Findings workbench for triaging biomarkers. (#593)
+- **Browsable Files page.** A new Files page lets you browse the repo's files directly, with a restyled table and dark-mode polish. (#591)
+- **`init` Advanced options.** `repowise init` gained an Advanced section with a docs toggle and a configurable index-only mode, and raised the commit-history cap. (#599)
+
+### Changed
+- **Large tables are virtualized.** A shared windowing primitive virtualizes large tables across the dashboard, keeping big repos responsive. (#598)
+
+### Fixed
+- **Execution-flow entry-point scores survive updates.** Incremental updates no longer wipe entry-point scores on the execution-flow graph. (#585)
+
+### Documentation
+- README and docs now lead with code health as a measure-locate-fix loop and document refactoring intelligence. (#595)
+- Plugin: version bump to 0.24.0.
+
+---
+
 ## [0.23.0] — 2026-06-23
 
 ### Added

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.24.0
+
+### Changed
+- Version bump to track the repowise 0.24.0 release. No command, skill, or MCP
+  tool-surface changes this cycle.
+
 ## 0.23.0
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.23.0"
+version = "0.24.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## release: v0.24.0 — refactoring intelligence

Bump-only release branch off latest `main`. The headline this cycle is **refactoring intelligence**: deterministic, graph-aware refactoring plans (Extract Class / Extract Helper / Move Method / Break Cycle) surfaced as ranked plan cards in a new web Refactoring tab, with opt-in LLM code generation and a diff viewer. Plus a redesigned Code Health overview, a browsable Files page, table virtualization, and `init` Advanced options.

### Changes in this branch
- Version bump to `0.24.0` across the four Python packages + both Claude Code plugin manifests
- `uv.lock` self-entry regenerated to `0.24.0`
- `docs/CHANGELOG.md` 0.24.0 section + bundled copy resynced
- Plugin `CHANGELOG.md` version entry

### Store format
Two new tables landed this cycle (`graph_node_membership`, `refactoring_suggestions`) but both are purely additive — `init_db()`'s `create_all` creates them on next open. No `STORE_FORMAT_VERSION` / `PARSER_SCHEMA_VERSION` bump, no migration entry needed.

### Test plan
- [x] Version drift grep clean (no `0.23.0` residue)
- [x] `uv build --wheel` — `repowise-0.24.0-py3-none-any.whl` built; commands + `.scm`/`.j2` present
- [x] `npm ci && npm run build --workspace packages/web` — all routes built, standalone `server.js` present, workspace code transpiled inline (HARD GATE, green)
- [x] Bundled changelog in sync with `docs/CHANGELOG.md`
- [ ] `repowise serve` browser smoke test (post-merge / hand-off)
- [ ] Tag `v0.24.0` on `main` after merge then `publish.yml`

**Merge convention: regular merge commit, NOT squash** so the tag points at a real merge commit on `main` for traceable artifact provenance.
