### PR TITLE
fix(web): declare @repowise-dev/api-client dependency (unblocks v0.26.0 publish)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18568,7 +18568,7 @@
     },
     "packages/vscode": {
       "name": "repowise",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@repowise-dev/api-client": "*",
@@ -18933,6 +18933,7 @@
       "version": "0.3.0",
       "dependencies": {
         "@lottiefiles/dotlottie-react": "^0.19.4",
+        "@repowise-dev/api-client": "*",
         "@repowise-dev/types": "*",
         "@repowise-dev/ui": "*",
         "clsx": "^2.1.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@lottiefiles/dotlottie-react": "^0.19.4",
+    "@repowise-dev/api-client": "*",
     "@repowise-dev/types": "*",
     "@repowise-dev/ui": "*",
     "clsx": "^2.1.1",


### PR DESCRIPTION
The v0.26.0 publish run failed: `publish.yml`'s `next build` of `packages/web` on a clean runner could not resolve `@repowise-dev/api-client` (`Module not found: Can't resolve '@repowise-dev/api-client'`), so the web tarball and PyPI publish never ran. Nothing shipped (PyPI still 0.25.0, no v0.26.0 release).

`packages/web` imports `@repowise-dev/api-client` (added in #642) but never declared it, unlike `@repowise-dev/ui` and `@repowise-dev/types`. Local/hoisted installs and the lint+type-check CI job tolerated it; only `publish.yml`'s `next build` exercises it. `packages/vscode` declares the same dep and builds cleanly, confirming the fix.

After merge, the `v0.26.0` tag will be moved to the fixed commit to re-trigger the publish.

### Test plan
- [x] `@repowise-dev/api-client` is the only imported-but-undeclared workspace package in `packages/web/src`
- [x] Fix mirrors the existing `ui`/`types` declarations and the `packages/vscode` declaration
- [x] Clean `npm ci` + `npm run build --workspace packages/web` green locally (0 vulns)
- [ ] `publish.yml` green after tag re-trigger (post-merge)