### PR TITLE
feat(api-client): add fetchAllPaginated pagination helper

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -29,6 +29,7 @@
     "./meta": "./src/meta.ts",
     "./modules": "./src/modules.ts",
     "./overview": "./src/overview.ts",
+    "./pagination": "./src/pagination.ts",
     "./owners": "./src/owners.ts",
     "./pages": "./src/pages.ts",
     "./providers": "./src/providers.ts",

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./client";
+export * from "./pagination";

--- a/packages/api-client/src/owners.test.ts
+++ b/packages/api-client/src/owners.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const apiGet = vi.fn();
+vi.mock("./client", () => ({
+  apiGet: (...args: unknown[]) => apiGet(...args),
+}));
+
+import { listAllOwners } from "./owners";
+
+describe("listAllOwners", () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+  });
+
+  it("walks pagination until has_more is false", async () => {
+    apiGet
+      .mockResolvedValueOnce({
+        items: [{ key: "a" }],
+        total: 2,
+        has_more: true,
+        next_offset: 1,
+      })
+      .mockResolvedValueOnce({
+        items: [{ key: "b" }],
+        total: 2,
+        has_more: false,
+        next_offset: null,
+      });
+
+    const owners = await listAllOwners({ repoId: "r1", pageSize: 1 });
+
+    expect(owners).toHaveLength(2);
+    expect(apiGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/api-client/src/owners.ts
+++ b/packages/api-client/src/owners.ts
@@ -1,4 +1,5 @@
 import { apiGet } from "./client";
+import { fetchAllPaginated } from "./pagination";
 import type {
   OwnerListEntry,
   OwnerProfileResponse,
@@ -25,6 +26,21 @@ export async function listOwnersPage(
 ): Promise<Paginated<OwnerListEntry>> {
   const { repoId, ...rest } = params;
   return apiGet<Paginated<OwnerListEntry>>(`/api/repos/${repoId}/owners`, rest);
+}
+
+/** Fetch every owner row by walking pagination — for charts/export surfaces. */
+export async function listAllOwners(
+  params: Omit<ListOwnersParams, "limit" | "offset"> & {
+    pageSize?: number;
+    maxItems?: number;
+  },
+): Promise<OwnerListEntry[]> {
+  const { repoId, pageSize, maxItems, ...rest } = params;
+  return fetchAllPaginated({
+    fetchPage: (offset, limit) => listOwnersPage({ repoId, ...rest, offset, limit }),
+    pageSize,
+    maxItems,
+  });
 }
 
 export async function getOwnerProfile(

--- a/packages/api-client/src/owners.ts
+++ b/packages/api-client/src/owners.ts
@@ -38,8 +38,8 @@ export async function listAllOwners(
   const { repoId, pageSize, maxItems, ...rest } = params;
   return fetchAllPaginated({
     fetchPage: (offset, limit) => listOwnersPage({ repoId, ...rest, offset, limit }),
-    pageSize,
-    maxItems,
+    ...(pageSize !== undefined ? { pageSize } : {}),
+    ...(maxItems !== undefined ? { maxItems } : {}),
   });
 }
 

--- a/packages/api-client/src/pagination.test.ts
+++ b/packages/api-client/src/pagination.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchAllPaginated } from "./pagination";
+import type { Paginated } from "./types/pagination";
+
+function page(
+  items: number[],
+  total: number,
+  hasMore: boolean,
+  nextOffset: number | null,
+): Paginated<number> {
+  return { items, total, has_more: hasMore, next_offset: nextOffset };
+}
+
+describe("fetchAllPaginated", () => {
+  it("follows next_offset until has_more is false", async () => {
+    const fetchPage = vi
+      .fn<(offset: number, limit: number) => Promise<Paginated<number>>>()
+      .mockResolvedValueOnce(page([1, 2], 4, true, 2))
+      .mockResolvedValueOnce(page([3, 4], 4, false, null));
+
+    const items = await fetchAllPaginated({ fetchPage, pageSize: 2 });
+
+    expect(items).toEqual([1, 2, 3, 4]);
+    expect(fetchPage).toHaveBeenNthCalledWith(1, 0, 2);
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 2, 2);
+  });
+
+  it("respects maxItems", async () => {
+    const fetchPage = vi
+      .fn<(offset: number, limit: number) => Promise<Paginated<number>>>()
+      .mockResolvedValueOnce(page([1, 2, 3], 10, true, 3));
+
+    const items = await fetchAllPaginated({ fetchPage, pageSize: 3, maxItems: 2 });
+
+    expect(items).toEqual([1, 2]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty list when the first page is empty", async () => {
+    const fetchPage = vi
+      .fn<(offset: number, limit: number) => Promise<Paginated<number>>>()
+      .mockResolvedValueOnce(page([], 0, false, null));
+
+    await expect(fetchAllPaginated({ fetchPage })).resolves.toEqual([]);
+  });
+});

--- a/packages/api-client/src/pagination.test.ts
+++ b/packages/api-client/src/pagination.test.ts
@@ -43,4 +43,22 @@ describe("fetchAllPaginated", () => {
 
     await expect(fetchAllPaginated({ fetchPage })).resolves.toEqual([]);
   });
+
+  it("stops when has_more is true but next_offset does not advance", async () => {
+    const fetchPage = vi
+      .fn<(offset: number, limit: number) => Promise<Paginated<number>>>()
+      .mockResolvedValueOnce(page([1], 10, true, 0));
+
+    await expect(fetchAllPaginated({ fetchPage })).resolves.toEqual([1]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops on an empty page that still claims has_more", async () => {
+    const fetchPage = vi
+      .fn<(offset: number, limit: number) => Promise<Paginated<number>>>()
+      .mockResolvedValueOnce(page([], 10, true, 5));
+
+    await expect(fetchAllPaginated({ fetchPage })).resolves.toEqual([]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/api-client/src/pagination.ts
+++ b/packages/api-client/src/pagination.ts
@@ -1,0 +1,43 @@
+/**
+ * Helpers for walking paginated list endpoints that return the shared
+ * `Paginated<T>` envelope from the repowise REST API.
+ */
+
+import type { Paginated } from "./types/pagination";
+
+export interface FetchAllPaginatedOptions<T> {
+  /** Fetch one page starting at `offset` with the given `limit`. */
+  fetchPage: (offset: number, limit: number) => Promise<Paginated<T>>;
+  /** Page size passed to `fetchPage` on each request. Defaults to 100. */
+  pageSize?: number;
+  /** Optional hard cap on the number of items collected. */
+  maxItems?: number;
+}
+
+/**
+ * Collect every item from a paginated endpoint by following `has_more` /
+ * `next_offset` until the list is complete or `maxItems` is reached.
+ */
+export async function fetchAllPaginated<T>({
+  fetchPage,
+  pageSize = 100,
+  maxItems,
+}: FetchAllPaginatedOptions<T>): Promise<T[]> {
+  const items: T[] = [];
+  let offset = 0;
+
+  while (true) {
+    const page = await fetchPage(offset, pageSize);
+    items.push(...page.items);
+
+    if (maxItems !== undefined && items.length >= maxItems) {
+      return items.slice(0, maxItems);
+    }
+    if (!page.has_more || page.next_offset == null) {
+      break;
+    }
+    offset = page.next_offset;
+  }
+
+  return items;
+}

--- a/packages/api-client/src/pagination.ts
+++ b/packages/api-client/src/pagination.ts
@@ -12,6 +12,8 @@ export interface FetchAllPaginatedOptions<T> {
   pageSize?: number;
   /** Optional hard cap on the number of items collected. */
   maxItems?: number;
+  /** Safety cap on page fetches — guards against misbehaving endpoints. */
+  maxPages?: number;
 }
 
 /**
@@ -22,11 +24,18 @@ export async function fetchAllPaginated<T>({
   fetchPage,
   pageSize = 100,
   maxItems,
+  maxPages = 1000,
 }: FetchAllPaginatedOptions<T>): Promise<T[]> {
   const items: T[] = [];
   let offset = 0;
+  let pages = 0;
 
   while (true) {
+    pages += 1;
+    if (pages > maxPages) {
+      break;
+    }
+
     const page = await fetchPage(offset, pageSize);
     items.push(...page.items);
 
@@ -34,6 +43,10 @@ export async function fetchAllPaginated<T>({
       return items.slice(0, maxItems);
     }
     if (!page.has_more || page.next_offset == null) {
+      break;
+    }
+    // Guard against endpoints that claim more pages but never advance.
+    if (page.items.length === 0 || page.next_offset <= offset) {
       break;
     }
     offset = page.next_offset;

--- a/packages/ui/src/owners/owner-directory.tsx
+++ b/packages/ui/src/owners/owner-directory.tsx
@@ -33,6 +33,10 @@ export interface OwnerDirectoryFilters {
 
 export interface OwnerDirectoryProps {
   owners: OwnerListEntry[];
+  /** Optional full owner set for the distribution bar (e.g. fetched via
+   *  listAllOwners when the contributor count is small). Falls back to
+   *  `owners` when omitted. */
+  distributionOwners?: OwnerListEntry[];
   isLoading: boolean;
   isValidating: boolean;
   total: number;
@@ -45,6 +49,7 @@ export interface OwnerDirectoryProps {
 
 export function OwnerDirectory({
   owners,
+  distributionOwners,
   isLoading,
   isValidating,
   total,
@@ -54,6 +59,7 @@ export function OwnerDirectory({
   onLoadMore,
   onSelect,
 }: OwnerDirectoryProps) {
+  const barOwners = distributionOwners ?? owners;
   // Spotlight metrics — drives the strip above the directory grid.
   const headline = useMemo(() => {
     const totalFiles = owners.reduce((s, o) => s + o.files_owned, 0);
@@ -65,9 +71,9 @@ export function OwnerDirectory({
 
   return (
     <div className="space-y-5">
-      {owners.length > 0 && (
+      {barOwners.length > 0 && (
         <OwnershipDistributionBar
-          owners={owners}
+          owners={barOwners}
           totalContributors={total}
           onSelect={onSelect}
         />

--- a/packages/web/src/app/repos/[id]/owners/page.tsx
+++ b/packages/web/src/app/repos/[id]/owners/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
+import useSWR from "swr";
 import useSWRInfinite from "swr/infinite";
 import { Users } from "lucide-react";
 import {
@@ -10,10 +11,13 @@ import {
 } from "@repowise-dev/ui/owners/owner-directory";
 import { PageShell } from "@repowise-dev/ui/shared/page-shell";
 import { useDebounce } from "@/lib/hooks/use-debounce";
-import { listOwnersPage } from "@/lib/api/owners";
+import { listAllOwners, listOwnersPage } from "@/lib/api/owners";
 import type { OwnerListEntry, Paginated } from "@/lib/api/types";
 
 const LIMIT = 30;
+/** When contributor count is at or below this, prefetch everyone for an
+ *  accurate ownership distribution bar via fetchAllPaginated. */
+const DISTRIBUTION_PREFETCH_CAP = 120;
 
 export default function OwnersDirectoryPage() {
   const { id } = useParams<{ id: string }>();
@@ -53,6 +57,14 @@ export default function OwnersDirectoryPage() {
   const total = data && data.length > 0 ? data[0].total : 0;
   const hasMore = data ? data[data.length - 1].has_more : false;
 
+  const shouldPrefetchDistribution =
+    debouncedQ === "" && total > 0 && total <= DISTRIBUTION_PREFETCH_CAP;
+  const { data: distributionOwners } = useSWR(
+    shouldPrefetchDistribution ? `owners-all:${id}:${filters.sort}` : null,
+    () => listAllOwners({ repoId: id, sort: filters.sort, maxItems: DISTRIBUTION_PREFETCH_CAP }),
+    { revalidateOnFocus: false },
+  );
+
   return (
     <PageShell
       maxWidth="wide"
@@ -62,6 +74,7 @@ export default function OwnersDirectoryPage() {
     >
       <OwnerDirectory
         owners={items}
+        distributionOwners={distributionOwners}
         isLoading={isLoading}
         isValidating={isValidating}
         total={total}

--- a/packages/web/src/app/repos/[id]/owners/page.tsx
+++ b/packages/web/src/app/repos/[id]/owners/page.tsx
@@ -61,7 +61,13 @@ export default function OwnersDirectoryPage() {
     debouncedQ === "" && total > 0 && total <= DISTRIBUTION_PREFETCH_CAP;
   const { data: distributionOwners } = useSWR(
     shouldPrefetchDistribution ? `owners-all:${id}:${filters.sort}` : null,
-    () => listAllOwners({ repoId: id, sort: filters.sort, maxItems: DISTRIBUTION_PREFETCH_CAP }),
+    () =>
+      listAllOwners({
+        repoId: id,
+        sort: filters.sort,
+        maxItems: DISTRIBUTION_PREFETCH_CAP,
+        pageSize: DISTRIBUTION_PREFETCH_CAP,
+      }),
     { revalidateOnFocus: false },
   );
 


### PR DESCRIPTION
## Summary
- Add fetchAllPaginated to walk paginated REST list endpoints via has_more and next_offset
- Export the helper from @repowise-dev/api-client/pagination with unit tests

## Test plan
- packages/api-client/src/pagination.test.ts covers multi-page fetch, empty pages, and maxItems
- npm run test --workspace=@repowise-dev/api-client