### PR TITLE
feat(embeddings): make Ollama embed timeout configurable via env

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -229,6 +229,7 @@ The embedder is separate from the LLM provider.
 |----------|---------|-------|
 | `gemini` | `GEMINI_API_KEY` | Default when key is present |
 | `openai` | `OPENAI_API_KEY` | OpenAI `text-embedding-3-small` |
+| `ollama` | `OLLAMA_EMBEDDING_MODEL` | Local Ollama embeddings, no API key |
 | `mock` | n/a | Dummy embeddings, no semantic search |
 
 ```bash
@@ -258,6 +259,9 @@ The `.repowise/.env` file is gitignored automatically.
 | `OPENAI_API_KEY` | OpenAI API key |
 | `GEMINI_API_KEY` / `GOOGLE_API_KEY` | Google Gemini API key |
 | `OLLAMA_BASE_URL` | Ollama server URL (default: `http://localhost:11434`) |
+| `OLLAMA_EMBEDDING_MODEL` | Ollama embedding model (also selects the `ollama` embedder) |
+| `OLLAMA_EMBEDDING_DIMS` | Ollama embedding output dimensions (optional; inferred from the model otherwise) |
+| `OLLAMA_EMBEDDING_TIMEOUT` | Ollama embed request timeout in seconds (default: `30`); raise it for long pages on slow local models |
 | `LITELLM_API_KEY` | LiteLLM proxy key |
 | `REPOWISE_PROVIDER` | Override provider (skips auto-detection) |
 | `REPOWISE_EMBEDDER` | Embedder: `gemini`, `openai`, or `mock` |

--- a/packages/cli/src/repowise/cli/providers/embedders.py
+++ b/packages/cli/src/repowise/cli/providers/embedders.py
@@ -15,10 +15,15 @@ def _embedder_kwargs(embedder_name: str) -> dict[str, Any]:
         dimensions = os.environ.get("OLLAMA_EMBEDDING_DIMS") or os.environ.get(
             "REPOWISE_EMBEDDING_DIMS"
         )
+        timeout = os.environ.get("OLLAMA_EMBEDDING_TIMEOUT") or os.environ.get(
+            "REPOWISE_EMBEDDING_TIMEOUT"
+        )
         if base_url:
             kwargs["base_url"] = base_url
         if dimensions:
             kwargs["dimensions"] = int(dimensions)
+        if timeout:
+            kwargs["timeout"] = float(timeout)
     elif embedder_name == "gemini":
         dimensions = os.environ.get("REPOWISE_EMBEDDING_DIMS")
         if dimensions:

--- a/packages/core/src/repowise/core/providers/embedding/ollama.py
+++ b/packages/core/src/repowise/core/providers/embedding/ollama.py
@@ -47,6 +47,10 @@ class OllamaEmbedder:
         base_url: Ollama server URL. Defaults to ``http://localhost:11434``.
         dimensions: Optional output dimension hint. Also sent to Ollama as
             ``dimensions`` when provided.
+        timeout: Per-request timeout in seconds. Falls back to the
+            ``OLLAMA_EMBEDDING_TIMEOUT`` / ``REPOWISE_EMBEDDING_TIMEOUT`` env
+            vars, then ``30.0``. Raise it when embedding long pages on a slow
+            local model that would otherwise exceed the default and be dropped.
     """
 
     def __init__(
@@ -54,7 +58,7 @@ class OllamaEmbedder:
         model: str | None = None,
         base_url: str | None = None,
         dimensions: int | None = None,
-        timeout: float = _DEFAULT_TIMEOUT,
+        timeout: float | None = None,
     ) -> None:
         self._model = (
             model
@@ -70,7 +74,14 @@ class OllamaEmbedder:
         )
         self._requested_dimensions = dimensions or (int(env_dimensions) if env_dimensions else None)
         self._dimensions = self._requested_dimensions or _infer_dimensions(self._model)
-        self._timeout = timeout
+        env_timeout = os.environ.get("OLLAMA_EMBEDDING_TIMEOUT") or os.environ.get(
+            "REPOWISE_EMBEDDING_TIMEOUT"
+        )
+        self._timeout = (
+            timeout
+            if timeout is not None
+            else (float(env_timeout) if env_timeout else _DEFAULT_TIMEOUT)
+        )
 
     @property
     def dimensions(self) -> int:

--- a/tests/unit/cli/test_shared_helpers.py
+++ b/tests/unit/cli/test_shared_helpers.py
@@ -86,6 +86,16 @@ def test_build_embedder_supports_ollama(monkeypatch: pytest.MonkeyPatch) -> None
     assert embedder._model == "qwen3-embedding:0.6b"
 
 
+def test_build_embedder_ollama_timeout_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from repowise.core.providers.embedding.ollama import OllamaEmbedder
+
+    monkeypatch.setenv("OLLAMA_EMBEDDING_MODEL", "qwen3-embedding:0.6b")
+    monkeypatch.setenv("OLLAMA_EMBEDDING_TIMEOUT", "300")
+    embedder = providers.build_embedder("ollama")
+    assert isinstance(embedder, OllamaEmbedder)
+    assert embedder._timeout == 300.0
+
+
 def test_build_vector_store_returns_a_store(tmp_path) -> None:
     from repowise.core.providers.embedding.base import MockEmbedder
 

--- a/tests/unit/test_persistence/test_ollama_embedder.py
+++ b/tests/unit/test_persistence/test_ollama_embedder.py
@@ -118,3 +118,34 @@ def test_qwen3_dimensions_are_inferred() -> None:
     assert OllamaEmbedder(model="qwen3-embedding:0.6b").dimensions == 1024
     assert OllamaEmbedder(model="qwen3-embedding:4b").dimensions == 2560
     assert OllamaEmbedder(model="qwen3-embedding:8b").dimensions == 4096
+
+
+def test_timeout_defaults_to_thirty_seconds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OLLAMA_EMBEDDING_TIMEOUT", raising=False)
+    monkeypatch.delenv("REPOWISE_EMBEDDING_TIMEOUT", raising=False)
+    assert OllamaEmbedder(model="embeddinggemma")._timeout == 30.0
+
+
+def test_timeout_can_come_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OLLAMA_EMBEDDING_TIMEOUT", "120")
+    assert OllamaEmbedder(model="embeddinggemma")._timeout == 120.0
+
+
+def test_repowise_embedding_timeout_is_a_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OLLAMA_EMBEDDING_TIMEOUT", raising=False)
+    monkeypatch.setenv("REPOWISE_EMBEDDING_TIMEOUT", "90")
+    assert OllamaEmbedder(model="embeddinggemma")._timeout == 90.0
+
+
+def test_explicit_timeout_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OLLAMA_EMBEDDING_TIMEOUT", "120")
+    assert OllamaEmbedder(model="embeddinggemma", timeout=5.0)._timeout == 5.0
+
+
+async def test_env_timeout_is_applied_to_the_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OLLAMA_EMBEDDING_TIMEOUT", "300")
+    embedder = OllamaEmbedder(model="embeddinggemma")
+
+    await embedder.embed(["one"])
+
+    assert _FakeAsyncClient.calls[0]["timeout"] == 300.0


### PR DESCRIPTION
## Summary

- `OllamaEmbedder`'s request timeout was hardcoded to 30s with no env or config override.
- On a slow local model, embedding a long wiki page can take longer than 30s (measured: `qwen3-embedding:8b` on a 47k-char page takes ~114s), so `repowise reindex` silently drops those pages from the vector store. The failure surfaces only as `Warning: failed to embed <id>:` with an empty message, because an httpx timeout raises with no message. The longest pages, which are often the ones most worth retrieving, are the ones that get lost.
- Make the timeout configurable via `OLLAMA_EMBEDDING_TIMEOUT` / `REPOWISE_EMBEDDING_TIMEOUT`, resolved in both the `OllamaEmbedder` constructor and the CLI `_embedder_kwargs` mapper, exactly mirroring how `OLLAMA_EMBEDDING_MODEL` and `OLLAMA_EMBEDDING_DIMS` are already handled. An explicit `timeout=` kwarg still wins, and the default stays 30s (fully backward compatible).
- Document the ollama embedder env vars in `docs/CONFIG.md` (they were previously undocumented).

## Related Issues

None filed. Happy to open a tracking issue if you'd prefer.

## Test Plan

- [x] Tests pass (`pytest`). Added 6 tests: default stays 30s, `OLLAMA_EMBEDDING_TIMEOUT` and the `REPOWISE_EMBEDDING_TIMEOUT` fallback, explicit-kwarg precedence, that the resolved value reaches the httpx request, and that it flows through `build_embedder`. `42 passed` across the ollama-embedder, shared-CLI-helpers, and MCP embedder-resolution suites.
- [x] Lint passes (`ruff check .`, `ruff format`).
- [ ] Web build (`npm run build`): N/A, no frontend changes.

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
