### PR TITLE
fix: don't linkify external-system graph nodes as file paths

### DIFF
--- a/packages/ui/src/files/file-graph-tab.tsx
+++ b/packages/ui/src/files/file-graph-tab.tsx
@@ -43,9 +43,11 @@ function NeighborList({
           <ul className="space-y-2">
             {neighbors.map((n) => {
               const isSymbol = n.node_type === "symbol" || n.node_id.includes("::");
-              const href = isSymbol ? symbolHref(n.node_id) : fileHref(n.node_id);
+              const isExternal = n.node_id.startsWith("external:");
+              const href = isExternal ? null : isSymbol ? symbolHref(n.node_id) : fileHref(n.node_id);
               return (
                 <li key={`${n.node_id}-${n.edge_type}`}>
+                  {href ? (
                   <a
                     href={href}
                     className="flex items-center gap-2 -mx-2 px-2 py-1 rounded hover:bg-[var(--color-bg-elevated)] transition-colors"
@@ -57,6 +59,18 @@ function NeighborList({
                       {n.edge_type}
                     </span>
                   </a>
+                  ) : (
+                  <span
+                    className="flex items-center gap-2 -mx-2 px-2 py-1 rounded"
+                  >
+                    <span className="font-mono text-xs text-[var(--color-text-tertiary)] truncate flex-1 min-w-0" title={n.node_id}>
+                      {truncatePath(n.node_id, 48)}
+                    </span>
+                    <span className="text-[10px] text-[var(--color-text-tertiary)] shrink-0">
+                      {n.edge_type}
+                    </span>
+                  </span>
+                  )}
                   {n.imported_names.length > 0 && (
                     <p
                       className="pl-1 text-[10px] text-[var(--color-text-tertiary)] truncate"

--- a/packages/ui/src/files/file-overview-tab.tsx
+++ b/packages/ui/src/files/file-overview-tab.tsx
@@ -106,15 +106,25 @@ export function FileOverviewTab({ data, symbolHref, fileHref }: FileOverviewTabP
               </p>
               {data.graph.dependencies.slice(0, 5).map((n) => {
                 const isSymbol = n.node_type === "symbol" || n.node_id.includes("::");
-                return (
+                const isExternal = n.node_id.startsWith("external:");
+                const href = isExternal ? null : isSymbol ? symbolHref(n.node_id) : fileHref(n.node_id);
+                return href ? (
                   <a
                     key={`out-${n.node_id}`}
-                    href={isSymbol ? symbolHref(n.node_id) : fileHref(n.node_id)}
+                    href={href}
                     className="block truncate font-mono text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-accent-primary)]"
                     title={n.node_id}
                   >
                     {truncatePath(n.node_id, 30)}
                   </a>
+                ) : (
+                  <span
+                    key={`out-${n.node_id}`}
+                    className="block truncate font-mono text-xs text-[var(--color-text-tertiary)]"
+                    title={n.node_id}
+                  >
+                    {truncatePath(n.node_id, 30)}
+                  </span>
                 );
               })}
             </div>


### PR DESCRIPTION
## What's wrong

On a file page, the neighbor lists (Dependents / Dependencies) linkify external-system graph nodes as file paths. Nodes with IDs like `external:System` get passed to `fileHref()` which produces dead links like `/files/external:System`. Clicking them lands on a "file not found" state.

## What this does

Checks if `node_id` starts with `external:` before generating a link. External nodes now render as non-clickable `<span>` elements with muted text styling instead of `<a>` links. Applied to both:
- `file-graph-tab.tsx` (Dependents / Dependencies lists)
- `file-overview-tab.tsx` (Dependencies preview)

## How to verify

1. Open a file page that has an external-system neighbor in the dependency graph
2. The external node should appear as muted text, not a clickable link
3. Other nodes (files, symbols) should still be clickable links

Fixes #668
