### PR TITLE
fix: handle '.' as glob pattern on Python 3.14+

### DIFF
--- a/packages/core/src/repowise/core/ingestion/resolvers/rust_workspace.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/rust_workspace.py
@@ -227,6 +227,8 @@ def _build_cargo_workspace_index(ctx) -> CargoWorkspaceIndex | None:
                 continue
             if member_path in excluded_paths:
                 continue
+            if member_path == repo and root_pkg.get("name"):
+                continue
             try:
                 member_rel = member_path.relative_to(repo).as_posix()
             except ValueError:

--- a/packages/core/src/repowise/core/ingestion/resolvers/rust_workspace.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/rust_workspace.py
@@ -206,12 +206,18 @@ def _build_cargo_workspace_index(ctx) -> CargoWorkspaceIndex | None:
     excluded_paths: set[Path] = set()
     for pattern in exclude_patterns:
         if isinstance(pattern, str):
-            excluded_paths.update(p.resolve() for p in repo.glob(pattern))
+            if pattern == ".":
+                excluded_paths.add(repo)
+            else:
+                excluded_paths.update(p.resolve() for p in repo.glob(pattern))
 
     for member_pattern in members:
         if not isinstance(member_pattern, str):
             continue
-        matched_paths = sorted(repo.glob(member_pattern))
+        if member_pattern == ".":
+            matched_paths = [repo]
+        else:
+            matched_paths = sorted(repo.glob(member_pattern))
         if not matched_paths:
             # Fallback to literal path for backward compat
             matched_paths = [(repo / member_pattern).resolve()]

--- a/packages/core/src/repowise/core/ingestion/resolvers/ts_workspace.py
+++ b/packages/core/src/repowise/core/ingestion/resolvers/ts_workspace.py
@@ -262,9 +262,11 @@ def build_workspace_info(repo_path: Path | None) -> dict[str, dict[str, Any]]:
 
     result: dict[str, dict[str, Any]] = {}
     for pattern in patterns:
-        # Glob each pattern relative to the repo root. ``pathlib.Path.glob``
-        # already understands ``*`` and ``**``.
-        for ws_dir in repo_path.glob(pattern):
+        if pattern == ".":
+            ws_dirs = [repo_path]
+        else:
+            ws_dirs = repo_path.glob(pattern)
+        for ws_dir in ws_dirs:
             if not ws_dir.is_dir():
                 continue
             ws_pkg = ws_dir / "package.json"

--- a/tests/unit/ingestion/test_rust_resolver.py
+++ b/tests/unit/ingestion/test_rust_resolver.py
@@ -101,6 +101,46 @@ class TestCargoWorkspaceGlobExpansion:
         assert idx.lookup("foo") == "crates/foo/src"
         assert idx.lookup("ignored") is None
 
+    def test_root_member_dot(self, tmp_path: Path) -> None:
+        """members = ["."] should index the root crate without crashing.
+
+        Python 3.14+ rejects ``pathlib.Path.glob(".")`` with
+        ``ValueError: Unacceptable pattern``. Cargo workspaces commonly
+        declare ``"."`` as a member to include the root crate.
+        """
+        (tmp_path / "Cargo.toml").write_text(
+            '[workspace]\nmembers = [".", "crates/foo"]\n'
+            '[package]\nname = "root_crate"\nversion = "0.1.0"\n'
+        )
+        _write_member_crate(tmp_path, "crates/foo", "foo")
+        (tmp_path / "src").mkdir(exist_ok=True)
+        (tmp_path / "src" / "lib.rs").write_text("// root crate\n")
+        ctx = _ctx(tmp_path, [
+            "src/lib.rs",
+            "crates/foo/src/lib.rs",
+        ])
+        idx = get_or_build_cargo_workspace_index(ctx)
+        assert idx is not None
+        assert idx.lookup("root_crate") == "src"
+        assert idx.lookup("foo") == "crates/foo/src"
+
+    def test_exclude_dot(self, tmp_path: Path) -> None:
+        """exclude = ["."] should not crash (root pkg still indexed via [package])."""
+        (tmp_path / "Cargo.toml").write_text(
+            '[workspace]\nmembers = [".", "crates/foo"]\nexclude = ["."]\n'
+            '[package]\nname = "root_crate"\nversion = "0.1.0"\n'
+        )
+        _write_member_crate(tmp_path, "crates/foo", "foo")
+        (tmp_path / "src").mkdir(exist_ok=True)
+        (tmp_path / "src" / "lib.rs").write_text("// root crate\n")
+        ctx = _ctx(tmp_path, [
+            "src/lib.rs",
+            "crates/foo/src/lib.rs",
+        ])
+        idx = get_or_build_cargo_workspace_index(ctx)
+        assert idx is not None
+        assert idx.lookup("foo") == "crates/foo/src"
+
 
 def test_rust_visibility_levels():
     from repowise.core.ingestion.extractors.visibility import rust_visibility

--- a/tests/unit/ingestion/test_ts_workspace_index.py
+++ b/tests/unit/ingestion/test_ts_workspace_index.py
@@ -79,6 +79,22 @@ class TestExportsWildcardEntries:
         second = get_or_build_ts_index(ctx)
         assert first is second
 
+    def test_root_workspace_dot(self, tmp_path: Path) -> None:
+        """workspaces: ["."] should not crash on Python 3.14+.
+
+        Python 3.14+ rejects pathlib.Path.glob(".") with ValueError.
+        Entry-point resolution for the root package is a separate concern.
+        """
+        _write(
+            tmp_path,
+            "package.json",
+            '{"name":"root","workspaces":["."],"main":"./src/index.ts"}',
+        )
+        _write(tmp_path, "src/index.ts", "export const x = 1;\n")
+        ctx = _ctx(tmp_path, ["src/index.ts"])
+        index = build_ts_workspace_index(ctx)
+        assert "root" in index.packages
+
 
 class TestVitestIncludeScanner:
     def test_runtime_tests_glob_matches(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`repowise init` crashes with `ValueError: Unacceptable pattern: '.'` on Python 3.14+ when indexing Cargo workspaces that declare the root crate as a member:

```toml
[workspace]
members = [".", "crates/foo", ...]
```

This is a common pattern in real-world Rust workspaces (e.g. [crank](https://github.com/madmansn0w/crank), rust-analyzer, and many others).

## Root Cause

Python 3.14 changed `pathlib.Path.glob()` to reject `'.'` as an invalid pattern:

```
>>> Path('.').glob('.')
ValueError: Unacceptable pattern: '.'
```

The affected code in `rust_workspace.py` passes Cargo workspace member/exclude patterns directly to `repo.glob()` without sanitization. The same pattern exists in `ts_workspace.py` for npm workspaces.

## Fix

**Guard against `'.'` before calling `glob()`** in three places:

1. **`rust_workspace.py` — members list** (line 214): When `member_pattern == "."`, treat it as a literal reference to the repo root (`[repo]`).
2. **`rust_workspace.py` — exclude patterns** (line 209): Same guard for `exclude = ["."]`.
3. **`ts_workspace.py` — npm/pnpm workspaces** (line 267): Same guard for `workspaces: ["."]` in `package.json`.

**Prevent duplicate root crate entry** in `rust_workspace.py`: When `members = ["."]` and the root has a `[package]` section, the root crate was indexed twice — once via `[package]` (`src_dir="src"`) and once via the members loop (`src_dir="./src"`). Added a guard to skip the root path in the members loop if `root_pkg` already has a name.

## Testing

Added regression tests:
- `test_root_member_dot` (rust) — verifies `members = ["."]` indexes the root crate without crashing
- `test_exclude_dot` (rust) — verifies `exclude = ["."]` doesn't crash
- `test_root_workspace_dot` (ts) — verifies `workspaces: ["."]` doesn't crash

All tests pass:
```
tests/unit/ingestion/test_rust_resolver.py::TestCargoWorkspaceGlobExpansion — 4 passed
tests/unit/ingestion/test_ts_workspace_index.py::TestExportsWildcardEntries — 5 passed
```

Verified against a real workspace (crank, 24 crates including root `members = ["."]`).

## Other potentially vulnerable call sites

I identified 8 `.glob()` calls in the ingestion module. The other 5 use hardcoded or derived patterns (not user-controlled from project config files), so they're not affected:
- `traverser.py:532` — hardcoded `"*/*"` pattern
- `npm.py:96` — appends `"/package.json"` (produces `"./package.json"` which is valid)
- `django.py:72`, `parse_cache.py:107`, `cmake.py:679` — hardcoded patterns

## Remaining notes (non-blocking)

- **Entry-point resolution for `workspaces: ["."]` in ts_workspace is a separate concern.** When `ws_dir == repo_path`, `rel = "."`, and downstream path joining `f"{dir_posix}/{...}"` produces `"./src/..."` which doesn't match `"src/..."` in `path_set`. This is pre-existing behavior (not introduced by this PR) and is out of scope for the crash fix. The `test_root_workspace_dot` test asserts only that the package is indexed (`"root" in index.packages`), not entry-point resolution.
- **Only affected test files were run.** The changes are minimal and additive (guards + skip), so the risk of breaking other tests is low, but the full test suite should be run via CI before merging.