### PR TITLE
docs: publish verified no-key quickstart (README + repowise.dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ the contributor recipe: **[docs/LANGUAGE_SUPPORT.md →](docs/LANGUAGE_SUPPORT.m
 
 ```bash
 pip install repowise          # Windows: python -m pip install repowise
-repowise --version            # -> repowise, version 0.25.x
+repowise --version            # -> repowise, version 0.27.x
 ```
 
 **2. Index your repo — no LLM, no key**

--- a/README.md
+++ b/README.md
@@ -360,67 +360,71 @@ the contributor recipe: **[docs/LANGUAGE_SUPPORT.md →](docs/LANGUAGE_SUPPORT.m
 
 ---
 
-## Quickstart
+<a id="quickstart"></a>
+
+## Quick start (under 5 minutes, no API key)
+
+*Index once, and give your agent the dependency graph + git history + code-health
+— not 40 greps.*
+
+**1. Install**
 
 ```bash
-pip install repowise          # or: uv tool install repowise
+pip install repowise          # Windows: python -m pip install repowise
+repowise --version            # -> repowise, version 0.25.x
 ```
 
-### Single repo
+**2. Index your repo — no LLM, no key**
 
 ```bash
-cd your-project
-repowise init        # builds all five intelligence layers (one-time)
-repowise serve       # starts MCP server + local dashboard
+cd /path/to/your/repo
+repowise init --index-only -y
 ```
 
-### Multi-repo workspace
+Builds the dependency graph, git history, code-health score, and dead-code findings
+in seconds. (Want the generated wiki + semantic search? Use
+`repowise init --provider gemini|anthropic|openai` with the matching key.)
+
+**3. Connect your agent** — the MCP server is `repowise mcp`, served from the repo dir.
+
+<details><summary><b>Claude Code</b></summary>
 
 ```bash
-cd my-workspace/     # parent dir containing backend/, frontend/, shared-libs/
-repowise init .      # scans for git repos, indexes each, runs cross-repo analysis
-repowise serve       # workspace dashboard, Live System Map + per-repo pages
-```
-
-The workspace **Live System Map** renders your services and their typed
-relationships (HTTP / gRPC / events / package deps / co-change) as a
-code-derived, always-current diagram, health-colored, filterable, with
-drill-down to the underlying contracts. See
-[Workspaces](docs/WORKSPACES.md#live-system-map).
-
-`repowise init` automatically registers the MCP server, installs a PostToolUse
-hook in `~/.claude/settings.json`, generates `.mcp.json` at the project root, and
-offers a post-commit hook that keeps everything in sync. If the Codex CLI is
-installed and logged in, interactive runs also offer to write project-local
-`.codex/config.toml`, `.codex/hooks.json`, and a managed `AGENTS.md`;
-non-interactive runs require `--codex`. Skip Codex setup with `--no-codex`; force or
-skip `AGENTS.md` with `--agents` / `--no-agents`.
-
-**Claude Code plugin.** Prefer a one-command setup? Install the plugin from the
-marketplace: it registers the MCP server and hook and adds `/repowise:*` slash
-commands (`init`, `health`, `risk`, `dead-code`, `decision`, …):
-
-```text
+# Plugin (adds 9 tools + slash commands + skills):
 /plugin marketplace add repowise-dev/repowise
 /plugin install repowise@repowise
+
+# …or wire the MCP server directly:
+claude mcp add repowise -- repowise mcp
 ```
-
-To add the MCP server to another editor manually:
-
+Or commit a project `.mcp.json`:
 ```json
-{
-  "mcpServers": {
-    "repowise": { "command": "repowise", "args": ["mcp", "/path/to/your/project"] }
-  }
-}
+{ "mcpServers": { "repowise": { "command": "repowise", "args": ["mcp"] } } }
 ```
+</details>
 
-> **Init time:** the graph, git, dead-code, and code-health layers build in
-> minutes with **zero LLM calls**; run `repowise init --index-only` for a
-> queryable index almost immediately. The one-time cost is the documentation
-> layer (LLM-generated wiki pages, can run in the background). After that, every
-> commit-triggered update takes **under 30 seconds** and only regenerates the
-> pages your change touched.
+<details><summary><b>Codex CLI</b></summary>
+
+Add to `~/.codex/config.toml`:
+```toml
+[mcp_servers.repowise]
+command = "repowise"
+args = ["mcp"]
+```
+Or: `codex mcp add repowise -- repowise mcp`
+</details>
+
+**4. First real call.** Ask your agent: *"Use repowise `get_overview` to summarize this
+repo,"* or *"`get_context` for `src/auth.py`."* You get graph-grounded architecture and
+per-file triage instead of a flurry of greps. ✅
+
+> `get_overview` / `get_context` work in **index-only mode** (no key) — they synthesize
+> from the graph/git/health layers. `search_codebase` / `get_answer` / `get_why` need
+> full mode (the generated wiki).
+
+Ready for the full picture? Run `repowise init --provider …` for the generated wiki +
+semantic search, or skip key management entirely with the hosted tier at
+[repowise.dev](https://www.repowise.dev). Full walkthrough: [docs/QUICKSTART.md](docs/QUICKSTART.md).
 
 **Docs:** [Quickstart](docs/QUICKSTART.md) · [User Guide](docs/USER_GUIDE.md) · [CLI Reference](docs/CLI_REFERENCE.md) · [Codex](docs/CODEX.md) · [MCP Tools](docs/MCP_TOOLS.md) · [Distill](docs/DISTILL.md) · [Workspaces](docs/WORKSPACES.md) · [Auto-Sync](docs/AUTO_SYNC.md) · [Upgrading](docs/UPGRADING.md) · [Config](docs/CONFIG.md)
 

--- a/website/getting-started.md
+++ b/website/getting-started.md
@@ -28,7 +28,7 @@ The 60-second path to codebase intelligence.
 
 ```bash
 pip install repowise          # Windows: python -m pip install repowise
-repowise --version            # -> repowise, version 0.25.x
+repowise --version            # -> repowise, version 0.27.x
 ```
 
 **2. Index your repo — no LLM, no key**

--- a/website/getting-started.md
+++ b/website/getting-started.md
@@ -20,6 +20,63 @@ The 60-second path to codebase intelligence.
 
 ---
 
+## Quick start (under 5 minutes, no API key)
+
+*Index once, and give your agent the dependency graph + git history + code-health — not 40 greps.*
+
+**1. Install**
+
+```bash
+pip install repowise          # Windows: python -m pip install repowise
+repowise --version            # -> repowise, version 0.25.x
+```
+
+**2. Index your repo — no LLM, no key**
+
+```bash
+cd /path/to/your/repo
+repowise init --index-only -y
+```
+
+Builds the dependency graph, git history, code-health score, and dead-code findings in seconds. (Want the generated wiki + semantic search? Use `repowise init --provider gemini|anthropic|openai` with the matching key.)
+
+**3. Connect your agent** — the MCP server is `repowise mcp`, served from the repo dir.
+
+<details markdown="block"><summary><b>Claude Code</b></summary>
+
+```bash
+# Plugin (adds 9 tools + slash commands + skills):
+/plugin marketplace add repowise-dev/repowise
+/plugin install repowise@repowise
+
+# …or wire the MCP server directly:
+claude mcp add repowise -- repowise mcp
+```
+Or commit a project `.mcp.json`:
+```json
+{ "mcpServers": { "repowise": { "command": "repowise", "args": ["mcp"] } } }
+```
+</details>
+
+<details markdown="block"><summary><b>Codex CLI</b></summary>
+
+Add to `~/.codex/config.toml`:
+```toml
+[mcp_servers.repowise]
+command = "repowise"
+args = ["mcp"]
+```
+Or: `codex mcp add repowise -- repowise mcp`
+</details>
+
+**4. First real call.** Ask your agent: *"Use repowise `get_overview` to summarize this repo,"* or *"`get_context` for `src/auth.py`."* You get graph-grounded architecture and per-file triage instead of a flurry of greps. ✅
+
+> `get_overview` / `get_context` work in **index-only mode** (no key) — they synthesize from the graph/git/health layers. `search_codebase` / `get_answer` / `get_why` need full mode (the generated wiki).
+
+Ready for the full picture? Run `repowise init --provider …` for the generated wiki + semantic search, or skip key management entirely with the [hosted tier](https://www.repowise.dev). The detailed setup paths below walk through each editor and mode.
+
+---
+
 ## Choose your path
 
 There are three ways to set up repowise. Pick the one that fits how you work.


### PR DESCRIPTION
## What

Publishes the **REP-2 verified, REP-9 board-approved** quickstart into the two public surfaces:

1. **README `## Quickstart`** — replaced the previous `init`/`serve` section with the no-key, under-5-minute path. The `#quickstart` nav anchor is preserved via an explicit `<a id="quickstart">`.
2. **`website/getting-started.md` (repowise.dev quickstart)** — same approved copy added as the **lead** section; the existing detailed multi-path setup (Plugin / pip+Claude / pip+Codex / standalone) is retained below it.

Source of truth: `docs/README-quickstart-section.md` (REP-2 deliverable).

## Why it's safe to ship

- **Docs-only.** No registry/PyPI/CI changes. `repowise` already installs (CLI 0.25.0).
- **Verified clean-run:** `docs/QUICKSTART-VERIFICATION.md` — `pip install` → `repowise init --index-only -y` (2.8s, no key) → `get_overview` / `get_context` return real structured data over MCP. The doc accurately states which tools need full mode.
- **CEO sign-off granted** via REP-9 (approved by the human board).

## Editorial notes for reviewer

- README: the old section also carried the multi-repo **Live System Map** blurb. That capability is still covered by the feature table above the Quickstart and in `docs/WORKSPACES.md`; flagging in case you want it echoed back into the new section.
- Both optional board polish notes were applied (non-blocking): the one-line payoff hook above Step 1, and a full-mode/hosted upsell near the closing note.
- README plugin marketplace ref uses `repowise-dev/repowise` (matches prior README). Note `website/getting-started.md`'s older Path 1 still says `repowise-dev/repowise-plugin` — left untouched as out of scope, but worth reconciling separately.

Tracking: REP-10.