### PR TITLE
fix(core): use spawn for parse and betweenness process pools (#678)

### DIFF
--- a/packages/core/src/repowise/core/ingestion/graph/_betweenness.py
+++ b/packages/core/src/repowise/core/ingestion/graph/_betweenness.py
@@ -21,6 +21,7 @@ are unavailable.
 
 from __future__ import annotations
 
+import multiprocessing
 import os
 from concurrent.futures import ProcessPoolExecutor
 
@@ -28,6 +29,14 @@ import networkx as nx
 import structlog
 
 log = structlog.get_logger(__name__)
+
+# ``spawn`` rather than the POSIX default ``fork``: graph metrics run after
+# ingestion, and in a workspace init an earlier repo's doc generation may have
+# already imported LanceDB (whose ``lance`` core is not fork-safe and installs
+# an ``os.register_at_fork`` hook that can deadlock the child). Clean spawned
+# workers never inherit that runtime. Same rationale as the parse pool in
+# ``pipeline/phases/ingestion.py`` (issue #678).
+_MP_SPAWN = multiprocessing.get_context("spawn")
 
 # Parallelize only when the estimated Brandes cost (~nodes x edges) is large
 # enough to amortize process startup (~2-3s for pool spawn + imports).
@@ -138,6 +147,7 @@ def betweenness_centrality_fast(
     try:
         with ProcessPoolExecutor(
             max_workers=workers,
+            mp_context=_MP_SPAWN,
             initializer=_init_worker,
             initargs=(n, edges, g.is_directed()),
         ) as pool:

--- a/packages/core/src/repowise/core/pipeline/phases/ingestion.py
+++ b/packages/core/src/repowise/core/pipeline/phases/ingestion.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import multiprocessing
 import os
 import time
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
@@ -59,6 +60,17 @@ async def _timed_step(
 # ---------------------------------------------------------------------------
 # Process-pool worker (module-level — must be picklable)
 # ---------------------------------------------------------------------------
+
+# Force ``spawn`` for the parse pool instead of the POSIX default ``fork``.
+# A workspace init generates docs for one repo (which imports and connects
+# LanceDB) before ingesting the next, and ``lance`` is not fork-safe — it
+# registers an ``os.register_at_fork`` hook that resets its native async
+# runtime in the child but can still deadlock. Forking the parse workers
+# after LanceDB is live is exactly what hung multi-repo inits at "Parsing
+# files" (issue #678). ``spawn`` starts clean workers that never inherit the
+# runtime; it is already the default on Windows/macOS, so ``_parse_one`` and
+# its picklable args are known to work under it.
+_MP_SPAWN = multiprocessing.get_context("spawn")
 
 # Module-level process-local parser cache (one per worker process).
 _WORKER_PARSER: Any = None
@@ -262,7 +274,7 @@ async def _run_ingestion(
 
     if to_parse:
         try:
-            with ProcessPoolExecutor(max_workers=workers) as pool:
+            with ProcessPoolExecutor(max_workers=workers, mp_context=_MP_SPAWN) as pool:
                 tasks = [
                     loop.run_in_executor(pool, _parse_one, item) for _idx, item, _h in to_parse
                 ]
@@ -551,7 +563,7 @@ async def reparse_for_resume(
 
     if to_parse:
         try:
-            with ProcessPoolExecutor(max_workers=workers) as pool:
+            with ProcessPoolExecutor(max_workers=workers, mp_context=_MP_SPAWN) as pool:
                 tasks = [
                     loop.run_in_executor(pool, _parse_one, item) for _idx, item, _h in to_parse
                 ]


### PR DESCRIPTION
## Summary

Fixes #678. Multi-repo (`workspace`) `repowise init` hung at "Parsing files" with a flood of `lance is not fork-safe` warnings.

## Root cause

The workspace init path ingests and generates docs for one repo before ingesting the next. Doc generation builds the LanceDB vector store, which does `import lancedb`. LanceDB's native `lance` core is not fork-safe and installs an `os.register_at_fork` hook that resets its async runtime in the child but can still deadlock.

The parse phase parses files with a `ProcessPoolExecutor`, which on Linux/macOS defaults to the `fork` start method. From the second repo onward, the parse workers were forked while LanceDB's runtime was already live, which deadlocked the child and hung the run.

Single-repo init was never affected because it parses before LanceDB is ever imported.

## Fix

Switch the two parse pools and the betweenness-centrality pool to the `spawn` start method, which is what LanceDB itself recommends. Spawned workers start clean and never inherit the runtime.

`spawn` is already the default on Windows and current macOS, so the worker functions (`_parse_one`, `_partial_betweenness`) and their picklable args already run under it unchanged. This only changes Linux behavior, where the fork was unsafe.

## Files

- `packages/core/src/repowise/core/pipeline/phases/ingestion.py` — initial + resume re-parse pools
- `packages/core/src/repowise/core/ingestion/graph/_betweenness.py` — betweenness pool

## Testing

- `tests/unit/ingestion/test_parallel_betweenness.py` + `test_parse_cache.py` — 25 passed
- `tests/integration/test_ingest_sample_repo.py` — 28 passed
- ruff clean on both files
- Verified a first-pass pipeline run parses cleanly with the spawn context

Note: the hang only reproduces on `fork` platforms (Linux/macOS), not Windows, since Windows already uses `spawn`.
