### PR TITLE
feat(vscode): editor-native UX pass with panel navigation and quieter defaults

### DIFF
--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -9,7 +9,7 @@ This extension brings that index into VS Code, for both halves of how code gets 
 
 ## What you get
 
-- **Inline health signals** on the files you open: findings in the Problems panel (quiet by default, high severity only), a gutter heat strip for the full set, and file health scores in the status bar.
+- **Inline health signals** on the files you open: a gutter heat strip for the full set of findings, file health scores in the status bar, and an optional Problems panel surface (off by default, opt in from Settings) for high-severity findings.
 - **Refactoring plans as CodeLens** above the symbols they target, with one click to copy the plan as a prompt for your agent.
 - **Branch risk before you push**: score a branch against its base from the SCM title bar, with the drivers behind the score.
 - **Hovers and tree views** for ownership, hotspots, dead code, and architectural decisions, all lazy and refreshed only when the index moves.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -80,8 +80,8 @@
         },
         "repowise.diagnostics.enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Show health findings for visible files in the Problems panel."
+          "default": false,
+          "description": "Show health findings for visible files in the Problems panel. Off by default to keep the panel quiet; the gutter, explorer badges, and hovers still surface findings."
         },
         "repowise.diagnostics.minSeverity": {
           "type": "string",

--- a/packages/vscode/src/core/webviews.ts
+++ b/packages/vscode/src/core/webviews.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "node:path";
 import { randomBytes } from "node:crypto";
-import { Commands, Views } from "../constants";
+import { Commands, EXTENSION_ID, Views } from "../constants";
 import type { RepowiseContext } from "./context";
 import { createHostApi } from "./webviewApi";
 import type {
@@ -284,6 +284,18 @@ class WebviewManager {
         openViewPanel(this.ctx, msg.view, params);
         return;
       }
+      case "focus-home":
+        // Reveal the sidebar Home view (its auto-generated focus command).
+        await vscode.commands.executeCommand(`${Views.homeDashboard}.focus`);
+        return;
+      case "open-native-settings":
+        // Hand off to the native Settings editor, prefiltered to this extension
+        // (search, sync, and per-scope overrides the custom panel does not offer).
+        await vscode.commands.executeCommand(
+          "workbench.action.openSettings",
+          `@ext:${EXTENSION_ID}`,
+        );
+        return;
       case "update-index":
         // Resolves when the update finishes (the command returns its promise).
         // A successful update also lands as a refresh broadcast; this ack is

--- a/packages/vscode/src/features/fileScoreStatus.ts
+++ b/packages/vscode/src/features/fileScoreStatus.ts
@@ -3,6 +3,7 @@ import { Commands } from "../constants";
 import { getBulkHealth, type FileScores } from "../core/bulkHealth";
 import type { RepowiseContext } from "../core/context";
 import { repoRelativePath } from "../core/fileSignals";
+import { openViewPanel } from "../core/webviews";
 
 /** Renders a score, or a dash when the dimension is absent from the payload. */
 function fmt(value: number | null): string {
@@ -109,9 +110,13 @@ export function registerFileScoreStatus(ctx: RepowiseContext): vscode.Disposable
     }
   });
 
-  // Clicking the score opens the full health dashboard panel.
+  // Clicking the score opens the health dashboard focused on the active file,
+  // so the score in the status bar and the dashboard are one continuous read
+  // instead of two disconnected surfaces.
   const commandSub = vscode.commands.registerCommand(Commands.showFileHealth, () => {
-    void vscode.commands.executeCommand(Commands.showHealthDashboard);
+    const editor = vscode.window.activeTextEditor;
+    const rel = editor ? repoRelativePath(ctx, editor.document.uri) : null;
+    openViewPanel(ctx, "health", rel ? { selectPath: rel } : {});
   });
 
   if (ctx.getExtensionState() === "ready") {

--- a/packages/vscode/src/shared/webviewMessages.ts
+++ b/packages/vscode/src/shared/webviewMessages.ts
@@ -52,7 +52,8 @@ export type WebviewViewId = PanelViewId | "home";
 
 /** Per-view open parameters, carried in the init message. */
 export interface ViewParams {
-  health: Record<string, never>;
+  /** selectPath focuses the dashboard on one file (from the status-bar score). */
+  health: { selectPath?: string };
   architecture: { selectPath?: string };
   graph: { selectNode?: string };
   refactoring: { planId?: string; filePath?: string };
@@ -275,6 +276,16 @@ export interface OpenViewMessage {
   params?: ViewParams[PanelViewId];
 }
 
+/** Webview -> host: reveal the sidebar Home view. Sent by a panel's chrome. */
+export interface FocusHomeMessage {
+  kind: "focus-home";
+}
+
+/** Webview -> host: open the native Settings editor filtered to the extension. */
+export interface OpenNativeSettingsMessage {
+  kind: "open-native-settings";
+}
+
 /** Webview -> host: run an incremental index update. Sent by Home. */
 export interface UpdateIndexMessage {
   kind: "update-index";
@@ -307,6 +318,8 @@ export type WebviewToHostMessage =
   | CopyTextMessage
   | OpenExternalMessage
   | OpenViewMessage
+  | FocusHomeMessage
+  | OpenNativeSettingsMessage
   | UpdateIndexMessage
   | SetThemeMessage;
 

--- a/packages/vscode/webview/src/runtime/chrome.tsx
+++ b/packages/vscode/webview/src/runtime/chrome.tsx
@@ -1,0 +1,108 @@
+/**
+ * Cross-panel navigation chrome shared by every editor-tab panel. Panels are
+ * otherwise dead-end tabs; this slim header gives each one a way back to the
+ * sidebar Home and a one-click switch to any sibling dashboard, so the whole
+ * extension reads as one surface instead of a scatter of disconnected views.
+ */
+
+import type { ComponentType } from "react";
+import {
+  Activity,
+  BookOpen,
+  GitBranch,
+  Home,
+  Layers,
+  Scale,
+  Settings2,
+  Share2,
+  Wrench,
+} from "lucide-react";
+import type { PanelViewId } from "../../../src/shared/webviewMessages";
+import type { WebviewHost } from "./rpc";
+
+interface NavItem {
+  view: PanelViewId;
+  title: string;
+  icon: ComponentType<{ className?: string }>;
+}
+
+/** The dashboards a panel can switch between, in the sidebar Home order. */
+const NAV: NavItem[] = [
+  { view: "health", title: "Health", icon: Activity },
+  { view: "architecture", title: "Architecture", icon: Layers },
+  { view: "graph", title: "Graph", icon: Share2 },
+  { view: "refactoring", title: "Refactoring", icon: Wrench },
+  { view: "decisions", title: "Decisions", icon: Scale },
+  { view: "docs", title: "Docs", icon: BookOpen },
+  { view: "risk", title: "Branch Risk", icon: GitBranch },
+];
+
+export function PanelChrome({ view, host }: { view: PanelViewId; host: WebviewHost }) {
+  return (
+    <header className="sticky top-0 z-30 flex h-11 shrink-0 items-center gap-1 border-b border-[var(--color-border-default)] bg-[var(--color-bg-root)] px-2">
+      <button
+        type="button"
+        onClick={() => host.focusHome()}
+        title="Back to Repowise home"
+        className="flex shrink-0 items-center gap-1.5 rounded-md px-1.5 py-1 text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-surface)] hover:text-[var(--color-text-primary)]"
+      >
+        <Home className="h-4 w-4" />
+        <span className="hidden text-[11px] font-semibold tracking-wide sm:inline">Repowise</span>
+      </button>
+      <span aria-hidden className="mx-1 h-4 w-px shrink-0 bg-[var(--color-border-default)]" />
+      <nav aria-label="Dashboards" className="flex min-w-0 items-center gap-0.5 overflow-x-auto">
+        {NAV.map((item) => (
+          <Tab
+            key={item.view}
+            item={item}
+            active={item.view === view}
+            onClick={() => (item.view === view ? undefined : host.openView(item.view))}
+          />
+        ))}
+      </nav>
+      <button
+        type="button"
+        onClick={() => (view === "settings" ? undefined : host.openView("settings"))}
+        title="Repowise settings"
+        aria-current={view === "settings" ? "page" : undefined}
+        className={
+          "ml-auto shrink-0 rounded-md p-1.5 transition-colors " +
+          (view === "settings"
+            ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
+            : "text-[var(--color-text-tertiary)] hover:bg-[var(--color-bg-surface)] hover:text-[var(--color-text-primary)]")
+        }
+      >
+        <Settings2 className="h-4 w-4" />
+      </button>
+    </header>
+  );
+}
+
+function Tab({
+  item,
+  active,
+  onClick,
+}: {
+  item: NavItem;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const Icon = item.icon;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-current={active ? "page" : undefined}
+      title={item.title}
+      className={
+        "flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors " +
+        (active
+          ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
+          : "text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-surface)] hover:text-[var(--color-text-primary)]")
+      }
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0" />
+      <span className="hidden md:inline">{item.title}</span>
+    </button>
+  );
+}

--- a/packages/vscode/webview/src/runtime/mount.tsx
+++ b/packages/vscode/webview/src/runtime/mount.tsx
@@ -8,11 +8,13 @@ import { Component, StrictMode, useEffect, useState, type ReactNode } from "reac
 import { createRoot } from "react-dom/client";
 import type {
   InitMessage,
+  PanelViewId,
   RepoInit,
   ViewParams,
   WebviewViewId,
 } from "../../../src/shared/webviewMessages";
 import { createHost, type WebviewHost } from "./rpc";
+import { PanelChrome } from "./chrome";
 import { initTheme, setThemePreference } from "./theme";
 
 /** Everything a view component receives. */
@@ -81,7 +83,7 @@ function Bootstrap<V extends WebviewViewId>({ view, host, App }: BootstrapProps<
     );
   }
 
-  return (
+  const content = (
     <ErrorBoundary key={initSeq}>
       <App
         host={host}
@@ -90,6 +92,17 @@ function Bootstrap<V extends WebviewViewId>({ view, host, App }: BootstrapProps<
         refreshToken={refreshToken}
       />
     </ErrorBoundary>
+  );
+
+  // The sidebar Home view is the launcher itself; it gets no panel chrome.
+  // Every editor-tab panel is wrapped so it has a way back to Home and a
+  // sibling switcher, with its own content scrolling under the sticky header.
+  if (view === "home") return content;
+  return (
+    <div className="flex h-screen flex-col">
+      <PanelChrome view={view as PanelViewId} host={host} />
+      <div className="min-h-0 flex-1 overflow-auto">{content}</div>
+    </div>
   );
 }
 

--- a/packages/vscode/webview/src/runtime/rpc.ts
+++ b/packages/vscode/webview/src/runtime/rpc.ts
@@ -34,6 +34,10 @@ export interface WebviewHost {
   openExternal(url: string): void;
   /** Open (or reveal) an editor-tab panel. Used by the sidebar Home view. */
   openView<V extends PanelViewId>(view: V, params?: ViewParams[V]): void;
+  /** Reveal the sidebar Home view. Used by a panel's navigation chrome. */
+  focusHome(): void;
+  /** Open the native Settings editor filtered to Repowise. Used by Settings. */
+  openNativeSettings(): void;
   /** Run an incremental index update; completion arrives via onUpdateDone. */
   updateIndex(): void;
   /** Persist a theme preference; every open view gets onThemeChanged. */
@@ -125,6 +129,8 @@ export function createHost(): WebviewHost {
     copyText: (text, toast) => vscode.postMessage({ kind: "copy-text", text, toast }),
     openExternal: (url) => vscode.postMessage({ kind: "open-external", url }),
     openView: (view, params) => vscode.postMessage({ kind: "open-view", view, params }),
+    focusHome: () => vscode.postMessage({ kind: "focus-home" }),
+    openNativeSettings: () => vscode.postMessage({ kind: "open-native-settings" }),
     updateIndex: () => vscode.postMessage({ kind: "update-index" }),
     setTheme: (theme) => vscode.postMessage({ kind: "set-theme", theme }),
   };

--- a/packages/vscode/webview/src/views/architecture/App.test.tsx
+++ b/packages/vscode/webview/src/views/architecture/App.test.tsx
@@ -97,6 +97,8 @@ function makeHost(overrides: Partial<WebviewHost["api"]> = {}): WebviewHost {
     copyText: vi.fn(),
     openExternal: vi.fn(),
     openView: vi.fn(),
+    focusHome: vi.fn(),
+    openNativeSettings: vi.fn(),
     updateIndex: vi.fn(),
     setTheme: vi.fn(),
   };

--- a/packages/vscode/webview/src/views/architecture/App.tsx
+++ b/packages/vscode/webview/src/views/architecture/App.tsx
@@ -175,7 +175,7 @@ function ArchitectureMap({ host, repo, params, refreshToken }: ViewProps<"archit
   return (
     <div
       data-testid="architecture-shell"
-      className="flex h-screen flex-col bg-[var(--color-bg-root)] text-[var(--color-text-primary)]"
+      className="flex h-full flex-col bg-[var(--color-bg-root)] text-[var(--color-text-primary)]"
     >
       <header className="shrink-0 border-b border-[var(--color-border-default)] px-4 py-3">
         <div className="flex items-center justify-between gap-3">

--- a/packages/vscode/webview/src/views/decisions/App.test.tsx
+++ b/packages/vscode/webview/src/views/decisions/App.test.tsx
@@ -52,6 +52,8 @@ function makeHost(list: DecisionRecordResponse[]): WebviewHost {
     copyText: () => {},
     openExternal: () => {},
     openView: () => {},
+    focusHome: () => {},
+    openNativeSettings: () => {},
     updateIndex: () => {},
     setTheme: () => {},
   };

--- a/packages/vscode/webview/src/views/decisions/App.tsx
+++ b/packages/vscode/webview/src/views/decisions/App.tsx
@@ -41,6 +41,53 @@ function recencyKey(d: DecisionRecordResponse): number {
   return Number.isNaN(t) ? 0 : t;
 }
 
+/** Loading placeholder that matches the master-detail layout so the panel does
+ *  not reflow when the decisions land. */
+function DecisionsSkeleton() {
+  return (
+    <div className="flex h-full flex-col" aria-hidden>
+      <header className="border-b border-[var(--color-border-default)] px-6 py-4">
+        <div className="h-6 w-32 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+        <div className="mt-3 flex gap-2">
+          {[56, 64, 72, 60].map((w, i) => (
+            <div
+              key={i}
+              className="h-7 animate-pulse rounded-full bg-[var(--color-bg-inset)]"
+              style={{ width: w }}
+            />
+          ))}
+        </div>
+      </header>
+      <div className="flex min-h-0 flex-1">
+        <div className="w-80 shrink-0 space-y-2 border-r border-[var(--color-border-default)] p-3">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <div
+              key={i}
+              className="space-y-2 rounded-lg border border-[var(--color-border-default)] p-3"
+            >
+              <div className="h-4 w-3/4 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+            </div>
+          ))}
+        </div>
+        <div className="min-w-0 flex-1 space-y-4 p-6">
+          <div className="h-6 w-2/3 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+          <div className="h-4 w-1/3 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+          <div className="space-y-2 pt-2">
+            {Array.from({ length: 7 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-3 animate-pulse rounded bg-[var(--color-bg-inset)]"
+                style={{ width: `${92 - i * 7}%` }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function App({ host, refreshToken }: ViewProps<"decisions">) {
   const [decisions, setDecisions] = useState<DecisionRecordResponse[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -98,11 +145,7 @@ export function App({ host, refreshToken }: ViewProps<"decisions">) {
   }
 
   if (decisions === null) {
-    return (
-      <div className="flex h-screen items-center justify-center text-[var(--color-text-tertiary)]">
-        Loading decisions…
-      </div>
-    );
+    return <DecisionsSkeleton />;
   }
 
   if (decisions.length === 0) {
@@ -127,7 +170,7 @@ export function App({ host, refreshToken }: ViewProps<"decisions">) {
   ];
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-full flex-col">
       <header className="border-b border-[var(--color-border-default)] px-6 py-4">
         <h1 className="flex items-center gap-2 text-lg font-semibold text-[var(--color-text-primary)]">
           <Landmark className="h-5 w-5 text-[var(--color-text-secondary)]" />

--- a/packages/vscode/webview/src/views/docs/App.test.tsx
+++ b/packages/vscode/webview/src/views/docs/App.test.tsx
@@ -80,6 +80,8 @@ function mockHost(pages: DocPage[]): WebviewHost {
     copyText: vi.fn(),
     openExternal: vi.fn(),
     openView: vi.fn(),
+    focusHome: vi.fn(),
+    openNativeSettings: vi.fn(),
     updateIndex: vi.fn(),
     setTheme: vi.fn(),
   };

--- a/packages/vscode/webview/src/views/docs/App.tsx
+++ b/packages/vscode/webview/src/views/docs/App.tsx
@@ -140,7 +140,7 @@ export function App({ host, repo, params, refreshToken }: ViewProps<"docs">) {
       : null;
 
   return (
-    <div className="flex h-screen bg-[var(--color-bg-root)]">
+    <div className="flex h-full bg-[var(--color-bg-root)]">
       {treeOpen && (
         <aside className="w-[280px] shrink-0 border-r border-[var(--color-border-default)] bg-[var(--color-bg-surface)]">
           <DocsTree
@@ -250,7 +250,7 @@ function CenteredState({
   detail?: string;
 }) {
   return (
-    <div className="flex h-screen flex-col items-center justify-center gap-3 px-8 text-center">
+    <div className="flex h-full flex-col items-center justify-center gap-3 px-8 text-center">
       {icon}
       <p className="text-sm font-semibold text-[var(--color-text-primary)]">{title}</p>
       {detail && (

--- a/packages/vscode/webview/src/views/graph/App.test.tsx
+++ b/packages/vscode/webview/src/views/graph/App.test.tsx
@@ -32,6 +32,8 @@ function mockHost(): { host: WebviewHost; api: Record<string, ReturnType<typeof 
     copyText: vi.fn(),
     openExternal: vi.fn(),
     openView: vi.fn(),
+    focusHome: vi.fn(),
+    openNativeSettings: vi.fn(),
     updateIndex: vi.fn(),
     setTheme: vi.fn(),
   } satisfies WebviewHost;

--- a/packages/vscode/webview/src/views/graph/App.tsx
+++ b/packages/vscode/webview/src/views/graph/App.tsx
@@ -52,7 +52,7 @@ export function App({ host, params, repo, refreshToken }: ViewProps<"graph">) {
   );
 
   return (
-    <div className="flex h-screen flex-col">
+    <div className="flex h-full flex-col">
       <GraphHeader repoName={repo.name} stats={data.stats} />
       <div className="relative min-h-0 flex-1">
         {data.error ? (

--- a/packages/vscode/webview/src/views/health/App.tsx
+++ b/packages/vscode/webview/src/views/health/App.tsx
@@ -5,15 +5,24 @@
  */
 
 import { useMemo, useState } from "react";
+import { ExternalLink } from "lucide-react";
 import { HealthKpiCards } from "@repowise-dev/ui/health/kpi-cards";
 import { CodeHealthMap, type CodeHealthOverlay } from "@repowise-dev/ui/health/code-health-map";
 import { ChurnComplexityQuadrant } from "@repowise-dev/ui/health/churn-complexity-quadrant";
-import type { HealthDimension } from "@repowise-dev/types/health";
+import type { HealthDimension, HealthFileMetric } from "@repowise-dev/types/health";
 import type { ViewProps } from "../../runtime/mount";
 import { useDashboardData, type DashboardData } from "./useDashboardData";
 import { DashboardError, DashboardSkeleton, SectionHeading } from "./chrome";
 
 type HeroTab = "map" | "quadrant";
+
+/** 0-10 health score to its band color; matches the sidebar Home hero. */
+function scoreColor(score: number | null): string {
+  if (score == null) return "var(--color-text-tertiary)";
+  if (score >= 7.5) return "var(--color-success)";
+  if (score >= 5) return "var(--color-warning)";
+  return "var(--color-error)";
+}
 
 /** The KPI pillar tiles map onto the code map's lenses (defect is "health"). */
 const PILLAR_TO_OVERLAY: Record<HealthDimension, CodeHealthOverlay> = {
@@ -22,7 +31,7 @@ const PILLAR_TO_OVERLAY: Record<HealthDimension, CodeHealthOverlay> = {
   performance: "performance",
 };
 
-export function App({ host, repo, refreshToken }: ViewProps<"health">) {
+export function App({ host, repo, params, refreshToken }: ViewProps<"health">) {
   const { data, error, loading } = useDashboardData(host, refreshToken);
 
   if (error) {
@@ -32,19 +41,31 @@ export function App({ host, repo, refreshToken }: ViewProps<"health">) {
     return <DashboardSkeleton />;
   }
 
-  return <Dashboard host={host} repo={repo} data={data} />;
+  return <Dashboard host={host} repo={repo} data={data} selectPath={params.selectPath ?? null} />;
 }
 
 function Dashboard({
   host,
   repo,
   data,
+  selectPath,
 }: {
   host: ViewProps<"health">["host"];
   repo: ViewProps<"health">["repo"];
   data: DashboardData;
+  selectPath: string | null;
 }) {
   const { overview, files, trend, churn } = data;
+
+  // When the dashboard is opened from the status-bar score, lead with a card
+  // for that file so the two surfaces read as one. The map file set is large
+  // (nloc desc), so the active file is almost always present; if not, the card
+  // still offers a way to open it.
+  const focused = useMemo(() => {
+    if (!selectPath) return null;
+    const entry = files.files.find((f) => f.file_path === selectPath) ?? null;
+    return { path: selectPath, entry };
+  }, [selectPath, files.files]);
   const [overlay, setOverlay] = useState<CodeHealthOverlay>("health");
   const [tab, setTab] = useState<HeroTab>("map");
 
@@ -85,6 +106,14 @@ function Dashboard({
           ) : null}
         </p>
       </header>
+
+      {focused ? (
+        <FocusedFile
+          path={focused.path}
+          entry={focused.entry}
+          onOpen={() => host.openFile(focused.path)}
+        />
+      ) : null}
 
       <section aria-label="Health signals">
         <HealthKpiCards
@@ -127,6 +156,63 @@ function Dashboard({
           />
         )}
       </section>
+    </div>
+  );
+}
+
+/** The file the dashboard was opened for (from the status-bar score), pinned
+ *  above the repo-wide views with its three scores and a jump-to-file action. */
+function FocusedFile({
+  path,
+  entry,
+  onOpen,
+}: {
+  path: string;
+  entry: HealthFileMetric | null;
+  onOpen: () => void;
+}) {
+  const name = path.split("/").pop() ?? path;
+  return (
+    <section
+      aria-label="Current file"
+      className="flex items-center justify-between gap-4 rounded-xl border border-[var(--color-accent-muted)] bg-[var(--color-bg-surface)] px-4 py-3"
+    >
+      <div className="min-w-0">
+        <p className="text-[10px] font-semibold uppercase tracking-wide text-[var(--color-text-tertiary)]">
+          Current file
+        </p>
+        <button
+          type="button"
+          onClick={onOpen}
+          className="flex max-w-full items-center gap-1.5 truncate font-mono text-sm text-[var(--color-text-primary)] transition-colors hover:text-[var(--color-accent-primary)]"
+          title={path}
+        >
+          <span className="truncate">{name}</span>
+          <ExternalLink className="h-3 w-3 shrink-0 opacity-70" />
+        </button>
+      </div>
+      {entry ? (
+        <div className="flex shrink-0 items-center gap-4 text-right">
+          <FocusedScore label="Defect" value={entry.defect_score ?? entry.score} />
+          <FocusedScore label="Maint" value={entry.maintainability_score ?? null} />
+          <FocusedScore label="Perf" value={entry.performance_score ?? null} />
+        </div>
+      ) : (
+        <span className="shrink-0 text-[11px] text-[var(--color-text-tertiary)]">
+          Not among the mapped files
+        </span>
+      )}
+    </section>
+  );
+}
+
+function FocusedScore({ label, value }: { label: string; value: number | null }) {
+  return (
+    <div>
+      <p className="text-[10px] uppercase tracking-wide text-[var(--color-text-tertiary)]">{label}</p>
+      <p className="font-mono text-sm tabular-nums" style={{ color: scoreColor(value) }}>
+        {value == null ? "-" : value.toFixed(1)}
+      </p>
     </div>
   );
 }

--- a/packages/vscode/webview/src/views/home/App.test.tsx
+++ b/packages/vscode/webview/src/views/home/App.test.tsx
@@ -61,7 +61,9 @@ describe("Home sidebar", () => {
     const { host } = makeHost();
     renderApp(host);
 
-    expect(await screen.findByText("5.1")).toBeTruthy();
+    // Average health leads the hero; hotspot health is the inline secondary.
+    expect(await screen.findByText("7.4")).toBeTruthy();
+    expect(screen.getByText(/hotspot 5\.1/)).toBeTruthy();
     expect(screen.getByText("demo-repo")).toBeTruthy();
     expect(screen.getByText("Index up to date")).toBeTruthy();
     expect(screen.getByText("12 ranked plans")).toBeTruthy();
@@ -114,7 +116,7 @@ describe("Home sidebar", () => {
   it("pins the theme through the host and applies it locally", async () => {
     const { host, setTheme } = makeHost();
     renderApp(host);
-    await screen.findByText("5.1");
+    await screen.findByText("7.4");
 
     fireEvent.click(screen.getByTitle("Dark"));
     expect(setTheme).toHaveBeenCalledWith("dark");
@@ -129,6 +131,8 @@ describe("Home sidebar", () => {
     const host = {
       api: { homeSummary: () => Promise.reject(new Error("down")) },
       openView: vi.fn(),
+      focusHome: vi.fn(),
+      openNativeSettings: vi.fn(),
       updateIndex: vi.fn(),
       setTheme: vi.fn(),
       onUpdateDone: () => () => {},

--- a/packages/vscode/webview/src/views/home/App.tsx
+++ b/packages/vscode/webview/src/views/home/App.tsx
@@ -288,10 +288,11 @@ function Hero({
   health: HomeSummary["health"];
   loading: boolean;
 }) {
-  // Quiet or small repos can gate hotspot scoring off; the hero then falls
-  // back to the repo average rather than claiming there is no health data.
-  const usingHotspot = health?.hotspot != null;
-  const headline = health?.hotspot ?? health?.average ?? null;
+  // Average health leads; hotspot health (NLOC-weighted, more volatile) is the
+  // secondary read. Quiet or small repos gate hotspot scoring off entirely, in
+  // which case only the average shows.
+  const hasHotspot = health?.hotspot != null;
+  const headline = health?.average ?? health?.hotspot ?? null;
   const color = scoreColor(headline);
   return (
     <section
@@ -322,17 +323,21 @@ function Hero({
               {headline.toFixed(1)}
             </span>
             <span className="pb-0.5 text-sm text-[var(--color-text-tertiary)]">/ 10</span>
-            {usingHotspot ? <DeltaChip delta={health?.hotspotDelta ?? null} /> : null}
           </div>
-          <p className="mt-1.5 text-[11px] text-[var(--color-text-secondary)]">
-            {usingHotspot ? "Hotspot health" : "Average health"}
-            {usingHotspot && health?.average != null
-              ? ` · average ${health.average.toFixed(1)}`
-              : ""}
-            {` · ${(health?.fileCount ?? 0).toLocaleString()} files`}
+          <p className="mt-1.5 flex flex-wrap items-center gap-x-1.5 text-[11px] text-[var(--color-text-secondary)]">
+            <span>Average health</span>
+            {hasHotspot ? (
+              <>
+                <span aria-hidden className="text-[var(--color-text-tertiary)]">·</span>
+                <span>hotspot {health?.hotspot?.toFixed(1)}</span>
+                <DeltaChip delta={health?.hotspotDelta ?? null} />
+              </>
+            ) : null}
+            <span aria-hidden className="text-[var(--color-text-tertiary)]">·</span>
+            <span>{(health?.fileCount ?? 0).toLocaleString()} files</span>
           </p>
-          {usingHotspot && (health?.history.length ?? 0) >= 2 ? (
-            <Sparkline values={health?.history ?? []} color={color} />
+          {hasHotspot && (health?.history.length ?? 0) >= 2 ? (
+            <Sparkline values={health?.history ?? []} color={scoreColor(health?.hotspot ?? null)} />
           ) : null}
         </>
       ) : (

--- a/packages/vscode/webview/src/views/refactoring/App.tsx
+++ b/packages/vscode/webview/src/views/refactoring/App.tsx
@@ -33,8 +33,10 @@ import type { WebviewHost } from "../../runtime/rpc";
  * `host.openFile`.
  */
 export function App({ host, params, refreshToken }: ViewProps<"refactoring">) {
-  // A plan opened directly is the initial (and only) selection. A card click
-  // sets its own; Back clears it, but only when we arrived via the list.
+  // A plan opened directly (CodeLens/tree) is the initial selection; a card
+  // click sets its own. Back always returns to the list so an entry from a
+  // lens or tree is never a dead end: the list is the file's plans when a
+  // filePath came along, otherwise every ranked plan.
   const [selectedId, setSelectedId] = useState<string | null>(params.planId ?? null);
 
   // The host can push new params into an already-open panel; honor them.
@@ -42,15 +44,13 @@ export function App({ host, params, refreshToken }: ViewProps<"refactoring">) {
     setSelectedId(params.planId ?? null);
   }, [params.planId]);
 
-  const rootIsDetail = params.planId != null;
-
   if (selectedId != null) {
     return (
       <PlanDetailView
         host={host}
         planId={selectedId}
         refreshToken={refreshToken}
-        onBack={rootIsDetail ? undefined : () => setSelectedId(null)}
+        onBack={() => setSelectedId(null)}
       />
     );
   }
@@ -139,7 +139,7 @@ interface PlanDetailViewProps {
   host: WebviewHost;
   planId: string;
   refreshToken: number;
-  /** Present only when a plan list exists to return to. */
+  /** Returns to the plan list; always provided so a detail is never a dead end. */
   onBack?: (() => void) | undefined;
 }
 
@@ -464,7 +464,7 @@ function Badge({
 
 function CenteredNote({ children }: { children: ReactNode }) {
   return (
-    <div className="flex h-screen items-center justify-center px-6 text-center text-sm text-[var(--color-text-tertiary)]">
+    <div className="flex h-full items-center justify-center px-6 text-center text-sm text-[var(--color-text-tertiary)]">
       {children}
     </div>
   );

--- a/packages/vscode/webview/src/views/risk/App.test.tsx
+++ b/packages/vscode/webview/src/views/risk/App.test.tsx
@@ -39,6 +39,8 @@ function makeHost(riskRange: WebviewHost["api"]["riskRange"]): WebviewHost {
     copyText: () => {},
     openExternal: () => {},
     openView: () => {},
+    focusHome: () => {},
+    openNativeSettings: () => {},
     updateIndex: () => {},
     setTheme: () => {},
   };

--- a/packages/vscode/webview/src/views/risk/App.tsx
+++ b/packages/vscode/webview/src/views/risk/App.tsx
@@ -90,7 +90,7 @@ export function App({ host, repo, refreshToken }: ViewProps<"risk">) {
       </header>
 
       {loading && !report ? (
-        <LoadingCard base={base} />
+        <RiskSkeleton base={base} />
       ) : error ? (
         <EmptyState
           icon={<ShieldCheck className="h-8 w-8" />}
@@ -105,16 +105,43 @@ export function App({ host, repo, refreshToken }: ViewProps<"risk">) {
   );
 }
 
-function LoadingCard({ base }: { base: string }) {
+/** Skeleton matching the report layout (score hero + driver bars) so the panel
+ *  holds its shape while the working tree is scored. */
+function RiskSkeleton({ base }: { base: string }) {
   return (
-    <Card>
-      <CardContent className="flex flex-col items-center gap-3 py-16 text-center">
-        <RotateCw className="h-6 w-6 animate-spin text-[var(--color-accent-primary)]" />
-        <p className="text-sm text-[var(--color-text-secondary)]">
-          Scoring the working tree{base ? ` against ${base}` : ""}
-        </p>
-      </CardContent>
-    </Card>
+    <div className="space-y-5">
+      <Card>
+        <CardContent className="flex flex-wrap items-center gap-6 py-6" aria-hidden>
+          <div className="h-24 w-24 shrink-0 animate-pulse rounded-2xl bg-[var(--color-bg-inset)]" />
+          <div className="min-w-0 flex-1 space-y-3">
+            <div className="h-5 w-24 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+            <div className="h-4 w-48 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+            <div className="flex gap-2 pt-1">
+              <div className="h-5 w-20 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+              <div className="h-5 w-28 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">What moves the score</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3" aria-hidden>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3">
+              <div className="h-3 w-40 shrink-0 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+              <div className="h-2 flex-1 animate-pulse rounded-full bg-[var(--color-bg-inset)]" />
+              <div className="h-3 w-14 shrink-0 animate-pulse rounded bg-[var(--color-bg-inset)]" />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+      <p className="flex items-center justify-center gap-2 text-xs text-[var(--color-text-tertiary)]">
+        <RotateCw className="h-3.5 w-3.5 animate-spin" />
+        Scoring the working tree{base ? ` against ${base}` : ""}
+      </p>
+    </div>
   );
 }
 

--- a/packages/vscode/webview/src/views/settings/App.tsx
+++ b/packages/vscode/webview/src/views/settings/App.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { RotateCcw, Settings2 } from "lucide-react";
+import { ExternalLink, RotateCcw, Settings2 } from "lucide-react";
 import type {
   SettingKey,
   SettingsValues,
@@ -47,7 +47,7 @@ const GROUPS: Group[] = [
         key: "diagnostics.enabled",
         label: "Problems panel findings",
         description:
-          "Show health findings for visible files in the Problems panel (the squiggles under flagged code, and the matching colors on files in the explorer).",
+          "Show health findings for visible files in the Problems panel (the squiggles under flagged code). Off by default to keep the panel quiet; the gutter, explorer badges, and hovers surface findings either way.",
         kind: "toggle",
       },
       {
@@ -199,19 +199,19 @@ export function App({ host, refreshToken }: ViewProps<"settings">) {
 
   if (!values) {
     return (
-      <div className="flex h-screen items-center justify-center text-[var(--color-text-tertiary)]">
+      <div className="flex h-full items-center justify-center text-[var(--color-text-tertiary)]">
         {error ?? "Loading settings…"}
       </div>
     );
   }
 
   return (
-    <div className="mx-auto min-h-screen max-w-3xl space-y-6 bg-[var(--color-bg-root)] px-6 py-6">
+    <div className="mx-auto min-h-full max-w-3xl space-y-6 bg-[var(--color-bg-root)] px-6 py-6">
       <header className="flex items-center gap-2.5">
         <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]">
           <Settings2 className="h-4 w-4" />
         </span>
-        <div>
+        <div className="min-w-0 flex-1">
           <h1 className="text-base font-semibold text-[var(--color-text-primary)]">
             Repowise Settings
           </h1>
@@ -219,6 +219,15 @@ export function App({ host, refreshToken }: ViewProps<"settings">) {
             Saved to this workspace. Changes apply immediately.
           </p>
         </div>
+        <button
+          type="button"
+          onClick={() => host.openNativeSettings()}
+          title="Open these settings in the VS Code Settings editor (search, sync, per-scope overrides)"
+          className="flex shrink-0 items-center gap-1.5 rounded-lg border border-[var(--color-border-default)] px-2.5 py-1.5 text-[11px] font-medium text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-border-hover)] hover:text-[var(--color-text-primary)]"
+        >
+          <ExternalLink className="h-3.5 w-3.5" />
+          Open in Settings editor
+        </button>
       </header>
 
       {error ? (
@@ -271,8 +280,23 @@ function SettingRow({
 }) {
   const value = values[row.key];
   const controlId = `set-${row.key.replace(/\./g, "-")}`;
+  // Rows gated by a parent toggle are indented under it with an elbow connector,
+  // so a dimmed child reads as "controlled by the switch above", not broken.
+  const indented = row.needs != null;
   return (
-    <div className={disabled ? "flex items-start gap-4 px-4 py-3 opacity-50" : "flex items-start gap-4 px-4 py-3"}>
+    <div
+      className={
+        (disabled ? "opacity-50 " : "") +
+        "flex items-start gap-3 py-3 pr-4 " +
+        (indented ? "pl-8" : "pl-4")
+      }
+    >
+      {indented ? (
+        <span
+          aria-hidden
+          className="mt-1 h-3 w-3 shrink-0 rounded-bl border-b border-l border-[var(--color-border-default)]"
+        />
+      ) : null}
       <div className="min-w-0 flex-1">
         <label htmlFor={controlId} className="block text-[13px] font-medium text-[var(--color-text-primary)]">
           {row.label}
@@ -383,14 +407,18 @@ function Toggle({
       disabled={disabled}
       onClick={() => onChange(!checked)}
       className={
-        "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors disabled:cursor-not-allowed " +
-        (checked ? "bg-[var(--color-accent-primary)]" : "bg-[var(--color-bg-inset)]")
+        // The off state carries a border and a filled knob so the switch stays
+        // visible on a light card, where bg-inset alone is nearly the surface color.
+        "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full border transition-colors disabled:cursor-not-allowed " +
+        (checked
+          ? "border-[var(--color-accent-primary)] bg-[var(--color-accent-primary)]"
+          : "border-[var(--color-border-default)] bg-[var(--color-bg-inset)]")
       }
     >
       <span
         className={
-          "inline-block h-4 w-4 transform rounded-full bg-white transition-transform " +
-          (checked ? "translate-x-4" : "translate-x-0.5")
+          "inline-block h-4 w-4 transform rounded-full shadow-sm transition-transform " +
+          (checked ? "translate-x-4 bg-white" : "translate-x-0.5 bg-[var(--color-text-tertiary)]")
         }
       />
     </button>


### PR DESCRIPTION
A presentation and coherence pass over the VS Code extension, plus the specific UX fixes from dogfooding.

## Quieter, clearer defaults
- The sidebar home now leads with **average health** as the headline; **hotspot health** is the inline secondary (with its trend delta and sparkline). Quiet or small repos that gate hotspot scoring off show the average alone.
- **Problems panel findings are off by default.** The panel stays quiet unless you opt in from Settings; the gutter heat, explorer badges, hovers, and the status-bar score still surface findings.
- Fixed the settings toggle so its **off state is visible in light mode** (previously a white knob on a near-surface track disappeared).

## Panel navigation and coherence
- Every dashboard panel now has a slim header with a way back to the home view and a switcher across the other dashboards, so panels are no longer dead-end tabs.
- A refactoring plan opened from a lens or a tree item can always return to the plan list instead of stranding you.
- Clicking the status-bar health score opens the health dashboard **focused on the active file** (a "Current file" card above the repo-wide views), so the two surfaces read as one.

## Polish
- Layout-matched loading skeletons for the decisions and branch risk panels.
- An "Open in Settings editor" action in the settings panel, and indentation with an elbow connector for the gated editor-signal rows so a dimmed control reads as controlled by the switch above it.

## Verification
- Type-check (host + webview), host bundle 102.8 KB (budget 300 KB), webview build, 28/28 webview unit tests, 4/4 extension smoke tests, shared-import lint, and UI type-check all pass.
- VSIX packaged (2.11 MB) and installed for dogfood.

No version bump; the extension version is bumped as its own release step.