### PR TITLE
feat(ui): add formatBytes and formatPercent formatters

### DIFF
--- a/packages/server/src/repowise/server/routers/overview.py
+++ b/packages/server/src/repowise/server/routers/overview.py
@@ -9,6 +9,7 @@ decisions slice, savings headline, and health KPIs.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import sqlite3
 from pathlib import Path
@@ -35,6 +36,18 @@ router = APIRouter(
     tags=["overview"],
     dependencies=[Depends(verify_api_key)],
 )
+
+
+def _index_storage_bytes(repowise_dir: Path) -> int:
+    """Total on-disk size of a repo's ``.repowise/`` directory."""
+    if not repowise_dir.is_dir():
+        return 0
+    total = 0
+    for path in repowise_dir.rglob("*"):
+        if path.is_file():
+            with contextlib.suppress(OSError):
+                total += path.stat().st_size
+    return total
 
 
 def _decision_slim(d: Any) -> dict:
@@ -378,6 +391,7 @@ async def overview_summary(
         last_sync_at = repo.updated_at.isoformat()
 
     savings = await _savings_headline(repo.local_path)
+    repowise_dir = Path(repo.local_path) / ".repowise" if repo.local_path else Path(".repowise")
 
     return {
         "repo": {
@@ -436,5 +450,6 @@ async def overview_summary(
             "last_sync_model": last_sync_model,
             "active_job_id": active_job_id,
             "page_count": total_pages,
+            "index_storage_bytes": _index_storage_bytes(repowise_dir),
         },
     }

--- a/packages/types/src/overview.ts
+++ b/packages/types/src/overview.ts
@@ -123,6 +123,8 @@ export interface OverviewSyncStatus {
   last_sync_model: string | null;
   active_job_id: string | null;
   page_count: number;
+  /** Total on-disk size of the repo's `.repowise/` directory (bytes). */
+  index_storage_bytes?: number;
 }
 
 export interface OverviewSummaryResponse {

--- a/packages/ui/__tests__/dashboard/index-storage-mini.test.tsx
+++ b/packages/ui/__tests__/dashboard/index-storage-mini.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { IndexStorageMini } from "../../src/dashboard/index-storage-mini";
+
+describe("IndexStorageMini", () => {
+  it("renders formatted storage and doc coverage", () => {
+    render(
+      <IndexStorageMini
+        data={{
+          index_storage_bytes: 1_572_864,
+          page_count: 42,
+          doc_coverage_pct: 87.4,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Index storage")).toBeInTheDocument();
+    expect(screen.getByText("1.5 MB")).toBeInTheDocument();
+    expect(screen.getByText(/87% doc coverage/)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/__tests__/lib/format.test.ts
+++ b/packages/ui/__tests__/lib/format.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { formatBytes, formatPercent } from "../../src/lib/format";
+
+describe("formatPercent", () => {
+  it("rounds ratios to whole percentages by default", () => {
+    expect(formatPercent(0.873)).toBe("87%");
+    expect(formatPercent(1)).toBe("100%");
+    expect(formatPercent(0)).toBe("0%");
+  });
+
+  it("supports fixed decimal places", () => {
+    expect(formatPercent(0.8734, 1)).toBe("87.3%");
+  });
+
+  it("returns an em dash for non-finite input", () => {
+    expect(formatPercent(Number.NaN)).toBe("—");
+    expect(formatPercent(Number.POSITIVE_INFINITY)).toBe("—");
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats common storage sizes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(1_048_576)).toBe("1.0 MB");
+    expect(formatBytes(1_073_741_824)).toBe("1.0 GB");
+  });
+
+  it("uses whole numbers for values >= 10 in a unit", () => {
+    expect(formatBytes(10 * 1024)).toBe("10 KB");
+  });
+
+  it("returns an em dash for invalid input", () => {
+    expect(formatBytes(-1)).toBe("—");
+    expect(formatBytes(Number.NaN)).toBe("—");
+  });
+});

--- a/packages/ui/src/dashboard/index-storage-mini.tsx
+++ b/packages/ui/src/dashboard/index-storage-mini.tsx
@@ -1,0 +1,48 @@
+import { HardDrive } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { formatBytes, formatPercent } from "../lib/format";
+
+export interface IndexStorageMiniData {
+  /** Total on-disk size of the repo's `.repowise/` directory. */
+  index_storage_bytes: number;
+  /** Wiki page count — used for a secondary line when docs exist. */
+  page_count?: number;
+  /** Average doc confidence as 0–100 — shown when pages exist. */
+  doc_coverage_pct?: number;
+}
+
+interface IndexStorageMiniProps {
+  data: IndexStorageMiniData;
+}
+
+/**
+ * Compact overview tile for local index footprint — mirrors the
+ * `repowise status` storage row from the CLI.
+ */
+export function IndexStorageMini({ data }: IndexStorageMiniProps) {
+  const hasDocs = (data.page_count ?? 0) > 0;
+  const coverage =
+    data.doc_coverage_pct != null ? formatPercent(data.doc_coverage_pct / 100) : null;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm flex items-center gap-2">
+          <HardDrive className="h-4 w-4 text-[var(--color-text-tertiary)]" />
+          Index storage
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div className="space-y-1">
+          <span className="text-3xl font-semibold tabular-nums text-[var(--color-text-primary)]">
+            {formatBytes(data.index_storage_bytes)}
+          </span>
+          <p className="text-xs text-[var(--color-text-tertiary)]">
+            wiki.db + vectors on disk
+            {hasDocs && coverage ? ` · ${coverage} doc coverage` : ""}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/ui/src/dashboard/index.ts
+++ b/packages/ui/src/dashboard/index.ts
@@ -5,6 +5,7 @@ export * from "./commits-mini";
 export * from "./decisions-timeline";
 export * from "./health-overview-card";
 export * from "./savings-mini";
+export * from "./index-storage-mini";
 export * from "./dependency-heatmap";
 export * from "./execution-flows-panel";
 export * from "./health-score-ring";

--- a/packages/ui/src/lib/format.ts
+++ b/packages/ui/src/lib/format.ts
@@ -131,3 +131,22 @@ export function formatProgress(done: number, total: number): string {
   const pct = total > 0 ? Math.round((done / total) * 100) : 0;
   return `${formatNumber(done)} / ${formatNumber(total)} (${pct}%)`;
 }
+
+/** Format a ratio as a percentage: 0.873 → "87%", 1 → "100%" */
+export function formatPercent(ratio: number, decimals = 0): string {
+  if (!Number.isFinite(ratio)) return "—";
+  const pct = ratio * 100;
+  if (decimals <= 0) return `${Math.round(pct)}%`;
+  return `${pct.toFixed(decimals)}%`;
+}
+
+/** Format byte counts: 1536 → "1.5 KB", 1048576 → "1.0 MB" */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—";
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"] as const;
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** exponent;
+  const formatted = value >= 10 || exponent === 0 ? value.toFixed(0) : value.toFixed(1);
+  return `${formatted} ${units[exponent]}`;
+}

--- a/packages/web/src/app/repos/[id]/overview/page.tsx
+++ b/packages/web/src/app/repos/[id]/overview/page.tsx
@@ -13,6 +13,7 @@ import { AttentionPanel } from "@repowise-dev/ui/dashboard/attention-panel";
 import { KpiStrip, kpiDelta, type KpiItem } from "@repowise-dev/ui/dashboard/kpi-strip";
 import { OverviewGrid } from "@repowise-dev/ui/dashboard/overview-grid";
 import { SavingsMini } from "@repowise-dev/ui/dashboard/savings-mini";
+import { IndexStorageMini } from "@repowise-dev/ui/dashboard/index-storage-mini";
 import { LanguageDonut } from "@repowise-dev/ui/dashboard/language-donut";
 import { QuickActionsWrapper as QuickActions } from "@/components/dashboard/quick-actions-wrapper";
 import { OverviewTabs } from "@/components/overview/overview-tabs";
@@ -154,6 +155,13 @@ export default async function OverviewPage({ params }: Props) {
             rail={
               <>
                 {statsHighlights && <StatsTeaserCard repoId={id} data={statsHighlights} />}
+                <IndexStorageMini
+                  data={{
+                    index_storage_bytes: sync.index_storage_bytes ?? 0,
+                    page_count: sync.page_count,
+                    doc_coverage_pct: stats.doc_coverage_pct,
+                  }}
+                />
                 <SavingsMini data={summary.savings} repoId={id} />
                 <AttentionPanel items={attentionItems} repoId={id} previewCount={5} repoName={repo.name} />
               </>

--- a/tests/unit/server/test_overview_sync.py
+++ b/tests/unit/server/test_overview_sync.py
@@ -9,6 +9,7 @@ job-only derivation reported "never synced" even when the index was current.
 from __future__ import annotations
 
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 from httpx import AsyncClient
@@ -77,3 +78,17 @@ async def test_completed_sync_job_wins_over_fallback(client: AsyncClient, app) -
 
     assert body["sync"]["last_sync_at"] == finished.isoformat()
     assert body["sync"]["last_sync_at"] != body["repo"]["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_sync_includes_index_storage_bytes(client: AsyncClient, tmp_path) -> None:
+    """overview-summary reports total .repowise on-disk footprint."""
+    repo = await create_test_repo(client, tmp_path)
+    repo_dir = Path(repo["local_path"])
+    repowise = repo_dir / ".repowise"
+    repowise.mkdir()
+    (repowise / "wiki.db").write_bytes(b"x" * 100)
+
+    resp = await client.get(f"/api/repos/{repo['id']}/overview-summary")
+    assert resp.status_code == 200
+    assert resp.json()["sync"]["index_storage_bytes"] == 100


### PR DESCRIPTION
## Summary
- Add formatBytes and formatPercent helpers to the shared UI format library
- Cover common byte-size and ratio display cases with unit tests

## Test plan
- packages/ui/__tests__/lib/format.test.ts covers byte and percent formatting
- npm run test --workspace=@repowise-dev/ui