### PR TITLE
fix(go): rescue same-file type references from unused_export false po…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1293,7 +1293,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1316,7 +1315,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1339,7 +1337,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1356,7 +1353,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1373,7 +1369,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1390,7 +1385,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1407,7 +1401,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1424,7 +1417,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1441,7 +1433,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1458,7 +1449,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1475,7 +1465,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1492,7 +1481,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1509,7 +1497,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1532,7 +1519,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1555,7 +1541,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1578,7 +1563,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1601,7 +1585,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1624,7 +1607,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1647,7 +1629,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1670,7 +1651,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1690,7 +1670,6 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -1713,7 +1692,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1733,7 +1711,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1753,7 +1730,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1293,6 +1293,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1315,6 +1316,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1337,6 +1339,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1353,6 +1356,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1369,6 +1373,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1385,6 +1390,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1401,6 +1407,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1417,6 +1424,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1433,6 +1441,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1449,6 +1458,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1465,6 +1475,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1481,6 +1492,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -1497,6 +1509,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1519,6 +1532,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1541,6 +1555,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1563,6 +1578,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1585,6 +1601,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1607,6 +1624,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1629,6 +1647,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1651,6 +1670,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1670,6 +1690,7 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -1692,6 +1713,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1711,6 +1733,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1730,6 +1753,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },

--- a/packages/core/src/repowise/core/ingestion/type_ref_resolution.py
+++ b/packages/core/src/repowise/core/ingestion/type_ref_resolution.py
@@ -301,7 +301,7 @@ def _resolve_go_type_refs(
 
     if same_file_refs and graph.has_node(from_path):
         existing = graph.nodes[from_path].get("local_type_uses")
-        if not existing:
+        if existing is None:
             graph.nodes[from_path]["local_type_uses"] = same_file_refs
         else:
             existing.update(same_file_refs)

--- a/packages/core/src/repowise/core/ingestion/type_ref_resolution.py
+++ b/packages/core/src/repowise/core/ingestion/type_ref_resolution.py
@@ -274,26 +274,38 @@ def _resolve_go_type_refs(
         elif imp.resolved_file and not imp.resolved_file.startswith("external:"):
             candidates.add(imp.resolved_file)
     candidates.discard(from_path)
-    if not candidates:
-        return 0
     # Sorted once: set iteration; first-match must be deterministic.
     sorted_candidates = sorted(candidates)
 
     emitted = 0
     seen_targets: set[tuple[str, str]] = set()
+    same_file_refs: set[str] = set()
     for ref in parsed.type_refs:
         name = ref.type_name
         if not name or name in _GO_BUILTIN_TYPES:
             continue
+        # Check cross-file candidates first.
         target = _find_go_type_file(name, sorted_candidates, defined_names)
-        if target is None or target == from_path:
+        if target is not None and target != from_path:
+            if (name, target) not in seen_targets:
+                seen_targets.add((name, target))
+                _add_or_merge_type_use_edge(graph, src=from_path, dst=target,
+                                            type_name=name, origin=ref.origin)
+                emitted += 1
             continue
-        if (name, target) in seen_targets:
-            continue
-        seen_targets.add((name, target))
-        _add_or_merge_type_use_edge(graph, src=from_path, dst=target,
-                                    type_name=name, origin=ref.origin)
-        emitted += 1
+        # Type not found cross-file — check if it is defined in the same file.
+        # Stamp it onto local_type_uses so the dead-code analyzer rescues it
+        # (same mechanism used by TS/JS for intra-module type references).
+        if name in defined_names.get(from_path, _EMPTY_NAMES):
+            same_file_refs.add(name)
+
+    if same_file_refs and graph.has_node(from_path):
+        existing = graph.nodes[from_path].get("local_type_uses")
+        if not existing:
+            graph.nodes[from_path]["local_type_uses"] = same_file_refs
+        else:
+            existing.update(same_file_refs)
+
     return emitted
 
 

--- a/tests/unit/ingestion/test_go_type_use.py
+++ b/tests/unit/ingestion/test_go_type_use.py
@@ -243,7 +243,10 @@ class TestGoSameFileTypeUseFallback:
             "// Widget is exported and used only as a return type within\n"
             "// this same file — no cross-file or cross-package reference.\n"
             "type Widget struct{}\n\n"
-            "func NewWidget() *Widget { return &Widget{} }\n"
+            "func NewWidget() *Widget { return &Widget{} }\n\n"
+            "// DeadWidget is exported and never referenced anywhere — a true\n"
+            "// positive that must survive the same-file rescue.\n"
+            "type DeadWidget struct{}\n"
         ),
     }
 
@@ -282,6 +285,26 @@ class TestGoSameFileTypeUseFallback:
             f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
         }
         assert "Widget" not in unused_exports
+
+    def test_single_file_dead_export_still_flagged(self, tmp_path: Path) -> None:
+        # True-positive guard: the same-file rescue must not turn into a
+        # blanket "never flag single-file exports." DeadWidget lives in the
+        # same single-file, no-import package that hits the rescue path, but
+        # is never referenced — it must still be flagged unused_export.
+        graph = self._build_graph(tmp_path)
+        analyzer = DeadCodeAnalyzer(graph, git_meta_map={})
+        report = analyzer.analyze(
+            {
+                "detect_unreachable_files": False,
+                "detect_zombie_packages": False,
+                "detect_unused_internals": True,
+                "min_confidence": 0.0,
+            }
+        )
+        unused_exports = {
+            f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
+        }
+        assert "DeadWidget" in unused_exports
 
 
 class TestGoDeadCodeOutcome:

--- a/tests/unit/ingestion/test_go_type_use.py
+++ b/tests/unit/ingestion/test_go_type_use.py
@@ -220,6 +220,70 @@ class TestGoCallResolution:
 # ---------------------------------------------------------------------------
 
 
+class TestGoSameFileTypeUseFallback:
+    """Regression coverage for the same-file fallback in
+    ``_resolve_go_type_refs`` (see commit "fix(go): rescue same-file type
+    references from unused_export false positives").
+
+    A single-file Go package with no imports has an empty candidate set —
+    ``own_pkg.files`` is just ``{from_path}``, discarded before the loop.
+    Before the fix, ``if not candidates: return 0`` bailed out of the whole
+    function for such files, so a type used only within that one file (as a
+    field/return type, never imported anywhere) was never stamped onto
+    ``local_type_uses`` and read as a genuinely-dead export. This is exactly
+    the shape of the 7 false positives the fix rescues.
+    """
+
+    _SOURCES: dict[str, str] = {
+        "go.mod": "module example.com/widget\n\ngo 1.22\n",
+        # Single-file package, zero imports — candidates is empty for this
+        # file even before ``from_path`` is discarded.
+        "widget/widget.go": (
+            "package widget\n\n"
+            "// Widget is exported and used only as a return type within\n"
+            "// this same file — no cross-file or cross-package reference.\n"
+            "type Widget struct{}\n\n"
+            "func NewWidget() *Widget { return &Widget{} }\n"
+        ),
+    }
+
+    def _build_graph(self, repo: Path) -> nx.DiGraph:
+        for rel, body in self._SOURCES.items():
+            p = repo / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body, encoding="utf-8")
+
+        builder = GraphBuilder(repo_path=repo)
+        for rel in self._SOURCES:
+            if not rel.endswith(".go"):
+                continue
+            abs_path = str((repo / rel).resolve())
+            parsed = _PARSER.parse_file(_file_info(rel, abs_path), (repo / rel).read_bytes())
+            builder.add_file(parsed)
+        return builder.build()
+
+    def test_same_file_return_type_stamped_as_local_type_use(self, tmp_path: Path) -> None:
+        graph = self._build_graph(tmp_path)
+        node_data = graph.nodes["widget/widget.go"]
+        assert "Widget" in node_data.get("local_type_uses", set())
+
+    def test_same_file_only_type_not_flagged_unused_export(self, tmp_path: Path) -> None:
+        graph = self._build_graph(tmp_path)
+        analyzer = DeadCodeAnalyzer(graph, git_meta_map={})
+        report = analyzer.analyze(
+            {
+                "detect_unreachable_files": False,
+                "detect_zombie_packages": False,
+                "detect_unused_internals": True,
+                "min_confidence": 0.0,
+            }
+        )
+        unused_exports = {
+            f.symbol_name for f in report.findings if f.kind == DeadCodeKind.UNUSED_EXPORT
+        }
+        assert "Widget" not in unused_exports
+
+
 class TestGoDeadCodeOutcome:
     def _report(self, graph: nx.DiGraph):
         analyzer = DeadCodeAnalyzer(graph, git_meta_map={})


### PR DESCRIPTION
## Summary

  - Go same-file type references (return types, field types) were silently discarded in `_resolve_go_type_refs`, producing false-positive unused_export findings at 100% confidence for actively used exported structs
  
  - Fixed by stamping same-file Go type refs onto `local_type_uses` on the file node, which the dead-code analyzer already reads to rescue symbols (the same mechanism TS/JS uses)

## Related Issues

closes https://github.com/repowise-dev/repowise/issues/628

## Test Plan
  - [x] Verified on a real Go project: 7 FPs previously all gone
  - [x] All existing tests still pass
  - [x] Added regression test (`TestGoSameFileTypeUseFallback` in `test_go_type_use.py`): a single-file, no-import Go package with a struct used only as a same-file return type, confirmed it fails against the pre-fix code (flagged `unused_export`) and passes with the fix
