### PR TITLE
test: preview the updated bot comment (do not merge)

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/complexity/walker.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/walker.py
@@ -29,6 +29,9 @@ drives the individual passes, each of which lives in its own sibling module:
 - ``error_handling`` — error-handling anti-patterns
 - ``perf_walk``      — the performance-risk pass
 - ``class_analysis`` — class-level LCOM4 / god-class metrics
+
+Each pass is independent and side-effect free, so ``walk_file`` can run them
+in any order over the single parsed tree.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Test PR to preview the refreshed Repowise PR-bot comment on a real diff. Touches a known hotspot file (`complexity/walker.py`) with a docs-only, no-op change so the bot fires its hotspot / change-risk / review-priority signals without altering behavior.

What to look at in the bot comment:
- The new **At a glance** opener (one factual line of what the PR touches, with the per-module breakdown in a nested expander).
- Auto-labels on the PR (`repowise:*`).
- The **Repowise / code health** Check Run and its details page.

Safe to close without merging.
