### PR TITLE
release: v0.28.0 — reliable incremental updates, Lean 4 support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.28.0] — 2026-07-07
+
+### Added
+- **Lean 4 support.** A lightweight regex tier brings symbol extraction to Lean 4 codebases. (#600)
+
+### Changed
+- **Reliable incremental updates.** `repowise update` was reworked this cycle. Incremental runs now rebuild the knowledge graph, so an updated index stays as fresh as a full one instead of serving a stale graph (#702). The store is persisted and locked atomically with honest failure reporting, so an interrupted update rolls back cleanly rather than leaving a torn store behind (#706). The workspace and single-repo update paths were reconciled onto one code path (#703).
+
+### Fixed
+- **Cleaner code-health flagging.** Resolved false-flag presentation in Code Health across grouping, dominant-cause attribution, and floor magnitude. (#700)
+- **Contributors counted once.** GitHub noreply emails are folded together, so one person no longer shows up as two contributors. (#701)
+- **Fewer Go dead-code false positives.** Same-file type references are rescued from unused-export false positives in Go. (#629)
+
+### Documentation
+- **No-key quickstart.** Published a verified no-API-key quickstart in the README and on repowise.dev. (#627)
+
+---
+
 ## [0.27.0] — 2026-07-05
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.28.0] — 2026-07-07
+
+### Added
+- **Lean 4 support.** A lightweight regex tier brings symbol extraction to Lean 4 codebases. (#600)
+
+### Changed
+- **Reliable incremental updates.** `repowise update` was reworked this cycle. Incremental runs now rebuild the knowledge graph, so an updated index stays as fresh as a full one instead of serving a stale graph (#702). The store is persisted and locked atomically with honest failure reporting, so an interrupted update rolls back cleanly rather than leaving a torn store behind (#706). The workspace and single-repo update paths were reconciled onto one code path (#703).
+
+### Fixed
+- **Cleaner code-health flagging.** Resolved false-flag presentation in Code Health across grouping, dominant-cause attribution, and floor magnitude. (#700)
+- **Contributors counted once.** GitHub noreply emails are folded together, so one person no longer shows up as two contributors. (#701)
+- **Fewer Go dead-code false positives.** Same-file type references are rescued from unused-export false positives in Go. (#629)
+
+### Documentation
+- **No-key quickstart.** Published a verified no-API-key quickstart in the README and on repowise.dev. (#627)
+
+---
+
 ## [0.27.0] — 2026-07-05
 
 ### Added

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.27.0"
+version = "0.28.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3056,7 +3056,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.27.0"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Release v0.28.0

Version bump + changelog for the v0.28.0 PyPI release. Cut from latest `main`.

### What's in this release

- **Reliable incremental updates.** `repowise update` was reworked: incremental runs rebuild the knowledge graph so an updated index stays as fresh as a full one (#702), the store is persisted and locked atomically with honest failure reporting so an interrupted update rolls back cleanly instead of leaving a torn store (#706), and the workspace and single-repo update paths were reconciled onto one code path (#703).
- **Lean 4 support** via a lightweight regex import tier (#600).
- **Fixes:** cleaner Code Health false-flag presentation (#700), contributors folded so GitHub noreply emails don't double-count one person (#701), fewer Go dead-code false positives on same-file type references (#629).
- **Docs:** verified no-API-key quickstart (#627).

### Version bump

- `pyproject.toml`, `packages/{cli,core,server}/src/**/__init__.py` → `0.28.0`
- `uv.lock` self-entry regenerated (`uv lock`)
- Plugin manifests: `.claude-plugin/marketplace.json` + `plugins/claude-code/.claude-plugin/plugin.json` → `0.28.0`
- `docs/CHANGELOG.md` + bundled copy resynced

### Test plan

- [x] Version drift grep clean (only `0.28.0`, no `0.27.0`)
- [x] Bundled-changelog sync guard test passes
- [x] Plugin MCP tool surface matches live `list_tools()` (no plugin surface change this cycle)
- [x] Wheel builds cleanly (`uv build --wheel`) with commands, `.scm` queries, `.j2` templates present
- [x] Web build (`npm run build --workspace packages/web`) green — standalone `server.js` emitted, workspace-package code inlined into compiled chunks
- [ ] End-to-end smoke: `repowise --version` + `repowise serve` (post-merge)

### Merge convention

Merge with a **regular merge commit** (not squash) so the tag points at a real merge of the bump-only diff and artifact provenance is traceable.
