### PR TITLE
perf(ui): virtualize workspace tables and bound the DSM grid

### DIFF
--- a/packages/ui/__tests__/workspace/co-change-table.test.tsx
+++ b/packages/ui/__tests__/workspace/co-change-table.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { WorkspaceCoChangeEntry } from "@repowise-dev/types/workspace";
+import { CoChangeTable } from "../../src/workspace/co-change-table.js";
+
+function cc(
+  sourceRepo: string,
+  sourceFile: string,
+  targetRepo: string,
+  targetFile: string,
+  strength = 5,
+): WorkspaceCoChangeEntry {
+  return {
+    source_repo: sourceRepo,
+    source_file: sourceFile,
+    target_repo: targetRepo,
+    target_file: targetFile,
+    strength,
+    frequency: 3,
+    last_date: "2026-06-01",
+  };
+}
+
+describe("CoChangeTable (virtualized)", () => {
+  it("renders a row per co-change with repos and files", () => {
+    const rows = [
+      cc("api", "api/a.py", "core", "core/b.py", 8),
+      cc("ui", "ui/c.tsx", "core", "core/d.py", 2),
+    ];
+    render(<CoChangeTable coChanges={rows} />);
+    expect(screen.getByText("api/a.py")).toBeInTheDocument();
+    expect(screen.getByText("core/b.py")).toBeInTheDocument();
+    expect(screen.getByText("ui/c.tsx")).toBeInTheDocument();
+    expect(screen.getByText("core/d.py")).toBeInTheDocument();
+    expect(screen.getAllByText("core").length).toBeGreaterThan(0);
+  });
+
+  it("shows the frequency cell when not compact", () => {
+    render(<CoChangeTable coChanges={[cc("api", "a.py", "core", "b.py")]} />);
+    expect(screen.getByText("3x")).toBeInTheDocument();
+  });
+
+  it("hides the frequency cell when compact", () => {
+    render(<CoChangeTable coChanges={[cc("api", "a.py", "core", "b.py")]} compact />);
+    expect(screen.queryByText("3x")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no co-changes", () => {
+    render(<CoChangeTable coChanges={[]} />);
+    expect(screen.getByText(/no cross-repo co-changes/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/__tests__/workspace/contract-links-table.test.tsx
+++ b/packages/ui/__tests__/workspace/contract-links-table.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { WorkspaceContractLinkEntry } from "@repowise-dev/types/workspace";
+import { ContractLinksTable } from "../../src/workspace/contract-links-table.js";
+
+function link(
+  overrides: Partial<WorkspaceContractLinkEntry> = {},
+): WorkspaceContractLinkEntry {
+  return {
+    contract_id: "GET /users/{id}",
+    contract_type: "http",
+    match_type: "exact",
+    confidence: 0.9,
+    provider_repo: "users-api",
+    provider_file: "src/routes/users.ts",
+    provider_symbol: "getUser",
+    consumer_repo: "web-app",
+    consumer_file: "src/api/users-client.ts",
+    consumer_symbol: "fetchUser",
+    ...overrides,
+  };
+}
+
+describe("ContractLinksTable (virtualized)", () => {
+  it("renders a row per link with key cells", () => {
+    const links = [
+      link(),
+      link({
+        contract_id: "POST /orders",
+        provider_repo: "orders-api",
+        consumer_repo: "checkout",
+      }),
+    ];
+    render(<ContractLinksTable links={links} />);
+    expect(screen.getByText("GET /users/{id}")).toBeInTheDocument();
+    expect(screen.getByText("POST /orders")).toBeInTheDocument();
+    expect(screen.getByText("users-api")).toBeInTheDocument();
+    expect(screen.getByText("orders-api")).toBeInTheDocument();
+  });
+
+  it("renders the contract type badge and confidence percentage", () => {
+    render(<ContractLinksTable links={[link({ confidence: 0.75 })]} />);
+    expect(screen.getByText("HTTP")).toBeInTheDocument();
+    expect(screen.getByText("75%")).toBeInTheDocument();
+  });
+
+  it("shows the provider and consumer file paths", () => {
+    render(<ContractLinksTable links={[link()]} />);
+    expect(screen.getByText("src/routes/users.ts")).toBeInTheDocument();
+    expect(screen.getByText("src/api/users-client.ts")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no links", () => {
+    render(<ContractLinksTable links={[]} />);
+    expect(
+      screen.getByText(/no matched contract links/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/ui/__tests__/workspace/dsm-matrix.test.tsx
+++ b/packages/ui/__tests__/workspace/dsm-matrix.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { DsmCell, DsmMatrix } from "@repowise-dev/types";
+import { DsmMatrixView } from "../../src/workspace/dsm/dsm-matrix";
+
+// Must mirror the named constant in dsm-matrix.tsx.
+const DSM_RENDER_BUDGET = 60;
+
+function cell(from: string, to: string, present: boolean): DsmCell {
+  return {
+    from_id: from,
+    to_id: to,
+    present,
+    kind: present ? "http" : null,
+    edge_ids: present ? [`${from}->${to}`] : [],
+    violation: false,
+    cycle: false,
+  };
+}
+
+/**
+ * Build an n×n matrix. `presentPairs` is a set of "i,j" row→col indices that
+ * are present; everything else is empty. Services are labelled `svc-<i>`.
+ */
+function matrix(n: number, presentPairs: Set<string> = new Set()): DsmMatrix {
+  const axis = Array.from({ length: n }, (_, i) => `svc-${i}`);
+  const labels = axis.slice();
+  const cells = axis.map((from, i) =>
+    axis.map((to, j) => cell(from, to, presentPairs.has(`${i},${j}`))),
+  );
+  return { axis, labels, cells };
+}
+
+describe("DsmMatrixView render budget", () => {
+  it("renders every axis label when n is under the budget", () => {
+    const n = 5;
+    render(<DsmMatrixView matrix={matrix(n)} />);
+    // Each service appears as both a row header and a column header.
+    for (let i = 0; i < n; i += 1) {
+      expect(screen.getAllByText(`svc-${i}`).length).toBeGreaterThanOrEqual(2);
+    }
+    // No "showing top" indicator under the budget.
+    expect(screen.queryByText(/showing top/i)).not.toBeInTheDocument();
+  });
+
+  it("budgets to the most-connected services when n exceeds the budget", () => {
+    const n = DSM_RENDER_BUDGET + 10; // 70 services
+    // Make the LAST `DSM_RENDER_BUDGET` services the high-degree ones by giving
+    // each of them an out-edge to the next, so the first 10 (svc-0..svc-9) have
+    // degree 0 and must be dropped.
+    const present = new Set<string>();
+    for (let i = n - DSM_RENDER_BUDGET; i < n - 1; i += 1) {
+      present.add(`${i},${i + 1}`); // svc-i depends on svc-(i+1)
+    }
+    render(<DsmMatrixView matrix={matrix(n, present)} />);
+
+    // The grid is bounded to (DSM_RENDER_BUDGET)² gridcells.
+    expect(screen.getAllByRole("gridcell")).toHaveLength(
+      DSM_RENDER_BUDGET * DSM_RENDER_BUDGET,
+    );
+
+    // The "showing top N of M" indicator is present with full M.
+    expect(
+      screen.getByText(
+        new RegExp(`showing top ${DSM_RENDER_BUDGET} of ${n} services`, "i"),
+      ),
+    ).toBeInTheDocument();
+
+    // The high-degree services (svc-10..svc-69) are kept; the zero-degree ones
+    // (svc-0..svc-9) are dropped.
+    expect(screen.getAllByText("svc-69").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("svc-10").length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText("svc-0")).not.toBeInTheDocument();
+    expect(screen.queryByText("svc-9")).not.toBeInTheDocument();
+
+    // The "services" summary reflects the FULL matrix (M), not the budget.
+    expect(screen.getByText(String(n))).toBeInTheDocument();
+  });
+});

--- a/packages/ui/__tests__/workspace/package-deps-table.test.tsx
+++ b/packages/ui/__tests__/workspace/package-deps-table.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { WorkspacePackageDepEntry } from "@repowise-dev/types/workspace";
+import { PackageDepsTable } from "../../src/workspace/package-deps-table.js";
+
+function dep(
+  overrides: Partial<WorkspacePackageDepEntry> = {},
+): WorkspacePackageDepEntry {
+  return {
+    source_repo: "web-app",
+    source_manifest: "package.json",
+    target_repo: "shared-lib",
+    target_package: "@acme/shared",
+    kind: "dependency",
+    ...overrides,
+  };
+}
+
+describe("PackageDepsTable (virtualized)", () => {
+  it("renders a row per dependency with key cells", () => {
+    const deps = [
+      dep(),
+      dep({
+        source_repo: "api",
+        source_manifest: "pyproject.toml",
+        target_repo: "core",
+        kind: "devDependency",
+      }),
+    ];
+    render(<PackageDepsTable deps={deps} />);
+    expect(screen.getByText("web-app")).toBeInTheDocument();
+    expect(screen.getByText("shared-lib")).toBeInTheDocument();
+    expect(screen.getByText("package.json")).toBeInTheDocument();
+    expect(screen.getByText("dependency")).toBeInTheDocument();
+    expect(screen.getByText("pyproject.toml")).toBeInTheDocument();
+    expect(screen.getByText("devDependency")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no deps", () => {
+    render(<PackageDepsTable deps={[]} />);
+    expect(
+      screen.getByText(/no cross-repo package dependencies/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/ui/__tests__/workspace/repo-pair-table.test.tsx
+++ b/packages/ui/__tests__/workspace/repo-pair-table.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RepoPairTable, type RepoPairSummary } from "../../src/workspace/repo-pair-table.js";
+
+function pair(
+  repo1: string,
+  repo2: string,
+  filePairCount = 4,
+  maxStrength = 6,
+): RepoPairSummary {
+  return {
+    id: `${repo1}↔${repo2}`,
+    repo1,
+    repo2,
+    filePairCount,
+    maxStrength,
+    lastDate: "2026-06-01",
+  };
+}
+
+describe("RepoPairTable (virtualized)", () => {
+  it("renders a row per pair with both repo names and the file-pair count", () => {
+    const rows = [pair("api", "core", 7), pair("ui", "core", 2)];
+    render(<RepoPairTable repoPairs={rows} />);
+    expect(screen.getByText("api")).toBeInTheDocument();
+    expect(screen.getByText("ui")).toBeInTheDocument();
+    expect(screen.getAllByText("core").length).toBe(2);
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("invokes onSelectPair when a row is clicked", () => {
+    const onSelect = vi.fn();
+    render(<RepoPairTable repoPairs={[pair("api", "core")]} onSelectPair={onSelect} />);
+    fireEvent.click(screen.getByText("api"));
+    expect(onSelect).toHaveBeenCalledWith("api↔core");
+  });
+
+  it("shows the empty state when there are no pairs", () => {
+    render(<RepoPairTable repoPairs={[]} />);
+    expect(screen.getByText(/no repository pairs/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/workspace/co-change-table.tsx
+++ b/packages/ui/src/workspace/co-change-table.tsx
@@ -2,10 +2,7 @@
 
 import { Badge } from "../ui/badge";
 import { EmptyState } from "../shared/empty-state";
-import {
-  ResponsiveTable,
-  type ResponsiveColumn,
-} from "../shared/responsive-table";
+import { VirtualizedTable } from "../shared/virtualized-table";
 import type { WorkspaceCoChangeEntry } from "@repowise-dev/types/workspace";
 
 interface CoChangeTableProps {
@@ -13,50 +10,69 @@ interface CoChangeTableProps {
   compact?: boolean;
 }
 
+// Column-priority hide classes, mirroring the shared ResponsiveTable scale:
+// priority 2 hides below md (768px), priority 3 hides below lg (1024px). The
+// source/target identity columns (priority 1) are always visible.
+const HIDE_BELOW_MD = "max-md:hidden";
+const HIDE_BELOW_LG = "max-lg:hidden";
+
+/**
+ * Cross-repo co-change list: one row per file pair that changed together.
+ *
+ * The body is virtualized (windowed `<tbody>`) so long co-change lists stay
+ * cheap to render; below the wrapper's threshold every row renders, so the
+ * common short list behaves exactly as a plain table.
+ */
 export function CoChangeTable({ coChanges, compact }: CoChangeTableProps) {
-  const columns: ResponsiveColumn<WorkspaceCoChangeEntry>[] = [
-    {
-      key: "source",
-      header: "Source",
-      priority: 1,
-      cellClassName: "min-w-[160px] max-w-[280px]",
-      render: (cc) => (
-        <div className="flex flex-col gap-0.5">
-          <Badge variant="default" className="w-fit text-xs">{cc.source_repo}</Badge>
-          <span className="text-xs font-mono text-[var(--color-text-secondary)] truncate block" title={cc.source_file}>
-            {cc.source_file}
-          </span>
-        </div>
-      ),
-    },
-    {
-      key: "target",
-      header: "Target",
-      priority: 1,
-      cellClassName: "min-w-[160px] max-w-[280px]",
-      render: (cc) => (
-        <div className="flex flex-col gap-0.5">
-          <Badge variant="default" className="w-fit text-xs">{cc.target_repo}</Badge>
-          <span className="text-xs font-mono text-[var(--color-text-secondary)] truncate block" title={cc.target_file}>
-            {cc.target_file}
-          </span>
-        </div>
-      ),
-    },
-    {
-      key: "strength",
-      header: (
+  if (coChanges.length === 0) {
+    return (
+      <EmptyState
+        title="No cross-repo co-changes"
+        description="No files in sibling repos have changed together yet."
+      />
+    );
+  }
+
+  const header = (
+    <tr className="bg-[var(--color-bg-elevated)] text-[var(--color-text-tertiary)] text-xs uppercase tracking-wider">
+      <th className="px-3 py-2 text-left font-medium">Source</th>
+      <th className="px-3 py-2 text-left font-medium">Target</th>
+      <th className={`px-3 py-2 text-left font-medium w-32 ${HIDE_BELOW_MD}`}>
         <span
           title="Relative, recency-weighted frequency of same-author commits across these repos. Higher means more or more-recent shared activity. It is not a percentage or a verified dependency."
           className="cursor-help underline decoration-dotted underline-offset-2"
         >
           Strength
         </span>
-      ),
-      mobileLabel: "Strength",
-      priority: 2,
-      headerClassName: "w-32",
-      render: (cc) => (
+      </th>
+      {compact ? null : (
+        <>
+          <th className={`px-3 py-2 text-right font-medium ${HIDE_BELOW_LG}`}>Freq</th>
+          <th className={`px-3 py-2 text-left font-medium ${HIDE_BELOW_LG}`}>Last</th>
+        </>
+      )}
+    </tr>
+  );
+
+  const renderRow = (cc: WorkspaceCoChangeEntry) => (
+    <tr className="border-t border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)]">
+      <td className="px-3 py-2 text-left min-w-[160px] max-w-[280px]">
+        <div className="flex flex-col gap-0.5">
+          <Badge variant="default" className="w-fit text-xs">{cc.source_repo}</Badge>
+          <span className="text-xs font-mono text-[var(--color-text-secondary)] truncate block" title={cc.source_file}>
+            {cc.source_file}
+          </span>
+        </div>
+      </td>
+      <td className="px-3 py-2 text-left min-w-[160px] max-w-[280px]">
+        <div className="flex flex-col gap-0.5">
+          <Badge variant="default" className="w-fit text-xs">{cc.target_repo}</Badge>
+          <span className="text-xs font-mono text-[var(--color-text-secondary)] truncate block" title={cc.target_file}>
+            {cc.target_file}
+          </span>
+        </div>
+      </td>
+      <td className={`px-3 py-2 text-left ${HIDE_BELOW_MD}`}>
         <div className="flex items-center gap-2 min-w-[90px]">
           <div className="h-1.5 flex-1 rounded-full bg-[var(--color-bg-inset)] overflow-hidden">
             <div
@@ -68,46 +84,29 @@ export function CoChangeTable({ coChanges, compact }: CoChangeTableProps) {
             {Math.round(cc.strength * 10) / 10}
           </span>
         </div>
-      ),
-      mobileRender: (cc) => Math.round(cc.strength * 10) / 10,
-    },
-    ...(compact
-      ? []
-      : ([
-          {
-            key: "frequency",
-            header: "Freq",
-            align: "right",
-            priority: 3,
-            cellClassName: "text-xs text-[var(--color-text-secondary)] tabular-nums",
-            render: (cc) => `${cc.frequency}x`,
-          },
-          {
-            key: "last",
-            header: "Last",
-            priority: 3,
-            cellClassName: "text-xs text-[var(--color-text-tertiary)]",
-            render: (cc) => (
-              <span title={cc.last_date ? new Date(cc.last_date).toLocaleString() : undefined}>
-                {cc.last_date ? new Date(cc.last_date).toLocaleDateString() : "—"}
-              </span>
-            ),
-          },
-        ] satisfies ResponsiveColumn<WorkspaceCoChangeEntry>[])),
-  ];
+      </td>
+      {compact ? null : (
+        <>
+          <td className={`px-3 py-2 text-right text-xs text-[var(--color-text-secondary)] tabular-nums ${HIDE_BELOW_LG}`}>
+            {`${cc.frequency}x`}
+          </td>
+          <td className={`px-3 py-2 text-left text-xs text-[var(--color-text-tertiary)] ${HIDE_BELOW_LG}`}>
+            <span title={cc.last_date ? new Date(cc.last_date).toLocaleString() : undefined}>
+              {cc.last_date ? new Date(cc.last_date).toLocaleDateString() : "—"}
+            </span>
+          </td>
+        </>
+      )}
+    </tr>
+  );
 
   return (
-    <ResponsiveTable
-      columns={columns}
+    <VirtualizedTable<WorkspaceCoChangeEntry>
       rows={coChanges}
       rowKey={(cc) => `${cc.source_repo}|${cc.source_file}|${cc.target_repo}|${cc.target_file}`}
-      bare
-      empty={
-        <EmptyState
-          title="No cross-repo co-changes"
-          description="No files in sibling repos have changed together yet."
-        />
-      }
+      header={header}
+      renderRow={renderRow}
+      aria-label="Cross-repo co-changed files"
     />
   );
 }

--- a/packages/ui/src/workspace/contract-links-table.tsx
+++ b/packages/ui/src/workspace/contract-links-table.tsx
@@ -2,121 +2,111 @@
 
 import { ContractTypeBadge } from "./contract-type-badge";
 import { EmptyState } from "../shared/empty-state";
-import {
-  ResponsiveTable,
-  type ResponsiveColumn,
-} from "../shared/responsive-table";
+import { VirtualizedTable } from "../shared/virtualized-table";
 import type { WorkspaceContractLinkEntry } from "@repowise-dev/types/workspace";
 
 interface ContractLinksTableProps {
   links: WorkspaceContractLinkEntry[];
 }
 
-const COLUMNS: ResponsiveColumn<WorkspaceContractLinkEntry>[] = [
-  {
-    key: "contract",
-    header: "Contract",
-    priority: 1,
-    cellClassName: "min-w-[140px] max-w-[280px]",
-    render: (link) => (
-      <span
-        className="text-xs font-mono text-[var(--color-text-secondary)] [overflow-wrap:anywhere]"
-        title={link.contract_id}
-      >
-        {link.contract_id}
-      </span>
-    ),
-  },
-  {
-    key: "type",
-    header: "Type",
-    priority: 2,
-    render: (link) => <ContractTypeBadge type={link.contract_type} />,
-  },
-  {
-    key: "provider",
-    header: "Provider",
-    priority: 1,
-    render: (link) => (
-      <div className="flex flex-col gap-0.5">
-        <span className="text-xs font-medium text-[var(--color-text-primary)]">
-          {link.provider_repo}
-        </span>
-        <span
-          className="text-xs font-mono text-[var(--color-text-tertiary)] truncate min-w-[140px] max-w-[260px] block"
-          title={link.provider_file}
-        >
-          {link.provider_file}
-        </span>
-      </div>
-    ),
-    mobileRender: (link) => link.provider_repo,
-  },
-  {
-    key: "consumer",
-    header: "Consumer",
-    priority: 2,
-    render: (link) => (
-      <div className="flex flex-col gap-0.5">
-        <span className="text-xs font-medium text-[var(--color-text-primary)]">
-          {link.consumer_repo}
-        </span>
-        <span
-          className="text-xs font-mono text-[var(--color-text-tertiary)] truncate min-w-[140px] max-w-[260px] block"
-          title={link.consumer_file}
-        >
-          {link.consumer_file}
-        </span>
-      </div>
-    ),
-    mobileRender: (link) => link.consumer_repo,
-  },
-  {
-    key: "confidence",
-    header: "Confidence",
-    mobileLabel: "Conf",
-    priority: 3,
-    headerClassName: "w-20",
-    render: (link) => (
-      <div className="flex items-center gap-1.5">
-        <div className="h-1.5 w-12 rounded-full bg-[var(--color-bg-inset)] overflow-hidden">
-          <div
-            className="h-full rounded-full transition-all"
-            style={{
-              width: `${Math.round(link.confidence * 100)}%`,
-              backgroundColor:
-                link.confidence >= 0.8
-                  ? "var(--color-confidence-fresh)"
-                  : link.confidence >= 0.6
-                  ? "var(--color-confidence-stale)"
-                  : "var(--color-confidence-outdated)",
-            }}
-          />
-        </div>
-        <span className="text-xs text-[var(--color-text-tertiary)] tabular-nums">
-          {Math.round(link.confidence * 100)}%
-        </span>
-      </div>
-    ),
-    mobileRender: (link) => `${Math.round(link.confidence * 100)}%`,
-  },
-];
+// Column-priority hide classes, mirroring the shared ResponsiveTable scale:
+// priority 2 hides below md (768px), priority 3 hides below lg (1024px). The
+// always-visible columns (priority 1) carry no hide class.
+const HIDE_BELOW_MD = "max-md:hidden";
+const HIDE_BELOW_LG = "max-lg:hidden";
 
 export function ContractLinksTable({ links }: ContractLinksTableProps) {
+  if (links.length === 0) {
+    return (
+      <EmptyState
+        title="No matched contract links"
+        description="No API contracts link providers and consumers across these repos yet."
+      />
+    );
+  }
+
+  const header = (
+    <tr className="bg-[var(--color-bg-elevated)] text-[var(--color-text-tertiary)] text-xs uppercase tracking-wider">
+      <th className="px-3 py-2 text-left font-medium">Contract</th>
+      <th className={`px-3 py-2 text-left font-medium ${HIDE_BELOW_MD}`}>Type</th>
+      <th className="px-3 py-2 text-left font-medium">Provider</th>
+      <th className={`px-3 py-2 text-left font-medium ${HIDE_BELOW_MD}`}>Consumer</th>
+      <th className={`px-3 py-2 text-left font-medium w-20 ${HIDE_BELOW_LG}`}>Confidence</th>
+    </tr>
+  );
+
+  const renderRow = (link: WorkspaceContractLinkEntry) => (
+    <tr className="border-t border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)]">
+      <td className="px-3 py-2 text-left min-w-[140px] max-w-[280px]">
+        <span
+          className="text-xs font-mono text-[var(--color-text-secondary)] [overflow-wrap:anywhere]"
+          title={link.contract_id}
+        >
+          {link.contract_id}
+        </span>
+      </td>
+      <td className={`px-3 py-2 text-left ${HIDE_BELOW_MD}`}>
+        <ContractTypeBadge type={link.contract_type} />
+      </td>
+      <td className="px-3 py-2 text-left">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-xs font-medium text-[var(--color-text-primary)]">
+            {link.provider_repo}
+          </span>
+          <span
+            className="text-xs font-mono text-[var(--color-text-tertiary)] truncate min-w-[140px] max-w-[260px] block"
+            title={link.provider_file}
+          >
+            {link.provider_file}
+          </span>
+        </div>
+      </td>
+      <td className={`px-3 py-2 text-left ${HIDE_BELOW_MD}`}>
+        <div className="flex flex-col gap-0.5">
+          <span className="text-xs font-medium text-[var(--color-text-primary)]">
+            {link.consumer_repo}
+          </span>
+          <span
+            className="text-xs font-mono text-[var(--color-text-tertiary)] truncate min-w-[140px] max-w-[260px] block"
+            title={link.consumer_file}
+          >
+            {link.consumer_file}
+          </span>
+        </div>
+      </td>
+      <td className={`px-3 py-2 text-left w-20 ${HIDE_BELOW_LG}`}>
+        <div className="flex items-center gap-1.5">
+          <div className="h-1.5 w-12 rounded-full bg-[var(--color-bg-inset)] overflow-hidden">
+            <div
+              className="h-full rounded-full transition-all"
+              style={{
+                width: `${Math.round(link.confidence * 100)}%`,
+                backgroundColor:
+                  link.confidence >= 0.8
+                    ? "var(--color-confidence-fresh)"
+                    : link.confidence >= 0.6
+                    ? "var(--color-confidence-stale)"
+                    : "var(--color-confidence-outdated)",
+              }}
+            />
+          </div>
+          <span className="text-xs text-[var(--color-text-tertiary)] tabular-nums">
+            {Math.round(link.confidence * 100)}%
+          </span>
+        </div>
+      </td>
+    </tr>
+  );
+
   return (
-    <ResponsiveTable
-      columns={COLUMNS}
+    <VirtualizedTable<WorkspaceContractLinkEntry>
       rows={links}
       rowKey={(link) =>
         `${link.contract_id}|${link.provider_repo}|${link.provider_file}|${link.consumer_repo}|${link.consumer_file}`
       }
-      bare
-      empty={
-        <EmptyState
-          title="No matched contract links"
-          description="No API contracts link providers and consumers across these repos yet."
-        />
-      }
+      header={header}
+      renderRow={renderRow}
+      aria-label="Cross-repo contract links"
     />
   );
 }

--- a/packages/ui/src/workspace/dsm/dsm-matrix.tsx
+++ b/packages/ui/src/workspace/dsm/dsm-matrix.tsx
@@ -31,6 +31,51 @@ export interface DsmMatrixViewProps {
 const CELL = 30;
 const HEADER = 150;
 
+/**
+ * Max services rendered per axis. The grid is a single flat CSS grid of
+ * `(n+1)²` cells — for large `n` that is tens of thousands of DOM nodes. Above
+ * this threshold we render only the top-N most-connected services on both axes
+ * (a render budget, mirroring the hosted system-map node budget) so the grid is
+ * bounded to `(N+1)²` cells. The counts strip still summarises the full matrix.
+ */
+const DSM_RENDER_BUDGET = 60;
+
+/**
+ * Slice `matrix` down to the `DSM_RENDER_BUDGET` most-connected services on both
+ * axes when it exceeds the budget. Degree = present cells in a service's row
+ * (out-degree) + present cells in its column (in-degree); ties break by original
+ * axis order for determinism. The sliced `cells[i][j]` still means
+ * selected-service-i depends on selected-service-j, so diagonal detection
+ * (`i === j`) and role lookup via the sliced `axis[j]` stay correct.
+ */
+function budgetMatrix(matrix: DsmMatrix): { matrix: DsmMatrix; total: number } {
+  const total = matrix.axis.length;
+  if (total <= DSM_RENDER_BUDGET) return { matrix, total };
+
+  const degree = new Array<number>(total).fill(0);
+  for (let i = 0; i < total; i += 1) {
+    const row = matrix.cells[i] ?? [];
+    for (let j = 0; j < total; j += 1) {
+      if (row[j]?.present) {
+        degree[i] = (degree[i] ?? 0) + 1; // out-degree (row i)
+        degree[j] = (degree[j] ?? 0) + 1; // in-degree (column j)
+      }
+    }
+  }
+
+  // Top-N by degree, tie-broken by original axis order (stable index ascending).
+  const selected = Array.from({ length: total }, (_, idx) => idx)
+    .sort((a, b) => (degree[b] ?? 0) - (degree[a] ?? 0) || a - b)
+    .slice(0, DSM_RENDER_BUDGET)
+    .sort((a, b) => a - b); // restore original axis order among the kept ones
+
+  const axis = selected.map((idx) => matrix.axis[idx] ?? "");
+  const labels = selected.map((idx) => matrix.labels[idx] ?? "");
+  const cells = selected.map((i) => selected.map((j) => matrix.cells[i]![j]!));
+
+  return { matrix: { axis, labels, cells }, total };
+}
+
 function cellBackground(cell: DsmCell, isDiagonal: boolean, role?: NodeRole): string {
   if (isDiagonal) {
     // The diagonal is a service vs itself — repurpose it to surface the
@@ -74,6 +119,11 @@ export function DsmMatrixView({ matrix, metrics, onSelectCell }: DsmMatrixViewPr
     return m;
   }, [metrics]);
 
+  // The grid renders from the budgeted matrix; the counts strip above stays on
+  // the full matrix (it is a data summary, not a view of what's drawn).
+  const { matrix: view, total } = useMemo(() => budgetMatrix(matrix), [matrix]);
+  const budgeted = total > view.axis.length;
+
   if (matrix.axis.length === 0) {
     return (
       <EmptyState
@@ -83,7 +133,7 @@ export function DsmMatrixView({ matrix, metrics, onSelectCell }: DsmMatrixViewPr
     );
   }
 
-  const n = matrix.axis.length;
+  const n = view.axis.length;
 
   return (
     <div>
@@ -97,12 +147,20 @@ export function DsmMatrixView({ matrix, metrics, onSelectCell }: DsmMatrixViewPr
         }}
       >
         <span>
-          <strong style={{ color: "var(--color-text-secondary)" }}>{n}</strong> services
+          <strong style={{ color: "var(--color-text-secondary)" }}>{total}</strong> services
         </span>
         <span>
           <strong style={{ color: "var(--color-text-secondary)" }}>{counts.present}</strong>{" "}
           dependencies
         </span>
+        {budgeted && (
+          <span
+            title="The matrix is capped for readability and rendering cost; the most-connected services are shown."
+            style={{ fontSize: 12, color: "var(--color-text-tertiary)" }}
+          >
+            showing top {n} of {total} services by connectivity
+          </span>
+        )}
         {metrics && (
           <span title="Deterministic 1-10 architecture score (higher = lower coupling)">
             score <strong style={{ color: "var(--color-text-secondary)" }}>{metrics.score.toFixed(1)}</strong>
@@ -142,10 +200,10 @@ export function DsmMatrixView({ matrix, metrics, onSelectCell }: DsmMatrixViewPr
         >
           {/* Top-left corner + column headers */}
           <div style={{ position: "sticky", left: 0, zIndex: 2, background: "var(--color-bg-canvas)" }} />
-          {matrix.labels.map((label, j) => (
+          {view.labels.map((label, j) => (
             <div
-              key={`col-${matrix.axis[j]}`}
-              title={matrix.axis[j]}
+              key={`col-${view.axis[j]}`}
+              title={view.axis[j]}
               style={{
                 height: HEADER,
                 display: "flex",
@@ -168,14 +226,14 @@ export function DsmMatrixView({ matrix, metrics, onSelectCell }: DsmMatrixViewPr
           ))}
 
           {/* Rows */}
-          {matrix.cells.map((row, i) => (
+          {view.cells.map((row, i) => (
             <RowCells
-              key={`row-${matrix.axis[i]}`}
+              key={`row-${view.axis[i]}`}
               i={i}
               row={row}
-              label={matrix.labels[i] ?? ""}
-              axisId={matrix.axis[i] ?? ""}
-              axis={matrix.axis}
+              label={view.labels[i] ?? ""}
+              axisId={view.axis[i] ?? ""}
+              axis={view.axis}
               rolesByNodeId={rolesByNodeId}
               hover={hover}
               onHover={setHover}

--- a/packages/ui/src/workspace/package-deps-table.tsx
+++ b/packages/ui/src/workspace/package-deps-table.tsx
@@ -1,71 +1,74 @@
+"use client";
+
 import { Badge } from "../ui/badge";
 import { EmptyState } from "../shared/empty-state";
-import {
-  ResponsiveTable,
-  type ResponsiveColumn,
-} from "../shared/responsive-table";
+import { VirtualizedTable } from "../shared/virtualized-table";
 import type { WorkspacePackageDepEntry } from "@repowise-dev/types/workspace";
 
 interface PackageDepsTableProps {
   deps: WorkspacePackageDepEntry[];
 }
 
-const COLUMNS: ResponsiveColumn<WorkspacePackageDepEntry>[] = [
-  {
-    key: "source",
-    header: "Source",
-    priority: 1,
-    render: (d) => (
-      <Badge variant="default" className="text-xs">
-        {d.source_repo}
-      </Badge>
-    ),
-  },
-  {
-    key: "target",
-    header: "Target",
-    priority: 1,
-    render: (d) => (
-      <Badge variant="default" className="text-xs">
-        {d.target_repo}
-      </Badge>
-    ),
-  },
-  {
-    key: "manifest",
-    header: "Manifest",
-    priority: 2,
-    cellClassName: "font-mono text-xs text-[var(--color-text-secondary)] max-w-[280px]",
-    render: (d) => (
-      <span className="block truncate" title={d.source_manifest}>
-        {d.source_manifest}
-      </span>
-    ),
-  },
-  {
-    key: "kind",
-    header: "Kind",
-    priority: 2,
-    cellClassName: "text-xs text-[var(--color-text-secondary)]",
-    render: (d) => d.kind,
-  },
-];
+// Column-priority hide classes, mirroring the shared ResponsiveTable scale:
+// priority 2 hides below md (768px), priority 3 hides below lg (1024px). The
+// always-visible columns (priority 1) carry no hide class.
+const HIDE_BELOW_MD = "max-md:hidden";
 
 export function PackageDepsTable({ deps }: PackageDepsTableProps) {
+  if (deps.length === 0) {
+    return (
+      <EmptyState
+        title="No cross-repo package dependencies"
+        description="No manifest in this workspace depends on a sibling repo's package."
+      />
+    );
+  }
+
+  const header = (
+    <tr className="bg-[var(--color-bg-elevated)] text-[var(--color-text-tertiary)] text-xs uppercase tracking-wider">
+      <th className="px-3 py-2 text-left font-medium">Source</th>
+      <th className="px-3 py-2 text-left font-medium">Target</th>
+      <th className={`px-3 py-2 text-left font-medium ${HIDE_BELOW_MD}`}>Manifest</th>
+      <th className={`px-3 py-2 text-left font-medium ${HIDE_BELOW_MD}`}>Kind</th>
+    </tr>
+  );
+
+  const renderRow = (d: WorkspacePackageDepEntry) => (
+    <tr className="border-t border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)]">
+      <td className="px-3 py-2 text-left">
+        <Badge variant="default" className="text-xs">
+          {d.source_repo}
+        </Badge>
+      </td>
+      <td className="px-3 py-2 text-left">
+        <Badge variant="default" className="text-xs">
+          {d.target_repo}
+        </Badge>
+      </td>
+      <td
+        className={`px-3 py-2 text-left font-mono text-xs text-[var(--color-text-secondary)] max-w-[280px] ${HIDE_BELOW_MD}`}
+      >
+        <span className="block truncate" title={d.source_manifest}>
+          {d.source_manifest}
+        </span>
+      </td>
+      <td
+        className={`px-3 py-2 text-left text-xs text-[var(--color-text-secondary)] ${HIDE_BELOW_MD}`}
+      >
+        {d.kind}
+      </td>
+    </tr>
+  );
+
   return (
-    <ResponsiveTable
-      columns={COLUMNS}
+    <VirtualizedTable<WorkspacePackageDepEntry>
       rows={deps}
       rowKey={(d) =>
         `${d.source_repo}|${d.target_repo}|${d.source_manifest}|${d.kind}`
       }
-      bare
-      empty={
-        <EmptyState
-          title="No cross-repo package dependencies"
-          description="No manifest in this workspace depends on a sibling repo's package."
-        />
-      }
+      header={header}
+      renderRow={renderRow}
+      aria-label="Cross-repo package dependencies"
     />
   );
 }

--- a/packages/ui/src/workspace/repo-pair-table.tsx
+++ b/packages/ui/src/workspace/repo-pair-table.tsx
@@ -2,10 +2,7 @@
 
 import { Badge } from "../ui/badge";
 import { EmptyState } from "../shared/empty-state";
-import {
-  ResponsiveTable,
-  type ResponsiveColumn,
-} from "../shared/responsive-table";
+import { VirtualizedTable } from "../shared/virtualized-table";
 import { ChevronRight } from "lucide-react";
 
 export interface RepoPairSummary {
@@ -23,88 +20,93 @@ interface RepoPairTableProps {
   selectedPairId?: string | null;
 }
 
+// Column-priority hide classes, mirroring the shared ResponsiveTable scale:
+// priority 2 hides below md (768px), priority 3 hides below lg (1024px). The
+// pair identity, max-strength and action columns (priority 1) stay visible.
+const HIDE_BELOW_MD = "max-md:hidden";
+const HIDE_BELOW_LG = "max-lg:hidden";
+
+/**
+ * Cross-repo pair summary: one row per repository pair, click to drill in.
+ *
+ * The body is virtualized (windowed `<tbody>`) so long pair lists stay cheap to
+ * render; below the wrapper's threshold every row renders, so the common short
+ * list behaves exactly as a plain table.
+ */
 export function RepoPairTable({ repoPairs, onSelectPair, selectedPairId }: RepoPairTableProps) {
-  const columns: ResponsiveColumn<RepoPairSummary>[] = [
-    {
-      key: "pair",
-      header: "Repository Pair",
-      priority: 1,
-      render: (p) => (
-        <div className="flex items-center gap-2">
-          <Badge variant="default" className="text-xs">{p.repo1}</Badge>
-          <span className="text-[var(--color-text-tertiary)] text-xs">↔</span>
-          <Badge variant="default" className="text-xs">{p.repo2}</Badge>
-        </div>
-      ),
-    },
-    {
-      key: "count",
-      header: "File Pairs",
-      priority: 2,
-      align: "right",
-      cellClassName: "text-xs text-[var(--color-text-secondary)] tabular-nums",
-      render: (p) => p.filePairCount,
-    },
-    {
-      key: "strength",
-      header: "Max Strength",
-      priority: 1,
-      headerClassName: "w-32",
-      render: (p) => (
-        <div className="flex items-center gap-2 min-w-[90px]">
-          <div className="h-1.5 flex-1 rounded-full bg-[var(--color-bg-inset)] overflow-hidden">
-            <div
-              className="h-full rounded-full bg-[var(--color-accent-primary)] transition-all"
-              style={{ width: `${Math.min(Math.round(p.maxStrength * 10), 100)}%` }}
-            />
+  if (repoPairs.length === 0) {
+    return (
+      <EmptyState
+        title="No repository pairs"
+        description="No cross-repository co-changes found."
+      />
+    );
+  }
+
+  const header = (
+    <tr className="bg-[var(--color-bg-elevated)] text-[var(--color-text-tertiary)] text-xs uppercase tracking-wider">
+      <th className="px-3 py-2 text-left font-medium">Repository Pair</th>
+      <th className={`px-3 py-2 text-right font-medium ${HIDE_BELOW_MD}`}>File Pairs</th>
+      <th className="px-3 py-2 text-left font-medium w-32">Max Strength</th>
+      <th className={`px-3 py-2 text-right font-medium ${HIDE_BELOW_LG}`}>Latest Activity</th>
+      {onSelectPair ? <th className="px-3 py-2 text-right font-medium" /> : null}
+    </tr>
+  );
+
+  const renderRow = (p: RepoPairSummary) => {
+    const onClick = onSelectPair ? () => onSelectPair(p.id) : undefined;
+    const isSelected = selectedPairId != null && selectedPairId === p.id;
+    return (
+      <tr
+        className={`border-t border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] ${
+          isSelected ? "bg-[var(--color-accent-muted)]/30 " : ""
+        }${onClick ? "cursor-pointer" : ""}`}
+        onClick={onClick}
+      >
+        <td className="px-3 py-2 text-left">
+          <div className="flex items-center gap-2">
+            <Badge variant="default" className="text-xs">{p.repo1}</Badge>
+            <span className="text-[var(--color-text-tertiary)] text-xs">↔</span>
+            <Badge variant="default" className="text-xs">{p.repo2}</Badge>
           </div>
-          <span className="text-xs text-[var(--color-text-tertiary)] tabular-nums w-8 text-right">
-            {Math.round(p.maxStrength * 10) / 10}
+        </td>
+        <td className={`px-3 py-2 text-right text-xs text-[var(--color-text-secondary)] tabular-nums ${HIDE_BELOW_MD}`}>
+          {p.filePairCount}
+        </td>
+        <td className="px-3 py-2 text-left">
+          <div className="flex items-center gap-2 min-w-[90px]">
+            <div className="h-1.5 flex-1 rounded-full bg-[var(--color-bg-inset)] overflow-hidden">
+              <div
+                className="h-full rounded-full bg-[var(--color-accent-primary)] transition-all"
+                style={{ width: `${Math.min(Math.round(p.maxStrength * 10), 100)}%` }}
+              />
+            </div>
+            <span className="text-xs text-[var(--color-text-tertiary)] tabular-nums w-8 text-right">
+              {Math.round(p.maxStrength * 10) / 10}
+            </span>
+          </div>
+        </td>
+        <td className={`px-3 py-2 text-right text-xs text-[var(--color-text-tertiary)] ${HIDE_BELOW_LG}`}>
+          <span title={p.lastDate ? new Date(p.lastDate).toLocaleString() : undefined}>
+            {p.lastDate ? new Date(p.lastDate).toLocaleDateString() : "—"}
           </span>
-        </div>
-      ),
-      mobileRender: (p) => Math.round(p.maxStrength * 10) / 10,
-    },
-    {
-      key: "last",
-      header: "Latest Activity",
-      priority: 3,
-      align: "right",
-      cellClassName: "text-xs text-[var(--color-text-tertiary)]",
-      render: (p) => (
-        <span title={p.lastDate ? new Date(p.lastDate).toLocaleString() : undefined}>
-          {p.lastDate ? new Date(p.lastDate).toLocaleDateString() : "—"}
-        </span>
-      ),
-    },
-    ...(onSelectPair
-      ? [
-          {
-            key: "action",
-            header: "",
-            priority: 1 as const,
-            align: "right" as const,
-            render: () => <ChevronRight className="h-4 w-4 text-[var(--color-text-tertiary)] inline-block" />,
-            hideInCard: true,
-          },
-        ]
-      : []),
-  ];
+        </td>
+        {onSelectPair ? (
+          <td className="px-3 py-2 text-right">
+            <ChevronRight className="h-4 w-4 text-[var(--color-text-tertiary)] inline-block" />
+          </td>
+        ) : null}
+      </tr>
+    );
+  };
 
   return (
-    <ResponsiveTable
-      columns={columns}
+    <VirtualizedTable<RepoPairSummary>
       rows={repoPairs}
       rowKey={(p) => p.id}
-      selectedKey={selectedPairId}
-      onRowClick={onSelectPair ? (p) => onSelectPair(p.id) : undefined}
-      bare
-      empty={
-        <EmptyState
-          title="No repository pairs"
-          description="No cross-repository co-changes found."
-        />
-      }
+      header={header}
+      renderRow={renderRow}
+      aria-label="Cross-repo pairs"
     />
   );
 }


### PR DESCRIPTION
## Summary

The workspace views render their tables (and the dependency-structure matrix) by putting every row/cell in the DOM. On large workspaces that means thousands of nodes per view — slow paint and janky scrolling. This applies the windowing primitive to those tables and bounds the DSM grid.

## Changes

**Tables → `VirtualizedTable`**
Converted four workspace tables from the non-windowed `ResponsiveTable` to the shared `VirtualizedTable` (windowed `<tbody>`):
- co-change table
- repo-pair table
- contract-links table
- package-deps table

Each keeps its exact cell markup, formatting, and row behavior. `ResponsiveTable`'s mobile-card mode is replaced with responsive column-hiding (`max-md:hidden` / `max-lg:hidden`), mirroring the priority scale — the same approach already used for the coupling table. Below the windowing threshold every row still renders, so small/common lists and SSR behave exactly as before.

**Dependency-structure matrix — render budget**
The DSM is a single flat CSS grid of `(n+1)²` cells. For a large service count that's tens of thousands of `<div>`s. Since it's an auto-placed grid (not discrete row elements), it now caps to the **top 60 services by connectivity** (in-degree + out-degree) on both axes when the workspace exceeds that, with a `showing top N of M services by connectivity` indicator. The summary counts (dependencies / violations / cycles) still reflect the full matrix; only the rendered grid is bounded. Diagonal role tinting, violation/cycle rings, hover highlight, and cell drill-through are unchanged.

## Verification
- `npm run type-check --workspace=@repowise-dev/ui` — clean
- `npm run gates --workspace=@repowise-dev/ui` — 0 failures
- `npm run test --workspace=@repowise-dev/ui` — 523 passed (includes new tests for each table + the DSM budget)

Scope: `packages/ui/src/workspace/**` + tests only.