### PR TITLE
fix: hide config languages from language usage

### DIFF
--- a/packages/ui/__tests__/dashboard/language-donut.test.tsx
+++ b/packages/ui/__tests__/dashboard/language-donut.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LanguageDonut } from "../../src/dashboard/language-donut.js";
+
+describe("LanguageDonut", () => {
+  it("hides config file formats from the visible language usage", () => {
+    render(
+      <LanguageDonut
+        distribution={{
+          Python: 7,
+          TypeScript: 3,
+          JSON: 5,
+          yaml: 4,
+          TOML: 1,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Python")).toBeInTheDocument();
+    expect(screen.getByText("TypeScript")).toBeInTheDocument();
+    expect(screen.queryByText("JSON")).not.toBeInTheDocument();
+    expect(screen.queryByText("yaml")).not.toBeInTheDocument();
+    expect(screen.queryByText("TOML")).not.toBeInTheDocument();
+    expect(screen.getByText("70%")).toBeInTheDocument();
+    expect(screen.getByText("30%")).toBeInTheDocument();
+  });
+
+  it("renders nothing when only config file formats are present", () => {
+    const { container } = render(
+      <LanguageDonut distribution={{ json: 2, YAML: 1, toml: 1 }} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/ui/src/dashboard/language-donut.tsx
+++ b/packages/ui/src/dashboard/language-donut.tsx
@@ -16,8 +16,14 @@ const LANG_COLORS: Record<string, string> = {
   config: "var(--color-lang-config)",
 };
 
+const HIDDEN_LANGUAGE_USAGE_FORMATS = new Set(["json", "yaml", "toml"]);
+
 function getLangColor(lang: string): string {
   return LANG_COLORS[lang.toLowerCase()] ?? "var(--color-lang-other)";
+}
+
+function shouldShowLanguageUsage(name: string): boolean {
+  return !HIDDEN_LANGUAGE_USAGE_FORMATS.has(name.trim().toLowerCase());
 }
 
 interface LanguageDonutProps {
@@ -29,6 +35,7 @@ interface LanguageDonutProps {
 
 export function LanguageDonut({ distribution, viewAllHref }: LanguageDonutProps) {
   const entries = Object.entries(distribution)
+    .filter(([name]) => shouldShowLanguageUsage(name))
     .map(([name, value]) => ({ name, value }))
     .sort((a, b) => b.value - a.value);
 


### PR DESCRIPTION
## Summary

- hide JSON, YAML, and TOML from the shared language usage donut
- recalculate visible percentages after filtering config/data formats
- add a regression test for mixed-case config language names

Fixes #371.

## Tests

- npm run test --workspace @repowise-dev/ui -- __tests__/dashboard/language-donut.test.tsx
- npm run type-check --workspace @repowise-dev/ui
- npm run test --workspace @repowise-dev/ui
- git diff --check
