### PR TITLE
release: v0.26.0 — VS Code extension, zoom architecture view, web build fix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.26.0] — 2026-07-03
+
+### Added
+- **VS Code extension.** Repowise now runs inside your editor. The extension manages the local server lifecycle, walks you through install to first insight, and registers the Repowise MCP tools for agent mode (#643, #644). Low-health files surface as diagnostics with gutter heat, and editor-native signals include live range risk scoring, a refactoring lens, dead-code line spans, and inline docs (#642, #644). A sidebar Home dashboard shows index freshness, a theme switcher, and consolidated trees (#650), and the shared visualization panels (graph, C4, health, blast radius) render directly in webviews (#649, #653). A settings panel configures editor signals and the server connection (#654), and the latest pass adds panel navigation and quieter defaults for an editor-native feel (#660). Install it from the VS Code Marketplace or Open VSX.
+- **Continuous-zoom architecture view.** The server builds a zoom-map artifact that drives a smooth, execution-aware zoom across the architecture graph. (#626)
+- **Configurable Ollama embedding timeout.** The Ollama embedding request timeout can now be set via environment variable for slower local models. (#656)
+
+### Changed
+- **Sharper `get_answer` grounding.** The `get_answer` MCP tool gained a frame-grounding gate and anchors rationale to in-code comments, with retrieval tuning across `get_answer` and `get_context`. (#621, #622)
+- **Faster decision embeddings.** Decision embeddings are batched during persistence and reindex, cutting indexing work on decision-heavy repos. (#641)
+
+### Fixed
+- **Config languages no longer inflate language usage.** Configuration-file languages are hidden from the language-usage breakdown. (#623)
+- **Index freshness stamp stays current on no-op syncs.** An `update` that finds no changes still refreshes the freshness stamp, so agents don't distrust a current index. (#652)
+
+### Dependencies
+- Cleared high and critical CVEs across the npm and Python dependency trees. (#645)
+
+---
+
 ## [0.25.0] — 2026-06-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -8332,6 +8332,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "license": "MIT"
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.26.0] — 2026-07-03
+
+### Added
+- **VS Code extension.** Repowise now runs inside your editor. The extension manages the local server lifecycle, walks you through install to first insight, and registers the Repowise MCP tools for agent mode (#643, #644). Low-health files surface as diagnostics with gutter heat, and editor-native signals include live range risk scoring, a refactoring lens, dead-code line spans, and inline docs (#642, #644). A sidebar Home dashboard shows index freshness, a theme switcher, and consolidated trees (#650), and the shared visualization panels (graph, C4, health, blast radius) render directly in webviews (#649, #653). A settings panel configures editor signals and the server connection (#654), and the latest pass adds panel navigation and quieter defaults for an editor-native feel (#660). Install it from the VS Code Marketplace or Open VSX.
+- **Continuous-zoom architecture view.** The server builds a zoom-map artifact that drives a smooth, execution-aware zoom across the architecture graph. (#626)
+- **Configurable Ollama embedding timeout.** The Ollama embedding request timeout can now be set via environment variable for slower local models. (#656)
+
+### Changed
+- **Sharper `get_answer` grounding.** The `get_answer` MCP tool gained a frame-grounding gate and anchors rationale to in-code comments, with retrieval tuning across `get_answer` and `get_context`. (#621, #622)
+- **Faster decision embeddings.** Decision embeddings are batched during persistence and reindex, cutting indexing work on decision-heavy repos. (#641)
+
+### Fixed
+- **Config languages no longer inflate language usage.** Configuration-file languages are hidden from the language-usage breakdown. (#623)
+- **Index freshness stamp stays current on no-op syncs.** An `update` that finds no changes still refreshes the freshness stamp, so agents don't distrust a current index. (#652)
+
+### Dependencies
+- Cleared high and critical CVEs across the npm and Python dependency trees. (#645)
+
+---
+
 ## [0.25.0] — 2026-06-27
 
 ### Added

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "repowise",
   "displayName": "Repowise",
   "description": "Code health, architecture, and git intelligence from one local index, in your editor and in your AI agent via MCP.",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publisher": "repowise-dev",
   "license": "AGPL-3.0-or-later",
   "homepage": "https://www.repowise.dev",

--- a/packages/vscode/src/constants.ts
+++ b/packages/vscode/src/constants.ts
@@ -13,7 +13,7 @@ export const CONFIG_SECTION = "repowise";
  * Lowest server version this build understands. Older servers may serve a
  * store shape this extension cannot read, so the status bar flags them.
  */
-export const MIN_SERVER_VERSION = "0.25.0";
+export const MIN_SERVER_VERSION = "0.26.0";
 
 /** Command ids contributed by the extension, mirrored from package.json. */
 export const Commands = {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.26.0
+
+### Changed
+- Version bump to track the repowise 0.26.0 release. No command, skill, or MCP
+  tool-surface changes this cycle.
+
 ## 0.25.0
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.25.0"
+version = "0.26.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3056,7 +3056,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.25.0"
+version = "0.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## release: v0.26.0

The headline this cycle is the **VS Code extension**: Repowise now runs inside the editor with server lifecycle management, editor-native signals (diagnostics, gutter heat, live range risk, refactoring lens, dead-code spans, inline docs), a sidebar Home dashboard, shared visualization panels, a settings panel, and MCP registration for agent mode. Also in this release: a continuous-zoom architecture view, a configurable Ollama embedding timeout, sharper `get_answer` grounding, faster decision embeddings, and dependency CVE clearing.

### Version bumps
- Python package -> 0.26.0 (`pyproject.toml`, cli/core/server `__init__`, `uv.lock` self-entry)
- Claude Code plugin -> 0.26.0 (`marketplace.json` + `plugin.json`)
- VS Code extension -> 0.2.0, `MIN_SERVER_VERSION` -> 0.26.0 (its editor signals rely on server contracts landing in this release)
- Codex plugin and store/parser format versions unchanged (no changes this cycle)

### Build fix included
The web build failed on the Files route with `Cannot find package 'emoji-regex-xs'`. The dependency CVE sweep (#645) regenerated `package-lock.json` and pruned the resolved `emoji-regex-xs` entry while leaving `shiki 1.29.2 -> oniguruma-to-es 2.3.0` (which requires `emoji-regex-xs`) in the tree, so `npm ci` produced a tree that could not resolve it at build time. Fixed by restoring the single `emoji-regex-xs@1.0.0` resolved entry (verbatim from the v0.25.0 lockfile). Minimal by design: it touches nothing else, so the vitest-3 transitives `packages/vscode` needs stay in place. This was broken on `main` and would have shipped broken. Aligning the web app up to shiki 4 is the cleaner long-term fix and is left as a focused follow-up.

### Test plan
- [x] Version bump drift grep clean (no stale 0.25.0 in the six manifests + `uv.lock`)
- [x] `uv.lock` self-entry moved 0.25.0 -> 0.26.0
- [x] Bundled changelog resynced (`test_bundled_changelog_sync` guard passes)
- [x] Wheel builds: `repowise-0.26.0-py3-none-any.whl` with commands (incl. `serve_cmd`), `.scm` queries, `.j2` templates, bundled changelog
- [x] `npm ci` clean, 0 vulns, `emoji-regex-xs` and `loupe` both present
- [x] Web build green: standalone `server.js` present, workspace code compiled into chunks
- [x] VS Code extension: type-check, host bundle (102.8 KB, under budget), webview build, and webview unit tests (28 passing) all pass
- [ ] End-to-end wheel smoke test in a fresh venv (post-merge, dev machine)
- [ ] VS Code clean-profile VSIX install smoke test (post-merge)
- [ ] Tag `v0.26.0` on main after merge -> `publish.yml`
- [ ] Tag `vscode-v0.2.0` -> `publish-vscode.yml`

### Merge convention
Use a **regular merge commit** (not squash), so the `v0.26.0` tag points at a real merge of the bump-only diff and artifact provenance stays traceable.
