### PR TITLE
feat(core): app-to-database contracts and SQL health markers

### DIFF
--- a/docs/CODE_HEALTH.md
+++ b/docs/CODE_HEALTH.md
@@ -113,6 +113,14 @@ same marker stream:
   count toward both dimensions.
 - Pure defect and organizational predictors (`change_entropy`, `ownership_risk`,
   `co_change_scatter`, and the like) stay out of maintainability entirely.
+- SQL markers (`sql_high_complexity` for branchy stored routines,
+  `sql_select_star` in views/routines, `sql_update_delete_without_where`) are
+  maintainability-only by construction: no defect corpus covers procedural SQL,
+  so they carry an advisory weight under their own capped `sql` category and
+  never touch the defect score. Routine complexity is counted from the decision
+  keywords in the body text (procedural bodies do not parse into an AST);
+  statement smells come from the sqlglot AST and stay silent on dbt/Jinja
+  templates and on statements whose parse looks garbled.
 
 The two signals are computed by the single shared scoring kernel
 (`scoring.score_file`) against independent weight/category/cap tables, and they
@@ -242,6 +250,12 @@ below) rather than the shared core:
 - **sync-over-async** (C#, via `blocking_sync_in_async`): `.Result` / `.Wait()`
   / `.GetAwaiter().GetResult()` inside an `async` method blocks a thread-pool
   thread. C# is the one non-Python language with real `async`/`await`.
+- **`sql_cartesian_join`** (SQL): a comma-join (`FROM a, b`) with no join
+  predicate anywhere in the statement produces the full cross product (O(n·m)
+  rows). An explicit `CROSS JOIN` states intent and is not flagged; a comma-join
+  whose statement carries a `WHERE` is old-style join syntax and is not flagged
+  either. Detected on the sqlglot AST; a statement whose parse looks garbled
+  (dialect mismatch) emits nothing. Advisory.
 
 Each performance finding's `details` carry the `boundary_kind` it crosses, a
 `cross_function` flag, and the reachability `path` for the cross-function case.

--- a/docs/LANGUAGE_SUPPORT.md
+++ b/docs/LANGUAGE_SUPPORT.md
@@ -182,7 +182,7 @@ honest file-to-file dependencies, no symbol-level claims.
 
 SQL is parsed by a dedicated special handler (sqlglot, multi-dialect and
 error-tolerant) rather than tree-sitter, plus the lightweight import tier
-for dbt lineage. Two independent capabilities:
+for dbt lineage. Four independent capabilities:
 
 **DDL symbols (any `.sql` file).** `CREATE TABLE` / `VIEW` /
 `MATERIALIZED VIEW` -> class-kind symbols with columns in the signature;
@@ -206,6 +206,29 @@ declare the same model name, the importer's own project wins; two-arg
 refs prefer the project whose declared `name` matches. Everything that
 rides the import graph falls out free: model-level lineage, hotspots,
 co-change, ownership, and Leiden communities of the DAG.
+
+**App-to-database contracts (workspace mode).** The workspace contract
+extractor pairs table *providers* (DDL `CREATE`/`ALTER` in `.sql` files,
+Alembic `op.create_table`, and ORM entities: SQLAlchemy `__tablename__`,
+SQLModel `table=True`, Django `db_table`, JPA `@Entity`/`@Table`, EF Core
+`DbSet<T>`/`[Table]`, ActiveRecord, Eloquent `$table`) with table
+*consumers* (SQL string literals in app code, parsed with sqlglot when the
+literal parses, recovered by a verb-anchored regex when interpolation
+breaks it). Matched pairs become `data` contracts rendered as `db` edges
+on the Live System Map: "which services touch table X" across repos.
+Table names are normalized in one place (quoting, `public`/`dbo`
+prefixes, case), and an interpolated table target emits nothing rather
+than a guess.
+
+**Health markers (maintainability/performance pillars only).** Stored
+routines get cyclomatic complexity counted from the decision keywords in
+the body (`sql_high_complexity`; procedural bodies do not parse into an
+AST, so nesting is deliberately not reported). Three statement smells
+ride the sqlglot AST: `sql_select_star` (a bare `*` in a view or
+routine), `sql_update_delete_without_where`, and `sql_cartesian_join`
+(comma-join with no predicate). All four are uncalibrated by construction
+and never move the defect headline; dbt/Jinja templates and garbled
+parses emit nothing. See `docs/CODE_HEALTH.md`.
 
 ### Structural (git + file tree only)
 
@@ -673,4 +696,4 @@ edits. The current coverage:
 | Dart | Good | Lightweight tier shipped; AST upgrade planned (`tree-sitter-dart` available) |
 | Elixir | Good | Lightweight tier shipped; AST upgrade planned (`tree-sitter-elixir` available) |
 | F# | Good | Lightweight tier shipped; AST upgrade planned (`tree-sitter-f-sharp` available) |
-| SQL / dbt | -- | DDL symbols (sqlglot) + dbt lineage shipped; next: app-to-database contracts (workspace data extractor), then precision-gated SQL health markers |
+| SQL / dbt | -- | DDL symbols, dbt lineage, app-to-database contracts (workspace `data` extractor), and precision-gated health markers all shipped; next: column-level blast radius |

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/registry.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/registry.py
@@ -53,6 +53,10 @@ from .primitive_obsession import PrimitiveObsessionDetector
 from .prior_defect import PriorDefectDetector
 from .resource_construction_in_loop import ResourceConstructionInLoopDetector
 from .serial_await_in_loop import SerialAwaitInLoopDetector
+from .sql_cartesian_join import SqlCartesianJoinDetector
+from .sql_high_complexity import SqlHighComplexityDetector
+from .sql_select_star import SqlSelectStarDetector
+from .sql_update_delete_without_where import SqlUpdateDeleteWithoutWhereDetector
 from .string_concat_in_loop import StringConcatInLoopDetector
 from .untested_hotspot import UntestedHotspotDetector
 
@@ -104,6 +108,12 @@ _DETECTOR_FACTORIES: list[type[Biomarker]] = [
     JsonParseInLoopDetector,  # type: ignore[list-item]
     ArraySpreadInReduceDetector,  # type: ignore[list-item]
     GoroutineInUnboundedLoopDetector,  # type: ignore[list-item]
+    # SQL markers (from the sqlglot-backed SQL walker; maintainability and
+    # performance only, never the defect headline).
+    SqlHighComplexityDetector,  # type: ignore[list-item]
+    SqlSelectStarDetector,  # type: ignore[list-item]
+    SqlUpdateDeleteWithoutWhereDetector,  # type: ignore[list-item]
+    SqlCartesianJoinDetector,  # type: ignore[list-item]
 ]
 
 

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/sql_cartesian_join.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/sql_cartesian_join.py
@@ -1,0 +1,41 @@
+"""Cartesian join: a comma-join with no join predicate anywhere.
+
+``FROM a, b`` with no ``WHERE`` produces the full cross product: O(n*m) rows
+where the author almost certainly wanted a keyed join. An explicit ``CROSS
+JOIN`` states intent and is not flagged; a comma-join whose statement carries
+any ``WHERE`` is old-style join syntax and is not flagged either (the
+predicate may live there). Performance-only, never the defect score.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "sql_cartesian_join"
+
+
+class SqlCartesianJoinDetector:
+    name = _KIND
+    category = "performance"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        return [
+            BiomarkerResult(
+                biomarker_type=self.name,
+                severity=Severity.MEDIUM,
+                function_name=hit.function,
+                line_start=hit.line,
+                line_end=hit.line,
+                details={"table": hit.detail},
+                reason=(
+                    f"comma-join with '{hit.detail}' has no join predicate: "
+                    "this is the full cross product"
+                ),
+            )
+            for hit in ctx.perf_hits
+            if hit.kind == _KIND
+        ]
+
+
+BIOMARKER = SqlCartesianJoinDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/sql_high_complexity.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/sql_high_complexity.py
@@ -1,0 +1,50 @@
+"""SQL routine complexity: a stored procedure/function with high CCN.
+
+Counted by the SQL health walker (``sql_complexity._walk_routines``) via
+decision-keyword counting on the routine body (procedural SQL bodies do not
+parse into an AST; see the walker's module docstring). Maintainability-only:
+procedural SQL has no defect calibration, so this marker never moves the
+surfaced defect score (``scoring._BIOMARKER_DIMENSIONS``).
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "sql_high_complexity"
+
+_HIGH_CCN = 20
+
+
+class SqlHighComplexityDetector:
+    name = _KIND
+    category = "sql"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        out: list[BiomarkerResult] = []
+        for hit in ctx.perf_hits:
+            if hit.kind != _KIND:
+                continue
+            try:
+                ccn = int(hit.detail)
+            except ValueError:
+                continue
+            out.append(
+                BiomarkerResult(
+                    biomarker_type=self.name,
+                    severity=Severity.HIGH if ccn >= _HIGH_CCN else Severity.MEDIUM,
+                    function_name=hit.function,
+                    line_start=hit.line,
+                    line_end=hit.line,
+                    details={"ccn": ccn},
+                    reason=(
+                        f"SQL routine has cyclomatic complexity {ccn} "
+                        "(decision keywords in the body)"
+                    ),
+                )
+            )
+        return out
+
+
+BIOMARKER = SqlHighComplexityDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/sql_select_star.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/sql_select_star.py
@@ -1,0 +1,42 @@
+"""``SELECT *`` inside a maintained relation (view / materialized view /
+routine body).
+
+A bare star projection in a *maintained* relation silently changes shape when
+the underlying table gains a column: downstream consumers break at a
+distance. Ad-hoc scripts are deliberately out of scope (exploration is what
+``*`` is for); the walker only emits the hit inside ``CREATE VIEW`` /
+``FUNCTION`` / ``PROCEDURE``. Maintainability-only, never the defect score.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "sql_select_star"
+
+
+class SqlSelectStarDetector:
+    name = _KIND
+    category = "sql"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        return [
+            BiomarkerResult(
+                biomarker_type=self.name,
+                severity=Severity.LOW,
+                function_name=hit.function,
+                line_start=hit.line,
+                line_end=hit.line,
+                details={"relation_kind": hit.detail},
+                reason=(
+                    f"SELECT * inside a {hit.detail or 'view'}: the relation's shape "
+                    "silently changes when the source table gains a column"
+                ),
+            )
+            for hit in ctx.perf_hits
+            if hit.kind == _KIND
+        ]
+
+
+BIOMARKER = SqlSelectStarDetector()

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/sql_update_delete_without_where.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/sql_update_delete_without_where.py
@@ -1,0 +1,38 @@
+"""``UPDATE``/``DELETE`` with no ``WHERE`` clause: the whole-table footgun.
+
+A checked-in statement that rewrites or empties an entire table. Sometimes
+intentional (seed resets), always worth a reviewer's eyes; near-zero false
+positives because the AST shape is unambiguous. Statements inside procedural
+bodies are not seen (those bodies don't parse); top-level DML in schema,
+migration, and seed files is. Maintainability-only, never the defect score.
+"""
+
+from __future__ import annotations
+
+from ..models import Severity
+from .base import BiomarkerResult, FileContext
+
+_KIND = "sql_update_delete_without_where"
+
+
+class SqlUpdateDeleteWithoutWhereDetector:
+    name = _KIND
+    category = "sql"
+
+    def detect(self, ctx: FileContext) -> list[BiomarkerResult]:
+        return [
+            BiomarkerResult(
+                biomarker_type=self.name,
+                severity=Severity.MEDIUM,
+                function_name=None,
+                line_start=hit.line,
+                line_end=hit.line,
+                details={"statement": hit.detail},
+                reason=f"{hit.detail} has no WHERE clause: it touches every row in the table",
+            )
+            for hit in ctx.perf_hits
+            if hit.kind == _KIND
+        ]
+
+
+BIOMARKER = SqlUpdateDeleteWithoutWhereDetector()

--- a/packages/core/src/repowise/core/analysis/health/engine.py
+++ b/packages/core/src/repowise/core/analysis/health/engine.py
@@ -697,6 +697,12 @@ class HealthAnalyzer:
             source = Path(path).read_bytes()
         except OSError:
             return FileComplexity(functions=[], classes=[])
+        if language == "sql":
+            # SQL has no tree-sitter grammar here; the sqlglot-backed walker
+            # produces routine CCN + the sql_* smell hits instead.
+            from .sql_complexity import walk_sql_file
+
+            return walk_sql_file(pf.file_info, source)
         return walk_file(path, language, source)
 
     def _extract_method_analyses(self, pf: Any, findings: list[HealthFindingData]) -> list[Any]:
@@ -752,7 +758,13 @@ class HealthAnalyzer:
         file_path = pf.file_info.path
 
         fc_list = fcx.functions
-        fn_metrics: dict[str, FunctionComplexity] = {fc.name: fc for fc in fc_list}
+        # SQL routine metrics are text-counted and defect-uncalibrated; they
+        # exist for symbol stamping and the sql_high_complexity marker
+        # (maintainability). Keeping them out of function_metrics keeps the
+        # calibrated method biomarkers (defect dimension) from firing on SQL.
+        fn_metrics: dict[str, FunctionComplexity] = (
+            {} if pf.file_info.language == "sql" else {fc.name: fc for fc in fc_list}
+        )
         max_ccn = max((fc.ccn for fc in fc_list), default=1)
         max_nesting = max((fc.max_nesting for fc in fc_list), default=0)
         nloc = fcx.file_nloc

--- a/packages/core/src/repowise/core/analysis/health/scoring.py
+++ b/packages/core/src/repowise/core/analysis/health/scoring.py
@@ -230,6 +230,14 @@ _BIOMARKER_DIMENSIONS: dict[str, set[str]] = {
     "json_parse_in_loop": {"performance"},
     "array_spread_in_reduce": {"performance"},
     "goroutine_in_unbounded_loop": {"performance"},
+    # SQL markers - uncalibrated by construction (no defect corpus covers
+    # procedural SQL), so they are maintainability/performance-only. Every
+    # sql_* name MUST be listed here: an unlisted biomarker defaults into
+    # ``defect`` and would break the golden guarantee.
+    "sql_high_complexity": {"maintainability"},
+    "sql_select_star": {"maintainability"},
+    "sql_update_delete_without_where": {"maintainability"},
+    "sql_cartesian_join": {"performance"},
 }
 
 # Maintainability per-biomarker weight multipliers. Expert-set by definition -
@@ -246,6 +254,11 @@ _MAINTAINABILITY_WEIGHT_MULTIPLIER: dict[str, float] = {
     "god_class": 1.0,
     "large_method": 1.0,
     "nested_complexity": 1.0,
+    # SQL smells ship advisory (0.7) pending a precision spot-check on a
+    # migrations-heavy corpus, mirroring how new perf markers land.
+    "sql_high_complexity": 0.7,
+    "sql_select_star": 0.7,
+    "sql_update_delete_without_where": 0.7,
 }
 
 # Maintainability category per biomarker - an OWN table, independent of the
@@ -259,6 +272,11 @@ _MAINTAINABILITY_CATEGORY: dict[str, str] = {
     "primitive_obsession": "size_and_complexity",
     "dry_violation": "duplication",
     "error_handling": "error_handling",
+    # SQL smells share one capped category so a smell-dense migrations dir
+    # can't dominate the maintainability score.
+    "sql_high_complexity": "sql",
+    "sql_select_star": "sql",
+    "sql_update_delete_without_where": "sql",
 }
 
 # Maintainability per-category caps. Bounded so no single category dominates the
@@ -269,6 +287,7 @@ _MAINTAINABILITY_CATEGORY_CAPS: dict[str, float] = {
     "size_and_complexity": 2.0,
     "duplication": 2.0,
     "error_handling": 2.0,
+    "sql": 2.0,
 }
 
 # A finding's single "home" dimension, used for display and per-pillar
@@ -277,7 +296,16 @@ _MAINTAINABILITY_CATEGORY_CAPS: dict[str, float] = {
 # primary, calibrated role). Multi-dimension membership for scoring lives in
 # ``_BIOMARKER_DIMENSIONS`` - this label is just the finding's primary bucket.
 _MAINTAINABILITY_HOME: frozenset[str] = frozenset(
-    {"low_cohesion", "brain_method", "primitive_obsession", "dry_violation", "error_handling"}
+    {
+        "low_cohesion",
+        "brain_method",
+        "primitive_obsession",
+        "dry_violation",
+        "error_handling",
+        "sql_high_complexity",
+        "sql_select_star",
+        "sql_update_delete_without_where",
+    }
 )
 
 
@@ -333,6 +361,9 @@ _PERFORMANCE_WEIGHT_MULTIPLIER: dict[str, float] = {
     "array_spread_in_reduce": 0.5,
     "json_parse_in_loop": 0.4,
     "goroutine_in_unbounded_loop": 0.4,
+    # SQL comma-join with no predicate: high-precision by AST shape, advisory
+    # weight pending a corpus spot-check like every new perf marker.
+    "sql_cartesian_join": 0.6,
 }
 
 # All perf biomarkers share one ``performance`` category, so the single cap
@@ -355,6 +386,7 @@ _PERFORMANCE_CATEGORY: dict[str, str] = {
     "json_parse_in_loop": "performance",
     "array_spread_in_reduce": "performance",
     "goroutine_in_unbounded_loop": "performance",
+    "sql_cartesian_join": "performance",
 }
 
 # One bounded performance category cap. ~1.0 keeps performance advisory.
@@ -382,6 +414,7 @@ _PERFORMANCE_HOME: frozenset[str] = frozenset(
         "json_parse_in_loop",
         "array_spread_in_reduce",
         "goroutine_in_unbounded_loop",
+        "sql_cartesian_join",
     }
 )
 

--- a/packages/core/src/repowise/core/analysis/health/sql_complexity.py
+++ b/packages/core/src/repowise/core/analysis/health/sql_complexity.py
@@ -1,0 +1,293 @@
+"""SQL health walker: routine complexity + high-precision statement smells.
+
+The SQL analogue of ``complexity.walker.walk_file``, registered as a dialect
+of the health engine's walk step (``engine._walk`` routes ``language ==
+"sql"`` here; every other language keeps the tree-sitter path). Output rides
+the same ``FileComplexity`` schema, and the smells travel as ``PerfHit``
+records with ``sql_*`` kinds so the existing biomarker pipeline lifts them
+into findings.
+
+Two analysis tiers, matching what sqlglot can actually see:
+
+* **Statements** (``CREATE VIEW``, top-level DML) parse into a full AST;
+  the three smells (``sql_select_star``, ``sql_update_delete_without_where``,
+  ``sql_cartesian_join``) are detected on AST shape, precision-first.
+* **Routine bodies** (T-SQL procedures, PL/pgSQL ``$$`` bodies) do NOT
+  parse: sqlglot degrades them to ``Command``/``Heredoc`` text. Cyclomatic
+  complexity is therefore counted from the body text (comment- and
+  string-stripped keyword counting), and nesting is not reported: a text
+  scan cannot measure it reliably across dialects, so we don't guess.
+
+Every SQL marker is maintainability/performance-only (see
+``scoring._BIOMARKER_DIMENSIONS``): none of this is defect-calibrated, so
+none of it may move the surfaced defect score.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from .complexity import FileComplexity, FunctionComplexity, PerfHit
+from .complexity.nloc import _count_file_nloc
+
+# CCN threshold for emitting a ``sql_high_complexity`` hit. Matches the
+# complex_method sensibility: a routine below 10 decision points is routine.
+_CCN_THRESHOLD = 10
+
+# ---------------------------------------------------------------------------
+# Routine discovery + text-based CCN
+# ---------------------------------------------------------------------------
+
+_ROUTINE_RE = re.compile(
+    r"\bCREATE\s+(?:OR\s+(?:ALTER|REPLACE)\s+)?(?:DEFINER\s*=\s*\S+\s+)?"
+    r"(?:FUNCTION|PROCEDURE|PROC)\s+([\w.\"\[\]`$]+)",
+    re.IGNORECASE,
+)
+
+_COMMENT_LINE_RE = re.compile(r"--[^\n]*")
+_COMMENT_BLOCK_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+_STRING_RE = re.compile(r"'[^']*'")
+
+_IF_RE = re.compile(r"\bIF\b", re.IGNORECASE)
+_END_IF_RE = re.compile(r"\bEND\s+IF\b", re.IGNORECASE)
+_ELSIF_RE = re.compile(r"\bELS(?:E)?IF\b", re.IGNORECASE)
+_WHEN_RE = re.compile(r"\bWHEN\b", re.IGNORECASE)
+_WHILE_RE = re.compile(r"\bWHILE\b", re.IGNORECASE)
+_LOOP_RE = re.compile(r"\bLOOP\b", re.IGNORECASE)
+_END_LOOP_RE = re.compile(r"\bEND\s+LOOP\b", re.IGNORECASE)
+_BOOL_RE = re.compile(r"\b(?:AND|OR)\b", re.IGNORECASE)
+_BETWEEN_RE = re.compile(r"\bBETWEEN\b", re.IGNORECASE)
+
+
+def _strip_noise(body: str) -> str:
+    body = _COMMENT_BLOCK_RE.sub(" ", body)
+    body = _COMMENT_LINE_RE.sub(" ", body)
+    return _STRING_RE.sub("''", body)
+
+
+def _body_ccn(body: str) -> int:
+    """Cyclomatic complexity of a routine body via decision-keyword counting.
+
+    ``END IF`` is subtracted from the ``IF`` count (same token); loop openers
+    are the net ``LOOP`` count where the dialect uses ``LOOP``/``END LOOP``
+    (PL/pgSQL: ``WHILE c LOOP`` nets to one), else the ``WHILE`` count
+    (T-SQL). ``BETWEEN``'s mandatory ``AND`` is not a decision, so one AND per
+    BETWEEN is subtracted.
+    """
+    text = _strip_noise(body)
+    ifs = len(_IF_RE.findall(text)) - len(_END_IF_RE.findall(text))
+    elsifs = len(_ELSIF_RE.findall(text))
+    whens = len(_WHEN_RE.findall(text))
+    net_loops = len(_LOOP_RE.findall(text)) - len(_END_LOOP_RE.findall(text))
+    loops = net_loops if net_loops > 0 else len(_WHILE_RE.findall(text))
+    bools = len(_BOOL_RE.findall(text)) - len(_BETWEEN_RE.findall(text))
+    return 1 + max(ifs, 0) + elsifs + whens + max(loops, 0) + max(bools, 0)
+
+
+def _bare_name(raw: str) -> str:
+    last = raw.split(".")[-1]
+    return last.strip('"[]`')
+
+
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _walk_routines(text: str) -> tuple[list[FunctionComplexity], list[PerfHit]]:
+    """Per-routine CCN from the raw file text.
+
+    A routine's body runs to the next ``CREATE FUNCTION/PROCEDURE`` header or
+    EOF: good enough for keyword counting even when trailing statements
+    (``LANGUAGE plpgsql``) ride along, since they carry no decision keywords.
+    """
+    matches = list(_ROUTINE_RE.finditer(text))
+    functions: list[FunctionComplexity] = []
+    hits: list[PerfHit] = []
+    for i, m in enumerate(matches):
+        body_end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        body = text[m.end() : body_end]
+        name = _bare_name(m.group(1))
+        if not name:
+            continue
+        start_line = _line_of(text, m.start())
+        end_line = _line_of(text, body_end - 1)
+        ccn = _body_ccn(body)
+        nloc = sum(1 for ln in body.splitlines() if ln.strip())
+        functions.append(
+            FunctionComplexity(
+                name=name,
+                start_line=start_line,
+                end_line=end_line,
+                ccn=ccn,
+                max_nesting=0,
+                cognitive=0,
+                nloc=nloc,
+            )
+        )
+        if ccn >= _CCN_THRESHOLD:
+            hits.append(
+                PerfHit(
+                    kind="sql_high_complexity",
+                    line=start_line,
+                    function=name,
+                    detail=str(ccn),
+                    func_start=start_line,
+                )
+            )
+    return functions, hits
+
+
+# ---------------------------------------------------------------------------
+# Statement smells (AST tier)
+# ---------------------------------------------------------------------------
+
+# CREATE kinds whose body is a maintained relation (the ``select_star`` gate):
+# ``SELECT *`` in an ad-hoc script is exploration, in a view it is a schema
+# time bomb (column additions silently change the view's shape).
+_STAR_SCOPES = frozenset({"VIEW", "MATERIALIZED VIEW", "FUNCTION", "PROCEDURE"})
+
+# A DML/join target must be a clean identifier for its statement's parse to be
+# trusted. When a dialect mismatch garbles the tokenization (a backtick-quoted
+# MySQL table read under the permissive default yields a name of ``\```), the
+# WHERE detection is equally garbled, so the smell stays silent, never guesses.
+_CLEAN_IDENT_RE = re.compile(r"^[A-Za-z_][\w$]*$")
+
+
+def _clean_ident(raw: str) -> str | None:
+    token = raw.strip().strip('"`[]')
+    return token if _CLEAN_IDENT_RE.match(token) else None
+
+
+def _locate(text: str, token: str, cursor: int) -> tuple[int, int]:
+    """First whole-word occurrence of *token* at/after *cursor* (forward-only
+    cursor, statements arrive in source order). Falls back to line 1."""
+    pattern = re.compile(rf"\b{re.escape(token)}\b", re.IGNORECASE)
+    match = pattern.search(text, cursor) or pattern.search(text)
+    if match is None:
+        return 1, cursor
+    return _line_of(text, match.start()), match.end()
+
+
+def _statement_smells(text: str, dialect: str | None) -> list[PerfHit]:
+    # dbt/Jinja templates parse unpredictably (placeholder braces land in the
+    # AST as junk nodes); a templated model is not a maintained DDL file, so
+    # the statement smells stay silent there rather than guess.
+    if "{{" in text or "{%" in text:
+        return []
+    try:
+        import sqlglot
+        from sqlglot import exp
+    except ImportError:
+        return []
+    logging.getLogger("sqlglot").setLevel(logging.ERROR)
+    try:
+        statements = sqlglot.parse(text, read=dialect, error_level=sqlglot.ErrorLevel.IGNORE)
+    except Exception:
+        return []
+
+    hits: list[PerfHit] = []
+    cursor = 0
+
+    def _anchor(token: str) -> int:
+        nonlocal cursor
+        line, cursor = _locate(text, token, cursor)
+        return line
+
+    for stmt in statements:
+        if stmt is None:
+            continue
+
+        # -- sql_select_star: bare * projection inside a maintained relation.
+        if isinstance(stmt, exp.Create) and (stmt.kind or "").upper() in _STAR_SCOPES:
+            name = _create_name(stmt, exp)
+            for sel in stmt.find_all(exp.Select):
+                if any(isinstance(e, exp.Star) for e in sel.expressions):
+                    hits.append(
+                        PerfHit(
+                            kind="sql_select_star",
+                            line=_anchor(name) if name else 1,
+                            function=name,
+                            detail=(stmt.kind or "").lower(),
+                        )
+                    )
+                    break  # one finding per relation, not per nested select
+
+        # -- sql_update_delete_without_where: whole-table DML.
+        elif isinstance(stmt, (exp.Update, exp.Delete)) and not stmt.args.get("where"):
+            table = _clean_ident(getattr(stmt.this, "name", "") or "")
+            if table:
+                hits.append(
+                    PerfHit(
+                        kind="sql_update_delete_without_where",
+                        line=_anchor(table),
+                        function=None,
+                        detail=f"{type(stmt).__name__.lower()} {table}",
+                    )
+                )
+
+        # -- sql_cartesian_join: comma-join with no predicate anywhere.
+        for sel in stmt.find_all(exp.Select):
+            if sel.args.get("where"):
+                continue
+            for join in sel.args.get("joins") or ():
+                if (
+                    not join.args.get("kind")  # CROSS/OUTER etc. are explicit intent
+                    and not join.args.get("side")
+                    and not join.args.get("on")
+                    and not join.args.get("using")
+                    and not join.args.get("method")  # NATURAL carries its predicate
+                ):
+                    right = _clean_ident(getattr(join.this, "name", "") or "")
+                    if right is None:
+                        continue
+                    hits.append(
+                        PerfHit(
+                            kind="sql_cartesian_join",
+                            line=_anchor(right),
+                            function=None,
+                            detail=right,
+                        )
+                    )
+                    break  # one finding per select
+    return hits
+
+
+def _create_name(stmt: Any, exp: Any) -> str | None:
+    target = stmt.this
+    if isinstance(target, exp.Schema):
+        target = target.this
+    if isinstance(target, exp.UserDefinedFunction):
+        target = target.this
+    return getattr(target, "name", "") or None
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def walk_sql_file(file_info: Any, source: bytes) -> FileComplexity:
+    """Health-walk one ``.sql`` file. Any failure degrades to the empty
+    ``FileComplexity`` the tree-sitter walker returns for unmapped languages -
+    no signal, never a crash."""
+    text = source.decode("utf-8", errors="replace")
+    file_nloc = _count_file_nloc(source)
+    try:
+        from repowise.core.ingestion.special_handlers import _sql_dialect_for
+
+        dialect = _sql_dialect_for(file_info)
+    except Exception:
+        dialect = None
+    try:
+        functions, routine_hits = _walk_routines(text)
+        smell_hits = _statement_smells(text, dialect)
+    except Exception:
+        return FileComplexity(functions=[], classes=[], file_nloc=file_nloc)
+    return FileComplexity(
+        functions=functions,
+        classes=[],
+        file_nloc=file_nloc,
+        perf_hits=[*routine_hits, *smell_hits],
+    )

--- a/packages/core/src/repowise/core/workspace/config.py
+++ b/packages/core/src/repowise/core/workspace/config.py
@@ -72,7 +72,7 @@ class ManualContractLink:
 
     from_repo: str
     to_repo: str
-    contract_type: str  # "http" | "grpc" | "topic"
+    contract_type: str  # "http" | "grpc" | "topic" | "data"
     contract_id: str  # normalized contract ID
     from_role: str = "consumer"  # the from_repo's role
 
@@ -103,6 +103,7 @@ class ContractConfig:
     detect_http: bool = True
     detect_grpc: bool = True
     detect_topics: bool = True
+    detect_data: bool = True
     manual_links: list[ManualContractLink] = field(default_factory=list)
     # Map a consumer base token or absolute host to the repo alias it targets,
     # so a ``fetch(`${API_BASE}/users`)`` whose base resolves to ``backend`` links
@@ -118,6 +119,7 @@ class ContractConfig:
             "detect_http": self.detect_http,
             "detect_grpc": self.detect_grpc,
             "detect_topics": self.detect_topics,
+            "detect_data": self.detect_data,
         }
         if self.manual_links:
             d["manual_links"] = [ml.to_dict() for ml in self.manual_links]
@@ -134,6 +136,7 @@ class ContractConfig:
             detect_http=bool(data.get("detect_http", True)),
             detect_grpc=bool(data.get("detect_grpc", True)),
             detect_topics=bool(data.get("detect_topics", True)),
+            detect_data=bool(data.get("detect_data", True)),
             manual_links=manual,
             service_bases={str(k): str(v) for k, v in data.get("service_bases", {}).items()},
             exclude_globs=[str(g) for g in data.get("exclude_globs", [])],
@@ -232,6 +235,7 @@ class WorkspaceConfig:
                     self.contracts.detect_http,
                     self.contracts.detect_grpc,
                     self.contracts.detect_topics,
+                    self.contracts.detect_data,
                 ]
             )
         ):

--- a/packages/core/src/repowise/core/workspace/contracts.py
+++ b/packages/core/src/repowise/core/workspace/contracts.py
@@ -1,4 +1,4 @@
-"""Contract extraction — HTTP routes, gRPC services, message topics.
+"""Contract extraction: HTTP routes, gRPC services, message topics, database tables.
 
 Write path: runs during ``repowise update --workspace``.
 Results read by ``CrossRepoEnricher`` in the MCP server (read path).
@@ -45,8 +45,8 @@ class Contract:
     """A single API contract extracted from source code."""
 
     repo: str  # repo alias
-    contract_id: str  # e.g. "http::GET::/api/users/{param}"
-    contract_type: str  # "http" | "grpc" | "topic"
+    contract_id: str  # e.g. "http::GET::/api/users/{param}", "data::orders"
+    contract_type: str  # "http" | "grpc" | "topic" | "data"
     role: str  # "provider" | "consumer"
     file_path: str  # relative to repo root
     symbol_name: str  # handler name, service.method, etc.
@@ -91,7 +91,7 @@ class ContractLink:
     """A matched provider↔consumer pair across repos."""
 
     contract_id: str
-    contract_type: str  # "http" | "grpc" | "topic"
+    contract_type: str  # "http" | "grpc" | "topic" | "data"
     match_type: str  # "exact" | "candidate" | "manual"
     confidence: float
     provider_repo: str
@@ -167,6 +167,9 @@ def normalize_contract_id(contract_id: str) -> str:
     - ``http::GET::/Api/Users/`` → ``http::GET::/api/users``
     - ``grpc::PKG.Service/Method`` → ``grpc::pkg.service/Method``
     - ``topic::Orders`` → ``topic::orders``
+    - ``data::Orders`` → ``data::orders`` (via the lowercase fallback; table
+      quoting/schema rules are applied at extraction time in
+      ``extractors.data.names``)
     """
     parts = contract_id.split("::", 2)
     if len(parts) < 2:
@@ -677,6 +680,7 @@ async def run_contract_extraction(
     6. Save ``contracts.json``
     """
     from .extractors import (
+        DataExtractor,
         GrpcExtractor,
         HttpExtractor,
         TopicExtractor,
@@ -715,6 +719,8 @@ async def run_contract_extraction(
             extractors.append(GrpcExtractor())
         if contract_config.detect_topics:
             extractors.append(TopicExtractor())
+        if contract_config.detect_data:
+            extractors.append(DataExtractor())
 
         for extractor in extractors:
             found = await asyncio.to_thread(extractor.extract, repo_path, alias, exclude)

--- a/packages/core/src/repowise/core/workspace/extractors/__init__.py
+++ b/packages/core/src/repowise/core/workspace/extractors/__init__.py
@@ -1,7 +1,9 @@
-"""Contract extractors — HTTP routes, gRPC services, message topics, service boundaries."""
+"""Contract extractors: HTTP routes, gRPC services, message topics, database
+tables, service boundaries."""
 
 from __future__ import annotations
 
+from .data import DataExtractor, normalize_table_name
 from .grpc_extractor import GrpcExtractor
 from .http_extractor import HttpExtractor, normalize_http_path
 from .service_boundary import (
@@ -12,6 +14,7 @@ from .service_boundary import (
 from .topic_extractor import TopicExtractor
 
 __all__ = [
+    "DataExtractor",
     "GrpcExtractor",
     "HttpExtractor",
     "ServiceBoundary",
@@ -19,4 +22,5 @@ __all__ = [
     "assign_service",
     "detect_service_boundaries",
     "normalize_http_path",
+    "normalize_table_name",
 ]

--- a/packages/core/src/repowise/core/workspace/extractors/data/__init__.py
+++ b/packages/core/src/repowise/core/workspace/extractors/data/__init__.py
@@ -1,0 +1,89 @@
+"""App-to-database contract extraction.
+
+Scans source files for table *providers* (DDL, migrations, ORM entities) and
+table *consumers* (SQL string literals in app code). Same architecture as the
+HTTP extractor: each recogniser is an independent dialect module registered in
+:data:`PROVIDER_DIALECTS` / :data:`CONSUMER_DIALECTS`; the :class:`DataExtractor`
+orchestrator owns only the file walk and dispatch. Matching happens downstream
+in ``contracts.match_contracts`` on the normalized ``data::<table>`` id, and a
+matched link renders as a ``db`` edge on the Live System Map.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..base import ScanContext, iter_source_files
+from .ddl import DdlDialect
+from .dialect import DataDialect
+from .names import normalize_table_name
+from .orm_models import (
+    ActiveRecordDialect,
+    EfCoreDialect,
+    EloquentDialect,
+    JpaDialect,
+    SqlAlchemyDjangoDialect,
+)
+from .sql_strings import SqlStringsDialect
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from repowise.core.workspace.contracts import Contract
+
+# Table-ownership recognisers (DDL + one per ORM family).
+PROVIDER_DIALECTS: tuple[DataDialect, ...] = (
+    DdlDialect(),
+    SqlAlchemyDjangoDialect(),
+    JpaDialect(),
+    EfCoreDialect(),
+    ActiveRecordDialect(),
+    EloquentDialect(),
+)
+
+# Table-access recognisers.
+CONSUMER_DIALECTS: tuple[DataDialect, ...] = (SqlStringsDialect(),)
+
+
+def _union_extensions(dialects: tuple[DataDialect, ...]) -> frozenset[str]:
+    out: set[str] = set()
+    for d in dialects:
+        out |= d.extensions
+    return frozenset(out)
+
+
+class DataExtractor:
+    """Extract table contracts from source files via registered dialects."""
+
+    provider_dialects: tuple[DataDialect, ...] = PROVIDER_DIALECTS
+    consumer_dialects: tuple[DataDialect, ...] = CONSUMER_DIALECTS
+
+    def extract(
+        self,
+        repo_path: Path,
+        repo_alias: str = "",
+        exclude: Callable[[str], bool] | None = None,
+    ) -> list[Contract]:
+        """Scan all source files in *repo_path* and return Contract instances."""
+        all_exts = _union_extensions(self.provider_dialects) | _union_extensions(
+            self.consumer_dialects
+        )
+        contracts: list[Contract] = []
+        for rel_path, suffix, content in iter_source_files(repo_path, all_exts, exclude):
+            ctx = ScanContext(repo_alias, rel_path, suffix, content)
+            for dialect in self.provider_dialects:
+                if suffix in dialect.extensions:
+                    contracts.extend(dialect.extract(ctx))
+            for dialect in self.consumer_dialects:
+                if suffix in dialect.extensions:
+                    contracts.extend(dialect.extract(ctx))
+        return contracts
+
+
+__all__ = [
+    "CONSUMER_DIALECTS",
+    "PROVIDER_DIALECTS",
+    "DataExtractor",
+    "normalize_table_name",
+]

--- a/packages/core/src/repowise/core/workspace/extractors/data/ddl.py
+++ b/packages/core/src/repowise/core/workspace/extractors/data/ddl.py
@@ -1,0 +1,77 @@
+"""DDL provider dialect: tables declared in ``.sql`` files.
+
+A ``CREATE TABLE`` / ``CREATE VIEW`` in a repo's schema files or migrations is
+the strongest ownership signal there is. Parsed with sqlglot in permissive
+mode (same engine as the ingestion SQL handler): a statement that fails to
+parse contributes nothing, never a guess. ``ALTER TABLE`` in migrations also
+asserts ownership (the repo evolves that table) at slightly lower confidence.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ..base import ScanContext
+from .dialect import build_table_provider
+
+if TYPE_CHECKING:
+    from repowise.core.workspace.contracts import Contract
+
+# CREATE kinds that declare a relation worth a provider contract. INDEX and
+# TRIGGER attach to a table but don't declare one.
+_CREATE_KINDS = frozenset({"TABLE", "VIEW", "MATERIALIZED VIEW"})
+
+
+def _qualified_name(node: object) -> str | None:
+    """``schema.table`` (or bare ``table``) for a sqlglot Table-ish node."""
+    name = getattr(node, "name", "") or ""
+    if not name:
+        return None
+    db = getattr(node, "db", "") or ""
+    return f"{db}.{name}" if db else name
+
+
+class DdlDialect:
+    """Providers from ``CREATE``/``ALTER`` statements in ``.sql`` files."""
+
+    name = "ddl"
+    extensions = frozenset({".sql"})
+
+    def extract(self, ctx: ScanContext) -> list[Contract]:
+        try:
+            import sqlglot
+            from sqlglot import exp
+        except ImportError:
+            return []
+        logging.getLogger("sqlglot").setLevel(logging.ERROR)
+
+        try:
+            statements = sqlglot.parse(ctx.content, error_level=sqlglot.ErrorLevel.IGNORE)
+        except Exception:
+            return []
+
+        out: list[Contract] = []
+        seen: set[str] = set()
+        for stmt in statements:
+            if stmt is None:
+                continue
+            raw: str | None = None
+            confidence = 0.85
+            if isinstance(stmt, exp.Create) and (stmt.kind or "").upper() in _CREATE_KINDS:
+                target = stmt.this
+                if isinstance(target, exp.Schema):
+                    target = target.this
+                raw = _qualified_name(target)
+            elif isinstance(stmt, exp.Alter) and (stmt.args.get("kind") or "").upper() == "TABLE":
+                raw = _qualified_name(stmt.this)
+                confidence = 0.8
+            if raw is None or raw in seen:
+                continue
+            seen.add(raw)
+            contract = build_table_provider(
+                ctx, table_raw=raw, framework="sql-ddl", confidence=confidence
+            )
+            if contract is not None:
+                out.append(contract)
+        return out

--- a/packages/core/src/repowise/core/workspace/extractors/data/dialect.py
+++ b/packages/core/src/repowise/core/workspace/extractors/data/dialect.py
@@ -1,0 +1,93 @@
+"""Data dialect protocol and the shared contract builders.
+
+A *dialect* is one framework's or file format's view of where table ownership
+(providers) or table access (consumers) is declared. Every dialect funnels raw
+table tokens through the two builders here, so all data contracts share one id
+scheme (``data::<normalized table>``) and the normalization rules stay in
+:mod:`.names`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from ..base import ScanContext
+from .names import normalize_table_name
+
+if TYPE_CHECKING:
+    from repowise.core.workspace.contracts import Contract
+
+
+@runtime_checkable
+class DataDialect(Protocol):
+    """A table-ownership/access recogniser for a set of file extensions."""
+
+    name: str
+    extensions: frozenset[str]
+
+    def extract(self, ctx: ScanContext) -> list[Contract]:
+        """Return the contracts found in *ctx* (may be empty)."""
+        ...
+
+
+def build_table_provider(
+    ctx: ScanContext,
+    *,
+    table_raw: str,
+    framework: str,
+    confidence: float = 0.85,
+) -> Contract | None:
+    """Build a provider contract for a declared table, or ``None``.
+
+    Providers are declarations of ownership: a ``CREATE TABLE``, an ORM entity,
+    a migration. ``None`` when the raw token does not normalize to a concrete
+    table name.
+    """
+    from repowise.core.workspace.contracts import Contract
+
+    table = normalize_table_name(table_raw)
+    if table is None:
+        return None
+    return Contract(
+        repo=ctx.repo_alias,
+        contract_id=f"data::{table}",
+        contract_type="data",
+        role="provider",
+        file_path=ctx.rel_path,
+        symbol_name=f"{framework}:{table_raw}",
+        confidence=confidence,
+        service=None,
+        meta={"table": table, "framework": framework},
+    )
+
+
+def build_table_consumer(
+    ctx: ScanContext,
+    *,
+    table_raw: str,
+    verb: str,
+    client: str,
+    confidence: float = 0.7,
+) -> Contract | None:
+    """Build a consumer contract for a table referenced from app code.
+
+    ``verb`` is the SQL operation that touched the table (``select`` /
+    ``insert`` / ``update`` / ``delete`` / ``join``), carried in ``meta`` so
+    downstream views can distinguish readers from writers.
+    """
+    from repowise.core.workspace.contracts import Contract
+
+    table = normalize_table_name(table_raw)
+    if table is None:
+        return None
+    return Contract(
+        repo=ctx.repo_alias,
+        contract_id=f"data::{table}",
+        contract_type="data",
+        role="consumer",
+        file_path=ctx.rel_path,
+        symbol_name=f"{client}:{verb} {table}",
+        confidence=confidence,
+        service=None,
+        meta={"table": table, "verb": verb, "client": client},
+    )

--- a/packages/core/src/repowise/core/workspace/extractors/data/names.py
+++ b/packages/core/src/repowise/core/workspace/extractors/data/names.py
@@ -1,0 +1,67 @@
+"""Table-name normalization shared by every data dialect.
+
+All the false links in table matching come from name mismatches: quoting
+(``"users"`` / `` `users` `` / ``[users]``), schema prefixes
+(``public.users`` vs ``users``), and case (``Users`` vs ``users``). Every
+dialect funnels raw table tokens through :func:`normalize_table_name` so the
+rules live in one place and providers/consumers meet on the same key.
+"""
+
+from __future__ import annotations
+
+import re
+
+# A normalized table name: starts with a letter/underscore, then word chars
+# (``$`` appears in Oracle/T-SQL identifiers). Anything else after stripping
+# quotes is not a concrete table token (interpolation residue, operators).
+_IDENT_RE = re.compile(r"^[a-z_][a-z0-9_$]*$")
+
+# Schema names that carry no ownership signal: every Postgres table lives in
+# ``public`` and every T-SQL table in ``dbo`` unless told otherwise, so a
+# provider that writes the prefix and a consumer that omits it must still meet.
+# Named schemas (``analytics.events``) are kept: they disambiguate for real.
+_DEFAULT_SCHEMAS = frozenset({"public", "dbo"})
+
+_QUOTE_CHARS = '"`'
+
+
+def _strip_quotes(token: str) -> str:
+    token = token.strip()
+    if len(token) >= 2 and token[0] == "[" and token[-1] == "]":
+        return token[1:-1]
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in _QUOTE_CHARS:
+        return token[1:-1]
+    return token
+
+
+def split_qualified(raw: str) -> tuple[str | None, str]:
+    """Split ``schema.table`` into ``(schema, table)``, unquoting each part.
+
+    A three-part name (``db.schema.table``) keeps only the last two parts;
+    the database qualifier never disambiguates within one workspace.
+    """
+    parts = [_strip_quotes(p) for p in raw.split(".")]
+    if len(parts) >= 2:
+        return parts[-2] or None, parts[-1]
+    return None, parts[0]
+
+
+def normalize_table_name(raw: str) -> str | None:
+    """Reduce a raw table token to its canonical match key, or ``None``.
+
+    Lower-cases, strips quoting and default-schema prefixes, and keeps a named
+    schema as ``schema.table``. Returns ``None`` for anything that is not a
+    concrete identifier (interpolated fragments, temp tables, empty tokens) -
+    a ``None`` here means "emit no contract", never "guess".
+    """
+    if not raw:
+        return None
+    schema, table = split_qualified(raw)
+    table = table.lower().strip()
+    if not table or table.startswith("#") or not _IDENT_RE.match(table):
+        return None
+    if schema:
+        schema = schema.lower().strip()
+        if schema in _DEFAULT_SCHEMAS or not _IDENT_RE.match(schema):
+            schema = None
+    return f"{schema}.{table}" if schema else table

--- a/packages/core/src/repowise/core/workspace/extractors/data/orm_models.py
+++ b/packages/core/src/repowise/core/workspace/extractors/data/orm_models.py
@@ -1,0 +1,161 @@
+"""ORM provider dialects: entity classes that declare (or imply) a table.
+
+The ORM model is the provider side of an app-to-database contract: it declares
+which table the repo owns. Consumers of the model are already visible through
+the import graph, so this module never scans for model *usage*; it only emits
+the declaration.
+
+Explicit names (``__tablename__``, ``@Table(name=...)``, ``$table``,
+``self.table_name``, ``db_table``) are extracted verbatim at high confidence.
+Convention-derived names (JPA entity class, ActiveRecord class, EF ``DbSet``
+property) are emitted at lower confidence: a wrong guess costs a missed link
+(the key just never matches), not a false one.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from ..base import ScanContext
+from ..langs import CSHARP, JAVA, KOTLIN, PHP, PYTHON, RUBY
+from .dialect import build_table_provider
+
+if TYPE_CHECKING:
+    from repowise.core.workspace.contracts import Contract
+
+_EXPLICIT_CONFIDENCE = 0.85
+_CONVENTION_CONFIDENCE = 0.6
+
+
+def _snake_case(name: str) -> str:
+    return re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name).lower()
+
+
+def _pluralize(name: str) -> str:
+    """Naive English pluralization, matching the common ActiveRecord cases.
+
+    Deliberate ceiling: irregular nouns (person/people) are wrong here and
+    yield a missed link, not a false one. Upgrade path: vendor a real
+    inflector if Rails smoke tests show it matters.
+    """
+    if name.endswith(("s", "x", "z", "ch", "sh")):
+        return name + "es"
+    if name.endswith("y") and len(name) > 1 and name[-2] not in "aeiou":
+        return name[:-1] + "ies"
+    return name + "s"
+
+
+def _dedup_emit(
+    ctx: ScanContext,
+    framework: str,
+    found: list[tuple[str, float]],
+) -> list[Contract]:
+    out: list[Contract] = []
+    seen: set[str] = set()
+    for raw, confidence in found:
+        if raw in seen:
+            continue
+        seen.add(raw)
+        contract = build_table_provider(
+            ctx, table_raw=raw, framework=framework, confidence=confidence
+        )
+        if contract is not None:
+            out.append(contract)
+    return out
+
+
+class SqlAlchemyDjangoDialect:
+    """Python ORMs and migrations: SQLAlchemy ``__tablename__``, Django
+    ``Meta.db_table``, SQLModel ``table=True`` classes (default table = class
+    name lower-cased), and Alembic ``op.create_table``."""
+
+    name = "python-orm"
+    extensions = PYTHON
+
+    _TABLENAME_RE = re.compile(r"^\s*__tablename__\s*[:=]\s*.*?['\"](\S+?)['\"]", re.MULTILINE)
+    _DB_TABLE_RE = re.compile(r"^\s*db_table\s*=\s*['\"](\S+?)['\"]", re.MULTILINE)
+    _CREATE_TABLE_RE = re.compile(r"\bop\.create_table\(\s*['\"](\w+)['\"]")
+    _SQLMODEL_RE = re.compile(r"\bclass\s+(\w+)\([^)]*\btable\s*=\s*True[^)]*\)")
+
+    def extract(self, ctx: ScanContext) -> list[Contract]:
+        found = [(m, _EXPLICIT_CONFIDENCE) for m in self._TABLENAME_RE.findall(ctx.content)]
+        found += [(m, _EXPLICIT_CONFIDENCE) for m in self._DB_TABLE_RE.findall(ctx.content)]
+        found += [(m, _EXPLICIT_CONFIDENCE) for m in self._CREATE_TABLE_RE.findall(ctx.content)]
+        found += [
+            (m.lower(), _CONVENTION_CONFIDENCE) for m in self._SQLMODEL_RE.findall(ctx.content)
+        ]
+        return _dedup_emit(ctx, self.name, found)
+
+
+class JpaDialect:
+    """JPA/Jakarta entities: ``@Table(name=...)``, defaulting to the class name."""
+
+    name = "jpa"
+    extensions = JAVA | KOTLIN
+
+    _TABLE_RE = re.compile(r"@Table\s*\(\s*name\s*=\s*\"([^\"]+)\"")
+    # @Entity (optionally parameterized) followed by its class declaration.
+    _ENTITY_CLASS_RE = re.compile(
+        r"@Entity\b(?:\s*\([^)]*\))?[\s\S]{0,200}?\bclass\s+(\w+)",
+    )
+
+    def extract(self, ctx: ScanContext) -> list[Contract]:
+        found = [(m, _EXPLICIT_CONFIDENCE) for m in self._TABLE_RE.findall(ctx.content)]
+        if not found:
+            # Only fall back to the class-name convention when no explicit
+            # @Table names the table (one entity per file is the JPA norm).
+            found = [
+                (_snake_case(m), _CONVENTION_CONFIDENCE)
+                for m in self._ENTITY_CLASS_RE.findall(ctx.content)
+            ]
+        return _dedup_emit(ctx, self.name, found)
+
+
+class EfCoreDialect:
+    """EF Core: ``[Table("x")]`` attributes and ``DbSet<T> Props`` (table = property)."""
+
+    name = "efcore"
+    extensions = CSHARP
+
+    _TABLE_ATTR_RE = re.compile(r"\[Table\(\s*\"([^\"]+)\"")
+    _DBSET_RE = re.compile(r"\bDbSet<\s*\w+\s*>\s+(\w+)")
+
+    def extract(self, ctx: ScanContext) -> list[Contract]:
+        found = [(m, _EXPLICIT_CONFIDENCE) for m in self._TABLE_ATTR_RE.findall(ctx.content)]
+        found += [(m, _CONVENTION_CONFIDENCE) for m in self._DBSET_RE.findall(ctx.content)]
+        return _dedup_emit(ctx, self.name, found)
+
+
+class ActiveRecordDialect:
+    """Rails ActiveRecord: explicit ``self.table_name`` or the class convention."""
+
+    name = "activerecord"
+    extensions = RUBY
+
+    _TABLE_NAME_RE = re.compile(r"self\.table_name\s*=\s*['\"](\w+)['\"]")
+    _MODEL_CLASS_RE = re.compile(
+        r"^\s*class\s+(\w+)\s*<\s*(?:ApplicationRecord|ActiveRecord::Base)\b", re.MULTILINE
+    )
+
+    def extract(self, ctx: ScanContext) -> list[Contract]:
+        found = [(m, _EXPLICIT_CONFIDENCE) for m in self._TABLE_NAME_RE.findall(ctx.content)]
+        if not found:
+            found = [
+                (_pluralize(_snake_case(m)), _CONVENTION_CONFIDENCE)
+                for m in self._MODEL_CLASS_RE.findall(ctx.content)
+            ]
+        return _dedup_emit(ctx, self.name, found)
+
+
+class EloquentDialect:
+    """Laravel Eloquent: ``protected $table = '...'``."""
+
+    name = "eloquent"
+    extensions = PHP
+
+    _TABLE_RE = re.compile(r"protected\s+\$table\s*=\s*['\"](\w+)['\"]")
+
+    def extract(self, ctx: ScanContext) -> list[Contract]:
+        found = [(m, _EXPLICIT_CONFIDENCE) for m in self._TABLE_RE.findall(ctx.content)]
+        return _dedup_emit(ctx, self.name, found)

--- a/packages/core/src/repowise/core/workspace/extractors/data/sql_strings.py
+++ b/packages/core/src/repowise/core/workspace/extractors/data/sql_strings.py
@@ -1,0 +1,165 @@
+"""Consumer dialect: SQL string literals embedded in application code.
+
+Precision rules (this is where the false links would come from):
+
+1. Only *string literals* are considered, and only ones that contain a SQL
+   verb; a prose comment mentioning "from users" never matches because it is
+   not inside a string carrying a verb shape.
+2. When the literal parses under sqlglot, table names come from the AST (the
+   high-precision path). When parsing fails (interpolation placeholders break
+   the grammar), a verb-anchored regex extracts the table token instead.
+3. A table token that is itself interpolated (``FROM {table}`` /
+   ``FROM ${table}`` / ``FROM " + name``) is skipped: normalization rejects
+   non-identifier tokens, so an interpolated target emits nothing.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from ..base import ScanContext
+from ..langs import CSHARP, GO, JAVA, JS_TS, KOTLIN, PHP, PYTHON, RUBY
+from .dialect import build_table_consumer
+
+if TYPE_CHECKING:
+    from repowise.core.workspace.contracts import Contract
+
+# String-literal shapes as ONE left-to-right alternation (longest delimiter
+# first within the alternation). A single scan matters: whichever literal
+# *starts* first consumes its full span, so a double-quoted fragment inside a
+# single-quoted SQL string (``'... JOIN "user" u ...'``) stays part of that
+# string instead of being lexed as its own literal. Template literals and
+# verbatim strings are included; the interpolation guard (rule 3) handles
+# their placeholders.
+_STRING_RE = re.compile(
+    r'"""(?P<t1>.*?)"""'
+    r"|'''(?P<t2>.*?)'''"
+    r"|`(?P<bt>[^`]*)`"
+    r'|"(?P<dq>(?:[^"\\\n]|\\.)*)"'
+    r"|'(?P<sq>(?:[^'\\\n]|\\.)*)'",
+    re.DOTALL,
+)
+
+# A literal must contain one of these verb shapes to be treated as SQL at all.
+# ``UPDATE`` alone matches prose ("update the settings"), so it requires its
+# ``SET`` companion; ``SELECT`` requires ``FROM``.
+_SQL_VERB_RE = re.compile(
+    r"\bSELECT\s[\s\S]+?\sFROM\s"
+    r"|\bINSERT\s+INTO\s"
+    r"|\bUPDATE\s+\S+\s+SET\s"
+    r"|\bDELETE\s+FROM\s"
+    r"|\bMERGE\s+INTO\s",
+    re.IGNORECASE,
+)
+
+# English prose can still satisfy the verb shape ("Select the id from users").
+# Real SQL in code is either upper-cased or carries SQL punctuation; prose is
+# neither. One of the two must hold for the literal to count.
+_UPPER_VERB_RE = re.compile(r"\b(?:SELECT|INSERT|UPDATE|DELETE|MERGE)\b")
+_SQL_PUNCT_RE = re.compile(r"[*=;()]")
+
+# Verb-anchored table extraction for the regex fallback path. The token class
+# excludes interpolation openers so ``FROM {table}`` captures nothing.
+_TABLE_TOKEN = r'([A-Za-z_"\[`][\w."\[\]`$]*)'
+_VERB_TABLE_RES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("select", re.compile(r"\bFROM\s+" + _TABLE_TOKEN, re.IGNORECASE)),
+    ("join", re.compile(r"\bJOIN\s+" + _TABLE_TOKEN, re.IGNORECASE)),
+    ("insert", re.compile(r"\bINSERT\s+INTO\s+" + _TABLE_TOKEN, re.IGNORECASE)),
+    ("update", re.compile(r"\bUPDATE\s+" + _TABLE_TOKEN, re.IGNORECASE)),
+    ("delete", re.compile(r"\bDELETE\s+FROM\s+" + _TABLE_TOKEN, re.IGNORECASE)),
+)
+
+# Identifier-shaped tokens a naive FROM/JOIN capture can grab instead of a
+# table name: SQL keywords (``FROM (SELECT``) and English stopwords from prose
+# that slipped past the literal gate. Normalization already rejects
+# non-identifiers; this rejects identifier-shaped non-tables.
+_SQL_KEYWORDS = frozenset(
+    {
+        "select", "where", "set", "values", "on", "using", "lateral", "unnest", "dual",
+        "the", "a", "an", "this", "that", "all", "each", "your", "their", "its",
+    }
+)  # fmt: skip
+
+_MIN_LITERAL_LEN = 12
+
+
+def _verb_for_statement(stmt: object) -> str:
+    kind = type(stmt).__name__.lower()
+    return kind if kind in ("insert", "update", "delete", "merge") else "select"
+
+
+class SqlStringsDialect:
+    """Consumers from SQL literals in app code (all supported app languages)."""
+
+    name = "sql-strings"
+    extensions = PYTHON | JS_TS | JAVA | KOTLIN | GO | CSHARP | RUBY | PHP
+
+    def extract(self, ctx: ScanContext) -> list[Contract]:
+        out: list[Contract] = []
+        seen: set[str] = set()
+        for literal in self._sql_literals(ctx.content):
+            for table_raw, verb in self._tables_in(literal):
+                if table_raw.lower().strip('"`[]') in _SQL_KEYWORDS:
+                    continue
+                key = table_raw.lower()
+                if key in seen:
+                    continue
+                seen.add(key)
+                contract = build_table_consumer(
+                    ctx, table_raw=table_raw, verb=verb, client=self.name
+                )
+                if contract is not None:
+                    out.append(contract)
+        return out
+
+    @staticmethod
+    def _sql_literals(content: str) -> list[str]:
+        literals: list[str] = []
+        for m in _STRING_RE.finditer(content):
+            s = next(g for g in m.groups() if g is not None)
+            if (
+                len(s) >= _MIN_LITERAL_LEN
+                and _SQL_VERB_RE.search(s)
+                and (_UPPER_VERB_RE.search(s) or _SQL_PUNCT_RE.search(s))
+            ):
+                literals.append(s)
+        return literals
+
+    def _tables_in(self, literal: str) -> list[tuple[str, str]]:
+        """``(raw_table, verb)`` pairs, AST-first with regex fallback."""
+        parsed = self._parse_tables(literal)
+        if parsed is not None:
+            return parsed
+        found: list[tuple[str, str]] = []
+        for verb, pattern in _VERB_TABLE_RES:
+            for m in pattern.findall(literal):
+                found.append((m, verb))
+        return found
+
+    @staticmethod
+    def _parse_tables(literal: str) -> list[tuple[str, str]] | None:
+        """Table names via sqlglot, or ``None`` when the literal won't parse."""
+        try:
+            import sqlglot
+            from sqlglot import exp
+        except ImportError:
+            return None
+        logging.getLogger("sqlglot").setLevel(logging.ERROR)
+        try:
+            statements = sqlglot.parse(literal, error_level=sqlglot.ErrorLevel.RAISE)
+        except Exception:
+            return None
+        found: list[tuple[str, str]] = []
+        for stmt in statements:
+            if stmt is None:
+                return None
+            verb = _verb_for_statement(stmt)
+            for table in stmt.find_all(exp.Table):
+                name = table.name
+                if not name:
+                    continue
+                raw = f"{table.db}.{name}" if table.db else name
+                found.append((raw, verb))
+        return found if found else None

--- a/packages/core/src/repowise/core/workspace/extractors/langs.py
+++ b/packages/core/src/repowise/core/workspace/extractors/langs.py
@@ -12,6 +12,8 @@ from repowise.core.ingestion.languages.registry import REGISTRY as _REGISTRY
 JS_TS = _REGISTRY.extensions_for(["javascript", "typescript"])
 PYTHON = _REGISTRY.extensions_for(["python"])
 JAVA = _REGISTRY.extensions_for(["java"])
+KOTLIN = _REGISTRY.extensions_for(["kotlin"])
+RUBY = _REGISTRY.extensions_for(["ruby"])
 PHP = _REGISTRY.extensions_for(["php"])
 GO = _REGISTRY.extensions_for(["go"])
 CSHARP = _REGISTRY.extensions_for(["csharp"])

--- a/packages/core/src/repowise/core/workspace/system_graph.py
+++ b/packages/core/src/repowise/core/workspace/system_graph.py
@@ -65,10 +65,11 @@ _CONTRACT_TYPE_TO_EDGE_KIND: dict[str, str] = {
     "http": "http",
     "grpc": "grpc",
     "topic": "event",
+    "data": "db",
 }
 
-#: All edge kinds the graph can carry. ``db`` is reserved for a future
-#: shared-table transport; the taxonomy is fixed now so views render consistently.
+#: All edge kinds the graph can carry. ``db`` carries the shared-table
+#: (``data``) contracts; the taxonomy is fixed so views render consistently.
 EDGE_KINDS: tuple[str, ...] = ("http", "grpc", "event", "package", "co_change", "db")
 
 #: ``match_type`` precedence when several links collapse onto one edge — the most

--- a/packages/server/src/repowise/server/routers/workspace.py
+++ b/packages/server/src/repowise/server/routers/workspace.py
@@ -245,7 +245,7 @@ async def get_workspace(
 async def get_contracts(
     ws_config=Depends(get_workspace_config),
     enricher=Depends(get_cross_repo_enricher),
-    contract_type: str | None = Query(None, description="Filter: http, grpc, or topic"),
+    contract_type: str | None = Query(None, description="Filter: http, grpc, topic, or data"),
     repo: str | None = Query(None, description="Filter by repo alias"),
     role: str | None = Query(None, description="Filter: provider or consumer"),
     limit: int = Query(200, ge=1, le=1000),

--- a/packages/ui/src/health/biomarker-glossary.ts
+++ b/packages/ui/src/health/biomarker-glossary.ts
@@ -16,7 +16,8 @@ export type BiomarkerCategory =
   | "test_quality"
   | "error_handling"
   | "performance"
-  | "organizational";
+  | "organizational"
+  | "sql";
 
 export interface BiomarkerInfo {
   label: string;
@@ -34,6 +35,7 @@ export const CATEGORY_LABEL: Record<BiomarkerCategory, string> = {
   error_handling: "Error handling",
   performance: "Performance",
   organizational: "Organizational",
+  sql: "SQL",
 };
 
 export const CATEGORY_CAP: Record<BiomarkerCategory, number> = {
@@ -49,6 +51,9 @@ export const CATEGORY_CAP: Record<BiomarkerCategory, number> = {
   // in scoring.py): the whole performance pillar deducts at most 1.0, keeping it
   // advisory.
   performance: 1.0,
+  // SQL smells deduct on the maintainability pillar only, bounded by the `sql`
+  // cap in `_MAINTAINABILITY_CATEGORY_CAPS` (scoring.py).
+  sql: 2.0,
 };
 
 export const BIOMARKER_GLOSSARY: Record<string, BiomarkerInfo> = {
@@ -292,6 +297,30 @@ export const BIOMARKER_GLOSSARY: Record<string, BiomarkerInfo> = {
     description:
       "A data-dependent loop nested inside another (O(n^2)) in a hot, central function. Advisory / informational — surfaced only where centrality ranking says it is worth a look; check the inner bound or use a set/map lookup if it is a search.",
   },
+  sql_high_complexity: {
+    label: "Complex SQL routine",
+    category: "sql",
+    description:
+      "A stored procedure or function with high cyclomatic complexity, counted from the decision keywords (IF / WHEN / WHILE / LOOP and boolean operators) in its body. Procedural SQL this branchy is hard to test and usually hides business logic that belongs in the application layer.",
+  },
+  sql_select_star: {
+    label: "SELECT * in a view",
+    category: "sql",
+    description:
+      "A bare * projection inside a view, materialized view, or routine. When the source table gains a column the relation silently changes shape, breaking downstream consumers at a distance. Ad-hoc scripts are not flagged.",
+  },
+  sql_update_delete_without_where: {
+    label: "UPDATE/DELETE without WHERE",
+    category: "sql",
+    description:
+      "A checked-in UPDATE or DELETE with no WHERE clause touches every row in the table. Sometimes intentional (seed resets), always worth a reviewer's attention.",
+  },
+  sql_cartesian_join: {
+    label: "Cartesian join",
+    category: "performance",
+    description:
+      "A comma-join (FROM a, b) with no join predicate anywhere in the statement produces the full cross product: O(n·m) rows. An explicit CROSS JOIN states intent and is not flagged; a comma-join with a WHERE clause is old-style join syntax and is not flagged either.",
+  },
 };
 
 export function biomarkerInfo(name: string): BiomarkerInfo {
@@ -332,6 +361,9 @@ export const MAINTAINABILITY_HOME_BIOMARKERS: ReadonlySet<string> = new Set([
   "primitive_obsession",
   "dry_violation",
   "error_handling",
+  "sql_high_complexity",
+  "sql_select_star",
+  "sql_update_delete_without_where",
 ]);
 
 /**
@@ -352,6 +384,13 @@ export const PERFORMANCE_HOME_BIOMARKERS: ReadonlySet<string> = new Set([
   "nested_loop_quadratic",
   "hot_path_sync_io",
   "blocking_io_under_lock",
+  "list_insert_zero_in_loop",
+  "pd_concat_in_loop",
+  "pandas_iterrows_in_loop",
+  "json_parse_in_loop",
+  "array_spread_in_reduce",
+  "goroutine_in_unbounded_loop",
+  "sql_cartesian_join",
 ]);
 
 /**

--- a/packages/ui/src/workspace/contract-type-badge.tsx
+++ b/packages/ui/src/workspace/contract-type-badge.tsx
@@ -6,6 +6,7 @@ const TYPE_STYLES: Record<string, { bg: string; text: string; label: string }> =
   http: { bg: "bg-blue-500/10", text: "text-blue-400", label: "HTTP" },
   grpc: { bg: "bg-purple-500/10", text: "text-purple-400", label: "gRPC" },
   topic: { bg: "bg-orange-500/10", text: "text-orange-400", label: "Topic" },
+  data: { bg: "bg-teal-500/10", text: "text-teal-400", label: "Table" },
 };
 
 export function ContractTypeBadge({ type }: { type: string }) {

--- a/packages/web/src/app/workspace/contracts/page.tsx
+++ b/packages/web/src/app/workspace/contracts/page.tsx
@@ -16,6 +16,7 @@ const TYPE_OPTIONS = [
   { value: "http", label: "HTTP" },
   { value: "grpc", label: "gRPC" },
   { value: "topic", label: "Topic" },
+  { value: "data", label: "Table" },
 ];
 
 const ROLE_OPTIONS = [

--- a/tests/unit/health/test_sql_markers.py
+++ b/tests/unit/health/test_sql_markers.py
@@ -1,0 +1,282 @@
+"""SQL health markers: routine CCN + statement smells.
+
+Acceptance rule from the marker plan: zero false fires on the negative set.
+Every smell test has a paired negative asserting silence.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from repowise.core.analysis.health.biomarkers.base import FileContext
+from repowise.core.analysis.health.biomarkers.registry import detect_all
+from repowise.core.analysis.health.models import Severity
+from repowise.core.analysis.health.scoring import (
+    biomarker_dimension,
+    dimensions_for,
+    score_file,
+)
+from repowise.core.analysis.health.sql_complexity import (
+    _body_ccn,
+    _statement_smells,
+    walk_sql_file,
+)
+
+
+def _fi(name: str = "schema.sql") -> SimpleNamespace:
+    return SimpleNamespace(abs_path=f"/repo/{name}", path=name, language="sql")
+
+
+def _walk(sql: str):
+    return walk_sql_file(_fi(), sql.encode("utf-8"))
+
+
+def _smell_kinds(sql: str) -> list[str]:
+    return sorted(h.kind for h in _statement_smells(sql, None))
+
+
+# ---------------------------------------------------------------------------
+# Routine CCN (text tier)
+# ---------------------------------------------------------------------------
+
+
+class TestBodyCcn:
+    def test_flat_body_is_one(self) -> None:
+        assert _body_ccn("BEGIN RETURN 1; END") == 1
+
+    def test_plpgsql_if_elsif(self) -> None:
+        body = "BEGIN IF a THEN RETURN 1; ELSIF b THEN RETURN 2; END IF; END"
+        # 1 + IF + ELSIF (END IF's token discounted)
+        assert _body_ccn(body) == 3
+
+    def test_while_loop_not_double_counted(self) -> None:
+        body = "BEGIN WHILE x < 10 LOOP SET x = x + 1; END LOOP; END"
+        # PL/pgSQL WHILE..LOOP nets to a single decision point.
+        assert _body_ccn(body) == 2
+
+    def test_tsql_while(self) -> None:
+        body = "BEGIN WHILE @x < 10 BEGIN SET @x = @x + 1 END END"
+        assert _body_ccn(body) == 2
+
+    def test_boolean_operators_count(self) -> None:
+        body = "BEGIN IF a > 0 AND b > 0 OR c THEN RETURN 1; END IF; END"
+        assert _body_ccn(body) == 4
+
+    def test_between_and_discounted(self) -> None:
+        body = "BEGIN SELECT 1 WHERE x BETWEEN 1 AND 10; END"
+        assert _body_ccn(body) == 1
+
+    def test_comments_and_strings_ignored(self) -> None:
+        body = "BEGIN -- IF this OR that\n SELECT 'WHILE AND OR'; /* WHEN */ END"
+        assert _body_ccn(body) == 1
+
+
+class TestWalkRoutines:
+    def test_postgres_function_metrics(self) -> None:
+        sql = (
+            "CREATE FUNCTION add_em(a INT, b INT) RETURNS INT AS $$\n"
+            "BEGIN\n"
+            "    IF a > 0 AND b > 0 THEN\n"
+            "        RETURN a + b;\n"
+            "    END IF;\n"
+            "    RETURN 0;\n"
+            "END;\n"
+            "$$ LANGUAGE plpgsql;\n"
+        )
+        fcx = _walk(sql)
+        assert [f.name for f in fcx.functions] == ["add_em"]
+        fn = fcx.functions[0]
+        assert fn.ccn == 3  # IF + AND
+        assert fn.start_line == 1
+        assert fn.nloc > 0
+        assert fcx.file_nloc > 0
+
+    def test_tsql_procedure_metrics(self) -> None:
+        sql = (
+            "CREATE PROCEDURE dbo.process_orders @status INT\n"
+            "AS\nBEGIN\n"
+            "    IF @status = 1\n"
+            "    BEGIN\n"
+            "        UPDATE orders SET state = 'x' WHERE id = @status;\n"
+            "    END\n"
+            "    WHILE @status < 10\n"
+            "    BEGIN\n"
+            "        SET @status = @status + 1;\n"
+            "    END\n"
+            "END\n"
+        )
+        fcx = _walk(sql)
+        assert [f.name for f in fcx.functions] == ["process_orders"]
+        assert fcx.functions[0].ccn == 3  # IF + WHILE
+
+    def test_high_ccn_emits_hit(self) -> None:
+        branches = "".join(f"    IF x = {i} THEN RETURN {i}; END IF;\n" for i in range(12))
+        sql = f"CREATE FUNCTION f() RETURNS INT AS $$\nBEGIN\n{branches}END;\n$$;"
+        fcx = _walk(sql)
+        hits = [h for h in fcx.perf_hits if h.kind == "sql_high_complexity"]
+        assert len(hits) == 1
+        assert int(hits[0].detail) == 13
+        assert hits[0].function == "f"
+
+    def test_simple_routine_emits_no_hit(self) -> None:
+        sql = "CREATE FUNCTION f() RETURNS INT AS $$ SELECT 1 $$;"
+        assert [h for h in _walk(sql).perf_hits if h.kind == "sql_high_complexity"] == []
+
+    def test_plain_ddl_yields_no_functions(self) -> None:
+        fcx = _walk("CREATE TABLE users (id INT);")
+        assert fcx.functions == []
+
+
+# ---------------------------------------------------------------------------
+# Statement smells (AST tier): every positive has a paired negative
+# ---------------------------------------------------------------------------
+
+
+class TestSelectStar:
+    def test_fires_in_view(self) -> None:
+        assert _smell_kinds("CREATE VIEW v AS SELECT * FROM t") == ["sql_select_star"]
+
+    def test_silent_in_ad_hoc_script(self) -> None:
+        assert _smell_kinds("SELECT * FROM t") == []
+
+    def test_silent_for_qualified_star(self) -> None:
+        assert _smell_kinds("CREATE VIEW v AS SELECT t.* FROM t") == []
+
+    def test_silent_for_count_star(self) -> None:
+        assert _smell_kinds("CREATE VIEW v AS SELECT COUNT(*) FROM t") == []
+
+    def test_one_finding_per_view(self) -> None:
+        sql = "CREATE VIEW v AS SELECT * FROM (SELECT * FROM t) sub"
+        assert _smell_kinds(sql) == ["sql_select_star"]
+
+
+class TestUpdateDeleteWithoutWhere:
+    def test_update_fires(self) -> None:
+        hits = _statement_smells("UPDATE users SET active = 0", None)
+        assert [h.kind for h in hits] == ["sql_update_delete_without_where"]
+        assert "update users" in hits[0].detail
+
+    def test_delete_fires(self) -> None:
+        assert _smell_kinds("DELETE FROM sessions") == ["sql_update_delete_without_where"]
+
+    def test_silent_with_where(self) -> None:
+        assert _smell_kinds("UPDATE users SET active = 0 WHERE id = 1") == []
+        assert _smell_kinds("DELETE FROM sessions WHERE expired = 1") == []
+
+    def test_silent_on_dialect_garble(self) -> None:
+        # A backtick-quoted MySQL UPDATE read under the permissive default
+        # dialect garbles the tokenization (found live on umami: the statement
+        # HAS a WHERE that the broken parse loses). An unclean target name
+        # means the parse is untrustworthy: no signal.
+        sql = "UPDATE `website_event`\nSET x = 1\nWHERE url_query IS NOT NULL;"
+        assert _smell_kinds(sql) == []
+
+
+class TestCartesianJoin:
+    def test_comma_join_without_where_fires(self) -> None:
+        assert _smell_kinds("SELECT a.x, b.y FROM a, b") == ["sql_cartesian_join"]
+
+    def test_comma_join_with_where_silent(self) -> None:
+        assert _smell_kinds("SELECT a.x FROM a, b WHERE a.id = b.id") == []
+
+    def test_explicit_cross_join_silent(self) -> None:
+        assert _smell_kinds("SELECT a.x FROM a CROSS JOIN b") == []
+
+    def test_keyed_join_silent(self) -> None:
+        assert _smell_kinds("SELECT a.x FROM a JOIN b ON a.id = b.id") == []
+        assert _smell_kinds("SELECT a.x FROM a JOIN b USING (id)") == []
+
+
+class TestTemplatedFilesSilent:
+    def test_dbt_model_yields_no_smells(self) -> None:
+        sql = "select * from {{ ref('stg_orders') }}\nwhere x = 1"
+        assert _statement_smells(sql, None) == []
+
+    def test_jinja_block_yields_no_smells(self) -> None:
+        sql = "{% set x = 1 %}\nUPDATE t SET y = 2"
+        assert _statement_smells(sql, None) == []
+
+
+class TestMalformedDegradation:
+    def test_garbage_yields_empty_complexity(self) -> None:
+        fcx = _walk("CREATE (((( garbage ;;;")
+        assert fcx.functions == []
+        assert fcx.perf_hits == []
+        assert fcx.file_nloc >= 1
+
+
+# ---------------------------------------------------------------------------
+# Detector lift + scoring dimensions
+# ---------------------------------------------------------------------------
+
+
+def _ctx_for(sql: str) -> FileContext:
+    fcx = _walk(sql)
+    return FileContext(
+        file_path="schema.sql",
+        language="sql",
+        nloc=fcx.file_nloc,
+        has_test_file=False,
+        module=None,
+        perf_hits=fcx.perf_hits,
+    )
+
+
+class TestDetectors:
+    def test_smells_become_findings(self) -> None:
+        ctx = _ctx_for(
+            "CREATE VIEW v AS SELECT * FROM t;\n"
+            "UPDATE users SET active = 0;\n"
+            "SELECT a.x FROM a, b;\n"
+        )
+        kinds = sorted(r.biomarker_type for r in detect_all(ctx))
+        assert kinds == [
+            "sql_cartesian_join",
+            "sql_select_star",
+            "sql_update_delete_without_where",
+        ]
+
+    def test_high_complexity_severity_scales(self) -> None:
+        branches = "".join(f"IF x = {i} THEN RETURN {i}; END IF;\n" for i in range(25))
+        ctx = _ctx_for(f"CREATE FUNCTION f() RETURNS INT AS $$\nBEGIN\n{branches}END $$;")
+        results = [r for r in detect_all(ctx) if r.biomarker_type == "sql_high_complexity"]
+        assert len(results) == 1
+        assert results[0].severity == Severity.HIGH
+
+    def test_clean_sql_yields_nothing(self) -> None:
+        ctx = _ctx_for(
+            "CREATE TABLE users (id INT PRIMARY KEY);\n"
+            "CREATE VIEW v AS SELECT id FROM users WHERE id > 0;\n"
+            "DELETE FROM users WHERE id = 1;\n"
+        )
+        assert [r for r in detect_all(ctx) if r.biomarker_type.startswith("sql_")] == []
+
+
+class TestScoringDimensions:
+    def test_every_sql_marker_excludes_defect(self) -> None:
+        for name in (
+            "sql_high_complexity",
+            "sql_select_star",
+            "sql_update_delete_without_where",
+            "sql_cartesian_join",
+        ):
+            assert "defect" not in dimensions_for(name), name
+
+    def test_homes(self) -> None:
+        assert biomarker_dimension("sql_high_complexity") == "maintainability"
+        assert biomarker_dimension("sql_select_star") == "maintainability"
+        assert biomarker_dimension("sql_update_delete_without_where") == "maintainability"
+        assert biomarker_dimension("sql_cartesian_join") == "performance"
+
+    def test_defect_score_untouched_by_sql_findings(self) -> None:
+        ctx = _ctx_for(
+            "CREATE VIEW v AS SELECT * FROM t;\n"
+            "UPDATE users SET active = 0;\n"
+            "SELECT a.x FROM a, b;\n"
+        )
+        results = detect_all(ctx)
+        assert results  # sanity: the smells fired
+        scores, _ = score_file(results)
+        assert scores["defect"] == 10.0
+        assert scores["maintainability"] < 10.0
+        assert scores["performance"] < 10.0

--- a/tests/unit/workspace/test_data_contracts.py
+++ b/tests/unit/workspace/test_data_contracts.py
@@ -1,0 +1,331 @@
+"""Data (app-to-database) contract extraction tests.
+
+Table-name normalization is tested first and hardest: it is where the false
+links would come from (quoting, schema prefixes, case). Then per-dialect
+provider/consumer extraction, then the cross-repo end-to-end match.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repowise.core.workspace.contracts import match_contracts, normalize_contract_id
+from repowise.core.workspace.extractors.data import DataExtractor
+from repowise.core.workspace.extractors.data.names import (
+    normalize_table_name,
+    split_qualified,
+)
+from repowise.core.workspace.system_graph import edge_kind_for_contract_type
+
+
+class TestNormalizeTableName:
+    def test_bare_lowercase_passthrough(self) -> None:
+        assert normalize_table_name("users") == "users"
+
+    def test_case_folds(self) -> None:
+        assert normalize_table_name("Users") == "users"
+
+    def test_double_quotes_stripped(self) -> None:
+        assert normalize_table_name('"Users"') == "users"
+
+    def test_backticks_stripped(self) -> None:
+        assert normalize_table_name("`users`") == "users"
+
+    def test_brackets_stripped(self) -> None:
+        assert normalize_table_name("[Users]") == "users"
+
+    def test_default_schema_dropped(self) -> None:
+        assert normalize_table_name("public.users") == "users"
+        assert normalize_table_name("dbo.Users") == "users"
+
+    def test_named_schema_kept(self) -> None:
+        assert normalize_table_name("analytics.events") == "analytics.events"
+
+    def test_quoted_qualified(self) -> None:
+        assert normalize_table_name('"public"."Users"') == "users"
+        assert normalize_table_name("[dbo].[Orders]") == "orders"
+
+    def test_three_part_name_keeps_last_two(self) -> None:
+        assert normalize_table_name("mydb.analytics.events") == "analytics.events"
+
+    def test_temp_table_rejected(self) -> None:
+        assert normalize_table_name("#tmp_orders") is None
+
+    def test_interpolation_rejected(self) -> None:
+        assert normalize_table_name("{table}") is None
+        assert normalize_table_name("${TABLE}") is None
+        assert normalize_table_name("%s") is None
+
+    def test_empty_rejected(self) -> None:
+        assert normalize_table_name("") is None
+
+    def test_split_qualified(self) -> None:
+        assert split_qualified("a.b") == ("a", "b")
+        assert split_qualified("b") == (None, "b")
+
+
+def _write(repo: Path, rel: str, content: str) -> None:
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class TestDdlProviders:
+    def test_create_table_and_view(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "schema.sql",
+            """
+            CREATE TABLE users (id INT PRIMARY KEY, email TEXT);
+            CREATE VIEW active_users AS SELECT * FROM users WHERE active;
+            CREATE INDEX idx_users_email ON users(email);
+            """,
+        )
+        contracts = DataExtractor().extract(tmp_path, "db")
+        providers = {c.contract_id for c in contracts if c.role == "provider"}
+        assert "data::users" in providers
+        assert "data::active_users" in providers
+        # INDEX attaches to a table; it declares none.
+        assert not any("idx_users_email" in c for c in providers)
+
+    def test_schema_qualified_and_quoted(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "migrations/001_init.sql",
+            'CREATE TABLE "public"."Orders" (id INT);\nCREATE TABLE analytics.events (id INT);\n',
+        )
+        contracts = DataExtractor().extract(tmp_path, "db")
+        ids = {c.contract_id for c in contracts}
+        assert "data::orders" in ids
+        assert "data::analytics.events" in ids
+
+    def test_alter_table_is_provider(self, tmp_path: Path) -> None:
+        _write(tmp_path, "migrations/002_add.sql", "ALTER TABLE users ADD COLUMN age INT;")
+        contracts = DataExtractor().extract(tmp_path, "db")
+        assert any(c.contract_id == "data::users" and c.role == "provider" for c in contracts)
+
+    def test_malformed_sql_yields_nothing(self, tmp_path: Path) -> None:
+        _write(tmp_path, "broken.sql", "CREATE TABLE ((((( ;;; garbage !!")
+        contracts = DataExtractor().extract(tmp_path, "db")
+        assert contracts == []
+
+
+class TestOrmProviders:
+    def test_sqlalchemy_tablename(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/models.py",
+            'class User(Base):\n    __tablename__ = "users"\n',
+        )
+        contracts = DataExtractor().extract(tmp_path, "api")
+        assert any(c.contract_id == "data::users" and c.role == "provider" for c in contracts)
+
+    def test_alembic_create_table(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "alembic/versions/abc_init.py",
+            'def upgrade():\n    op.create_table("orders", sa.Column("id", sa.Integer))\n',
+        )
+        contracts = DataExtractor().extract(tmp_path, "api")
+        assert any(c.contract_id == "data::orders" for c in contracts)
+
+    def test_sqlmodel_table_true(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/models.py",
+            "class HeroTeam(SQLModel, table=True):\n    id: int\n",
+        )
+        contracts = DataExtractor().extract(tmp_path, "api")
+        # SQLModel default table name is the class name lower-cased.
+        assert any(c.contract_id == "data::heroteam" for c in contracts)
+
+    def test_django_db_table(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/models.py",
+            "class Order(models.Model):\n    class Meta:\n        db_table = 'shop_orders'\n",
+        )
+        contracts = DataExtractor().extract(tmp_path, "shop")
+        assert any(c.contract_id == "data::shop_orders" for c in contracts)
+
+    def test_jpa_table_annotation(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "src/main/java/User.java",
+            '@Entity\n@Table(name = "app_users")\npublic class User {}\n',
+        )
+        contracts = DataExtractor().extract(tmp_path, "svc")
+        assert any(c.contract_id == "data::app_users" for c in contracts)
+
+    def test_jpa_entity_class_convention(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "src/main/java/OrderItem.java",
+            "@Entity\npublic class OrderItem {}\n",
+        )
+        contracts = DataExtractor().extract(tmp_path, "svc")
+        match = [c for c in contracts if c.contract_id == "data::order_item"]
+        assert match and match[0].confidence < 0.85
+
+    def test_efcore_dbset_and_table_attr(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "Data/AppDbContext.cs",
+            "public class AppDbContext : DbContext {\n"
+            "    public DbSet<User> Users { get; set; }\n"
+            "}\n",
+        )
+        _write(tmp_path, "Models/Legacy.cs", '[Table("legacy_orders")]\npublic class Legacy {}\n')
+        contracts = DataExtractor().extract(tmp_path, "svc")
+        ids = {c.contract_id for c in contracts}
+        assert "data::users" in ids
+        assert "data::legacy_orders" in ids
+
+    def test_activerecord_convention_and_override(self, tmp_path: Path) -> None:
+        _write(tmp_path, "app/models/blog_post.rb", "class BlogPost < ApplicationRecord\nend\n")
+        _write(
+            tmp_path,
+            "app/models/legacy.rb",
+            "class Legacy < ApplicationRecord\n  self.table_name = 'old_stuff'\nend\n",
+        )
+        contracts = DataExtractor().extract(tmp_path, "rails")
+        ids = {c.contract_id for c in contracts}
+        assert "data::blog_posts" in ids
+        assert "data::old_stuff" in ids
+
+    def test_eloquent_table_property(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/Models/Order.php",
+            "<?php\nclass Order extends Model {\n    protected $table = 'orders';\n}\n",
+        )
+        contracts = DataExtractor().extract(tmp_path, "shop")
+        assert any(c.contract_id == "data::orders" for c in contracts)
+
+
+class TestSqlStringConsumers:
+    def test_parseable_select(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/queries.py",
+            'q = "SELECT id, email FROM users WHERE active = 1"\n',
+        )
+        contracts = DataExtractor().extract(tmp_path, "api")
+        consumers = [c for c in contracts if c.role == "consumer"]
+        assert [c.contract_id for c in consumers] == ["data::users"]
+        assert consumers[0].meta["verb"] == "select"
+
+    def test_quoted_table_inside_single_quoted_literal(self, tmp_path: Path) -> None:
+        # The inner double quotes must stay part of the single-quoted literal;
+        # lexing them as their own string turns the alias into a phantom
+        # table (found live: data::u from JOIN "user" u).
+        _write(
+            tmp_path,
+            "app/report.py",
+            "q = 'SELECT i.id FROM item i JOIN \"user\" u ON i.owner_id = u.id'\n",
+        )
+        contracts = DataExtractor().extract(tmp_path, "api")
+        ids = {c.contract_id for c in contracts if c.role == "consumer"}
+        assert ids == {"data::item", "data::user"}
+
+    def test_join_tables_all_captured(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/queries.go",
+            'var q = "SELECT o.id FROM orders o JOIN customers c ON o.cid = c.id"\n',
+        )
+        contracts = DataExtractor().extract(tmp_path, "api")
+        ids = {c.contract_id for c in contracts if c.role == "consumer"}
+        assert ids == {"data::orders", "data::customers"}
+
+    def test_interpolated_query_falls_back_to_regex(self, tmp_path: Path) -> None:
+        # %s placeholder breaks the sqlglot parse; the verb-anchored regex
+        # still recovers the literal table token.
+        _write(
+            tmp_path,
+            "app/db.py",
+            'q = "UPDATE orders SET state = %s WHERE id = %s"\n',
+        )
+        contracts = DataExtractor().extract(tmp_path, "api")
+        consumers = [c for c in contracts if c.role == "consumer"]
+        assert [c.contract_id for c in consumers] == ["data::orders"]
+
+    def test_interpolated_table_name_skipped(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/db.py",
+            'q = f"SELECT * FROM {table} WHERE id = 1"\n',
+        )
+        contracts = DataExtractor().extract(tmp_path, "api")
+        assert [c for c in contracts if c.role == "consumer"] == []
+
+    def test_prose_comment_not_matched(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/notes.py",
+            '"""Select the widest rows from users and update the cache."""\n'
+            "# fetch data from the users service\n",
+        )
+        contracts = DataExtractor().extract(tmp_path, "api")
+        assert contracts == []
+
+    def test_insert_and_delete_verbs(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "app/db.ts",
+            "const a = `INSERT INTO audit_log (id) VALUES (1)`;\n"
+            "const b = `DELETE FROM sessions WHERE expired = true`;\n",
+        )
+        contracts = DataExtractor().extract(tmp_path, "web")
+        by_id = {c.contract_id: c for c in contracts if c.role == "consumer"}
+        assert set(by_id) == {"data::audit_log", "data::sessions"}
+        assert by_id["data::audit_log"].meta["verb"] == "insert"
+        assert by_id["data::sessions"].meta["verb"] == "delete"
+
+    def test_test_files_excluded_by_default(self, tmp_path: Path) -> None:
+        from repowise.core.workspace.extractors.base import make_exclude_predicate
+
+        _write(tmp_path, "tests/test_db.py", 'q = "SELECT id FROM users WHERE x = 1"\n')
+        contracts = DataExtractor().extract(tmp_path, "api", make_exclude_predicate())
+        assert contracts == []
+
+
+class TestDataMatching:
+    def test_normalize_contract_id_lowercases(self) -> None:
+        assert normalize_contract_id("data::Users") == "data::users"
+
+    def test_edge_kind_is_db(self) -> None:
+        assert edge_kind_for_contract_type("data") == "db"
+
+    def test_cross_repo_link(self, tmp_path: Path) -> None:
+        backend = tmp_path / "backend"
+        worker = tmp_path / "worker"
+        _write(backend, "migrations/001.sql", "CREATE TABLE orders (id INT);")
+        _write(worker, "jobs/process.py", 'q = "SELECT id FROM orders WHERE done = 0"\n')
+
+        contracts = DataExtractor().extract(backend, "backend")
+        contracts += DataExtractor().extract(worker, "worker")
+        links = match_contracts(contracts)
+
+        assert len(links) == 1
+        link = links[0]
+        assert link.contract_type == "data"
+        assert link.provider_repo == "backend"
+        assert link.consumer_repo == "worker"
+        assert link.match_type == "exact"
+
+    def test_same_repo_not_linked(self, tmp_path: Path) -> None:
+        repo = tmp_path / "app"
+        _write(repo, "schema.sql", "CREATE TABLE orders (id INT);")
+        _write(repo, "db.py", 'q = "SELECT id FROM orders WHERE done = 0"\n')
+        contracts = DataExtractor().extract(repo, "app")
+        assert match_contracts(contracts) == []
+
+    def test_quoting_and_schema_survive_matching(self, tmp_path: Path) -> None:
+        backend = tmp_path / "backend"
+        worker = tmp_path / "worker"
+        _write(backend, "schema.sql", 'CREATE TABLE "public"."Orders" (id INT);')
+        _write(worker, "job.py", 'q = "SELECT id FROM orders WHERE x = 1"\n')
+        contracts = DataExtractor().extract(backend, "backend")
+        contracts += DataExtractor().extract(worker, "worker")
+        assert len(match_contracts(contracts)) == 1


### PR DESCRIPTION
Builds on #683 (DDL symbols + dbt lineage) with the two remaining SQL capabilities: app-to-database contracts in workspace mode, and SQL health markers.

## App-to-database contracts (workspace)

New `workspace/extractors/data/` package, same dialect architecture as the HTTP extractor: the orchestrator owns only the file walk, every recogniser is a module in a registry tuple, and table-name normalization lives in one place (`names.py`: quoting, `public`/`dbo` prefixes, case; named schemas kept as `schema.table`; anything that is not a concrete identifier emits nothing rather than a guess).

- Providers (table ownership): DDL `CREATE TABLE/VIEW/MATERIALIZED VIEW` and `ALTER TABLE` in `.sql` files (sqlglot, permissive, error-tolerant), Alembic `op.create_table`, SQLAlchemy `__tablename__`, SQLModel `table=True`, Django `db_table`, JPA `@Entity`/`@Table` (Java + Kotlin), EF Core `DbSet<T>`/`[Table]`, ActiveRecord (convention + `self.table_name`), Eloquent `$table`. Convention-derived names carry lower confidence; a wrong guess costs a missed link, not a false one.
- Consumers: SQL string literals in app code (Python, JS/TS, Java, Kotlin, Go, C#, Ruby, PHP). AST-first via sqlglot, verb-anchored regex fallback when interpolation breaks the parse. Precision gates: the literal must match a real verb shape and carry an uppercase verb or SQL punctuation (kills prose docstrings), interpolated table targets are skipped, and all literal shapes are scanned in one left-to-right pass so a quoted fragment inside another string cannot mint a phantom table.
- Matched pairs are `data` contracts (`data::<table>`) rendered as the already-reserved `db` edge kind on the Live System Map, answering "which services touch table X". Threading: `detect_data` config flag, contract type badge and filter entries, router filter description.

## SQL health markers (maintainability/performance only)

New `analysis/health/sql_complexity.py`, routed from `engine._walk` for `language == "sql"`:

- `sql_high_complexity`: cyclomatic complexity for stored procedures/functions. Procedural bodies do not parse into an AST (T-SQL degrades to `Command`, PL/pgSQL `$$` bodies arrive as text), so CCN is counted from decision keywords in the comment/string-stripped body; nesting is deliberately not reported rather than guessed. Routine metrics still stamp `Symbol.complexity_estimate`.
- `sql_select_star`: bare `*` projection inside a view/materialized view/routine (ad-hoc scripts exempt).
- `sql_update_delete_without_where`: whole-table DML, near-zero FP by AST shape.
- `sql_cartesian_join`: comma-join with no predicate anywhere in the statement; explicit `CROSS JOIN` and old-style comma joins with a `WHERE` are exempt.

All four are registered explicitly in `_BIOMARKER_DIMENSIONS` as maintainability/performance-only (an unlisted marker would default into the defect score), ship at advisory weight under their own capped category, and SQL routine metrics are kept out of `function_metrics` so the calibrated defect-dimension method biomarkers can never fire on SQL. The defect golden guarantee is untouched. dbt/Jinja templates and statements whose parse looks garbled (dialect mismatch) emit nothing.

## Validation

- 39 new workspace tests (normalization first: quoting, schema prefixes, case, temp tables, interpolation) + 34 new health tests (every smell has a paired negative; defect score asserted unchanged with SQL findings present).
- Smoke, contracts: full-stack-fastapi-template as provider repo + a raw-SQL consumer repo: 4/4 exact cross-repo links, 0 false links on manual review, providers found through both the SQLModel and Alembic paths.
- Smoke, health: umami (35 SQL files, mixed Postgres/MySQL/ClickHouse) + jaffle-shop (15 dbt models): 0 false fires. Two live-found bugs fixed during smoke: the phantom-table lexing case above, and a garbled-dialect UPDATE that would have flagged a statement that does have a WHERE.
- Full unit suite: 6384 passed (one unrelated wall-clock timing test flaked under load and passes in isolation). ruff clean on all new files; ui and web type-checks pass.

Also updates `docs/LANGUAGE_SUPPORT.md`, `docs/CODE_HEALTH.md`, and the UI biomarker glossary (including completing the performance home-set mirror with the six newest perf markers).
