### PR TITLE
feat(vscode): settings panel for editor signals and server config

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -207,6 +207,12 @@
         "title": "Show Decision Timeline",
         "category": "Repowise",
         "icon": "$(milestone)"
+      },
+      {
+        "command": "repowise.showSettings",
+        "title": "Open Settings",
+        "category": "Repowise",
+        "icon": "$(gear)"
       }
     ],
     "menus": {
@@ -222,6 +228,11 @@
           "command": "repowise.showHealthDashboard",
           "group": "navigation",
           "when": "view == repowise.findingsView"
+        },
+        {
+          "command": "repowise.showSettings",
+          "group": "navigation",
+          "when": "view == repowise.homeView"
         }
       ]
     },

--- a/packages/vscode/src/constants.ts
+++ b/packages/vscode/src/constants.ts
@@ -31,6 +31,7 @@ export const Commands = {
   showArchitecture: "repowise.showArchitecture",
   showKnowledgeGraph: "repowise.showKnowledgeGraph",
   showDecisionTimeline: "repowise.showDecisionTimeline",
+  showSettings: "repowise.showSettings",
 } as const;
 
 /**

--- a/packages/vscode/src/core/webviewApi.ts
+++ b/packages/vscode/src/core/webviewApi.ts
@@ -29,7 +29,15 @@ import { getPageById, listAllPages } from "@repowise-dev/api-client/pages";
 import { getRiskRange } from "@repowise-dev/api-client/risk";
 import { buildRefactoringPlanPrompt } from "@repowise-dev/ui/health/ai-prompt-builder";
 import { CONFIG_SECTION } from "../constants";
-import type { HomeSummary, HostApi, RiskRangeReport } from "../shared/webviewMessages";
+import {
+  SETTING_KEYS,
+  type HomeSummary,
+  type HostApi,
+  type RiskRangeReport,
+  type SettingKey,
+  type SettingsValues,
+  type SettingValue,
+} from "../shared/webviewMessages";
 import type { RepowiseContext } from "./context";
 import { commitsMatch, getCurrentBranchName, resolveLiveHead } from "./gitApi";
 
@@ -38,6 +46,88 @@ class NotReadyError extends Error {
   constructor() {
     super("The Repowise server is not connected.");
   }
+}
+
+/** Defaults mirrored from the package.json contribution, for a robust read. */
+const SETTING_DEFAULTS: SettingsValues = {
+  "diagnostics.enabled": true,
+  "diagnostics.minSeverity": "high",
+  "diagnostics.dimensions": ["defect", "maintainability", "performance"],
+  "gutterHeat.enabled": true,
+  "fileDecorations.enabled": true,
+  "fileDecorations.maxScore": 4,
+  "codeLens.enabled": true,
+  "hover.enabled": true,
+  "server.autoStart": "ask",
+  "server.port": null,
+  "cliPath": "",
+  "risk.baseBranch": "",
+};
+
+const SEVERITIES = ["critical", "high", "medium", "low"];
+const DIMENSIONS = ["defect", "maintainability", "performance"];
+
+/**
+ * Per-key validator for writes. The webview is untrusted input, so an out-of-
+ * shape value is rejected before it reaches config.update rather than trusting
+ * VS Code to coerce it. Returns the value to write, or throws.
+ */
+const SETTING_VALIDATORS: Record<SettingKey, (v: SettingValue) => SettingValue> = {
+  "diagnostics.enabled": expectBoolean,
+  "diagnostics.minSeverity": (v) => expectEnum(v, SEVERITIES),
+  "diagnostics.dimensions": (v) => expectStringSubset(v, DIMENSIONS),
+  "gutterHeat.enabled": expectBoolean,
+  "fileDecorations.enabled": expectBoolean,
+  "fileDecorations.maxScore": (v) => expectNumberInRange(v, 0, 10),
+  "codeLens.enabled": expectBoolean,
+  "hover.enabled": expectBoolean,
+  "server.autoStart": (v) => expectEnum(v, ["ask", "always", "never"]),
+  "server.port": expectNullablePort,
+  "cliPath": expectString,
+  "risk.baseBranch": expectString,
+};
+
+function expectBoolean(v: SettingValue): boolean {
+  if (typeof v !== "boolean") throw new Error("Expected a boolean.");
+  return v;
+}
+function expectString(v: SettingValue): string {
+  if (typeof v !== "string") throw new Error("Expected a string.");
+  return v;
+}
+function expectEnum(v: SettingValue, allowed: string[]): string {
+  if (typeof v !== "string" || !allowed.includes(v)) throw new Error("Value not allowed.");
+  return v;
+}
+function expectStringSubset(v: SettingValue, allowed: string[]): string[] {
+  if (!Array.isArray(v) || v.some((x) => !allowed.includes(x))) {
+    throw new Error("Value not allowed.");
+  }
+  // De-dupe and preserve the canonical order so the array stays stable.
+  return allowed.filter((x) => v.includes(x));
+}
+function expectNumberInRange(v: SettingValue, min: number, max: number): number {
+  if (typeof v !== "number" || !Number.isFinite(v) || v < min || v > max) {
+    throw new Error(`Expected a number in [${min}, ${max}].`);
+  }
+  return v;
+}
+function expectNullablePort(v: SettingValue): number | null {
+  if (v === null) return null;
+  if (typeof v !== "number" || !Number.isInteger(v) || v < 1 || v > 65535) {
+    throw new Error("Expected a port in [1, 65535] or null.");
+  }
+  return v;
+}
+
+/** Reads every allowlisted setting into a plain value map (defaults applied). */
+function readSettings(): SettingsValues {
+  const cfg = vscode.workspace.getConfiguration(CONFIG_SECTION);
+  const out = {} as SettingsValues;
+  for (const key of SETTING_KEYS) {
+    out[key] = cfg.get<SettingValue>(key, SETTING_DEFAULTS[key]);
+  }
+  return out;
 }
 
 /**
@@ -217,5 +307,19 @@ export function createHostApi(ctx: RepowiseContext, epoch: () => number): HostAp
 
     // Sidebar home
     homeSummary,
+
+    // Settings panel
+    getSettings: async () => readSettings(),
+    updateSetting: async (key, value) => {
+      if (!SETTING_KEYS.includes(key)) throw new Error(`Unknown setting: ${String(key)}`);
+      const validated = SETTING_VALIDATORS[key](value);
+      // Workspace scope when a folder is open (the common case, so the choice
+      // travels with the repo); user scope otherwise so the write still lands.
+      const target = vscode.workspace.workspaceFolders?.length
+        ? vscode.ConfigurationTarget.Workspace
+        : vscode.ConfigurationTarget.Global;
+      await vscode.workspace.getConfiguration(CONFIG_SECTION).update(key, validated, target);
+      return readSettings();
+    },
   };
 }

--- a/packages/vscode/src/core/webviews.ts
+++ b/packages/vscode/src/core/webviews.ts
@@ -38,6 +38,7 @@ const VIEW_META: Record<PanelViewId, ViewMeta> = {
   decisions: { title: "Repowise Decisions", retainContextWhenHidden: false },
   docs: { title: "Repowise Docs", retainContextWhenHidden: false },
   risk: { title: "Repowise Branch Risk", retainContextWhenHidden: false },
+  settings: { title: "Repowise Settings", retainContextWhenHidden: false },
 };
 
 /** Tab title for a panel; the sidebar Home view's title lives in the manifest. */

--- a/packages/vscode/src/features/dashboards.ts
+++ b/packages/vscode/src/features/dashboards.ts
@@ -23,6 +23,9 @@ export function registerDashboards(ctx: RepowiseContext): vscode.Disposable {
     vscode.commands.registerCommand(Commands.showDecisionTimeline, () =>
       openViewPanel(ctx, "decisions"),
     ),
+    vscode.commands.registerCommand(Commands.showSettings, () =>
+      openViewPanel(ctx, "settings"),
+    ),
   ];
   return {
     dispose(): void {

--- a/packages/vscode/src/shared/webviewMessages.ts
+++ b/packages/vscode/src/shared/webviewMessages.ts
@@ -44,7 +44,8 @@ export type PanelViewId =
   | "refactoring"
   | "decisions"
   | "docs"
-  | "risk";
+  | "risk"
+  | "settings";
 
 /** Panels plus the sidebar Home view (a WebviewView, never a tab). */
 export type WebviewViewId = PanelViewId | "home";
@@ -58,8 +59,38 @@ export interface ViewParams {
   decisions: Record<string, never>;
   docs: { pageId?: string; filePath?: string };
   risk: Record<string, never>;
+  settings: Record<string, never>;
   home: Record<string, never>;
 }
+
+/**
+ * The settings the Settings panel can read and write. Kept in lockstep with
+ * the `repowise.*` keys contributed in package.json (the extension-side source
+ * of truth); the panel offers a friendlier grouped surface over the same keys,
+ * and the host validates every write against this allowlist.
+ */
+export const SETTING_KEYS = [
+  "diagnostics.enabled",
+  "diagnostics.minSeverity",
+  "diagnostics.dimensions",
+  "gutterHeat.enabled",
+  "fileDecorations.enabled",
+  "fileDecorations.maxScore",
+  "codeLens.enabled",
+  "hover.enabled",
+  "server.autoStart",
+  "server.port",
+  "cliPath",
+  "risk.baseBranch",
+] as const;
+
+export type SettingKey = (typeof SETTING_KEYS)[number];
+
+/** The value shapes a setting can hold across the whole allowlist. */
+export type SettingValue = boolean | number | string | string[] | null;
+
+/** Current value of every allowlisted setting, keyed by its `repowise.*` tail. */
+export type SettingsValues = Record<SettingKey, SettingValue>;
 
 /**
  * Webview color scheme. "auto" follows the editor theme; a fixed value pins
@@ -119,6 +150,11 @@ export interface HostApi {
   riskRange(): Promise<RiskRangeReport>;
   // Sidebar home
   homeSummary(): Promise<HomeSummary>;
+  // Settings panel
+  /** Current value of every allowlisted setting. */
+  getSettings(): Promise<SettingsValues>;
+  /** Persist one setting, then echo the full fresh value map back. */
+  updateSetting(key: SettingKey, value: SettingValue): Promise<SettingsValues>;
 }
 
 /**

--- a/packages/vscode/webview/src/views/home/App.tsx
+++ b/packages/vscode/webview/src/views/home/App.tsx
@@ -18,6 +18,7 @@ import {
   Moon,
   RefreshCw,
   Scale,
+  Settings2,
   Share2,
   Sun,
   Wrench,
@@ -194,6 +195,24 @@ export function App({ host, repo, refreshToken }: ViewProps<"home">) {
           />
         ))}
       </nav>
+      <button
+        type="button"
+        onClick={() => host.openView("settings")}
+        className="group flex w-full items-center gap-3 rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2.5 text-left transition-colors hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-elevated)]"
+      >
+        <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-[var(--color-bg-inset)] text-[var(--color-text-secondary)]">
+          <Settings2 className="h-4 w-4" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[13px] font-medium text-[var(--color-text-primary)]">
+            Settings
+          </span>
+          <span className="block truncate text-[11px] text-[var(--color-text-tertiary)]">
+            Toggle editor signals, server, and more
+          </span>
+        </span>
+        <ChevronRight className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-tertiary)] opacity-0 transition-opacity group-hover:opacity-100" />
+      </button>
       <Footer host={host} />
     </div>
   );

--- a/packages/vscode/webview/src/views/settings/App.test.tsx
+++ b/packages/vscode/webview/src/views/settings/App.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { App } from "./App";
+import type { WebviewHost } from "../../runtime/rpc";
+import type {
+  RepoInit,
+  SettingsValues,
+} from "../../../../src/shared/webviewMessages";
+
+const REPO: RepoInit = { id: "r1", name: "repo", headCommit: null, defaultBranch: "main" };
+
+const DEFAULTS: SettingsValues = {
+  "diagnostics.enabled": true,
+  "diagnostics.minSeverity": "high",
+  "diagnostics.dimensions": ["defect", "maintainability", "performance"],
+  "gutterHeat.enabled": true,
+  "fileDecorations.enabled": true,
+  "fileDecorations.maxScore": 4,
+  "codeLens.enabled": true,
+  "hover.enabled": true,
+  "server.autoStart": "ask",
+  "server.port": null,
+  "cliPath": "",
+  "risk.baseBranch": "",
+};
+
+/** Host whose updateSetting echoes the merged map back, like the real one. */
+function makeHost(initial: Partial<SettingsValues> = {}) {
+  const values: SettingsValues = { ...DEFAULTS, ...initial };
+  const updateSetting = vi.fn((key: keyof SettingsValues, value: unknown) => {
+    (values as Record<string, unknown>)[key] = value;
+    return Promise.resolve({ ...values });
+  });
+  const host = {
+    api: {
+      getSettings: vi.fn(() => Promise.resolve({ ...values })),
+      updateSetting,
+    },
+    onInit: () => () => {},
+    onRefresh: () => () => {},
+    onUpdateDone: () => () => {},
+    onThemeChanged: () => () => {},
+    ready: () => {},
+    openFile: () => {},
+    copyText: () => {},
+    openExternal: () => {},
+    openView: () => {},
+    updateIndex: () => {},
+    setTheme: () => {},
+  } as unknown as WebviewHost;
+  return { host, updateSetting };
+}
+
+function renderApp(host: WebviewHost) {
+  return render(<App host={host} repo={REPO} params={{}} refreshToken={0} />);
+}
+
+describe("settings App", () => {
+  afterEach(() => cleanup());
+
+  it("renders grouped rows and reflects loaded values", async () => {
+    const { host } = makeHost();
+    renderApp(host);
+
+    expect(await screen.findByText("Editor signals")).toBeTruthy();
+    expect(screen.getByText("Server")).toBeTruthy();
+    expect(screen.getByText("Branch risk")).toBeTruthy();
+
+    const toggle = screen.getByLabelText("Problems panel findings");
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("writes and optimistically flips a toggle", async () => {
+    const { host, updateSetting } = makeHost();
+    renderApp(host);
+
+    const toggle = await screen.findByLabelText("Problems panel findings");
+    fireEvent.click(toggle);
+
+    expect(updateSetting).toHaveBeenCalledWith("diagnostics.enabled", false);
+    await waitFor(() =>
+      expect(screen.getByLabelText("Problems panel findings").getAttribute("aria-checked")).toBe(
+        "false",
+      ),
+    );
+  });
+
+  it("disables dependent controls when the parent signal is off", async () => {
+    const { host } = makeHost({ "diagnostics.enabled": false });
+    renderApp(host);
+
+    const severity = (await screen.findByLabelText("Minimum severity")) as HTMLSelectElement;
+    expect(severity.disabled).toBe(true);
+  });
+});

--- a/packages/vscode/webview/src/views/settings/App.tsx
+++ b/packages/vscode/webview/src/views/settings/App.tsx
@@ -1,0 +1,604 @@
+/**
+ * Settings panel: a friendly, grouped surface over the `repowise.*` workspace
+ * settings, opened from the sidebar Home launcher. Every control writes through
+ * one host RPC (`updateSetting`) which validates and persists to the workspace,
+ * so the change reaches the same live features the native Settings editor would
+ * drive. The "Editor signals" group up top is the reason this panel exists:
+ * one place to quiet the squiggles, gutter, and explorer badges.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { RotateCcw, Settings2 } from "lucide-react";
+import type {
+  SettingKey,
+  SettingsValues,
+  SettingValue,
+} from "../../../../src/shared/webviewMessages";
+import type { ViewProps } from "../../runtime/mount";
+import type { WebviewHost } from "../../runtime/rpc";
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+type Row =
+  | { key: SettingKey; label: string; description: string; kind: "toggle"; needs?: SettingKey }
+  | { key: SettingKey; label: string; description: string; kind: "select"; options: Option[]; needs?: SettingKey }
+  | { key: SettingKey; label: string; description: string; kind: "multiselect"; options: Option[]; needs?: SettingKey }
+  | { key: SettingKey; label: string; description: string; kind: "number"; min: number; max: number; step: number; needs?: SettingKey }
+  | { key: SettingKey; label: string; description: string; kind: "port"; needs?: SettingKey }
+  | { key: SettingKey; label: string; description: string; kind: "text"; placeholder: string; needs?: SettingKey };
+
+interface Group {
+  title: string;
+  blurb: string;
+  rows: Row[];
+}
+
+/** Hand-curated grouping over the package.json contribution keys. */
+const GROUPS: Group[] = [
+  {
+    title: "Editor signals",
+    blurb:
+      "What Repowise paints into your editor and file explorer. Turn any of these off to quiet the surface.",
+    rows: [
+      {
+        key: "diagnostics.enabled",
+        label: "Problems panel findings",
+        description:
+          "Show health findings for visible files in the Problems panel (the squiggles under flagged code, and the matching colors on files in the explorer).",
+        kind: "toggle",
+      },
+      {
+        key: "diagnostics.minSeverity",
+        label: "Minimum severity",
+        description:
+          "Lowest finding severity surfaced in the Problems panel. Lower-severity findings stay visible in the gutter and tree views.",
+        kind: "select",
+        needs: "diagnostics.enabled",
+        options: [
+          { value: "critical", label: "Critical" },
+          { value: "high", label: "High" },
+          { value: "medium", label: "Medium" },
+          { value: "low", label: "Low" },
+        ],
+      },
+      {
+        key: "diagnostics.dimensions",
+        label: "Problem dimensions",
+        description: "Which health dimensions appear in the Problems panel.",
+        kind: "multiselect",
+        needs: "diagnostics.enabled",
+        options: [
+          { value: "defect", label: "Defect" },
+          { value: "maintainability", label: "Maintainability" },
+          { value: "performance", label: "Performance" },
+        ],
+      },
+      {
+        key: "gutterHeat.enabled",
+        label: "Gutter heat",
+        description: "Shade the gutter next to lines with health findings in visible editors.",
+        kind: "toggle",
+      },
+      {
+        key: "fileDecorations.enabled",
+        label: "Explorer badges",
+        description: "Badge the worst-health files in the file explorer.",
+        kind: "toggle",
+      },
+      {
+        key: "fileDecorations.maxScore",
+        label: "Badge threshold",
+        description: "Badge files whose defect score is at or below this value (0 to 10).",
+        kind: "number",
+        needs: "fileDecorations.enabled",
+        min: 0,
+        max: 10,
+        step: 0.5,
+      },
+      {
+        key: "codeLens.enabled",
+        label: "Refactoring lenses",
+        description:
+          "Show refactoring plan lenses above symbols with a detected refactoring opportunity.",
+        kind: "toggle",
+      },
+      {
+        key: "hover.enabled",
+        label: "Hover cards",
+        description: "Show file health, ownership, and decision context on hover.",
+        kind: "toggle",
+      },
+    ],
+  },
+  {
+    title: "Server",
+    blurb: "How the extension connects to the local Repowise server.",
+    rows: [
+      {
+        key: "server.autoStart",
+        label: "Auto-start server",
+        description:
+          "Whether to start the local Repowise server automatically when a Repowise index is present.",
+        kind: "select",
+        options: [
+          { value: "ask", label: "Ask first" },
+          { value: "always", label: "Always" },
+          { value: "never", label: "Never" },
+        ],
+      },
+      {
+        key: "server.port",
+        label: "Server port",
+        description:
+          "Port the local server listens on. Leave empty to discover it from the running server's lockfile.",
+        kind: "port",
+      },
+      {
+        key: "cliPath",
+        label: "CLI path",
+        description:
+          "Absolute path to the repowise CLI executable. Leave empty to use 'repowise' from your PATH.",
+        kind: "text",
+        placeholder: "repowise",
+      },
+    ],
+  },
+  {
+    title: "Branch risk",
+    blurb: "Defaults for branch risk scoring.",
+    rows: [
+      {
+        key: "risk.baseBranch",
+        label: "Base branch",
+        description:
+          "Base branch for branch risk scoring. Leave empty to use the repository's default branch.",
+        kind: "text",
+        placeholder: "main",
+      },
+    ],
+  },
+];
+
+export function App({ host, refreshToken }: ViewProps<"settings">) {
+  const [values, setValues] = useState<SettingsValues | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    host.api
+      .getSettings()
+      .then((v) => {
+        setValues(v);
+        setError(null);
+      })
+      .catch(() => setError("Could not load settings."));
+  }, [host]);
+
+  useEffect(() => load(), [load, refreshToken]);
+
+  const commit = useCallback(
+    (key: SettingKey, value: SettingValue) => {
+      // Optimistic: the control reflects the new value immediately; the host
+      // echoes the canonical map back, and a rejected write reverts.
+      setValues((prev) => (prev ? { ...prev, [key]: value } : prev));
+      host.api
+        .updateSetting(key, value)
+        .then((fresh) => {
+          setValues(fresh);
+          setError(null);
+        })
+        .catch((e: unknown) => {
+          setError(e instanceof Error ? e.message : "Could not save that setting.");
+          load();
+        });
+    },
+    [host, load],
+  );
+
+  if (!values) {
+    return (
+      <div className="flex h-screen items-center justify-center text-[var(--color-text-tertiary)]">
+        {error ?? "Loading settings…"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto min-h-screen max-w-3xl space-y-6 bg-[var(--color-bg-root)] px-6 py-6">
+      <header className="flex items-center gap-2.5">
+        <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]">
+          <Settings2 className="h-4 w-4" />
+        </span>
+        <div>
+          <h1 className="text-base font-semibold text-[var(--color-text-primary)]">
+            Repowise Settings
+          </h1>
+          <p className="text-xs text-[var(--color-text-tertiary)]">
+            Saved to this workspace. Changes apply immediately.
+          </p>
+        </div>
+      </header>
+
+      {error ? (
+        <p
+          role="alert"
+          className="rounded-lg border border-[var(--color-error)] bg-[var(--color-bg-surface)] px-3 py-2 text-xs text-[var(--color-error)]"
+        >
+          {error}
+        </p>
+      ) : null}
+
+      {GROUPS.map((group) => (
+        <section
+          key={group.title}
+          className="rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)]"
+        >
+          <div className="border-b border-[var(--color-border-default)] px-4 py-3">
+            <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+              {group.title}
+            </h2>
+            <p className="mt-0.5 text-[11px] text-[var(--color-text-tertiary)]">{group.blurb}</p>
+          </div>
+          <div className="divide-y divide-[var(--color-border-default)]">
+            {group.rows.map((row) => (
+              <SettingRow
+                key={row.key}
+                row={row}
+                values={values}
+                disabled={row.needs != null && values[row.needs] === false}
+                onCommit={commit}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function SettingRow({
+  row,
+  values,
+  disabled,
+  onCommit,
+}: {
+  row: Row;
+  values: SettingsValues;
+  disabled: boolean;
+  onCommit: (key: SettingKey, value: SettingValue) => void;
+}) {
+  const value = values[row.key];
+  const controlId = `set-${row.key.replace(/\./g, "-")}`;
+  return (
+    <div className={disabled ? "flex items-start gap-4 px-4 py-3 opacity-50" : "flex items-start gap-4 px-4 py-3"}>
+      <div className="min-w-0 flex-1">
+        <label htmlFor={controlId} className="block text-[13px] font-medium text-[var(--color-text-primary)]">
+          {row.label}
+        </label>
+        <p className="mt-0.5 text-[11px] leading-relaxed text-[var(--color-text-tertiary)]">
+          {row.description}
+        </p>
+      </div>
+      <div className="shrink-0 pt-0.5">
+        <Control
+          id={controlId}
+          row={row}
+          value={value}
+          disabled={disabled}
+          onCommit={(v) => onCommit(row.key, v)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function Control({
+  id,
+  row,
+  value,
+  disabled,
+  onCommit,
+}: {
+  id: string;
+  row: Row;
+  value: SettingValue;
+  disabled: boolean;
+  onCommit: (value: SettingValue) => void;
+}) {
+  switch (row.kind) {
+    case "toggle":
+      return <Toggle id={id} checked={value === true} disabled={disabled} onChange={onCommit} />;
+    case "select":
+      return (
+        <Select
+          id={id}
+          value={typeof value === "string" ? value : ""}
+          options={row.options}
+          disabled={disabled}
+          onChange={onCommit}
+        />
+      );
+    case "multiselect":
+      return (
+        <MultiSelect
+          value={Array.isArray(value) ? value : []}
+          options={row.options}
+          disabled={disabled}
+          onChange={onCommit}
+        />
+      );
+    case "number":
+      return (
+        <NumberInput
+          id={id}
+          value={typeof value === "number" ? value : row.min}
+          min={row.min}
+          max={row.max}
+          step={row.step}
+          disabled={disabled}
+          onCommit={onCommit}
+        />
+      );
+    case "port":
+      return (
+        <PortInput
+          id={id}
+          value={typeof value === "number" ? value : null}
+          disabled={disabled}
+          onCommit={onCommit}
+        />
+      );
+    case "text":
+      return (
+        <TextInput
+          id={id}
+          value={typeof value === "string" ? value : ""}
+          placeholder={row.placeholder}
+          disabled={disabled}
+          onCommit={onCommit}
+        />
+      );
+  }
+}
+
+function Toggle({
+  id,
+  checked,
+  disabled,
+  onChange,
+}: {
+  id: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <button
+      id={id}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={
+        "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors disabled:cursor-not-allowed " +
+        (checked ? "bg-[var(--color-accent-primary)]" : "bg-[var(--color-bg-inset)]")
+      }
+    >
+      <span
+        className={
+          "inline-block h-4 w-4 transform rounded-full bg-white transition-transform " +
+          (checked ? "translate-x-4" : "translate-x-0.5")
+        }
+      />
+    </button>
+  );
+}
+
+const CONTROL_CLASS =
+  "rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-inset)] px-2 py-1 text-[12px] text-[var(--color-text-primary)] focus:border-[var(--color-accent-primary)] focus:outline-none disabled:cursor-not-allowed";
+
+function Select({
+  id,
+  value,
+  options,
+  disabled,
+  onChange,
+}: {
+  id: string;
+  value: string;
+  options: Option[];
+  disabled: boolean;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <select
+      id={id}
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
+      className={CONTROL_CLASS}
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function MultiSelect({
+  value,
+  options,
+  disabled,
+  onChange,
+}: {
+  value: string[];
+  options: Option[];
+  disabled: boolean;
+  onChange: (value: string[]) => void;
+}) {
+  const toggle = (opt: string) => {
+    const next = value.includes(opt) ? value.filter((v) => v !== opt) : [...value, opt];
+    onChange(next);
+  };
+  return (
+    <div className="flex flex-wrap justify-end gap-1.5">
+      {options.map((o) => {
+        const on = value.includes(o.value);
+        return (
+          <button
+            key={o.value}
+            type="button"
+            disabled={disabled}
+            aria-pressed={on}
+            onClick={() => toggle(o.value)}
+            className={
+              "rounded-full border px-2 py-0.5 text-[11px] transition-colors disabled:cursor-not-allowed " +
+              (on
+                ? "border-[var(--color-accent-primary)] bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
+                : "border-[var(--color-border-default)] text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)]")
+            }
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function NumberInput({
+  id,
+  value,
+  min,
+  max,
+  step,
+  disabled,
+  onCommit,
+}: {
+  id: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  disabled: boolean;
+  onCommit: (value: number) => void;
+}) {
+  const [draft, setDraft] = useState(String(value));
+  useEffect(() => setDraft(String(value)), [value]);
+  const commit = () => {
+    const n = Number(draft);
+    if (!Number.isFinite(n)) return setDraft(String(value));
+    const clamped = Math.min(max, Math.max(min, n));
+    if (clamped !== value) onCommit(clamped);
+    setDraft(String(clamped));
+  };
+  return (
+    <input
+      id={id}
+      type="number"
+      inputMode="decimal"
+      value={draft}
+      min={min}
+      max={max}
+      step={step}
+      disabled={disabled}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
+      className={CONTROL_CLASS + " w-20 text-right"}
+    />
+  );
+}
+
+function PortInput({
+  id,
+  value,
+  disabled,
+  onCommit,
+}: {
+  id: string;
+  value: number | null;
+  disabled: boolean;
+  onCommit: (value: number | null) => void;
+}) {
+  const [draft, setDraft] = useState(value == null ? "" : String(value));
+  useEffect(() => setDraft(value == null ? "" : String(value)), [value]);
+  const commit = () => {
+    const trimmed = draft.trim();
+    if (trimmed === "") {
+      if (value !== null) onCommit(null);
+      return;
+    }
+    const n = Number(trimmed);
+    if (!Number.isInteger(n) || n < 1 || n > 65535) {
+      setDraft(value == null ? "" : String(value));
+      return;
+    }
+    if (n !== value) onCommit(n);
+  };
+  return (
+    <input
+      id={id}
+      type="text"
+      inputMode="numeric"
+      placeholder="auto"
+      value={draft}
+      disabled={disabled}
+      onChange={(e) => setDraft(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
+      className={CONTROL_CLASS + " w-20 text-right"}
+    />
+  );
+}
+
+function TextInput({
+  id,
+  value,
+  placeholder,
+  disabled,
+  onCommit,
+}: {
+  id: string;
+  value: string;
+  placeholder: string;
+  disabled: boolean;
+  onCommit: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState(value);
+  useEffect(() => setDraft(value), [value]);
+  const commit = () => {
+    if (draft !== value) onCommit(draft);
+  };
+  return (
+    <span className="flex items-center gap-1.5">
+      <input
+        id={id}
+        type="text"
+        value={draft}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
+        className={CONTROL_CLASS + " w-44"}
+      />
+      {value !== "" ? (
+        <button
+          type="button"
+          title="Clear"
+          disabled={disabled}
+          onClick={() => onCommit("")}
+          className="text-[var(--color-text-tertiary)] transition-colors hover:text-[var(--color-text-primary)] disabled:cursor-not-allowed"
+        >
+          <RotateCcw className="h-3.5 w-3.5" />
+        </button>
+      ) : null}
+    </span>
+  );
+}

--- a/packages/vscode/webview/src/views/settings/main.tsx
+++ b/packages/vscode/webview/src/views/settings/main.tsx
@@ -1,0 +1,5 @@
+import "../../styles/index.css";
+import { mountView } from "../../runtime/mount";
+import { App } from "./App";
+
+mountView("settings", App);

--- a/packages/vscode/webview/vite.config.mts
+++ b/packages/vscode/webview/vite.config.mts
@@ -16,6 +16,7 @@ const VIEWS = [
   "decisions",
   "docs",
   "risk",
+  "settings",
 ] as const;
 
 export default defineConfig({


### PR DESCRIPTION
## What

Adds a **Settings page** to the VS Code extension, opened from a new launcher row in the sidebar Home view. It presents the `repowise.*` workspace settings in a grouped, UI-friendly surface instead of sending users to the raw Settings editor.

## Why

The in-editor signals (Problems-panel findings, gutter heat, explorer badges) are useful but noisy for some users: whole functions get squiggled and files light up red/yellow in the explorer. There was no discoverable in-extension way to quiet them. The **Editor signals** group at the top of the page is the answer, one place to turn each surface on or off.

## Details

- **Editor signals** group: toggles for Problems-panel findings, gutter heat, explorer badges, refactoring lenses, and hover cards, plus minimum severity, problem dimensions, and badge threshold. Turning Problems-panel findings off removes both the diagnostic squiggles and the matching file coloring in the explorer.
- **Server** group: auto-start mode, port, CLI path.
- **Branch risk** group: base branch.
- Dependent controls dim out when their parent signal is disabled.
- Every control writes through a single host RPC that validates the value against an allowlist before persisting to the workspace, so changes apply live to the same features the native Settings editor drives.

## Wiring

- New `settings` webview panel registered alongside the existing dashboards (panel manager, vite entry).
- `getSettings` / `updateSetting` added to the typed host API contract.
- Settings launcher added to the Home sidebar.

## Testing

- `npm run type-check` passes (host + webview).
- `npm run build:webview` produces the new `settings.js` entry.
- `npm run test:webview` green (25 tests).