### PR TITLE
feat(vscode): trim webview bundle, graph panels, a11y, and release tooling

### DIFF
--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -1,0 +1,73 @@
+name: Publish VS Code extension
+
+# Stable releases run on a `vscode-v*` tag push. A manual dispatch publishes to
+# the pre-release channel by default (uncheck to cut a stable build from main).
+# The extension version is read from packages/vscode/package.json and is
+# independent of the Python package; the only coupling is MIN_SERVER_VERSION.
+on:
+  push:
+    tags:
+      - "vscode-v*"
+  workflow_dispatch:
+    inputs:
+      preRelease:
+        description: "Publish to the pre-release channel"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run type-check --workspace packages/vscode
+
+      # Build must run in CI, not just type-check: a barrel value-import once
+      # passed tsc but broke the bundle (see packages/vscode/RELEASING.md).
+      - name: Build extension host (asserts bundle size budget)
+        run: npm run build --workspace packages/vscode
+
+      - name: Build webviews
+        run: npm run build:webview --workspace packages/vscode
+
+      - name: Webview unit tests
+        run: npm run test:webview --workspace packages/vscode
+
+      - name: Smoke test under a virtual display
+        run: xvfb-run -a npm run test --workspace packages/vscode
+
+      - name: Resolve release channel
+        id: channel
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.preRelease }}" != "false" ]; then
+            echo "flag=--pre-release" >> "$GITHUB_OUTPUT"
+          else
+            echo "flag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Package and publish
+        working-directory: packages/vscode
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          FLAG: ${{ steps.channel.outputs.flag }}
+        run: |
+          npx @vscode/vsce package $FLAG --no-dependencies -o repowise.vsix
+          npx @vscode/vsce publish $FLAG --no-dependencies --packagePath repowise.vsix
+          npx ovsx publish repowise.vsix $FLAG

--- a/README.md
+++ b/README.md
@@ -308,6 +308,21 @@ pattern scan) · **Costs** · **Workspace**
 
 ---
 
+## VS Code extension
+
+The **Repowise** extension puts the index where code gets written: inline health
+diagnostics and gutter heat on the files you open, refactoring plans as CodeLens,
+branch risk before you push, and the same dashboards (health, architecture,
+knowledge graph, decisions, docs) inside the editor. One install also registers
+the Repowise MCP server with VS Code, so the same local index serves both you and
+your AI agent.
+
+Install from the Marketplace (search **Repowise**) or Open VSX, then run
+**Repowise: Set Up This Repository**. Full guide in
+[docs/VSCODE.md →](docs/VSCODE.md).
+
+---
+
 ## Supported languages
 
 **15 languages parsed to AST · 9 at the Full tier · framework-aware across all of them.**

--- a/docs/VSCODE.md
+++ b/docs/VSCODE.md
@@ -1,0 +1,83 @@
+# Repowise for VS Code
+
+The Repowise extension brings the local index into your editor and registers the
+Repowise MCP server with VS Code, so the same index serves both you and your AI
+coding agent. It is a thin client over the local `repowise` CLI and server:
+everything is computed on your machine and nothing about your code leaves it
+through the extension.
+
+## Install
+
+1. Install the CLI: `pip install repowise` (or `uv tool install repowise`).
+2. Install the extension from the Marketplace (search **Repowise**, publisher
+   `repowise-dev`) or from Open VSX for VS Code forks.
+3. Open a repository and run **Repowise: Set Up This Repository** to build the
+   index, or follow the **Get Started with Repowise** walkthrough.
+
+The extension activates only in trusted workspaces and does no work at startup
+beyond registering its commands. It discovers a running server from the lockfile
+under `.repowise/`, or offers to start one when you first need data.
+
+## What it surfaces
+
+### Editor-native signals
+
+- **Diagnostics** for the files you open, published to the Problems panel. Quiet
+  by default: only high-severity findings, capped at Warning. Lower-severity
+  findings live in the gutter and tree views.
+- **Gutter heat**: a severity-tiered strip next to lines with findings in the
+  visible editor.
+- **File health in the status bar**: defect, maintainability, and performance
+  scores for the active file.
+- **File explorer badges** on the worst-health files (threshold configurable).
+- **Refactoring CodeLens** above symbols with a detected plan, including
+  **Copy plan for agent** (the same payload the web Refactoring tab produces).
+- **Hovers** with file health, hotspot flag, primary owner, and governing
+  decisions.
+- **Branch risk** from the SCM title bar: score the current branch against its
+  base, with the drivers behind the score.
+
+### Tree views
+
+A single Repowise activity-bar container with a **Home** overview, a **Findings**
+tree (health, hotspots, ownership, dead code), and a **Refactoring** tree. All
+lazy: data is fetched on first expand and refreshed only when the index moves.
+
+### Dashboards
+
+Editor-tab webviews rendered from the same shared visualization library the web
+app uses (no duplicated components): **health overview**, **C4 architecture**,
+**knowledge graph** (with node search, path finder, and community detail),
+**refactoring plans**, **decision timeline**, and a **docs browser**.
+
+## MCP for your AI agent
+
+One install registers the Repowise MCP server with VS Code, so agent-mode
+assistants query the index through task-shaped tools instead of guessing from
+open files. For editors that read a config file, run **Repowise: Configure MCP
+for this Workspace** to write `.vscode/mcp.json`.
+
+## Settings
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `repowise.server.autoStart` | `ask` | Start the local server automatically, ask first, or never |
+| `repowise.server.port` | discover | Override the server port instead of using lockfile discovery |
+| `repowise.cliPath` | PATH | Absolute path to the `repowise` executable |
+| `repowise.diagnostics.enabled` | `true` | Show health findings in the Problems panel |
+| `repowise.diagnostics.minSeverity` | `high` | Lowest severity surfaced in the Problems panel |
+| `repowise.diagnostics.dimensions` | all | Health dimensions included in the Problems panel |
+| `repowise.gutterHeat.enabled` | `true` | Shade the gutter next to findings |
+| `repowise.fileDecorations.enabled` | `true` | Badge the worst-health files in the explorer |
+| `repowise.codeLens.enabled` | `true` | Show refactoring plan lenses |
+| `repowise.hover.enabled` | `true` | Show file health context on hover |
+| `repowise.risk.baseBranch` | default branch | Base branch for branch risk scoring |
+
+## Privacy
+
+The extension talks only to the local Repowise CLI and server on your machine
+and reads the index under `.repowise/`. It sends no telemetry of its own. The
+CLI's own telemetry opt-out is respected because the extension itself sends
+nothing.
+
+The extension source lives in [`packages/vscode`](../packages/vscode).

--- a/packages/ui/src/health/kpi-cards.tsx
+++ b/packages/ui/src/health/kpi-cards.tsx
@@ -233,7 +233,9 @@ function SignalTile({
         <span className="inline-flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
           <span className="text-[var(--color-text-secondary)]">{icon}</span>
           {label}
-          <InfoTip content={hint} label={`About ${label}`} />
+          {/* z-10 keeps this info button clickable above the tile's stretched
+              click target (which is a sibling, never a wrapping button). */}
+          <InfoTip content={hint} label={`About ${label}`} className="relative z-10" />
         </span>
         {sparkline && sparkline.length > 1 ? (
           <span className="text-[var(--color-text-tertiary)]">
@@ -274,29 +276,40 @@ function SignalTile({
       {children}
     </>
   );
-  return <TileShell onClick={onClick}>{inner}</TileShell>;
+  return (
+    <TileShell onClick={onClick} ariaLabel={`View ${label} findings`}>
+      {inner}
+    </TileShell>
+  );
 }
 
-/** Shared chrome for a hero signal tile — a static card, or a button when an
- *  `onClick` makes it a jump into the pillar-filtered view. */
+/** Shared chrome for a hero signal tile: a static card, or a card with a
+ *  stretched click target when an `onClick` makes it a jump into the
+ *  pillar-filtered view. The click target is a sibling button covering the
+ *  card rather than a button wrapping the content, so the header's info button
+ *  is not an (invalid) interactive descendant of another button. */
 function TileShell({
   onClick,
+  ariaLabel,
   children,
 }: {
   onClick?: (() => void) | undefined;
+  ariaLabel?: string | undefined;
   children: React.ReactNode;
 }) {
   const cls =
-    "flex w-full flex-col rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 text-left transition-colors";
+    "relative flex w-full flex-col rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 text-left transition-colors";
   if (onClick) {
     return (
-      <button
-        type="button"
-        onClick={onClick}
-        className={`${cls} cursor-pointer hover:border-[var(--color-border-strong)]`}
-      >
+      <div className={`${cls} hover:border-[var(--color-border-strong)]`}>
         {children}
-      </button>
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          onClick={onClick}
+          className="absolute inset-0 cursor-pointer rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)]"
+        />
+      </div>
     );
   }
   return <div className={cls}>{children}</div>;
@@ -324,7 +337,7 @@ function PerformanceTile({
           <Gauge className="h-4 w-4" />
         </span>
         Performance
-        <InfoTip content={PERF_HINT} label="About Performance" />
+        <InfoTip content={PERF_HINT} label="About Performance" className="relative z-10" />
       </span>
 
       {score == null ? (
@@ -368,5 +381,9 @@ function PerformanceTile({
       )}
     </>
   );
-  return <TileShell onClick={interactive ? onClick : undefined}>{inner}</TileShell>;
+  return (
+    <TileShell onClick={interactive ? onClick : undefined} ariaLabel="View Performance findings">
+      {inner}
+    </TileShell>
+  );
 }

--- a/packages/vscode/.vscodeignore
+++ b/packages/vscode/.vscodeignore
@@ -11,3 +11,5 @@ esbuild.mjs
 **/*.map
 **/.gitkeep
 .gitignore
+RELEASING.md
+*.vsix

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -7,6 +7,16 @@ This extension brings that index into VS Code, for both halves of how code gets 
 - **For you:** discover or start the local Repowise server for the current workspace, see connection and setup state at a glance, and get guided from a fresh clone to a fully indexed repository without leaving the editor.
 - **For your AI agent:** one install registers the Repowise MCP server with VS Code, so agent-mode assistants query the index through task-shaped tools and answer "why does auth work this way?" from grounded architecture, history, and health data instead of guessing from open files.
 
+## What you get
+
+- **Inline health signals** on the files you open: findings in the Problems panel (quiet by default, high severity only), a gutter heat strip for the full set, and file health scores in the status bar.
+- **Refactoring plans as CodeLens** above the symbols they target, with one click to copy the plan as a prompt for your agent.
+- **Branch risk before you push**: score a branch against its base from the SCM title bar, with the drivers behind the score.
+- **Hovers and tree views** for ownership, hotspots, dead code, and architectural decisions, all lazy and refreshed only when the index moves.
+- **Dashboards inside the editor**: health overview, C4 architecture, knowledge graph, refactoring plans, decision timeline, and a docs browser, rendered from the same visualizations the web app uses.
+
+<!-- Screenshots / GIFs: drop captures under media/screenshots and link them here before the stable Marketplace release. -->
+
 ## Getting started
 
 1. Install the CLI: `pip install repowise` (or `uv tool install repowise`).
@@ -21,6 +31,13 @@ This extension brings that index into VS Code, for both halves of how code gets 
 | Repowise: Set Up This Repository | Build the index for this workspace |
 | Repowise: Start Server / Stop Server | Manage the local API server |
 | Repowise: Configure MCP for this Workspace | Write `.vscode/mcp.json` for MCP clients |
+| Repowise: Check Branch Risk | Score the current branch against its base |
+| Repowise: Update Index | Sync the index with your latest commits |
+| Repowise: Show Health Dashboard | Open the health overview |
+| Repowise: Show Architecture Map | Open the C4 architecture view |
+| Repowise: Show Knowledge Graph | Open the dependency constellation |
+| Repowise: Show Decision Timeline | Browse mined architectural decisions |
+| Repowise: Open Docs for This File | Open the generated docs for the active file |
 | Repowise: Check Setup | Diagnose install, keys, and index state |
 | Repowise: Show Log | Open the extension log |
 

--- a/packages/vscode/RELEASING.md
+++ b/packages/vscode/RELEASING.md
@@ -1,0 +1,87 @@
+# Releasing the VS Code extension
+
+The extension publishes to the Visual Studio Marketplace (publisher
+`repowise-dev`) and to Open VSX (for VS Code forks). Releases are driven by the
+`publish-vscode.yml` workflow; this doc is the checklist around it.
+
+## Versioning
+
+- The extension version in `package.json` is **independent of the Python
+  package**. The only cross-version coupling is the `MIN_SERVER_VERSION`
+  constant the extension checks against the running server. Bump it only when
+  the extension starts relying on a newer server contract.
+- Marketplace pre-releases use the same version number published to the
+  pre-release channel. Cut a stable release from a tag once a pre-release has
+  been dogfooded.
+
+## The one rule that has bitten us before
+
+**CI (and this checklist) must BUILD, not just type-check.** A barrel
+value-import once passed `tsc` and still broke the built bundle (see the web
+lesson in `.claude/RELEASING.md`). Both the host esbuild bundle and the Vite
+webview bundle must be built and exercised before every publish. The publish
+workflow builds both and runs the webview + electron smoke tests for exactly
+this reason.
+
+## Pre-publish checklist
+
+Run from the repo root unless noted.
+
+1. `npm run type-check --workspace packages/vscode`
+2. `npm run build --workspace packages/vscode` (asserts the host bundle size
+   budget)
+3. `npm run build:webview --workspace packages/vscode` (review the chunk-size
+   report; the largest lazy chunk is ELK, shared by the graph and C4 views)
+4. `npm run test:webview --workspace packages/vscode`
+5. `npm run test --workspace packages/vscode` (electron smoke; use
+   `xvfb-run -a` on Linux)
+6. `npm run package --workspace packages/vscode` and note the VSIX size
+7. **Clean-profile install smoke test**: install the packaged VSIX into a fresh
+   VS Code profile with no `repowise` CLI configured, and confirm:
+   - the walkthrough appears and walks install -> index -> first insight -> MCP
+   - after setup, a low-health file shows diagnostics and gutter heat
+   - a dashboard opens and renders (health or knowledge graph)
+   - the Repowise MCP tools are listed in agent mode
+8. **Fork check (optional but recommended)**: install the VSIX in Cursor and
+   confirm the MCP tools load via the `.vscode/mcp.json` fallback written by
+   **Repowise: Configure MCP for this Workspace**.
+
+## Publishing
+
+Secrets required in the repository (Settings -> Secrets -> Actions):
+
+- `VSCE_PAT` - a Marketplace Personal Access Token for the `repowise-dev`
+  publisher.
+- `OVSX_PAT` - an Open VSX access token.
+
+### Pre-release (from main)
+
+Run the **Publish VS Code extension** workflow via `workflow_dispatch` with the
+default (pre-release checked). It builds, tests, packages with `--pre-release`,
+and publishes to both marketplaces.
+
+### Stable
+
+Bump `packages/vscode/package.json` version, commit, then push a tag:
+
+```
+git tag vscode-v0.1.0
+git push origin vscode-v0.1.0
+```
+
+The tag push triggers the workflow and publishes a stable build to both
+marketplaces.
+
+## After publishing
+
+- Verify the listing on the Marketplace and Open VSX (icon, gallery banner,
+  README render, screenshots).
+- Install the published build from the Marketplace into a clean profile once
+  more as a final confirmation.
+
+## Notes
+
+- No plan or phase references, competitor names, AI attribution, or em dashes in
+  the published README, CHANGELOG, or listing copy.
+- Screenshots and GIFs go under `media/screenshots` and are linked from the
+  README before the first stable release.

--- a/packages/vscode/media/walkthrough/first-insight.md
+++ b/packages/vscode/media/walkthrough/first-insight.md
@@ -1,0 +1,7 @@
+# See your first insight
+
+Once the index is connected, open a file to see its health findings inline, or
+open the **Home** view in the Repowise sidebar for the repository overview.
+
+Run **Repowise: Show Health Dashboard** to see the health map, the hotspots that
+drive most of the risk, and the files worth refactoring first.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -35,6 +35,11 @@
     "codebase intelligence"
   ],
   "icon": "media/icon.png",
+  "pricing": "Free",
+  "galleryBanner": {
+    "color": "#1e1b2e",
+    "theme": "dark"
+  },
   "main": "./dist/extension.js",
   "extensionKind": ["workspace"],
   "capabilities": {
@@ -315,6 +320,15 @@
               "markdown": "media/walkthrough/connect-server.md"
             },
             "completionEvents": ["onCommand:repowise.startServer"]
+          },
+          {
+            "id": "firstInsight",
+            "title": "See your first insight",
+            "description": "Open the health dashboard for a first look at your repository.\n[Show Health Dashboard](command:repowise.showHealthDashboard)",
+            "media": {
+              "markdown": "media/walkthrough/first-insight.md"
+            },
+            "completionEvents": ["onCommand:repowise.showHealthDashboard"]
           },
           {
             "id": "connectMcp",

--- a/packages/vscode/src/core/webviewApi.ts
+++ b/packages/vscode/src/core/webviewApi.ts
@@ -10,12 +10,15 @@ import { getFileContent, getFileDetail } from "@repowise-dev/api-client/files";
 import {
   getArchitectureCommunityGraph,
   getCommunities,
+  getCommunityDetail,
   getCommunitySlice,
   getDeadCodeGraph,
   getExecutionFlows,
   getGraph,
+  getGraphPath,
   getHotFilesGraph,
   getModuleGraph,
+  searchNodes,
 } from "@repowise-dev/api-client/graph";
 import {
   getRefactoringPlan,
@@ -165,6 +168,12 @@ export function createHostApi(ctx: RepowiseContext, epoch: () => number): HostAp
     communities: () => cached("graph:communities", (id) => getCommunities(id)),
     communitySlice: (communityId) =>
       cached(`graph:slice:${communityId}`, (id) => getCommunitySlice(id, communityId)),
+    communityDetail: (communityId) =>
+      cached(`graph:community:${communityId}`, (id) => getCommunityDetail(id, communityId)),
+    graphPath: (from, to) =>
+      cached(`graph:path:${from}|${to}`, (id) => getGraphPath(id, from, to)),
+    // Autocomplete over an unbounded query space: live, never cached.
+    searchNodes: (query, limit) => searchNodes(repoId(), query, limit),
     deadCodeGraph: () => cached("graph:dead", (id) => getDeadCodeGraph(id)),
     hotFilesGraph: () => cached("graph:hot", (id) => getHotFilesGraph(id)),
     executionFlows: () => cached("graph:flows", (id) => getExecutionFlows(id)),

--- a/packages/vscode/src/shared/webviewMessages.ts
+++ b/packages/vscode/src/shared/webviewMessages.ts
@@ -18,14 +18,17 @@ import type {
 import type { FileDetailResponse } from "@repowise-dev/types/files";
 import type {
   ArchitectureGraphResponse,
+  CommunityDetailResponse,
   CommunitySliceResponse,
   CommunitySummaryItem,
   DeadCodeGraphResponse,
   DecisionRecordResponse,
   ExecutionFlowsResponse,
   GraphExportResponse,
+  GraphPathResponse,
   HotFilesGraphResponse,
   ModuleGraphResponse,
+  NodeSearchResult,
   PageResponse,
 } from "@repowise-dev/api-client/types";
 import type { RiskRangeResponse } from "@repowise-dev/api-client/risk";
@@ -93,6 +96,11 @@ export interface HostApi {
   architectureCommunityGraph(): Promise<ArchitectureGraphResponse>;
   communities(): Promise<CommunitySummaryItem[]>;
   communitySlice(communityId: number): Promise<CommunitySliceResponse>;
+  communityDetail(communityId: number): Promise<CommunityDetailResponse>;
+  /** Shortest path between two graph nodes (path finder panel). */
+  graphPath(from: string, to: string): Promise<GraphPathResponse>;
+  /** Node-name autocomplete for the path finder inputs. */
+  searchNodes(query: string, limit?: number): Promise<NodeSearchResult[]>;
   deadCodeGraph(): Promise<DeadCodeGraphResponse>;
   hotFilesGraph(): Promise<HotFilesGraphResponse>;
   executionFlows(): Promise<ExecutionFlowsResponse>;

--- a/packages/vscode/webview/src/shims/shiki.ts
+++ b/packages/vscode/webview/src/shims/shiki.ts
@@ -1,0 +1,127 @@
+/**
+ * Fine-grained syntax highlighter for the docs webview.
+ *
+ * The shared markdown renderer highlights fenced code with `import("shiki")`,
+ * whose meta bundle statically re-exports every grammar and theme shiki ships
+ * (hundreds of languages, ~10 MB of lazy chunks). Inside the packaged extension
+ * that whole registry rides along in the VSIX even though a repo's docs only
+ * ever touch a handful of languages and two themes. The webview Vite build
+ * aliases the bare `shiki` specifier to this module, so only the curated
+ * language set below is bundled; anything outside it renders as plain
+ * monospace. The JavaScript regex engine replaces the ~600 KB wasm oniguruma
+ * engine (the CSP blocks runtime wasm fetches anyway).
+ *
+ * The exported `codeToHtml` matches the singleton shiki calls the renderer
+ * makes: `codeToHtml(code, { lang, themes: { light, dark }, defaultColor })`.
+ */
+import { createHighlighterCore, type HighlighterCore } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import githubLight from "@shikijs/themes/github-light";
+import vesper from "@shikijs/themes/vesper";
+
+/** Languages bundled into the webview. Keep this list to what a code wiki
+ *  realistically contains; each entry adds its grammar chunk to the VSIX. */
+const LANG_LOADERS: Record<string, () => Promise<{ default: unknown }>> = {
+  typescript: () => import("@shikijs/langs/typescript"),
+  tsx: () => import("@shikijs/langs/tsx"),
+  javascript: () => import("@shikijs/langs/javascript"),
+  jsx: () => import("@shikijs/langs/jsx"),
+  python: () => import("@shikijs/langs/python"),
+  json: () => import("@shikijs/langs/json"),
+  yaml: () => import("@shikijs/langs/yaml"),
+  bash: () => import("@shikijs/langs/bash"),
+  shellscript: () => import("@shikijs/langs/shellscript"),
+  markdown: () => import("@shikijs/langs/markdown"),
+  html: () => import("@shikijs/langs/html"),
+  xml: () => import("@shikijs/langs/xml"),
+  css: () => import("@shikijs/langs/css"),
+  scss: () => import("@shikijs/langs/scss"),
+  sql: () => import("@shikijs/langs/sql"),
+  go: () => import("@shikijs/langs/go"),
+  rust: () => import("@shikijs/langs/rust"),
+  java: () => import("@shikijs/langs/java"),
+  c: () => import("@shikijs/langs/c"),
+  cpp: () => import("@shikijs/langs/cpp"),
+  csharp: () => import("@shikijs/langs/csharp"),
+  ruby: () => import("@shikijs/langs/ruby"),
+  php: () => import("@shikijs/langs/php"),
+  toml: () => import("@shikijs/langs/toml"),
+  ini: () => import("@shikijs/langs/ini"),
+  dockerfile: () => import("@shikijs/langs/dockerfile"),
+  diff: () => import("@shikijs/langs/diff"),
+  kotlin: () => import("@shikijs/langs/kotlin"),
+  swift: () => import("@shikijs/langs/swift"),
+};
+
+/** Common fenced-block aliases mapped onto the canonical grammar name. */
+const ALIASES: Record<string, string> = {
+  ts: "typescript",
+  js: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  py: "python",
+  py3: "python",
+  sh: "bash",
+  shell: "bash",
+  zsh: "bash",
+  yml: "yaml",
+  rs: "rust",
+  golang: "go",
+  "c++": "cpp",
+  cxx: "cpp",
+  "c#": "csharp",
+  cs: "csharp",
+  md: "markdown",
+  markdown: "markdown",
+  rb: "ruby",
+  htm: "html",
+  docker: "dockerfile",
+  kt: "kotlin",
+};
+
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+function getHighlighter(): Promise<HighlighterCore> {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighterCore({
+      themes: [githubLight, vesper],
+      engine: createJavaScriptRegexEngine(),
+    });
+  }
+  return highlighterPromise;
+}
+
+// One in-flight load per language so concurrent code blocks don't double-register.
+const langLoads = new Map<string, Promise<void>>();
+function ensureLanguage(highlighter: HighlighterCore, lang: string): Promise<void> {
+  let load = langLoads.get(lang);
+  if (!load) {
+    const loader = LANG_LOADERS[lang];
+    load = loader
+      ? loader().then((mod) => {
+          highlighter.loadLanguage(mod.default as never);
+        })
+      : Promise.resolve();
+    langLoads.set(lang, load);
+  }
+  return load;
+}
+
+interface CodeToHtmlOptions {
+  lang?: string;
+  themes?: { light: string; dark: string };
+  defaultColor?: string | false;
+}
+
+export async function codeToHtml(code: string, options: CodeToHtmlOptions): Promise<string> {
+  const requested = String(options.lang ?? "text").toLowerCase();
+  const canonical = ALIASES[requested] ?? requested;
+  const highlighter = await getHighlighter();
+
+  let lang = "text";
+  if (LANG_LOADERS[canonical]) {
+    await ensureLanguage(highlighter, canonical);
+    lang = canonical;
+  }
+
+  return highlighter.codeToHtml(code, { ...options, lang } as never);
+}

--- a/packages/vscode/webview/src/styles/theme-bridge.css
+++ b/packages/vscode/webview/src/styles/theme-bridge.css
@@ -10,6 +10,16 @@
 :root {
   --font-sans: var(--vscode-font-family, ui-sans-serif, system-ui, sans-serif);
   --font-mono: var(--vscode-editor-font-family, ui-monospace, monospace);
+
+  /* The knowledge-graph card texture layers a ruled-paper photo served from
+     the web app's public folder; that path 404s inside a packaged webview.
+     Drop the photo layer and render solid node cards instead (no bundled
+     asset, no failed request). The .dark override below matches. */
+  --kg-card-texture: none;
+}
+
+.dark {
+  --kg-card-texture: none;
 }
 
 html,

--- a/packages/vscode/webview/src/views/graph/App.tsx
+++ b/packages/vscode/webview/src/views/graph/App.tsx
@@ -5,19 +5,25 @@
  * back into the lazy data hook so scope changes fetch just what they render.
  */
 
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   GraphFlow,
   type GraphFlowProps as GraphFlowShellProps,
 } from "@repowise-dev/ui/graph/graph-flow";
+import { PathFinderPanel } from "@repowise-dev/ui/graph/path-finder-panel";
+import { GraphCommunityPanel } from "@repowise-dev/ui/graph/graph-community-panel";
 import type {
   ArchitectureGraph,
+  CommunityDetail,
   CommunitySlice,
   CommunitySummaryItem,
   ExecutionFlows,
   GraphExport,
+  GraphPath,
   ModuleGraph,
+  NodeSearchResult,
 } from "@repowise-dev/types/graph";
+import type { WebviewHost } from "../../runtime/rpc";
 import type { ViewProps } from "../../runtime/mount";
 import { useGraphData } from "./use-graph-data";
 import { GraphHeader } from "./graph-header";
@@ -89,9 +95,83 @@ export function App({ host, params, repo, refreshToken }: ViewProps<"graph">) {
             }
             onNodeClick={handleNodeClick}
             onNodeViewDocs={openIfFile}
+            renderPathFinder={(p) => (
+              <PathFinderPanel
+                searchNodes={(q, l) =>
+                  host.api.searchNodes(q, l) as Promise<NodeSearchResult[]>
+                }
+                findPath={(from, to) =>
+                  host.api.graphPath(from, to) as Promise<GraphPath>
+                }
+                onPathFound={p.onPathFound}
+                onClear={p.onClear}
+                onClose={p.onClose}
+                initialFrom={p.initialFrom}
+                initialTo={p.initialTo}
+              />
+            )}
+            renderCommunityPanel={(p) => (
+              <CommunityPanel
+                host={host}
+                communityId={p.communityId}
+                onClose={p.onClose}
+                onExpandOnCanvas={p.onExpandOnCanvas}
+              />
+            )}
           />
         )}
       </div>
     </div>
+  );
+}
+
+/**
+ * Fetches one community's detail on open and feeds the shared panel shell.
+ * The shell expects pre-fetched data + a loading flag (it does no fetching of
+ * its own), so this thin wrapper owns the host call, mirroring the web app's
+ * SWR wrapper. Member links open the file in an editor column.
+ */
+function CommunityPanel({
+  host,
+  communityId,
+  onClose,
+  onExpandOnCanvas,
+}: {
+  host: WebviewHost;
+  communityId: number;
+  onClose: () => void;
+  onExpandOnCanvas: () => void;
+}) {
+  const [community, setCommunity] = useState<CommunityDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    setCommunity(null);
+    host.api
+      .communityDetail(communityId)
+      .then((detail) => {
+        if (!cancelled) setCommunity(detail as CommunityDetail);
+      })
+      .catch(() => {
+        if (!cancelled) setCommunity(null);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [host, communityId]);
+
+  return (
+    <GraphCommunityPanel
+      communityId={communityId}
+      community={community}
+      isLoading={isLoading}
+      onClose={onClose}
+      onExpandOnCanvas={onExpandOnCanvas}
+    />
   );
 }

--- a/packages/vscode/webview/vite.config.mts
+++ b/packages/vscode/webview/vite.config.mts
@@ -22,14 +22,21 @@ export default defineConfig({
   root: here,
   plugins: [react(), tailwindcss()],
   resolve: {
-    alias: {
+    alias: [
       // The shared UI package peers on next-themes; inside a webview the
       // editor owns the theme, so the hook is served by a local shim.
-      "next-themes": path.resolve(here, "src/shims/next-themes.ts"),
+      { find: "next-themes", replacement: path.resolve(here, "src/shims/next-themes.ts") },
       // The Lottie loader fetches WASM + JSON at runtime; both are blocked by
       // the webview CSP, so loading states render a CSS spinner instead.
-      "@lottiefiles/dotlottie-react": path.resolve(here, "src/shims/dotlottie-react.tsx"),
-    },
+      {
+        find: "@lottiefiles/dotlottie-react",
+        replacement: path.resolve(here, "src/shims/dotlottie-react.tsx"),
+      },
+      // The bare `shiki` meta bundle ships every grammar; the shim narrows it
+      // to a curated language set. Anchored regex so `shiki/core` and the
+      // fine-grained subpaths the shim itself imports still resolve normally.
+      { find: /^shiki$/, replacement: path.resolve(here, "src/shims/shiki.ts") },
+    ],
   },
   build: {
     outDir: path.resolve(here, "../dist/webview"),


### PR DESCRIPTION
Polish and release-readiness for the VS Code extension.

## Changes

- **Webview bundle size.** Syntax highlighting now loads a curated set of languages on the JS regex engine through a webview-only alias shim, instead of the full highlighter with the wasm oniguruma engine. Web and hosted keep the full dynamic highlighter.
- **Knowledge graph.** Wire the path finder and community detail panels to host RPC methods (`searchNodes`, `graphPath`, `communityDetail`), all backed by endpoints that already existed.
- **Accessibility.** The health KPI tiles wrapped info tooltips inside a card-level button (nested interactive elements). Reworked to a static card plus a stretched-overlay button so the whole tile stays clickable without the nesting.
- **Packaged-asset fix.** Drop the web-only card texture inside the webview so the packaged extension stops requesting an asset that 404s.
- **Release tooling.** Marketplace metadata (pricing, gallery banner, an extra walkthrough step), an expanded README plus a user-facing doc under `docs/`, a publish workflow (`publish-vscode.yml`), and a release checklist.

The publish workflow is author-triggered only (a `vscode-v*` tag or manual dispatch) and builds both the host bundle and the webviews before publishing.
