### PR TITLE
fix(files): stop linking external dependency nodes as files

### DIFF
--- a/packages/ui/__tests__/files/file-graph-tab.test.tsx
+++ b/packages/ui/__tests__/files/file-graph-tab.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FileGraphTab } from "../../src/files/file-graph-tab.js";
+import type { FileDetailGraph, FileGraphNeighbor } from "@repowise-dev/types/files";
+
+function makeNeighbor(overrides: Partial<FileGraphNeighbor> = {}): FileGraphNeighbor {
+  return {
+    node_id: "src/app.ts",
+    node_type: "file",
+    language: "typescript",
+    edge_type: "imports",
+    imported_names: [],
+    ...overrides,
+  };
+}
+
+function makeGraph(overrides: Partial<FileDetailGraph> = {}): FileDetailGraph {
+  return {
+    language: "typescript",
+    is_entry_point: false,
+    is_test: false,
+    symbol_count: 3,
+    pagerank: 0.001,
+    pagerank_percentile: 42,
+    in_degree: 1,
+    out_degree: 1,
+    community_id: 0,
+    community_label: null,
+    dependents: [],
+    dependencies: [],
+    ...overrides,
+  };
+}
+
+const fileHref = (path: string) => `/files/${path}`;
+const symbolHref = (symbolId: string) => `/symbols/${symbolId}`;
+
+describe("FileGraphTab", () => {
+  it("links a regular file neighbor to its file page", () => {
+    const graph = makeGraph({
+      dependencies: [makeNeighbor({ node_id: "src/util.ts" })],
+    });
+    render(
+      <FileGraphTab
+        graph={graph}
+        filePath="src/app.ts"
+        linkPrefix="/repos/1"
+        fileHref={fileHref}
+        symbolHref={symbolHref}
+      />,
+    );
+    const link = screen.getByText("src/util.ts").closest("a");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe("/files/src/util.ts");
+  });
+
+  it("does not linkify an external-system neighbor as a file", () => {
+    const graph = makeGraph({
+      dependencies: [makeNeighbor({ node_id: "external:fastapi", node_type: "file" })],
+    });
+    render(
+      <FileGraphTab
+        graph={graph}
+        filePath="src/app.ts"
+        linkPrefix="/repos/1"
+        fileHref={fileHref}
+        symbolHref={symbolHref}
+      />,
+    );
+    const label = screen.getByText("external:fastapi");
+    expect(label.closest("a")).toBeNull();
+    expect(label.getAttribute("title")).toContain("external dependency");
+  });
+
+  it("still links a symbol neighbor to its symbol page", () => {
+    const graph = makeGraph({
+      dependencies: [makeNeighbor({ node_id: "src/app.ts::handler", node_type: "symbol" })],
+    });
+    render(
+      <FileGraphTab
+        graph={graph}
+        filePath="src/app.ts"
+        linkPrefix="/repos/1"
+        fileHref={fileHref}
+        symbolHref={symbolHref}
+      />,
+    );
+    const link = screen.getByText("src/app.ts::handler").closest("a");
+    expect(link?.getAttribute("href")).toBe("/symbols/src/app.ts::handler");
+  });
+});

--- a/packages/ui/src/files/file-graph-tab.tsx
+++ b/packages/ui/src/files/file-graph-tab.tsx
@@ -42,21 +42,36 @@ function NeighborList({
         ) : (
           <ul className="space-y-2">
             {neighbors.map((n) => {
-              const isSymbol = n.node_type === "symbol" || n.node_id.includes("::");
+              const isExternal = n.node_id.startsWith("external:");
+              const isSymbol = !isExternal && (n.node_type === "symbol" || n.node_id.includes("::"));
               const href = isSymbol ? symbolHref(n.node_id) : fileHref(n.node_id);
+              const row = (
+                <>
+                  <span
+                    className={`font-mono text-xs truncate flex-1 min-w-0 ${
+                      isExternal ? "text-[var(--color-text-tertiary)]" : "text-[var(--color-text-primary)]"
+                    }`}
+                    title={isExternal ? `${n.node_id} (external dependency, not part of this repo)` : n.node_id}
+                  >
+                    {truncatePath(n.node_id, 48)}
+                  </span>
+                  <span className="text-[10px] text-[var(--color-text-tertiary)] shrink-0">
+                    {n.edge_type}
+                  </span>
+                </>
+              );
               return (
                 <li key={`${n.node_id}-${n.edge_type}`}>
-                  <a
-                    href={href}
-                    className="flex items-center gap-2 -mx-2 px-2 py-1 rounded hover:bg-[var(--color-bg-elevated)] transition-colors"
-                  >
-                    <span className="font-mono text-xs text-[var(--color-text-primary)] truncate flex-1 min-w-0" title={n.node_id}>
-                      {truncatePath(n.node_id, 48)}
-                    </span>
-                    <span className="text-[10px] text-[var(--color-text-tertiary)] shrink-0">
-                      {n.edge_type}
-                    </span>
-                  </a>
+                  {isExternal ? (
+                    <div className="flex items-center gap-2 -mx-2 px-2 py-1 rounded">{row}</div>
+                  ) : (
+                    <a
+                      href={href}
+                      className="flex items-center gap-2 -mx-2 px-2 py-1 rounded hover:bg-[var(--color-bg-elevated)] transition-colors"
+                    >
+                      {row}
+                    </a>
+                  )}
                   {n.imported_names.length > 0 && (
                     <p
                       className="pl-1 text-[10px] text-[var(--color-text-tertiary)] truncate"

--- a/packages/ui/src/files/file-overview-tab.tsx
+++ b/packages/ui/src/files/file-overview-tab.tsx
@@ -105,7 +105,19 @@ export function FileOverviewTab({ data, symbolHref, fileHref }: FileOverviewTabP
                 Dependencies ({data.graph.out_degree})
               </p>
               {data.graph.dependencies.slice(0, 5).map((n) => {
-                const isSymbol = n.node_type === "symbol" || n.node_id.includes("::");
+                const isExternal = n.node_id.startsWith("external:");
+                const isSymbol = !isExternal && (n.node_type === "symbol" || n.node_id.includes("::"));
+                if (isExternal) {
+                  return (
+                    <p
+                      key={`out-${n.node_id}`}
+                      className="block truncate font-mono text-xs text-[var(--color-text-tertiary)]"
+                      title={`${n.node_id} (external dependency, not part of this repo)`}
+                    >
+                      {truncatePath(n.node_id, 30)}
+                    </p>
+                  );
+                }
                 return (
                   <a
                     key={`out-${n.node_id}`}


### PR DESCRIPTION
Fixes #668

On a file page, the Dependents/Dependencies lists build a file-page href for any graph neighbor that isn't a symbol:

```tsx
const isSymbol = n.node_type === "symbol" || n.node_id.includes("::");
const href = isSymbol ? symbolHref(n.node_id) : fileHref(n.node_id);
```

External-system nodes (id like `external:fastapi`) are not symbols and not real files, so they fell into the file branch and produced a dead link such as `/files/external:fastapi`. Clicking it landed on a file-not-found state.

I checked how `node_type` gets set for these nodes (`ResolverContext.add_external_node` in `packages/core/.../resolvers/context.py` only sets `language="external"`, and `pipeline/persist.py` defaults `node_type` to `"file"` when it isn't set), so `node_type` alone isn't a reliable signal here. `dependency-heatmap.tsx` already works around this in the same package by checking the `external:` id prefix, so I used the same check in `file-graph-tab.tsx` and `file-overview-tab.tsx`.

External neighbors now render as plain (non-clickable) text with a tooltip explaining they're an external dependency, instead of a link to a page that doesn't exist. Regular file and symbol neighbors are unaffected.

Testing:
- Added `packages/ui/__tests__/files/file-graph-tab.test.tsx` covering a file neighbor (still links to its file page), a symbol neighbor (still links to its symbol page), and an external neighbor (renders as text, no link).
- `npx vitest run` in `packages/ui` passes (544 pre-existing tests plus the 3 new ones; one unrelated pre-existing test, `dsm-matrix.test.tsx`, is a slow/flaky timeout under load and passes on its own with a longer timeout).
- `npx tsc --noEmit` in `packages/ui` passes.
- `bash packages/ui/scripts/ui-gates.sh` (design token gates) passes.