### PR TITLE
refactor(update): reconcile the workspace and single-repo update paths

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import sys
 import time
+from typing import Any
 
 import click
 import structlog
@@ -64,6 +65,28 @@ from .reporting import (
 from .workspace import _workspace_update
 
 log = structlog.get_logger(__name__)
+
+
+def _refresh_editor_stamp(repo_path: Any, agents_md: bool | None) -> None:
+    """Re-stamp managed editor files (CLAUDE.md / AGENTS.md), best-effort.
+
+    Runs on every update outcome — including the "already up to date" and
+    "no changed files" fast paths, matching the workspace flow — so the
+    "Last indexed" stamp always reflects the latest successful sync check
+    instead of freezing at the last content-changing run.
+    """
+    try:
+        from repowise.cli.editor_integrations.defaults import get_default_project_file_overrides
+        from repowise.cli.editor_setup import EditorSetupOptions, refresh_editor_project_files
+
+        options = None
+        if agents_md is not None:
+            options = EditorSetupOptions(
+                project_file_overrides=get_default_project_file_overrides(agents_md=agents_md),
+            )
+        refresh_editor_project_files(console, repo_path, options=options)
+    except Exception:
+        pass  # editor project-file refresh must never fail the update command
 
 
 def _surface_release_news(*, written_by: str | None) -> None:
@@ -377,6 +400,7 @@ def update_command(
         # current here while the DB head_commit is still the last full index.
         if not dry_run:
             stamp_head_commit(repo_path, head)
+            _refresh_editor_stamp(repo_path, agents_md)
         if emitter is not None:
             emitter.done(
                 ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
@@ -495,6 +519,7 @@ def update_command(
         # Keep the DB freshness stamp in lockstep with state.json: the server's
         # /repos endpoint reads head_commit from the row, not the state file.
         stamp_head_commit(repo_path, head)
+        _refresh_editor_stamp(repo_path, agents_md)
         if emitter is not None:
             emitter.done(
                 ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
@@ -522,6 +547,7 @@ def update_command(
             if emitter is not None:
                 emitter.error(str(exc))
             raise
+        _refresh_editor_stamp(repo_path, agents_md)
         if emitter is not None:
             emitter.done(
                 ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
@@ -621,6 +647,7 @@ def update_command(
             if emitter is not None:
                 emitter.error(str(exc))
             raise
+        _refresh_editor_stamp(repo_path, agents_md)
         if emitter is not None:
             emitter.done(
                 ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
@@ -851,7 +878,7 @@ def update_command(
         else:
             gen_progress.update(gen_task, advance=1, cost=cost_tracker.session_cost)
 
-    with (make_generation_progress() if emitter is None else nullcontext()) as gen_progress:
+    with make_generation_progress() if emitter is None else nullcontext() as gen_progress:
         gen_task = (
             gen_progress.add_task("Generating pages...", total=None, cost=0.0)
             if gen_progress is not None
@@ -1121,24 +1148,7 @@ def update_command(
         raise
 
     # ---- Editor project files (best-effort) ----
-    try:
-        from repowise.cli.editor_integrations.defaults import get_default_project_file_overrides
-        from repowise.cli.editor_setup import EditorSetupOptions, refresh_editor_project_files
-
-        editor_options = None
-        if agents_md is not None:
-            editor_options = EditorSetupOptions(
-                project_file_overrides=get_default_project_file_overrides(
-                    agents_md=agents_md,
-                ),
-            )
-        refresh_editor_project_files(
-            console,
-            repo_path,
-            options=editor_options,
-        )
-    except Exception:
-        pass  # Editor project-file refresh must never fail the update command
+    _refresh_editor_stamp(repo_path, agents_md)
 
     # Update state
     from repowise.cli.helpers import config_fingerprint

--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -113,29 +113,14 @@ def stamp_head_commit(repo_path: Any, head: str | None) -> None:
     if not head:
         return
 
-    async def _stamp() -> None:
-        from repowise.cli.helpers import get_db_url_for_repo
-        from repowise.core.persistence import (
-            create_engine,
-            create_session_factory,
-            get_session,
-            init_db,
-            upsert_repository,
-        )
+    # One stamper for both update paths: delegate to the core implementation
+    # the workspace updater uses. It touches only head_commit/updated_at on an
+    # existing row (the old upsert here clobbered url/default_branch with
+    # defaults), creates the row when missing from an existing wiki.db, and
+    # no-ops when wiki.db itself is absent instead of conjuring an empty DB.
+    from repowise.core.workspace.update import reconcile_repo_head_commit
 
-        url = get_db_url_for_repo(repo_path)
-        engine = create_engine(url)
-        await init_db(engine)
-        sf = create_session_factory(engine)
-        async with get_session(sf) as session:
-            await upsert_repository(
-                session,
-                name=Path(repo_path).name,
-                local_path=str(repo_path),
-                head_commit=head,
-            )
-
-    run_async(_stamp())
+    run_async(reconcile_repo_head_commit(Path(repo_path), head))
 
 
 def _persist_index_only_update(

--- a/packages/cli/src/repowise/cli/commands/workspace_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/workspace_cmd.py
@@ -475,7 +475,6 @@ def _run_index_for_repo(
         save_config,
         save_state,
     )
-    from repowise.core.pipeline.orchestrator import run_pipeline
     from repowise.core.workspace.update import run_cross_repo_hooks
 
     console.print(f"  Indexing [cyan]{alias}[/cyan]…")
@@ -519,47 +518,17 @@ def _run_index_for_repo(
     _inherit_distill_verdict(repo_path, primary_cfg)
 
     async def _do_index() -> tuple[int, int, int]:
-        result = await run_pipeline(
+        # Shared full-index step (run pipeline, persist, export the curated KG
+        # artifact so doc generation can load curated module grouping) — the
+        # same helper the workspace updater's first-time indexing uses.
+        from repowise.core.pipeline.full_index import index_repo_full
+
+        result = await index_repo_full(
             repo_path,
             commit_depth=int(commit_limit) if commit_limit else 500,
-            exclude_patterns=exclude_patterns or None,
-            generate_docs=False,
+            exclude_patterns=exclude_patterns,
         )
-
-        from repowise.core.persistence import (
-            create_engine,
-            create_session_factory,
-            get_session,
-            init_db,
-            upsert_repository,
-        )
-        from repowise.core.persistence.database import resolve_db_url
-        from repowise.core.pipeline import persist_pipeline_result
-
-        url = resolve_db_url(repo_path)
-        engine = create_engine(url)
-        await init_db(engine)
-        sf = create_session_factory(engine)
-        page_count = 0
-        async with get_session(sf) as session:
-            repo = await upsert_repository(
-                session, name=result.repo_name, local_path=str(repo_path)
-            )
-            await persist_pipeline_result(result, session, repo.id)
-
-        await engine.dispose()
-
-        # Save the curated KG artifact so doc generation can load curated
-        # module grouping (matches the `repowise init` idiom in
-        # init_cmd/command.py). Without it, generation falls back to raw
-        # community grouping and emits wrong module pages.
-        from repowise.cli.state_persistence import save_knowledge_graph_json
-
-        kg = getattr(result, "knowledge_graph_result", None)
-        if kg is not None:
-            save_knowledge_graph_json(repo_path, kg)
-
-        return result.file_count, result.symbol_count, page_count
+        return result.file_count, result.symbol_count, 0
 
     try:
         file_count, symbol_count, _ = run_async(_do_index())

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -21,6 +21,26 @@ from repowise.core.reasoning import (
 )
 from repowise.core.repo_config import CONFIG_FILENAME, load_repo_config
 
+# Update lock — coordinates concurrent `repowise update` invocations and lets
+# the augment hook suppress stale-wiki warnings while a refresh is in flight.
+# One shared implementation in core (the workspace updater used to carry a
+# hand-synced copy); re-exported here for the existing CLI/hook imports.
+from repowise.core.update_lock import (
+    UPDATE_LOCK_FILENAME as UPDATE_LOCK_FILENAME,
+)
+from repowise.core.update_lock import (
+    UPDATE_LOCK_STALE_AFTER_SECONDS as UPDATE_LOCK_STALE_AFTER_SECONDS,
+)
+from repowise.core.update_lock import (
+    acquire_update_lock as acquire_update_lock,
+)
+from repowise.core.update_lock import (
+    read_update_lock as read_update_lock,
+)
+from repowise.core.update_lock import (
+    release_update_lock as release_update_lock,
+)
+
 T = TypeVar("T")
 
 console = Console()
@@ -214,108 +234,6 @@ def save_state(repo_path: Path, state: dict[str, Any]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Update lock — coordinates concurrent `repowise update` invocations and
-# lets the augment hook suppress stale-wiki warnings while a refresh is in
-# flight (post-commit hook firing → tool-call warning would be spurious).
-# ---------------------------------------------------------------------------
-
-UPDATE_LOCK_FILENAME = ".update.lock"
-
-# Locks older than this are considered stale (a crashed update); the hook
-# will ignore them and the next update will overwrite. Generous enough to
-# cover a slow full-update on a large repo.
-UPDATE_LOCK_STALE_AFTER_SECONDS = 30 * 60
-
-
-def _update_lock_path(repo_path: Path) -> Path:
-    return get_repowise_dir(repo_path) / UPDATE_LOCK_FILENAME
-
-
-def acquire_update_lock(repo_path: Path, target_commit: str | None) -> Path:
-    """Write the update lock file. Returns its path.
-
-    The lock contains the PID and target commit so the augment hook can
-    decide whether a stale-wiki warning is redundant, plus the writing
-    process's creation-time token so ``read_update_lock`` can tell a live
-    lock owner apart from an unrelated process that recycled the PID.
-    Best-effort: if write fails (read-only fs, permissions), returns the
-    path anyway — callers must still call ``release_update_lock`` in a
-    finally block.
-    """
-    import time
-
-    from repowise.core.procutils import process_create_token
-
-    ensure_repowise_dir(repo_path)
-    lock_path = _update_lock_path(repo_path)
-    payload = {
-        "pid": os.getpid(),
-        "pid_create_token": process_create_token(os.getpid()),
-        "target_commit": target_commit,
-        "started_at": time.time(),
-    }
-    try:
-        lock_path.write_text(json.dumps(payload), encoding="utf-8")
-    except OSError:
-        pass
-    return lock_path
-
-
-def release_update_lock(repo_path: Path) -> None:
-    """Remove the update lock file. Safe to call if it doesn't exist."""
-    try:
-        _update_lock_path(repo_path).unlink(missing_ok=True)
-    except OSError:
-        pass
-
-
-def read_update_lock(repo_path: Path) -> dict[str, Any] | None:
-    """Return the lock payload if present and not stale, else ``None``.
-
-    A lock is stale when its wall-clock age exceeds
-    ``UPDATE_LOCK_STALE_AFTER_SECONDS`` (a hung-but-alive update must not
-    block forever) — or, much sooner, when its owning PID is positively
-    dead or has been recycled by an unrelated process. The PID probe means
-    a crashed/killed update (SIGKILL, power loss — paths atexit can't
-    cover) no longer blocks further updates for the full 30-minute window.
-    Probes that can't decide ("unknown") fall back to the wall clock, so a
-    live update is never treated as stale by mistake.
-    """
-    import time
-
-    from repowise.core.procutils import pid_alive, process_create_token
-
-    lock_path = _update_lock_path(repo_path)
-    if not lock_path.exists():
-        return None
-    try:
-        payload = json.loads(lock_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return None
-
-    started = payload.get("started_at")
-    if not isinstance(started, (int, float)):
-        return None
-    if time.time() - started > UPDATE_LOCK_STALE_AFTER_SECONDS:
-        return None
-
-    pid = payload.get("pid")
-    if isinstance(pid, int) and pid > 0:
-        alive = pid_alive(pid)
-        if alive is False:
-            return None
-        if alive is True:
-            stored_token = payload.get("pid_create_token")
-            # Legacy locks (pre-token) skip the identity check and rely on
-            # liveness + wall clock alone.
-            if isinstance(stored_token, str) and stored_token:
-                current_token = process_create_token(pid)
-                if current_token is not None and current_token != stored_token:
-                    return None
-    return payload
-
-
-# ---------------------------------------------------------------------------
 # Queued / pending markers — coordinate the post-commit hook with a running
 # update so rapid-fire commits don't spawn N concurrent updates that race
 # on save_state. Two distinct markers, deliberately:
@@ -488,16 +406,15 @@ def rotate_update_log_if_needed(repo_path: Path) -> None:
 
 
 def get_head_commit(repo_path: Path) -> str | None:
-    """Return the HEAD commit SHA or ``None`` if not a git repo."""
-    try:
-        import git as gitpython
+    """Return the HEAD commit SHA or ``None`` if not a git repo.
 
-        repo = gitpython.Repo(repo_path, search_parent_directories=True)
-        sha = repo.head.commit.hexsha
-        repo.close()
-        return sha
-    except Exception:
-        return None
+    Delegates to the core implementation (``git rev-parse HEAD``) so the CLI
+    and the workspace updater resolve HEAD identically — the old gitpython
+    version here could diverge on worktree/detached-HEAD edge cases.
+    """
+    from repowise.core.workspace.update import get_head_commit as _core_head
+
+    return _core_head(Path(repo_path))
 
 
 # ---------------------------------------------------------------------------

--- a/packages/core/src/repowise/core/pipeline/full_index.py
+++ b/packages/core/src/repowise/core/pipeline/full_index.py
@@ -1,0 +1,73 @@
+"""Full index-only pipeline run + persistence for a single repo.
+
+The "index this repo from scratch" step shared by ``repowise workspace add``
+and the workspace updater's first-time / fallback indexing — both previously
+hand-rolled the same run_pipeline → init_db → upsert_repository →
+persist_pipeline_result sequence, and only one of them exported the
+knowledge-graph artifact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+async def index_repo_full(
+    repo_path: Path,
+    *,
+    commit_depth: int = 500,
+    exclude_patterns: list[str] | None = None,
+    include_submodules: bool = False,
+    include_nested_repos: bool = False,
+    progress: Any | None = None,
+) -> Any:
+    """Run the full pipeline (index-only, no LLM docs) and persist everything.
+
+    Persists to the repo-local DB and exports ``.repowise/knowledge-graph.json``
+    so downstream doc generation can load the curated module grouping. Returns
+    the :class:`PipelineResult`.
+    """
+    from repowise.core.persistence import (
+        create_engine,
+        create_session_factory,
+        get_session,
+        init_db,
+        upsert_repository,
+    )
+    from repowise.core.persistence.database import resolve_db_url
+    from repowise.core.pipeline import run_pipeline
+    from repowise.core.pipeline.persist import persist_pipeline_result
+
+    result = await run_pipeline(
+        repo_path,
+        commit_depth=commit_depth,
+        exclude_patterns=exclude_patterns or None,
+        include_submodules=include_submodules,
+        include_nested_repos=include_nested_repos,
+        generate_docs=False,
+        progress=progress,
+    )
+
+    url = resolve_db_url(repo_path)
+    engine = create_engine(url)
+    try:
+        await init_db(engine)
+        sf = create_session_factory(engine)
+        async with get_session(sf) as session:
+            repo = await upsert_repository(
+                session,
+                name=result.repo_name,
+                local_path=str(repo_path),
+            )
+            await persist_pipeline_result(result, session, repo.id)
+    finally:
+        await engine.dispose()
+
+    kg = getattr(result, "knowledge_graph_result", None)
+    if kg is not None:
+        from repowise.core.analysis.knowledge_graph import save_knowledge_graph_json
+
+        save_knowledge_graph_json(repo_path, kg)
+
+    return result

--- a/packages/core/src/repowise/core/update_lock.py
+++ b/packages/core/src/repowise/core/update_lock.py
@@ -1,0 +1,106 @@
+"""Per-repo update lock — single-flight guard for ``repowise update``.
+
+One implementation shared by the CLI update command (``cli/helpers.py``
+re-exports these) and the core workspace updater, which previously carried a
+hand-synced copy. The lock file records the owning PID, its creation-time
+token, and the target commit so readers can tell a live update apart from a
+crashed one (and the augment hook can suppress redundant stale-wiki warnings).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+UPDATE_LOCK_FILENAME = ".update.lock"
+
+# Locks older than this are considered stale (a crashed update); the hook
+# will ignore them and the next update will overwrite. Generous enough to
+# cover a slow full-update on a large repo.
+UPDATE_LOCK_STALE_AFTER_SECONDS = 30 * 60
+
+
+def update_lock_path(repo_path: Path) -> Path:
+    return Path(repo_path) / ".repowise" / UPDATE_LOCK_FILENAME
+
+
+def acquire_update_lock(repo_path: Path, target_commit: str | None) -> Path:
+    """Write the update lock file. Returns its path.
+
+    The lock contains the PID and target commit so the augment hook can
+    decide whether a stale-wiki warning is redundant, plus the writing
+    process's creation-time token so ``read_update_lock`` can tell a live
+    lock owner apart from an unrelated process that recycled the PID.
+    Best-effort: if write fails (read-only fs, permissions), returns the
+    path anyway — callers must still call ``release_update_lock`` in a
+    finally block.
+    """
+    from repowise.core.procutils import process_create_token
+
+    lock_path = update_lock_path(repo_path)
+    payload = {
+        "pid": os.getpid(),
+        "pid_create_token": process_create_token(os.getpid()),
+        "target_commit": target_commit,
+        "started_at": time.time(),
+    }
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps(payload), encoding="utf-8")
+    except OSError:
+        pass
+    return lock_path
+
+
+def release_update_lock(repo_path: Path) -> None:
+    """Remove the update lock file. Safe to call if it doesn't exist."""
+    with contextlib.suppress(OSError):
+        update_lock_path(repo_path).unlink(missing_ok=True)
+
+
+def read_update_lock(repo_path: Path) -> dict[str, Any] | None:
+    """Return the lock payload if present and not stale, else ``None``.
+
+    A lock is stale when its wall-clock age exceeds
+    ``UPDATE_LOCK_STALE_AFTER_SECONDS`` (a hung-but-alive update must not
+    block forever) — or, much sooner, when its owning PID is positively
+    dead or has been recycled by an unrelated process. The PID probe means
+    a crashed/killed update (SIGKILL, power loss — paths atexit can't
+    cover) no longer blocks further updates for the full 30-minute window.
+    Probes that can't decide ("unknown") fall back to the wall clock, so a
+    live update is never treated as stale by mistake.
+    """
+    from repowise.core.procutils import pid_alive, process_create_token
+
+    lock_path = update_lock_path(repo_path)
+    if not lock_path.exists():
+        return None
+    try:
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    started = payload.get("started_at")
+    if not isinstance(started, (int, float)):
+        return None
+    if time.time() - started > UPDATE_LOCK_STALE_AFTER_SECONDS:
+        return None
+
+    pid = payload.get("pid")
+    if isinstance(pid, int) and pid > 0:
+        alive = pid_alive(pid)
+        if alive is False:
+            return None
+        if alive is True:
+            stored_token = payload.get("pid_create_token")
+            # Legacy locks (pre-token) skip the identity check and rely on
+            # liveness + wall clock alone.
+            if isinstance(stored_token, str) and stored_token:
+                current_token = process_create_token(pid)
+                if current_token is not None and current_token != stored_token:
+                    return None
+    return payload

--- a/packages/core/src/repowise/core/workspace/update.py
+++ b/packages/core/src/repowise/core/workspace/update.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import asyncio
 import json as _json
 import logging
-import os
 import sqlite3
 import subprocess
 import time
@@ -20,22 +19,24 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+# Per-repo update lock — the shared single-flight guard (one implementation
+# for the CLI update command and this workspace updater, which used to carry
+# a hand-synced copy). ``update_single_repo_index`` calls these directly,
+# bypassing the CLI lock acquisition in update_cmd, so workspace updates are
+# themselves single-flight per repo.
+from repowise.core.update_lock import (
+    acquire_update_lock as _acquire_lock,
+)
+from repowise.core.update_lock import (
+    read_update_lock as _read_lock,
+)
+from repowise.core.update_lock import (
+    release_update_lock as _release_lock,
+)
+
 from .config import WorkspaceConfig
 
 _log = logging.getLogger("repowise.workspace.update")
-
-
-# ---------------------------------------------------------------------------
-# Per-repo update lock — duplicated from cli/helpers.py to avoid a core →
-# cli import. The format and stale-after threshold MUST stay in sync with
-# the canonical helpers; both versions are tiny and rarely change. This
-# lives in core/ so ``update_single_repo_index`` (which workspace updates
-# call directly, bypassing the CLI lock acquisition in update_cmd.py) is
-# itself single-flight per repo.
-# ---------------------------------------------------------------------------
-
-_LOCK_FILENAME = ".update.lock"
-_LOCK_STALE_AFTER_SECONDS = 30 * 60
 
 
 def _merged_repo_excludes(
@@ -62,73 +63,6 @@ def _merged_repo_excludes(
         if pattern not in patterns:
             patterns.append(pattern)
     return patterns
-
-
-def _lock_path(repo_path: Path) -> Path:
-    return repo_path / ".repowise" / _LOCK_FILENAME
-
-
-def _read_lock(repo_path: Path) -> dict[str, Any] | None:
-    """Return a live lock payload, or None when absent / stale / unreadable.
-
-    Mirrors ``cli/helpers.read_update_lock``: a lock is stale past the
-    wall-clock window, or immediately when its owning PID is positively
-    dead / recycled (so a crashed update can't block the repo for 30 min).
-    Unknown probe results fall back to the wall clock.
-    """
-    from repowise.core.procutils import pid_alive, process_create_token
-
-    path = _lock_path(repo_path)
-    if not path.exists():
-        return None
-    try:
-        payload = _json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return None
-    started = payload.get("started_at")
-    if not isinstance(started, (int, float)):
-        return None
-    if time.time() - started > _LOCK_STALE_AFTER_SECONDS:
-        return None
-
-    pid = payload.get("pid")
-    if isinstance(pid, int) and pid > 0:
-        alive = pid_alive(pid)
-        if alive is False:
-            return None
-        if alive is True:
-            stored_token = payload.get("pid_create_token")
-            if isinstance(stored_token, str) and stored_token:
-                current_token = process_create_token(pid)
-                if current_token is not None and current_token != stored_token:
-                    return None
-    return payload
-
-
-def _acquire_lock(repo_path: Path, target_commit: str | None) -> None:
-    """Best-effort write of the lock file. Caller still must release."""
-    from repowise.core.procutils import process_create_token
-
-    try:
-        (repo_path / ".repowise").mkdir(parents=True, exist_ok=True)
-        _lock_path(repo_path).write_text(
-            _json.dumps(
-                {
-                    "pid": os.getpid(),
-                    "pid_create_token": process_create_token(os.getpid()),
-                    "target_commit": target_commit,
-                    "started_at": time.time(),
-                }
-            ),
-            encoding="utf-8",
-        )
-    except OSError:
-        pass
-
-
-def _release_lock(repo_path: Path) -> None:
-    with suppress(OSError):
-        _lock_path(repo_path).unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------
@@ -303,7 +237,15 @@ async def reconcile_repo_head_commit(repo_path: Path, head: str | None) -> None:
     Stamps ``head_commit`` only on drift (avoids needless churn), but always
     advances ``updated_at`` so the freshness time reflects the latest
     sync-check — a routine ``repowise update`` that finds nothing to do still
-    counts as "verified current now". A no-op when the repo row is absent.
+    counts as "verified current now". Creates the row when it is missing from
+    an existing ``wiki.db`` (self-heals a corrupt/blank store — the policy the
+    CLI's ``stamp_head_commit``, now a thin wrapper over this, always had);
+    still a no-op when ``wiki.db`` itself is absent, so a stamp can never
+    conjure an empty database.
+
+    This is the single head-commit stamper for both update paths — the CLI
+    fast paths and the workspace updater used to run two implementations with
+    different creation semantics.
     """
     if not head or not (repo_path / ".repowise" / "wiki.db").is_file():
         return
@@ -312,6 +254,7 @@ async def reconcile_repo_head_commit(repo_path: Path, head: str | None) -> None:
         create_session_factory,
         get_session,
         init_db,
+        upsert_repository,
     )
     from ..persistence.crud import get_repository_by_path
     from ..persistence.database import resolve_db_url
@@ -323,7 +266,14 @@ async def reconcile_repo_head_commit(repo_path: Path, head: str | None) -> None:
         sf = create_session_factory(engine)
         async with get_session(sf) as session:
             repo = await get_repository_by_path(session, str(repo_path))
-            if repo is not None:
+            if repo is None:
+                await upsert_repository(
+                    session,
+                    name=repo_path.name,
+                    local_path=str(repo_path),
+                    head_commit=head,
+                )
+            else:
                 if repo.head_commit != head:
                     repo.head_commit = head
                 repo.updated_at = datetime.now(UTC)
@@ -349,13 +299,11 @@ async def _incremental_repo_update(
     Mirrors the single-repo ``repowise update --index-only`` flow: diff
     ``base_ref..HEAD``, rebuild the graph (parse-cache backed), re-index git
     metadata for the changed files only, run partial health/dead-code
-    analysis, and upsert the results. State-file updates stay with the
-    caller (``update_workspace``'s ``_update_one``).
-
-    Returns ``None`` when the diff contains deletions or renames: the
-    incremental persistence is upsert-only, so rows for removed paths would
-    linger in graph/health tables forever. The full pipeline's
-    delete-then-insert persistence prunes them — the caller runs it instead.
+    analysis, and upsert the results. Deletions and renames are handled the
+    same way the single-repo path handles them — stale rows are pruned
+    against the rebuilt graph and pages for removed files are tombstoned —
+    instead of the old bail-out to a full re-index. State-file updates stay
+    with the caller (``update_workspace``'s ``_update_one``).
 
     Raises on failure — the caller falls back to the full pipeline.
     """
@@ -377,16 +325,6 @@ async def _incremental_repo_update(
         # commits, or every change excluded). Report success so the caller
         # bumps ``last_sync_commit`` instead of re-diffing forever.
         return RepoUpdateResult(alias=alias, updated=True)
-
-    if any(fd.status in ("deleted", "renamed") for fd in file_diffs):
-        # Upsert-only persistence can't remove rows for paths that no longer
-        # exist; hand off to the full pipeline so its prune pass cleans up.
-        _log.info(
-            "workspace_update: %s has deleted/renamed files — using the full "
-            "pipeline so stale index rows are pruned",
-            alias,
-        )
-        return None
 
     # Per-repo config, like the single-repo update path. The workspace-level
     # ``exclude_patterns`` (when provided) apply on top.
@@ -446,6 +384,10 @@ async def _incremental_repo_update(
         partial_health_report,
         [fd.path for fd in file_diffs],
         current_graph_file_paths={pf.file_info.path for pf in parsed_files},
+        # Tombstones pages for deleted/renamed paths, mirroring the single-repo
+        # path — without this a page for a removed file misleads retrieval
+        # until the next full regeneration.
+        file_diffs=file_diffs,
         knowledge_graph_result=kg,
         log=_log.info,
     )
@@ -481,27 +423,38 @@ async def update_single_repo_index(
     Already-indexed repos (a persisted ``last_sync_commit`` whose commit
     still resolves, plus an existing ``wiki.db``) go through the incremental
     update path — changed-files diff, partial analysis, upsert persistence.
-    Never-indexed repos, and any incremental failure, run the full
-    ingestion pipeline instead (index-only — no wiki pages).
+    Never-indexed repos, config changes (``config.yaml`` / health-rules
+    fingerprint drift, which invalidates every persisted score), and any
+    incremental failure run the full ingestion pipeline instead (index-only —
+    no wiki pages).
     """
-    from ..persistence import (
-        create_engine,
-        create_session_factory,
-        get_session,
-        init_db,
-        upsert_repository,
-    )
-    from ..persistence.database import resolve_db_url
-    from ..pipeline import run_pipeline
-    from ..pipeline.persist import persist_pipeline_result
+    from ..repo_config import config_fingerprint
 
     alias = repo_path.name
     state = read_repo_state(repo_path)
     base_ref = state.get("last_sync_commit")
     merged_excludes = _merged_repo_excludes(repo_path, exclude_patterns)
 
+    # Config drift check, mirroring the single-repo update path: a changed
+    # config.yaml / health-rules.json invalidates persisted health scores and
+    # exclude handling, so the incremental (changed-files-only) path must not
+    # run. The full pipeline below re-derives everything under the new config;
+    # _update_one stamps the new fingerprint into state.json afterwards.
+    # A missing stored fingerprint (legacy state) is NOT drift — same as the
+    # single-repo path, which only stamps it — so legacy repos don't pay a
+    # surprise full re-index.
+    stored_fp = state.get("config_fingerprint")
+    config_changed = stored_fp is not None and stored_fp != config_fingerprint(repo_path)
+    if config_changed and (repo_path / ".repowise" / "wiki.db").is_file():
+        _log.info(
+            "workspace_update: %s config fingerprint drifted — full re-index "
+            "so health scores reflect the new config",
+            alias,
+        )
+
     if (
-        base_ref
+        not config_changed
+        and base_ref
         and (repo_path / ".repowise" / "wiki.db").is_file()
         and commit_exists(repo_path, str(base_ref))
     ):
@@ -514,7 +467,6 @@ async def update_single_repo_index(
             )
             if incremental_result is not None:
                 return incremental_result
-            # None → the diff needs the full pipeline's prune pass.
         except Exception:
             _log.warning(
                 "Incremental update failed for %s — falling back to the full pipeline",
@@ -523,45 +475,25 @@ async def update_single_repo_index(
             )
 
     try:
-        result = await run_pipeline(
+        from ..pipeline.full_index import index_repo_full
+
+        result = await index_repo_full(
             repo_path,
             commit_depth=commit_depth,
-            exclude_patterns=merged_excludes or None,
+            exclude_patterns=merged_excludes,
             include_submodules=bool(state.get("include_submodules", False)),
             include_nested_repos=bool(state.get("include_nested_repos", False)),
-            generate_docs=False,
             progress=progress,
         )
 
-        # Persist to repo-local DB
-        url = resolve_db_url(repo_path)
-        engine = create_engine(url)
-        await init_db(engine)
-        sf = create_session_factory(engine)
-
-        async with get_session(sf) as session:
-            repo = await upsert_repository(
-                session,
-                name=result.repo_name,
-                local_path=str(repo_path),
-            )
-            await persist_pipeline_result(result, session, repo.id)
-
-        await engine.dispose()
-
-        # Export the pipeline's freshly built KG so the artifact matches the
-        # rows just persisted — the workspace add path already does this; the
-        # update-triggered full index previously skipped it.
+        # index_repo_full already exported knowledge-graph.json; build the
+        # state.json summary block so _update_one stamps it too.
         kg_state: dict[str, Any] | None = None
         kg = getattr(result, "knowledge_graph_result", None)
         if kg is not None:
-            from ..analysis.knowledge_graph import build_kg_state, save_knowledge_graph_json
+            from ..analysis.knowledge_graph import build_kg_state
 
-            try:
-                save_knowledge_graph_json(repo_path, kg)
-                kg_state = build_kg_state(kg)
-            except Exception:
-                _log.warning("knowledge-graph.json export failed for %s", alias, exc_info=True)
+            kg_state = build_kg_state(kg)
 
         return RepoUpdateResult(
             alias=alias,
@@ -747,6 +679,13 @@ async def update_workspace(
                 state["last_sync_commit"] = new_head
                 if result.kg_state:
                     state["knowledge_graph"] = result.kg_state
+                # Stamp the config fingerprint so the drift check in
+                # update_single_repo_index stays calibrated (and legacy repos
+                # without one stop re-triggering the full re-index).
+                with suppress(Exception):
+                    from ..repo_config import config_fingerprint
+
+                    state["config_fingerprint"] = config_fingerprint(path)
                 # Mark first-time so downstream tooling (status, doctor) can
                 # distinguish a never-indexed repo from one that's been
                 # updated at least once.

--- a/tests/unit/cli/test_editor_setup.py
+++ b/tests/unit/cli/test_editor_setup.py
@@ -512,12 +512,20 @@ def test_claude_refresh_project_files_skips_when_options_disable_file(
 
 
 def test_update_command_uses_editor_refresh_abstraction() -> None:
-    source = inspect.getsource(update_cmd.update_command.callback)
+    from repowise.cli.commands.update_cmd.command import _refresh_editor_stamp
 
-    assert "refresh_editor_project_files" in source
-    assert "ClaudeMdGenerator" not in source
-    assert "EditorFileDataFetcher" not in source
-    assert "claude_md" not in source
+    command_source = inspect.getsource(update_cmd.update_command.callback)
+    stamp_source = inspect.getsource(_refresh_editor_stamp)
+
+    # The command routes every editor-file write through the shared stamp
+    # helper, which in turn uses the refresh abstraction — never the raw
+    # generator/fetcher internals.
+    assert "_refresh_editor_stamp" in command_source
+    assert "refresh_editor_project_files" in stamp_source
+    for source in (command_source, stamp_source):
+        assert "ClaudeMdGenerator" not in source
+        assert "EditorFileDataFetcher" not in source
+        assert "claude_md" not in source
 
 
 def test_workspace_update_refreshes_agents_for_selected_repos(

--- a/tests/unit/workspace/test_incremental_update.py
+++ b/tests/unit/workspace/test_incremental_update.py
@@ -3,9 +3,10 @@
 ``update_single_repo_index`` previously re-ran the full init pipeline for
 every stale repo. Already-indexed repos (persisted ``last_sync_commit`` that
 still resolves + existing ``wiki.db``) now take the incremental update path —
-changed-files diff, partial analysis, upsert persistence — and inherit the
-persisted state flags (``git_tier``, ``include_submodules``,
-``include_nested_repos``). Never-indexed repos and incremental failures fall
+changed-files diff, partial analysis, upsert persistence (including prune +
+tombstone for deletions/renames) — and inherit the persisted state flags
+(``git_tier``, ``include_submodules``, ``include_nested_repos``).
+Never-indexed repos, config-fingerprint drift, and incremental failures fall
 back to the full pipeline.
 """
 
@@ -170,10 +171,10 @@ def test_no_relevant_changes_still_reports_updated(tmp_path, forbid_full_pipelin
     assert result.file_count == 0
 
 
-def test_deleted_file_falls_back_to_full_pipeline(tmp_path, stub_full_pipeline):
-    """Incremental persistence is upsert-only — it can't prune rows for
-    removed paths. A diff containing deletions must run the full pipeline
-    (delete-then-insert) so stale graph/health rows are cleaned up."""
+def test_deleted_file_stays_on_incremental_path(tmp_path, forbid_full_pipeline):
+    """Deletions are handled incrementally: the persistence pass prunes rows
+    against the rebuilt graph and tombstones pages for removed paths, same as
+    the single-repo update — no more full-pipeline fallback."""
     repo = _make_git_repo(tmp_path)
     _add_commit(repo, "b.py")
     base = get_head_commit(repo)
@@ -184,17 +185,33 @@ def test_deleted_file_falls_back_to_full_pipeline(tmp_path, stub_full_pipeline):
 
     result = asyncio.run(update_single_repo_index(repo))
 
-    _assert_full_pipeline_fallback(result, stub_full_pipeline)
+    assert result.error is None
+    assert result.updated is True
 
 
-def test_renamed_file_falls_back_to_full_pipeline(tmp_path, stub_full_pipeline):
-    """Renames leave the old path behind in upsert-only persistence —
-    same prune requirement as deletions."""
+def test_renamed_file_stays_on_incremental_path(tmp_path, forbid_full_pipeline):
+    """Renames prune the old path and index the new one incrementally —
+    same handling as deletions."""
     repo = _make_git_repo(tmp_path)
     base = get_head_commit(repo)
     _mark_indexed(repo, base)
     _git(repo, "mv", "a.py", "renamed.py")
     _git(repo, "commit", "-m", "rename a.py")
+
+    result = asyncio.run(update_single_repo_index(repo))
+
+    assert result.error is None
+    assert result.updated is True
+
+
+def test_config_drift_runs_full_reindex(tmp_path, stub_full_pipeline):
+    """A stored config fingerprint that no longer matches the on-disk config
+    invalidates every persisted health score — the repo must take the full
+    pipeline, not the changed-files-only path."""
+    repo = _make_git_repo(tmp_path)
+    base = get_head_commit(repo)
+    _mark_indexed(repo, base, config_fingerprint="0" * 64)
+    _add_commit(repo, "b.py")
 
     result = asyncio.run(update_single_repo_index(repo))
 


### PR DESCRIPTION
Follow-up to #702. The workspace and single-repo update flows had drifted into parallel implementations with different behavior; this consolidates the duplicated pieces and closes the behavioral gaps.

## Deduplication

- **One update lock.** New `core/update_lock.py`; `cli/helpers` re-exports it and `core/workspace/update.py` drops its hand-synced copy (whose own comment admitted the duplication and asked for the formats to be kept in sync by hand — that requirement is now structural).
- **One `get_head_commit`.** The CLI's gitpython version now delegates to the core `git rev-parse` implementation, removing a potential worktree/detached-HEAD divergence between two same-named functions.
- **One head-commit stamper.** `reconcile_repo_head_commit` is the single implementation: touches only `head_commit`/`updated_at` on an existing row, creates the row when missing from an existing `wiki.db`, and never conjures an empty database. The CLI's `stamp_head_commit` is now a thin wrapper — its old upsert also clobbered `url`/`default_branch` with defaults on every fast-path stamp.
- **One first-time-index step.** New `core/pipeline/full_index.index_repo_full` (run pipeline, persist, export `knowledge-graph.json`) shared by `workspace add` and the workspace updater's first-time/fallback indexing, which previously skipped the KG artifact export.

## Behavioral gaps closed

- **Workspace updates now honor config changes.** A drifted `config.yaml` / health-rules fingerprint routes the repo through the full re-index so health scores pick up the new rules, matching single-repo behavior; previously `update --workspace` silently ignored member-repo config changes. The fingerprint is stamped into `state.json` after every update (missing legacy fingerprints are not treated as drift, same as single-repo).
- **Deletions/renames stay on the incremental path in workspace mode** (stale-row prune + page tombstones, same as single-repo) instead of silently falling back to a full re-index of the whole repo.
- **CLAUDE.md/AGENTS.md stamping is uniform.** Every single-repo update outcome — already up to date, no changed files, index-only, config re-score, full generation — now re-stamps the editor files the way the workspace flow always did, so the "Last indexed" stamp tracks the latest successful sync check instead of freezing at the last content-changing run.

## Verification

- Full unit suite green (6,523 passed); affected suites re-run green after rebasing onto #702's merge.
- Dogfooded on this repo: a no-op `repowise update` now advances the CLAUDE.md freshness stamp; the workspace lock round-trip parity test now exercises one shared implementation.