### PR TITLE
ci: scope publish.yml tag filter to v[0-9]* (avoid vscode-v* collision)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,10 @@ name: Publish to PyPI
 
 on:
   push:
-    tags: ['v*']
+    # Match release tags like v0.26.0 but NOT the extension's vscode-v* tags
+    # (which also start with "v"). Requiring a digit right after the "v" keeps
+    # the two tag namespaces from triggering each other.
+    tags: ['v[0-9]*']
 
 permissions:
   contents: write  # needed for creating GitHub releases


### PR DESCRIPTION
`publish.yml` filtered `tags: ['v*']`, which also matches the extension's `vscode-v*` tags (both start with `v`). Extension 0.1.x releases went out via `workflow_dispatch`, so it stayed hidden until the first `vscode-v0.2.0` **tag** push during the 0.26.0 release, which fired a spurious (failing) PyPI publish run alongside the extension publish.

Require a digit right after the `v` (`v[0-9]*`) so `v0.26.0` still matches but `vscode-v0.2.0` does not. GitHub Actions tag filters support `[0-9]` character ranges. The two tag namespaces no longer trigger each other.

### Test plan
- [x] `v[0-9]*` matches `v0.26.0` and not `vscode-v0.2.0` (digit-after-v required)
- [ ] Next `vscode-v*` tag push triggers only `publish-vscode.yml`, not `publish.yml`