### PR TITLE
Port Extract Method to Go and TypeScript/JavaScript

### DIFF
--- a/docs/LANGUAGE_SUPPORT.md
+++ b/docs/LANGUAGE_SUPPORT.md
@@ -448,6 +448,51 @@ without touching the shared pipeline files:
   false perf findings. Adding a language's perf support is one module plus a
   `call_kinds` line on its `LanguageNodeMap` and its
   `external_systems/io_kind.py` ecosystem rows --- no walker edits.
+- `analysis/health/dataflow/dialects/` --- the **dataflow** layer
+  (intra-procedural CFG + def/use + reaching definitions, powering the
+  **Extract Method** refactoring) is driven by a per-language `DefUseDialect`
+  plugin, registered in `DEFUSE_DIALECTS` exactly like `perf/dialects/`. A
+  dialect owns the read-vs-write classification of each statement (the
+  per-grammar seam: which node is an assignment / declaration / destructuring
+  target, which is a member or index target that binds no local, how a loop's
+  binder reads and writes) and the parameter binders (including a Go method
+  receiver). The CFG builder, the reaching-definitions fixpoint, and the
+  Extract Method slicer stay language-agnostic: the control-flow grammar they
+  branch on (`if_kinds` / `block_kinds` / `return_kinds` / `raise_kinds` /
+  `break_kinds` / `continue_kinds`, alongside the existing
+  `branch_kinds` / `loop_kinds` / `try_kinds`) lives on the `LanguageNodeMap`,
+  so the same builder serves Python's clause-style `elif` / `else` and the
+  C-family's `alternative`-field `else if` without a per-language branch. Every
+  facet has a safe "no signal" default, so a language without a dialect (or one
+  whose map omits the control-flow kinds) produces no def/use and therefore no
+  Extract Method suggestion --- never a wrong one. Adding a language is one
+  module plus the `assignment_kinds` / `local_decl_kinds` and control-flow
+  lines on its `LanguageNodeMap` --- no core edits. The full dataflow pass runs
+  only for functions a structural biomarker already flagged
+  (`large_method` / `brain_method` / `complex_method`), so it stays within the
+  health-pass budget.
+
+#### Dataflow / Extract Method coverage
+
+The dataflow layer needs a `DefUseDialect` (plus the `assignment_kinds` /
+`local_decl_kinds` and control-flow kinds on the language's `LanguageNodeMap`);
+it is independent of the perf / class / assertion tiers. A language without a
+dialect emits no Extract Method suggestions. Coverage rolls out in value order
+(the high-yield set first), degrading to silence elsewhere.
+
+| Language | CFG + def/use | Extract Method | Notes |
+|----------|:---:|:---:|---|
+| Python | Y | Y | assignment, augmented, walrus, tuple-unpack, `for` / `with`-as / comprehension targets |
+| Go | Y | Y | `:=` / `var`, `=` vs `+=` (operator-sniffed), `x++`, `range` binders, selector / index targets; method `receiver` seeded as a param |
+| TypeScript / JavaScript | Y | Y | `let` / `const` / `var`, `=` / `+=`, `++`, array / object destructuring, `for...of` / `for...in` binders, member / subscript targets |
+| Java / Rust | --- | --- | next (high-yield tail) |
+| Kotlin / C++ / C# | --- | --- | later |
+
+Validated on real code (flagged-only, the production path): Go fires on
+`gorilla/mux` (e.g. `setMatch` sheds ccn 15); TS/JS fires across the hosted
+Next.js frontend. The flagged-only gate held in both runs (Go 8 / 108
+functions, TS 212 / 1172), keeping the per-file cost in the low single-digit
+milliseconds.
 
 #### Performance-signal coverage
 

--- a/packages/core/src/repowise/core/analysis/health/complexity/languages.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/languages.py
@@ -154,6 +154,39 @@ class LanguageNodeMap:
     augmented_assign_kinds: frozenset[str] = frozenset()
     local_decl_kinds: frozenset[str] = frozenset()
 
+    # ------------------------------------------------------------------
+    # Dataflow control-flow grammar (CFG builder + Extract Method slicer).
+    # These name the structured-statement node kinds the language-agnostic
+    # CFG builder (``dataflow/cfg.py``) and the slicer (``dataflow/slice.py``)
+    # branch on, so the structural pass needs no per-language ``if`` chain.
+    # All default to empty: a language that maps none builds a degenerate
+    # (straight-line) CFG and so produces no Extract Method signal -- the same
+    # precision-first "no signal" default the def/use dialect uses. They sit on
+    # the node-map (next to ``branch_kinds`` / ``loop_kinds`` / ``try_kinds``,
+    # which already drive the CFG) rather than on the ``DefUseDialect`` so the
+    # CFG builder keeps taking only an ``lmap`` -- additive and registry-
+    # dispatched exactly like the control-flow kinds above it.
+    #
+    #   * ``if_kinds`` -- the *statement-level* conditional node(s) that open a
+    #     CFG branch (Python ``if_statement``; Rust ``if_expression``). Narrower
+    #     than ``branch_kinds``, which also carries expression-level conditionals
+    #     (ternary / ``conditional_expression``) that are NOT block boundaries.
+    #   * ``block_kinds`` -- statement-container node(s) whose named children are
+    #     a flat statement sequence (Python/Go/Java ``block``; TS
+    #     ``statement_block``; Go additionally nests a ``statement_list`` inside
+    #     its ``block``, so it maps both and the builder unwraps the wrapper).
+    #   * ``return_kinds`` / ``raise_kinds`` / ``break_kinds`` /
+    #     ``continue_kinds`` -- the jump statements. ``return`` / ``raise``
+    #     (``throw``) edge to the function exit; ``break`` / ``continue`` edge to
+    #     the enclosing loop's exit / header. A language that omits one simply
+    #     records that statement as a plain straight-line node (no special edge).
+    if_kinds: frozenset[str] = frozenset()
+    block_kinds: frozenset[str] = frozenset()
+    return_kinds: frozenset[str] = frozenset()
+    raise_kinds: frozenset[str] = frozenset()
+    break_kinds: frozenset[str] = frozenset()
+    continue_kinds: frozenset[str] = frozenset()
+
 
 _PY = LanguageNodeMap(
     function_kinds=frozenset({"function_definition", "async_function_definition"}),
@@ -176,6 +209,12 @@ _PY = LanguageNodeMap(
     async_function_kinds=frozenset({"async_function_definition"}),
     assignment_kinds=frozenset({"assignment"}),
     augmented_assign_kinds=frozenset({"augmented_assignment"}),
+    if_kinds=frozenset({"if_statement"}),
+    block_kinds=frozenset({"block"}),
+    return_kinds=frozenset({"return_statement"}),
+    raise_kinds=frozenset({"raise_statement"}),
+    break_kinds=frozenset({"break_statement"}),
+    continue_kinds=frozenset({"continue_statement"}),
 )
 
 _TS = LanguageNodeMap(
@@ -215,6 +254,19 @@ _TS = LanguageNodeMap(
     # TS/JS async is a modifier token, not a distinct node type; the walker
     # sniffs the ``async`` child token instead, so this stays empty.
     async_function_kinds=frozenset(),
+    # ``x = ...`` is an ``assignment_expression``; ``x += ...`` a dedicated
+    # ``augmented_assignment_expression``. ``let`` / ``const`` declare via
+    # ``lexical_declaration``, ``var`` via ``variable_declaration`` (both nest a
+    # ``variable_declarator``); the dialect reads their ``name`` binding.
+    assignment_kinds=frozenset({"assignment_expression"}),
+    augmented_assign_kinds=frozenset({"augmented_assignment_expression"}),
+    local_decl_kinds=frozenset({"lexical_declaration", "variable_declaration"}),
+    if_kinds=frozenset({"if_statement"}),
+    block_kinds=frozenset({"statement_block"}),
+    return_kinds=frozenset({"return_statement"}),
+    raise_kinds=frozenset({"throw_statement"}),
+    break_kinds=frozenset({"break_statement"}),
+    continue_kinds=frozenset({"continue_statement"}),
 )
 
 _JS = _TS  # identical control-flow nodes; tree-sitter-javascript shares shape.
@@ -237,6 +289,20 @@ _GO = LanguageNodeMap(
     # ``assert.Equal(t, ...)`` (testify) — best-effort call detection.
     assert_call_kinds=frozenset({"call_expression"}),
     call_kinds=frozenset({"call_expression"}),
+    # ``x = ...`` and ``x += ...`` are both ``assignment_statement`` (the dialect
+    # tells them apart by the operator token), so the augmented set stays empty.
+    # ``:=`` is a ``short_var_declaration``; ``var x = ...`` a ``var_declaration``
+    # (nesting ``var_spec``) -- both introduce fresh locals.
+    assignment_kinds=frozenset({"assignment_statement"}),
+    local_decl_kinds=frozenset({"short_var_declaration", "var_declaration"}),
+    if_kinds=frozenset({"if_statement"}),
+    # A Go ``block`` wraps its statements in a ``statement_list`` child; both are
+    # mapped so the CFG builder unwraps the wrapper to reach the statements.
+    block_kinds=frozenset({"block", "statement_list"}),
+    return_kinds=frozenset({"return_statement"}),
+    # Go has no exceptions (``panic`` is an ordinary call), so no raise kind.
+    break_kinds=frozenset({"break_statement"}),
+    continue_kinds=frozenset({"continue_statement"}),
 )
 
 _JAVA = LanguageNodeMap(

--- a/packages/core/src/repowise/core/analysis/health/dataflow/cfg.py
+++ b/packages/core/src/repowise/core/analysis/health/dataflow/cfg.py
@@ -25,9 +25,15 @@ therefore yields byte-identical block ids and edges across runs -- a
 prerequisite for stable trends and cache hits downstream.
 
 **Language scope.** The block-structure logic is language-agnostic over
-``LanguageNodeMap``; only the jump classification (``return`` / ``raise`` /
-``break`` / ``continue``) is Python-specific in this phase. A later phase lifts
-that into a per-language dialect alongside the other ``DefUseDialect`` work.
+``LanguageNodeMap``: the conditional node kind (``if_kinds``), the statement-
+container kinds (``block_kinds``), and the jump kinds (``return`` / ``raise`` /
+``break`` / ``continue``) all come from the node-map, so the same builder serves
+every full-tier language whose map populates them. Two grammar families are
+handled transparently: Python encodes ``elif`` / ``else`` as sibling *clause*
+children, while the C-family (Go / TS / Java / Rust) hangs the else arm off an
+``alternative`` field -- the builder recognises both. A language that maps no
+``if_kinds`` / ``block_kinds`` simply yields a straight-line CFG (degrade to
+silence), the same precision-first default as the def/use dialect.
 """
 
 from __future__ import annotations
@@ -39,15 +45,6 @@ from ..complexity.languages import LanguageNodeMap
 
 if TYPE_CHECKING:
     from tree_sitter import Node
-
-# Python jump node types. The layer is Python-only for now; a later pass generalises
-# these behind a dialect (mirroring ``perf/dialects/`` and the ``DefUseDialect``
-# pattern). Each set degrades to "no special handling" for a language that does
-# not map it -- the statement is then recorded as a plain straight-line node.
-_RETURN_KINDS: frozenset[str] = frozenset({"return_statement"})
-_RAISE_KINDS: frozenset[str] = frozenset({"raise_statement"})
-_BREAK_KINDS: frozenset[str] = frozenset({"break_statement"})
-_CONTINUE_KINDS: frozenset[str] = frozenset({"continue_statement"})
 
 # Upper bound on basic blocks per function. A structured CFG has roughly one
 # block per branch/loop arm, so a few hundred is already an extreme function;
@@ -240,25 +237,30 @@ class _CFGBuilder:
 
     # -- block / clause access ------------------------------------------------
 
-    @staticmethod
-    def _block_of(node: Node | None) -> Node | None:
-        """The ``block`` body of a clause (``consequence`` / ``body`` field, or
-        the first child of type ``block`` for clauses with no body field)."""
+    def _block_of(self, node: Node | None) -> Node | None:
+        """The statement-container body of a clause (``consequence`` / ``body``
+        field, or the first child whose kind is a ``block_kind`` for clauses with
+        no body field, e.g. a Python ``except_clause``)."""
         if node is None:
             return None
         body = node.child_by_field_name("consequence") or node.child_by_field_name("body")
         if body is not None:
             return body
         for child in node.children:
-            if child.type == "block":
+            if child.type in self.lmap.block_kinds:
                 return child
         return None
 
-    @staticmethod
-    def _body_stmts(block: Node | None) -> list[Node]:
+    def _body_stmts(self, block: Node | None) -> list[Node]:
+        """The statement sequence inside a container, unwrapping a single nested
+        statement-container (Go wraps a ``block``'s statements in a
+        ``statement_list``; Python/TS expose them directly)."""
         if block is None:
             return []
-        return [c for c in block.named_children]
+        kids = list(block.named_children)
+        while len(kids) == 1 and kids[0].type in self.lmap.block_kinds:
+            kids = list(kids[0].named_children)
+        return kids
 
     # -- the recursive walk ---------------------------------------------------
 
@@ -288,22 +290,22 @@ class _CFGBuilder:
                 # silently dropped, but it is reachable from nothing.
                 cur = self._new("unreachable")
             t = st.type
-            if t == "if_statement":
+            if t in self.lmap.if_kinds:
                 cur = self._build_if(st, cur)
             elif t in self.lmap.loop_kinds:
                 cur = self._build_loop(st, cur)
             elif t in self.lmap.try_kinds:
                 cur = self._build_try(st, cur)
-            elif t in _RETURN_KINDS or t in _RAISE_KINDS:
+            elif t in self.lmap.return_kinds or t in self.lmap.raise_kinds:
                 self._record_stmt(cur, st)
                 self._edge(cur, self.exit_block)
                 cur = None
-            elif t in _BREAK_KINDS:
+            elif t in self.lmap.break_kinds:
                 self._record_stmt(cur, st)
                 if self._loops:
                     self._edge(cur, self._loops[-1].break_target)
                 cur = None
-            elif t in _CONTINUE_KINDS:
+            elif t in self.lmap.continue_kinds:
                 self._record_stmt(cur, st)
                 if self._loops:
                     self._edge(cur, self._loops[-1].continue_target)
@@ -326,9 +328,24 @@ class _CFGBuilder:
         if then_out is not None:
             self._edge(then_out, join)
 
-        # elif / else chain. Each ``elif`` hangs off the previous test's false
-        # edge as a nested branch; ``else`` consumes the final false edge.
-        alts = [c for c in if_node.children if c.type in ("elif_clause", "else_clause")]
+        # Two grammar families for the false arm:
+        #  - Python's *flat* ``elif`` chain: sibling ``elif_clause`` (and a final
+        #    ``else_clause``) children, all converging on one join.
+        #  - everything else (a plain ``else``, or the C-family's nested
+        #    ``else if``): a single else arm reached via the ``alternative`` field
+        #    or an ``else_clause`` child. ``else_clause`` is shared between Python
+        #    and TS, so the discriminator is specifically an ``elif_clause``.
+        if any(c.type == "elif_clause" for c in if_node.children):
+            alts = [c for c in if_node.children if c.type in ("elif_clause", "else_clause")]
+            self._build_py_else_chain(alts, cur, join)
+        else:
+            self._build_c_alternative(if_node, cur, join)
+        return join
+
+    def _build_py_else_chain(
+        self, alts: list[Node], cur: BasicBlock, join: BasicBlock
+    ) -> None:
+        """Python ``elif`` / ``else`` clause chain off *cur*'s false edge."""
         false_src: BasicBlock | None = cur
         for alt in alts:
             if alt.type == "elif_clause":
@@ -350,11 +367,38 @@ class _CFGBuilder:
                 if else_out is not None:
                     self._edge(else_out, join)
                 false_src = None
-
         # No ``else``: the last test's false edge falls straight through.
         if false_src is not None:
             self._edge(false_src, join)
-        return join
+
+    def _build_c_alternative(self, if_node: Node, cur: BasicBlock, join: BasicBlock) -> None:
+        """The single else arm off *cur*'s false edge (non-flat-``elif`` case).
+
+        Covers a plain ``else`` (Python / Go / TS), a TS / Python ``else_clause``
+        wrapping that block or a nested ``if``, and the C-family ``else if``
+        chain. A nested ``if`` is threaded through :meth:`_process_seq` so it
+        recurses into :meth:`_build_if` and converges on the same *join*; a plain
+        block is unwrapped to its statements. No alternative => the false edge
+        falls straight through to *join*."""
+        alt = if_node.child_by_field_name("alternative")
+        if alt is None:  # Python's else arm is an ``else_clause`` child, no field
+            alt = next((c for c in if_node.children if c.type == "else_clause"), None)
+        if alt is None:
+            self._edge(cur, join)
+            return
+        if alt.type == "else_clause":  # Python / TS wrap the else arm in a clause
+            inner = next((c for c in alt.named_children), None)
+            if inner is None:
+                self._edge(cur, join)
+                return
+            alt = inner
+        else_entry = self._new()
+        self._edge(cur, else_entry)
+        # ``else if`` -> a nested branch; a plain else block -> its statements.
+        stmts = [alt] if alt.type in self.lmap.if_kinds else self._body_stmts(alt)
+        else_out = self._process_seq(stmts, else_entry)
+        if else_out is not None:
+            self._edge(else_out, join)
 
     def _build_loop(self, loop_node: Node, cur: BasicBlock) -> BasicBlock:
         header = self._new("loop_header")

--- a/packages/core/src/repowise/core/analysis/health/dataflow/defuse.py
+++ b/packages/core/src/repowise/core/analysis/health/dataflow/defuse.py
@@ -92,8 +92,10 @@ def compute_def_use(
         bdu.defs.append(definition)
         definitions.append(definition)
 
-    # Parameters reach the body: seed them at the entry block.
-    params = dialect.parameter_defs(fn_node.child_by_field_name("parameters"))
+    # Parameters reach the body: seed them at the entry block. The dialect is
+    # given the whole function node so languages that bind names outside the
+    # ``parameters`` field (Go's method ``receiver``) can seed those too.
+    params = dialect.parameter_defs(fn_node)
     blocks.setdefault(cfg.entry_id, BlockDefUse(cfg.entry_id))
     for occ in params:
         _add_def(occ, cfg.entry_id)

--- a/packages/core/src/repowise/core/analysis/health/dataflow/dialects/__init__.py
+++ b/packages/core/src/repowise/core/analysis/health/dataflow/dialects/__init__.py
@@ -14,7 +14,9 @@ def/use pass is silent for it (no dialect = no signal), the safe default.
 
 from __future__ import annotations
 
+from . import go as _go
 from . import python as _python
+from . import ts_js as _ts_js
 from .base import (
     DEFUSE_DIALECTS,
     BaseDefUseDialect,
@@ -26,7 +28,14 @@ from .base import (
 
 # (LanguageTag, dialect instance). One dialect can serve several tags. Each
 # key is a ``LanguageTag`` from ``ingestion/models.py``.
-_REGISTER: tuple[tuple[str, BaseDefUseDialect], ...] = (("python", _python.DIALECT),)
+_REGISTER: tuple[tuple[str, BaseDefUseDialect], ...] = (
+    ("python", _python.DIALECT),
+    ("go", _go.DIALECT),
+    ("typescript", _ts_js.DIALECT),
+    ("tsx", _ts_js.DIALECT),
+    ("javascript", _ts_js.DIALECT),
+    ("jsx", _ts_js.DIALECT),
+)
 
 for _tag, _dialect in _REGISTER:
     DEFUSE_DIALECTS[_tag] = _dialect

--- a/packages/core/src/repowise/core/analysis/health/dataflow/dialects/base.py
+++ b/packages/core/src/repowise/core/analysis/health/dataflow/dialects/base.py
@@ -18,8 +18,11 @@ Member                            What it answers
                                   dialect inspects only the condition / loop
                                   clause, not the body (which lives in other
                                   CFG blocks).
-``parameter_defs(params_node)``   the parameter names a function signature
-                                  binds -- seeded as defs at the CFG entry.
+``parameter_defs(fn_node)``       the parameter names a function signature
+                                  binds -- seeded as defs at the CFG entry. The
+                                  whole function node is passed so a language can
+                                  also seed names bound outside the
+                                  ``parameters`` field (a Go method receiver).
 ================================  ============================================
 
 :class:`BaseDefUseDialect` carries the language-agnostic machinery a concrete
@@ -76,7 +79,7 @@ class DefUseDialect(Protocol):
         self, node: Node, lmap: LanguageNodeMap, *, head_only: bool
     ) -> StatementDefUse: ...
 
-    def parameter_defs(self, params_node: Node | None) -> tuple[Occurrence, ...]: ...
+    def parameter_defs(self, fn_node: Node) -> tuple[Occurrence, ...]: ...
 
 
 class BaseDefUseDialect:
@@ -156,8 +159,9 @@ class BaseDefUseDialect:
 
     # -- defaults a subclass may override -------------------------------------
 
-    def parameter_defs(self, params_node: Node | None) -> tuple[Occurrence, ...]:
-        """Parameter names bound by a signature, as entry defs. Default: none."""
+    def parameter_defs(self, fn_node: Node) -> tuple[Occurrence, ...]:
+        """Parameter names bound by *fn_node*'s signature, as entry defs.
+        Default: none (a language with no override seeds no parameters)."""
         return ()
 
     def statement_def_use(

--- a/packages/core/src/repowise/core/analysis/health/dataflow/dialects/go.py
+++ b/packages/core/src/repowise/core/analysis/health/dataflow/dialects/go.py
@@ -1,0 +1,174 @@
+"""Go ``DefUseDialect``.
+
+Classifies each identifier in a statement as a write (def) or a read (use). Go's
+write sites are: ``:=`` short variable declarations (``a, b := ...``), ``var``
+declarations (``var x int = ...``), plain and compound assignments (both are an
+``assignment_statement`` -- told apart by the operator token, ``=`` vs ``+=``),
+increment / decrement (``x++`` is a read-modify-write), and the loop variables of
+a ``range`` clause. Selector targets (``obj.field = ...``) and index targets
+(``arr[i] = ...``) bind no *local*, so their base identifiers are reads -- the
+precision-first choice that keeps reaching definitions sound for the locals they
+actually track. The method ``receiver`` (``func (s *Server) m()``) is seeded as a
+parameter so a span that reads it infers it as an IN.
+
+A Go ``block`` nests its statements in a ``statement_list``; the CFG builder
+unwraps that, so this dialect only ever sees individual statements.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseDefUseDialect, Occurrence, StatementDefUse
+
+if TYPE_CHECKING:
+    from tree_sitter import Node
+
+    from ...complexity.languages import LanguageNodeMap
+
+# Write-site / structural node kinds (kept in lockstep with the Go
+# ``LanguageNodeMap``; declared here so the traversal needs no lmap threading).
+_ASSIGN_KINDS = frozenset({"assignment_statement"})
+_SHORT_VAR = "short_var_declaration"
+_VAR_DECL_KINDS = frozenset({"var_declaration", "const_declaration"})
+_INC_DEC_KINDS = frozenset({"inc_statement", "dec_statement"})
+_EXPRESSION_LIST = "expression_list"
+_RANGE_CLAUSE = "range_clause"
+_FOR_CLAUSE = "for_clause"
+# Selector (``obj.field``) and index (``arr[i]``) targets bind no local.
+_SELECTOR = "selector_expression"
+_INDEX = "index_expression"
+# Nested scopes whose identifiers belong to a different function (closures).
+_SCOPE_BOUNDARIES = frozenset({"func_literal"})
+
+
+class GoDefUseDialect(BaseDefUseDialect):
+    language = "go"
+    member_access_kinds = frozenset({"selector_expression"})
+    keyword_kinds = frozenset()  # Go has no keyword arguments.
+
+    def _is_scope_boundary(self, node: Node) -> bool:
+        return node.type in _SCOPE_BOUNDARIES
+
+    # -- public contract ------------------------------------------------------
+
+    def statement_def_use(
+        self, node: Node, lmap: LanguageNodeMap, *, head_only: bool
+    ) -> StatementDefUse:
+        defs: list[Occurrence] = []
+        uses: list[Occurrence] = []
+        if head_only:
+            self._head(node, lmap, defs, uses)
+        else:
+            self._process(node, defs, uses)
+        return StatementDefUse(defs=tuple(defs), uses=tuple(uses))
+
+    def parameter_defs(self, fn_node: Node) -> tuple[Occurrence, ...]:
+        """Names bound by the signature -- both the ``parameters`` list and a
+        method ``receiver``. A ``parameter_declaration``'s names are its plain
+        ``identifier`` children (the type is a ``type_identifier`` / ``*T`` /
+        ``[]T`` node, never a bare identifier)."""
+        out: list[Occurrence] = []
+        for field in ("receiver", "parameters"):
+            plist = fn_node.child_by_field_name(field)
+            if plist is None:
+                continue
+            for decl in plist.named_children:
+                for child in decl.named_children:
+                    if child.type in self.identifier_kinds and child.text != b"_":
+                        out.append(self._occ(child))
+        return tuple(out)
+
+    # -- head (loop clause / if condition) ------------------------------------
+
+    def _head(
+        self, node: Node, lmap: LanguageNodeMap, defs: list[Occurrence], uses: list[Occurrence]
+    ) -> None:
+        if node.type in lmap.loop_kinds:  # for_statement: range / clause / cond
+            for child in node.named_children:
+                t = child.type
+                if t in lmap.block_kinds:
+                    continue  # the body lives in successor blocks
+                if t == _RANGE_CLAUSE:
+                    self._targets(child.child_by_field_name("left"), defs, uses)
+                    self._process(child.child_by_field_name("right"), defs, uses)
+                elif t == _FOR_CLAUSE:
+                    self._process(child.child_by_field_name("initializer"), defs, uses)
+                    self._process(child.child_by_field_name("condition"), defs, uses)
+                    self._process(child.child_by_field_name("update"), defs, uses)
+                else:  # bare condition (while-style ``for cond {}``)
+                    self._process(child, defs, uses)
+        elif node.type in lmap.branch_kinds:  # if_statement: init + condition
+            self._process(node.child_by_field_name("initializer"), defs, uses)
+            self._process(node.child_by_field_name("condition"), defs, uses)
+        else:
+            self._process(node, defs, uses)
+
+    # -- the unified expression / statement walk ------------------------------
+
+    def _process(self, node: Node | None, defs: list[Occurrence], uses: list[Occurrence]) -> None:
+        if node is None:
+            return
+        t = node.type
+        if t in _ASSIGN_KINDS:
+            left = node.child_by_field_name("left")
+            self._targets(left, defs, uses)
+            op = node.child_by_field_name("operator")
+            if op is not None and op.text not in (b"=", None):  # compound: read too
+                self.collect_reads(left, uses)
+            self._process(node.child_by_field_name("right"), defs, uses)
+            return
+        if t == _SHORT_VAR:  # ``a, b := ...``
+            self._targets(node.child_by_field_name("left"), defs, uses)
+            self._process(node.child_by_field_name("right"), defs, uses)
+            return
+        if t in _VAR_DECL_KINDS:  # ``var x int = ...`` / ``const c = ...``
+            for spec in node.named_children:
+                self._var_spec(spec, defs, uses)
+            return
+        if t in _INC_DEC_KINDS:  # ``x++`` / ``x--`` -- read-modify-write
+            for child in node.named_children:
+                self._targets(child, defs, uses)
+                self.collect_reads(child, uses)
+            return
+        if t in self.member_access_kinds:
+            self.collect_reads(node, uses)  # receiver is a read; field name is not
+            return
+        if t in self.identifier_kinds:
+            uses.append(self._occ(node))
+            return
+        if self._is_scope_boundary(node):
+            return
+        for child in node.named_children:
+            self._process(child, defs, uses)
+
+    def _var_spec(self, spec: Node, defs: list[Occurrence], uses: list[Occurrence]) -> None:
+        """A ``var_spec`` / ``const_spec``: its direct ``identifier`` children are
+        the bound names (defs); its ``value`` is a read."""
+        for child in spec.named_children:
+            if child.type in self.identifier_kinds and child.text != b"_":
+                defs.append(self._occ(child))
+        self._process(spec.child_by_field_name("value"), defs, uses)
+
+    # -- write-target extraction ----------------------------------------------
+
+    def _targets(self, node: Node | None, defs: list[Occurrence], uses: list[Occurrence]) -> None:
+        if node is None:
+            return
+        t = node.type
+        if t in self.identifier_kinds:
+            if node.text != b"_":  # the blank identifier binds nothing
+                defs.append(self._occ(node))
+            return
+        if t == _EXPRESSION_LIST:
+            for child in node.named_children:
+                self._targets(child, defs, uses)
+            return
+        if t in (_SELECTOR, _INDEX):  # ``obj.f = ...`` / ``a[i] = ...``: base is a read
+            self.collect_reads(node, uses)
+            return
+        for child in node.named_children:
+            self._targets(child, defs, uses)
+
+
+DIALECT = GoDefUseDialect()

--- a/packages/core/src/repowise/core/analysis/health/dataflow/dialects/python.py
+++ b/packages/core/src/repowise/core/analysis/health/dataflow/dialects/python.py
@@ -63,7 +63,8 @@ class PythonDefUseDialect(BaseDefUseDialect):
             self._process(node, defs, uses)
         return StatementDefUse(defs=tuple(defs), uses=tuple(uses))
 
-    def parameter_defs(self, params_node: Node | None) -> tuple[Occurrence, ...]:
+    def parameter_defs(self, fn_node: Node) -> tuple[Occurrence, ...]:
+        params_node = fn_node.child_by_field_name("parameters")
         if params_node is None:
             return ()
         out: list[Occurrence] = []

--- a/packages/core/src/repowise/core/analysis/health/dataflow/dialects/ts_js.py
+++ b/packages/core/src/repowise/core/analysis/health/dataflow/dialects/ts_js.py
@@ -1,0 +1,191 @@
+"""TypeScript / JavaScript ``DefUseDialect`` (one dialect, shared grammar).
+
+Classifies each identifier in a statement as a write (def) or a read (use).
+The write sites are: ``let`` / ``const`` / ``var`` declarations (each nesting a
+``variable_declarator``), plain assignments (``x = ...``), compound assignments
+(``x += ...``), update expressions (``x++`` / ``--x``, read-modify-write),
+destructuring binders (``const [a, b] = ...`` / ``const {p, q} = ...``), and the
+loop binder of a ``for ... of`` / ``for ... in``. Member and subscript targets
+(``obj.attr = ...`` / ``arr[i] = ...``) bind no *local*, so their base
+identifiers are reads -- the precision-first choice that keeps reaching
+definitions sound for the locals they actually track.
+
+All grammar specifics live here; the CFG / reaching / slice core stays language-
+agnostic. JavaScript and TypeScript share the relevant node shapes, so one
+dialect serves ``typescript`` / ``tsx`` / ``javascript`` / ``jsx``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .base import BaseDefUseDialect, Occurrence, StatementDefUse
+
+if TYPE_CHECKING:
+    from tree_sitter import Node
+
+    from ...complexity.languages import LanguageNodeMap
+
+# Write-site / structural node kinds (kept in lockstep with the TS
+# ``LanguageNodeMap``; declared here so the traversal needs no lmap threading).
+_ASSIGN_KINDS = frozenset({"assignment_expression"})
+_AUG_KINDS = frozenset({"augmented_assignment_expression"})
+_UPDATE_KINDS = frozenset({"update_expression"})  # ``x++`` / ``--x``
+_DECL_KINDS = frozenset({"lexical_declaration", "variable_declaration"})
+_DECLARATOR = "variable_declarator"
+# Destructuring patterns and their parts.
+_ARRAY_PATTERN = "array_pattern"
+_OBJECT_PATTERN = "object_pattern"
+_SHORTHAND_PAT = "shorthand_property_identifier_pattern"
+_PAIR_PATTERN = "pair_pattern"
+_REST_PATTERN = "rest_pattern"
+_ASSIGN_PATTERN = "assignment_pattern"  # default value ``a = 1`` in a pattern
+# Member / subscript targets bind no local.
+_MEMBER = "member_expression"
+_SUBSCRIPT = "subscript_expression"
+# Nested scopes whose identifiers belong to a different function.
+_SCOPE_BOUNDARIES = frozenset(
+    {
+        "arrow_function",
+        "function_expression",
+        "function_declaration",
+        "generator_function",
+        "generator_function_declaration",
+        "method_definition",
+    }
+)
+
+
+class TsJsDefUseDialect(BaseDefUseDialect):
+    language = "typescript"
+    member_access_kinds = frozenset({"member_expression"})
+    keyword_kinds = frozenset()  # object-property keys are not variable reads.
+
+    def _is_scope_boundary(self, node: Node) -> bool:
+        return node.type in _SCOPE_BOUNDARIES
+
+    # -- public contract ------------------------------------------------------
+
+    def statement_def_use(
+        self, node: Node, lmap: LanguageNodeMap, *, head_only: bool
+    ) -> StatementDefUse:
+        defs: list[Occurrence] = []
+        uses: list[Occurrence] = []
+        if head_only:
+            self._head(node, lmap, defs, uses)
+        else:
+            self._process(node, defs, uses)
+        return StatementDefUse(defs=tuple(defs), uses=tuple(uses))
+
+    def parameter_defs(self, fn_node: Node) -> tuple[Occurrence, ...]:
+        params_node = fn_node.child_by_field_name("parameters")
+        if params_node is None:
+            return ()
+        out: list[Occurrence] = []
+        sink: list[Occurrence] = []
+        for child in params_node.named_children:
+            pattern = child.child_by_field_name("pattern")
+            if pattern is None:
+                pattern = child if child.type in self.identifier_kinds else None
+            self._targets(pattern, out, sink)
+        return tuple(out)
+
+    # -- head (loop clause / if condition) ------------------------------------
+
+    def _head(
+        self, node: Node, lmap: LanguageNodeMap, defs: list[Occurrence], uses: list[Occurrence]
+    ) -> None:
+        if node.type in lmap.loop_kinds:
+            left = node.child_by_field_name("left")
+            right = node.child_by_field_name("right")
+            if left is not None or right is not None:  # for-of / for-in binder
+                self._targets(left, defs, uses)
+                self._process(right, defs, uses)
+                return
+            # C-style for / while / do: initializer + condition + increment.
+            self._process(node.child_by_field_name("initializer"), defs, uses)
+            self._process(node.child_by_field_name("condition"), defs, uses)
+            self._process(node.child_by_field_name("increment"), defs, uses)
+        elif node.type in lmap.branch_kinds:
+            self._process(node.child_by_field_name("condition"), defs, uses)
+        else:
+            self._process(node, defs, uses)
+
+    # -- the unified expression / statement walk ------------------------------
+
+    def _process(self, node: Node | None, defs: list[Occurrence], uses: list[Occurrence]) -> None:
+        if node is None:
+            return
+        t = node.type
+        if t in _ASSIGN_KINDS:
+            self._targets(node.child_by_field_name("left"), defs, uses)
+            self._process(node.child_by_field_name("right"), defs, uses)
+            return
+        if t in _AUG_KINDS:
+            left = node.child_by_field_name("left")
+            self._targets(left, defs, uses)  # write
+            self.collect_reads(left, uses)  # ...and read (read-modify-write)
+            self._process(node.child_by_field_name("right"), defs, uses)
+            return
+        if t in _UPDATE_KINDS:  # ``x++`` -- read-modify-write of the argument
+            arg = node.child_by_field_name("argument")
+            self._targets(arg, defs, uses)
+            self.collect_reads(arg, uses)
+            return
+        if t in _DECL_KINDS:
+            for declarator in node.named_children:
+                if declarator.type != _DECLARATOR:
+                    continue
+                self._targets(declarator.child_by_field_name("name"), defs, uses)
+                self._process(declarator.child_by_field_name("value"), defs, uses)
+            return
+        if t in self.member_access_kinds:
+            self.collect_reads(node, uses)  # receiver is a read; property is not
+            return
+        if t in self.identifier_kinds:
+            uses.append(self._occ(node))
+            return
+        if self._is_scope_boundary(node):
+            return
+        for child in node.named_children:
+            self._process(child, defs, uses)
+
+    # -- write-target extraction ----------------------------------------------
+
+    def _targets(self, node: Node | None, defs: list[Occurrence], uses: list[Occurrence]) -> None:
+        if node is None:
+            return
+        t = node.type
+        if t in self.identifier_kinds or t == _SHORTHAND_PAT:
+            defs.append(self._occ(node))
+            return
+        if t == _ARRAY_PATTERN:
+            for child in node.named_children:
+                self._targets(child, defs, uses)
+            return
+        if t == _OBJECT_PATTERN:
+            for child in node.named_children:
+                if child.type == _PAIR_PATTERN:
+                    self._targets(child.child_by_field_name("value"), defs, uses)
+                else:  # shorthand / rest / nested pattern
+                    self._targets(child, defs, uses)
+            return
+        if t == _REST_PATTERN:
+            for child in node.named_children:
+                self._targets(child, defs, uses)
+            return
+        if t == _ASSIGN_PATTERN:  # ``a = default`` in a pattern / param
+            self._targets(node.child_by_field_name("left"), defs, uses)
+            self._process(node.child_by_field_name("right"), defs, uses)  # default is a read
+            return
+        if t in _DECL_KINDS:  # a declaration used as a loop binder (``for (let x ...``)
+            self._process(node, defs, uses)
+            return
+        if t in (_MEMBER, _SUBSCRIPT):  # ``obj.f = ...`` / ``a[i] = ...``: base is a read
+            self.collect_reads(node, uses)
+            return
+        for child in node.named_children:
+            self._targets(child, defs, uses)
+
+
+DIALECT = TsJsDefUseDialect()

--- a/packages/core/src/repowise/core/analysis/health/dataflow/slice.py
+++ b/packages/core/src/repowise/core/analysis/health/dataflow/slice.py
@@ -19,8 +19,10 @@ matter, and has at most one return and a small parameter list. Everything else
 is suppressed -- ten great extractions, not two hundred maybes.
 
 Line-based liveness over D2's def/use occurrences realises the IN/OUT inference;
-the CFG/jump scan realises the single-exit predicate. Python only for now;
-the jump classification is the sole language-specific piece.
+the CFG/jump scan realises the single-exit predicate. The jump and nested-scope
+node kinds come from the language's ``LanguageNodeMap`` (the same source the CFG
+builder uses), so every full-tier language whose map populates them is served by
+this one slicer.
 """
 
 from __future__ import annotations
@@ -35,16 +37,6 @@ if TYPE_CHECKING:
     from ..complexity.languages import LanguageNodeMap
     from .analyze import FunctionAnalysis
     from .defuse import FunctionDefUse
-
-# Python jump node types (a span containing any of these is not single-exit).
-# The sole language-specific set here; generalised behind a dialect later.
-_JUMP_KINDS: frozenset[str] = frozenset(
-    {"return_statement", "raise_statement", "break_statement", "continue_statement"}
-)
-# Nested scopes whose statements/jumps belong to a different function.
-_SCOPE_BOUNDARIES: frozenset[str] = frozenset(
-    {"lambda", "function_definition", "async_function_definition"}
-)
 
 # Gates (precision-first; tuned to suppress trivial or unwieldy extractions).
 _MIN_STMTS = 2  # at least two statements
@@ -88,6 +80,9 @@ def find_extractions(analysis: FunctionAnalysis, lmap: LanguageNodeMap) -> list[
     body = fn_node.child_by_field_name("body")
     if body is None:
         return []
+    # The statement container of the body (Go nests it in a ``statement_list``
+    # inside the ``block``); spans covering it whole are not extractions.
+    body_container = _unwrap_container(body, lmap.block_kinds)
 
     def_lines, use_lines = _var_lines(analysis.def_use)
     decision_kinds = (
@@ -97,13 +92,15 @@ def find_extractions(analysis: FunctionAnalysis, lmap: LanguageNodeMap) -> list[
         | lmap.catch_kinds
         | lmap.boolean_operator_kinds
     )
+    jump_kinds = lmap.return_kinds | lmap.raise_kinds | lmap.break_kinds | lmap.continue_kinds
+    scope_kinds = lmap.function_kinds | lmap.lambda_kinds
 
     out: list[Extraction] = []
     evaluated = 0
-    for block in _all_blocks(fn_node):
+    for block in _all_blocks(fn_node, lmap.block_kinds, scope_kinds):
         stmts = block.named_children
         n = len(stmts)
-        is_body = block.id == body.id
+        is_body = block.id == body_container.id
         for i in range(n):
             for j in range(i, n):
                 evaluated += 1
@@ -116,7 +113,7 @@ def find_extractions(analysis: FunctionAnalysis, lmap: LanguageNodeMap) -> list[
                 if is_body and length == n:
                     continue
                 span = stmts[i : j + 1]
-                decisions, has_jump = _span_metrics(span, decision_kinds)
+                decisions, has_jump = _span_metrics(span, decision_kinds, jump_kinds, scope_kinds)
                 if has_jump or decisions < _MIN_CCN_REMOVED:
                     continue
                 slice_nloc = sum(st.end_point[0] - st.start_point[0] + 1 for st in span)
@@ -203,8 +200,23 @@ def _infer_in_out(
     return tuple(params), tuple(returns)
 
 
-def _all_blocks(fn_node: Node) -> list[Node]:
-    """Every statement ``block`` in the function (body + nested), excluding the
+def _unwrap_container(node: Node, block_kinds: frozenset[str]) -> Node:
+    """Descend through a single nested statement-container (Go's
+    ``block`` -> ``statement_list``) to the node whose named children are the
+    actual statements; returns *node* unchanged when it is already that node."""
+    cur = node
+    while True:
+        named = cur.named_children
+        if len(named) == 1 and named[0].type in block_kinds:
+            cur = named[0]
+        else:
+            return cur
+
+
+def _all_blocks(
+    fn_node: Node, block_kinds: frozenset[str], scope_kinds: frozenset[str]
+) -> list[Node]:
+    """Every statement container in the function (body + nested), excluding the
     bodies of nested functions / lambdas."""
     body = fn_node.child_by_field_name("body")
     if body is None:
@@ -213,16 +225,21 @@ def _all_blocks(fn_node: Node) -> list[Node]:
     stack: list[Node] = [body]
     while stack:
         node = stack.pop()
-        if node.type == "block":
+        if node.type in block_kinds:
             blocks.append(node)
         for child in node.children:
-            if child.type in _SCOPE_BOUNDARIES:
+            if child.type in scope_kinds:
                 continue
             stack.append(child)
     return blocks
 
 
-def _span_metrics(span: list[Node], decision_kinds: frozenset[str]) -> tuple[int, bool]:
+def _span_metrics(
+    span: list[Node],
+    decision_kinds: frozenset[str],
+    jump_kinds: frozenset[str],
+    scope_kinds: frozenset[str],
+) -> tuple[int, bool]:
     """Decision-point count and jump presence within *span* (nested scopes are
     not descended into)."""
     decisions = 0
@@ -232,12 +249,12 @@ def _span_metrics(span: list[Node], decision_kinds: frozenset[str]) -> tuple[int
         while stack:
             node = stack.pop()
             t = node.type
-            if t in _JUMP_KINDS:
+            if t in jump_kinds:
                 has_jump = True
             if t in decision_kinds:
                 decisions += 1
             for child in node.children:
-                if child.type in _SCOPE_BOUNDARIES:
+                if child.type in scope_kinds:
                     continue
                 stack.append(child)
     return decisions, has_jump

--- a/tests/unit/health/test_dataflow_langs.py
+++ b/tests/unit/health/test_dataflow_langs.py
@@ -1,0 +1,405 @@
+"""Dataflow def/use + CFG + Extract Method coverage for the ported languages.
+
+Covers the Go and TS/JS ``DefUseDialect``s and the language-agnostic CFG /
+slicer once the Python-specific grammar was lifted onto ``LanguageNodeMap``.
+Best-effort like the other dataflow tests: each language skips when its
+tree-sitter pack is missing rather than failing.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from repowise.core.analysis.health.complexity.languages import get_language_map
+from repowise.core.analysis.health.dataflow import (
+    analyze_file,
+    build_cfgs_for_file,
+    find_extractions,
+)
+
+
+def _require(language: str) -> None:
+    try:
+        from repowise.core.ingestion.parser import _get_language
+    except Exception:
+        pytest.skip(f"tree-sitter language pack missing for {language}")
+    if _get_language(language) is None:
+        pytest.skip(f"tree-sitter language pack missing for {language}")
+
+
+def _analyses(language: str, src: str):
+    _require(language)
+    res = analyze_file(f"m.{language}", language, textwrap.dedent(src).encode(), flagged_only=False)
+    if res.stats.functions_seen == 0:
+        pytest.skip(f"tree-sitter language pack missing for {language}")
+    return res.functions
+
+
+def _first(language: str, src: str):
+    fns = _analyses(language, src)
+    assert fns, "no function analysed"
+    return fns[0]
+
+
+def _def_names(fn) -> set[str]:
+    return {d.var for d in fn.def_use.definitions}
+
+
+def _use_names(fn) -> set[str]:
+    return {u.name for b in fn.def_use.blocks.values() for u in b.uses}
+
+
+# == Go =========================================================================
+
+# Every Go write shape in one function: ``:=``, ``var``, ``=``, ``+=``, ``x++``,
+# a ``range`` binder, a multi-assign, and a selector/index target (not a local).
+_GO_SHAPES = """
+package main
+func shapes(input []int, base int) int {
+    total := 0
+    var scale int = 2
+    for i, v := range input {
+        total += v * scale
+        seen[i] = v
+        cfg.count++
+    }
+    a, b := base, total
+    a, b = b, a
+    return a + b
+}
+"""
+
+
+def test_go_def_use_classification():
+    fn = _first("go", _GO_SHAPES)
+    defs = _def_names(fn)
+    # ``:=`` / ``var`` / ``range`` / multi-assign targets are all locals.
+    assert {"total", "scale", "i", "v", "a", "b"} <= defs
+    assert {"input", "base"} <= _def_names(fn)  # parameters seeded as defs
+    # A selector target (``cfg.count++``) and index target (``seen[i] = v``) bind
+    # no local: their bases are reads, never defs.
+    assert "seen" not in defs
+    assert "cfg" not in defs
+    assert "count" not in defs
+    uses = _use_names(fn)
+    assert {"scale", "v", "seen", "cfg", "base"} <= uses
+
+
+def test_go_for_clause_and_while_heads():
+    fn = _first(
+        "go",
+        """
+        package main
+        func loops(n int) int {
+            sum := 0
+            for j := 0; j < n; j++ {
+                sum += j
+            }
+            for sum < 100 {
+                sum *= 2
+            }
+            return sum
+        }
+        """,
+    )
+    # ``j`` is bound by the C-style for-clause initializer.
+    assert "j" in _def_names(fn)
+    # The CFG has two loop headers with back-edges.
+    headers = [b for b in fn.cfg.blocks if b.kind == "loop_header"]
+    assert len(headers) == 2
+    assert fn.cfg.back_edges()
+
+
+def test_go_method_receiver_is_seeded():
+    fn = _first(
+        "go",
+        """
+        package main
+        func (s *Server) handle(req int) int {
+            x := s.lookup(req)
+            return x
+        }
+        """,
+    )
+    assert "s" in _def_names(fn)  # the receiver is available in the body
+
+
+def test_go_else_if_chain_branches():
+    # The C-family ``else if`` nests in the ``alternative`` field; each arm is a
+    # branch and every path reaches exit.
+    fn = _first(
+        "go",
+        """
+        package main
+        func grade(x int) int {
+            y := 0
+            if x == 1 {
+                y = 1
+            } else if x == 2 {
+                y = 2
+            } else if x == 3 {
+                y = 3
+            } else {
+                y = 4
+            }
+            return y
+        }
+        """,
+    )
+    branches = [b for b in fn.cfg.blocks if b.kind == "branch"]
+    assert len(branches) == 3  # three ``if`` tests
+    assert fn.cfg.exit_id in fn.cfg.reachable_ids()
+
+
+def test_go_if_else_branch_and_continue():
+    fn = _first(
+        "go",
+        """
+        package main
+        func f(items []int, x int) int {
+            total := 0
+            for _, it := range items {
+                if it > x {
+                    total += it
+                } else {
+                    total -= it
+                }
+                if it == 0 {
+                    continue
+                }
+            }
+            return total
+        }
+        """,
+    )
+    branches = [b for b in fn.cfg.blocks if b.kind == "branch"]
+    assert len(branches) == 2
+    # The else arm and a join both exist; the loop has a back-edge.
+    assert [b for b in fn.cfg.blocks if b.kind == "join"]
+    assert fn.cfg.back_edges()
+
+
+# A long Go function whose compute-average tail is a clean extraction.
+_GO_PROCESS = """
+package main
+func process(records []int, threshold int) (int, int) {
+    results := []int{}
+    errors := 0
+    for _, r := range records {
+        if r < 0 {
+            errors++
+            continue
+        }
+        results = append(results, r)
+    }
+    total := 0
+    count := 0
+    for _, v := range results {
+        if v > threshold {
+            total += v
+            count++
+        } else {
+            total -= v
+        }
+    }
+    average := 0
+    if count > 0 {
+        average = total / count
+    }
+    return average, errors
+}
+"""
+
+
+def test_go_extract_method_fires():
+    lmap = get_language_map("go")
+    extractions = find_extractions(_first("go", _GO_PROCESS), lmap)
+    assert extractions, "expected at least one Go extraction"
+    best = extractions[0]
+    # The strongest extraction is the compute-average tail.
+    assert "average" in best.returns
+    assert "results" in best.params and "threshold" in best.params
+    assert len(best.returns) <= 1
+    assert best.ccn_removed >= 1
+    assert best.slice_nloc >= 6
+    # The whole function body is never offered as an extraction.
+    assert not (best.start_line <= 4 and best.end_line >= 27)
+
+
+def test_go_extractions_are_deterministic():
+    lmap = get_language_map("go")
+    fn = _first("go", _GO_PROCESS)
+
+    def serialize():
+        return [
+            (e.start_line, e.end_line, e.params, e.returns, e.ccn_removed)
+            for e in find_extractions(fn, lmap)
+        ]
+
+    first = serialize()
+    for _ in range(3):
+        assert serialize() == first
+
+
+# == TypeScript / JavaScript ====================================================
+
+_TS_SHAPES = """
+function shapes(input: number[], base: number): number {
+    let total = 0;
+    const scale = 2;
+    var legacy = 1;
+    for (const v of input) {
+        total += v * scale;
+        legacy++;
+    }
+    const [a, b] = pair(total);
+    const {p, q} = obj;
+    obj.attr = base;
+    arr[0] = total;
+    return a + b + p + q + legacy;
+}
+"""
+
+
+def test_ts_def_use_classification():
+    fn = _first("typescript", _TS_SHAPES)
+    defs = _def_names(fn)
+    # let / const / var / array-destructure / object-destructure are all locals.
+    assert {"total", "scale", "legacy", "v", "a", "b", "p", "q"} <= defs
+    assert {"input", "base"} <= defs  # parameters
+    # Member / subscript targets bind no local; their bases are reads.
+    assert "obj" not in defs
+    assert "attr" not in defs
+    assert "arr" not in defs
+    uses = _use_names(fn)
+    assert {"scale", "v", "obj", "base", "total"} <= uses
+
+
+def test_js_def_use_destructuring():
+    # Plain JS (no type annotations) exercises the shared dialect on the JS pack.
+    fn = _first(
+        "javascript",
+        """
+        function f(items, factor) {
+            let acc = 0;
+            for (const x of items) {
+                acc += x * factor;
+            }
+            const [head, ...tail] = items;
+            return acc + head + tail.length;
+        }
+        """,
+    )
+    defs = _def_names(fn)
+    assert {"acc", "x", "head", "tail"} <= defs
+    assert {"items", "factor"} <= defs
+
+
+_TS_PROCESS = """
+function process(records: number[], threshold: number): [number, number] {
+    const results: number[] = [];
+    let errors = 0;
+    for (const r of records) {
+        if (r < 0) {
+            errors += 1;
+            continue;
+        }
+        results.push(r);
+    }
+    let total = 0;
+    let count = 0;
+    for (const v of results) {
+        if (v > threshold) {
+            total += v;
+            count += 1;
+        } else {
+            total -= v;
+        }
+    }
+    let average = 0;
+    if (count > 0) {
+        average = total / count;
+    }
+    return [average, errors];
+}
+"""
+
+
+def test_ts_extract_method_fires():
+    lmap = get_language_map("typescript")
+    extractions = find_extractions(_first("typescript", _TS_PROCESS), lmap)
+    assert extractions, "expected at least one TS extraction"
+    best = extractions[0]
+    assert "average" in best.returns
+    assert "results" in best.params and "threshold" in best.params
+    assert len(best.returns) <= 1
+    assert best.ccn_removed >= 1
+    assert best.slice_nloc >= 6
+
+
+def test_ts_guard_cascade_has_no_extraction():
+    # Every span contains a return -> no single-exit slice.
+    lmap = get_language_map("typescript")
+    src = """
+        function classify(x: number): string {
+            if (x < 0) {
+                return "neg";
+            }
+            if (x === 0) {
+                return "zero";
+            }
+            if (x < 10) {
+                return "small";
+            }
+            return "large";
+        }
+        """
+    assert find_extractions(_first("typescript", src), lmap) == []
+
+
+def test_ts_extractions_are_deterministic():
+    lmap = get_language_map("typescript")
+    fn = _first("typescript", _TS_PROCESS)
+
+    def serialize():
+        return [
+            (e.start_line, e.end_line, e.params, e.returns, e.ccn_removed)
+            for e in find_extractions(fn, lmap)
+        ]
+
+    first = serialize()
+    for _ in range(3):
+        assert serialize() == first
+
+
+# == flagged-only gate (the per-language budget contract) =======================
+
+
+def test_go_flagged_only_gate_skips_small_functions():
+    _require("go")
+    lines = ["package main", "func big(x int) int {", "    y := 0"]
+    for i in range(12):
+        lines += [f"    if x == {i} {{", f"        y = {i}", "    }"]
+    lines += ["    return y", "}", "", "func tiny() int {", "    return 1", "}", ""]
+    result = build_cfgs_for_file("m.go", "go", "\n".join(lines).encode())
+    if result.stats.functions_seen == 0:
+        pytest.skip("tree-sitter language pack missing for go")
+    assert result.stats.functions_seen == 2
+    assert result.stats.functions_built == 1  # only the flagged big function
+    assert [fc.name for fc in result.functions] == ["big"]
+
+
+def test_ts_flagged_only_gate_skips_small_functions():
+    _require("typescript")
+    lines = ["function big(x: number): number {", "    let y = 0;"]
+    for i in range(12):
+        lines += [f"    if (x === {i}) {{", f"        y = {i};", "    }"]
+    lines += ["    return y;", "}", "", "function tiny(): number {", "    return 1;", "}", ""]
+    result = build_cfgs_for_file("m.ts", "typescript", "\n".join(lines).encode())
+    if result.stats.functions_seen == 0:
+        pytest.skip("tree-sitter language pack missing for typescript")
+    assert result.stats.functions_seen == 2
+    assert result.stats.functions_built == 1
+    assert [fc.name for fc in result.functions] == ["big"]


### PR DESCRIPTION
Extends the intra-procedural dataflow layer (CFG + def/use + reaching definitions) and the Extract Method refactoring from Python to **Go** and **TypeScript/JavaScript**.

## What changed

**1. The CFG builder and Extract Method slicer are now language-agnostic.**
The Python-specific grammar moved onto `LanguageNodeMap`, next to the existing `branch_kinds` / `loop_kinds` / `try_kinds`:
- `if_kinds` — the statement-level conditional (narrower than `branch_kinds`, which also carries ternaries that are not block boundaries)
- `block_kinds` — statement containers (Go nests a `statement_list` inside its `block`, which the builder unwraps)
- `return_kinds` / `raise_kinds` / `break_kinds` / `continue_kinds` — the jumps

The if/else builder handles both grammar families transparently: Python's flat `elif` / `else` clause chain and the C-family `alternative`-field `else if`. `parameter_defs` receives the whole function node so a language can seed binders outside the `parameters` field (a Go method receiver).

No behavioural change for Python.

**2. Go and TS/JS `DefUseDialect`s.**
- **Go:** `:=` / `var` declarations, plain vs compound assignment (told apart by the operator token), `++` / `--` read-modify-write, `range` binders, selector / index targets that bind no local, and the method receiver as a parameter.
- **TS/JS** (one dialect, shared grammar): `let` / `const` / `var`, plain and compound assignment, update expressions, array and object destructuring binders, `for...of` / `for...in` binders, and member / subscript targets. Registered for `typescript`, `tsx`, `javascript`, `jsx`.

Both inherit the flagged-only gate, so the pass stays within the health-pass budget.

## Validation

- **Tests:** 61 dataflow tests pass (14 new): def/use classification across each language's assignment shapes, CFG branch/loop/jump shape (including the C-family else-if chain), a real Extract Method firing per language, the flagged-only gate, and determinism. Full health suite: 708 passed. ruff + mypy clean.
- **Real code (production flagged-only path):**
  - Go on `gorilla/mux` — fires on 4 methods, e.g. `setMatch` sheds ccn 15; gate held 8/108 functions, ~9 ms/file.
  - TS/JS on a Next.js frontend — fires on 60 functions; gate held 212/1172, ~3 ms/file.

## Scope

This is the high-yield set (TS/JS + Go). Java and Rust, then the tail (Kotlin / C++ / C#), follow in later PRs; the core is now general, so each is a new dialect module plus its grammar lines.