### PR TITLE
release: v0.25.0 - Split File + Extract Method refactoring, coverage ingestion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.24.1",
+      "version": "0.25.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.25.0] — 2026-06-27
+
+### Added
+- **Split File refactoring.** Code Health now detects files that should be decomposed into smaller modules and proposes a concrete split. A new detector identifies low-cohesion modules and groups their members into coherent target files (#607), with richer cohesion signals driving the grouping (#614). Each plan is browsable in the web Refactoring tab and can be turned into real code via the deterministic code-gen path (#608).
+- **Extract Method refactoring.** Long, complex functions get an Extract Method suggestion computed over a real dataflow layer: an intra-procedural control-flow graph for flagged functions (#612), def/use chains and reaching definitions over that CFG (#613), and the Extract Method planner built on top (#615). The refactoring is available for Python, Go, and TypeScript/JavaScript (#616).
+- **Coverage report ingestion.** Indexing can now ingest test-coverage reports, folding coverage into the code-health picture during a run. (#604)
+
+### Changed
+- **"Biomarker" is now "marker" in the UI.** Code Health display copy renames the user-facing "biomarker" term to "marker" across the web app and plugin surfaces; internal identifiers are unchanged. (#619)
+
+### Fixed
+- **`.` works as a glob pattern on Python 3.14+.** Passing `.` as a path/glob no longer errors on newer Python. (#609)
+- **Decision harvest skips title-only records.** The decision harvester no longer emits empty records that carry only a title. (#605)
+
+### Documentation
+- Strengthened the code-health validation story and fixed stale references across the docs. (#617)
+- Tightened the code-health docs, named CodeScene explicitly, and moved deeper internals into the architecture doc. (#618)
+
+---
+
 ## [0.24.1] — 2026-06-25
 
 ### Changed

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.24.1"
+__version__ = "0.25.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.24.1"
+__version__ = "0.25.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.25.0] — 2026-06-27
+
+### Added
+- **Split File refactoring.** Code Health now detects files that should be decomposed into smaller modules and proposes a concrete split. A new detector identifies low-cohesion modules and groups their members into coherent target files (#607), with richer cohesion signals driving the grouping (#614). Each plan is browsable in the web Refactoring tab and can be turned into real code via the deterministic code-gen path (#608).
+- **Extract Method refactoring.** Long, complex functions get an Extract Method suggestion computed over a real dataflow layer: an intra-procedural control-flow graph for flagged functions (#612), def/use chains and reaching definitions over that CFG (#613), and the Extract Method planner built on top (#615). The refactoring is available for Python, Go, and TypeScript/JavaScript (#616).
+- **Coverage report ingestion.** Indexing can now ingest test-coverage reports, folding coverage into the code-health picture during a run. (#604)
+
+### Changed
+- **"Biomarker" is now "marker" in the UI.** Code Health display copy renames the user-facing "biomarker" term to "marker" across the web app and plugin surfaces; internal identifiers are unchanged. (#619)
+
+### Fixed
+- **`.` works as a glob pattern on Python 3.14+.** Passing `.` as a path/glob no longer errors on newer Python. (#609)
+- **Decision harvest skips title-only records.** The decision harvester no longer emits empty records that carry only a title. (#605)
+
+### Documentation
+- Strengthened the code-health validation story and fixed stale references across the docs. (#617)
+- Tightened the code-health docs, named CodeScene explicitly, and moved deeper internals into the architecture doc. (#618)
+
+---
+
 ## [0.24.1] — 2026-06-25
 
 ### Changed

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.24.1"
+__version__ = "0.25.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.25.0
+
+### Changed
+- Version bump to track the repowise 0.25.0 release.
+- Renamed the user-facing "biomarker" term to "marker" across the README and the
+  code-health / pre-modification skills, matching the Code Health UI copy change.
+  No MCP tool-surface or command-flag changes this cycle.
+
 ## 0.24.1
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.24.1"
+version = "0.25.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3040,7 +3040,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.24.1"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## release: v0.25.0

Cuts v0.25.0 from latest `main`. Bump-only + changelog; no feature changes in this branch.

### What's in this release
Everything merged to `main` since v0.24.0, headlined by the refactoring/health work:

- **Split File refactoring** — detector for low-cohesion modules (#607), richer cohesion signals (#614), web UI surfacing + code-gen (#608).
- **Extract Method refactoring** — built over a real dataflow layer: intra-procedural CFG (#612), def/use + reaching definitions (#613), the Extract Method planner (#615); available for Python, Go, and TypeScript/JavaScript (#616).
- **Coverage report ingestion** during indexing (#604).
- **"Biomarker" renamed to "marker"** in Code Health display copy (#619).
- Fixes: `.` as a glob on Python 3.14+ (#609); decision harvest skips title-only records (#605).
- Docs: code-health validation story + stale refs (#617); tightened code-health docs, named CodeScene (#618).

(The 0.24.1 changelog entry is preserved as-is; 0.24.1 was bumped in-tree but never tagged, so its changes ship under this release.)

### Version bump
- `pyproject.toml`, the three package `__init__.py`, both plugin manifests, and the `uv.lock` self-entry all moved 0.24.1 -> 0.25.0.
- Store/parser format versions unchanged (additive features only).
- Codex plugin unchanged (stays 0.1.1).

### Test plan
- [x] Version drift grep clean (no 0.24.1 self-references)
- [x] `uv lock` self-entry updated to 0.25.0
- [x] Wheel build clean (`repowise-0.25.0-py3-none-any.whl`); commands + `.scm`/`.j2` data present; bundled changelog has 0.25.0
- [x] Web build clean (Next.js standalone, all routes, workspace-package code transpiled into chunks)
- [x] Bundled-changelog sync guard passes
- [ ] End-to-end browser smoke test (post-merge, hand-off)
- [ ] Tag merge commit on `main` + push (post-merge)

### Merge convention
**Regular merge commit, not squash** — the tag must point at a real merge of the bump-only diff for artifact provenance.
