### PR TITLE
feat(health): color the performance map by findings and coverage, not the score

### DIFF
--- a/packages/server/src/repowise/server/routers/code_health.py
+++ b/packages/server/src/repowise/server/routers/code_health.py
@@ -22,6 +22,7 @@ from repowise.core.analysis.health.defect_accuracy import compute_defect_accurac
 from repowise.core.analysis.health.grading import band_for
 from repowise.core.analysis.health.grading import distribution as health_distribution
 from repowise.core.analysis.health.models import Severity
+from repowise.core.analysis.health.perf.coverage import supported_perf_languages
 from repowise.core.analysis.health.scoring import (
     CATEGORY_CAPS,
     biomarker_category,
@@ -112,7 +113,13 @@ def _leads_by_file(findings: list[Any]) -> dict[str, dict]:
     return {path: _primary_and_magnitude(fs) for path, fs in by_file.items()}
 
 
-def _metric_to_dict(m: Any, lead: dict | None = None) -> dict:
+def _metric_to_dict(
+    m: Any,
+    lead: dict | None = None,
+    *,
+    perf_findings: int = 0,
+    perf_analyzed: bool | None = None,
+) -> dict:
     return {
         "file_path": m.file_path,
         "score": round(m.score, 2),
@@ -129,6 +136,12 @@ def _metric_to_dict(m: Any, lead: dict | None = None) -> dict:
         "defect_score": _round_opt(getattr(m, "defect_score", None)),
         "maintainability_score": _round_opt(getattr(m, "maintainability_score", None)),
         "performance_score": _round_opt(getattr(m, "performance_score", None)),
+        # Performance lens inputs for the code-health map: the open perf-finding
+        # count colors the heat, and ``perf_analyzed`` (did a detector run on this
+        # language?) separates green ("analyzed, none found") from grey ("never
+        # looked"). Presentation only — the score above is untouched.
+        "performance_findings": perf_findings,
+        "performance_analyzed": perf_analyzed,
         # Dominant-cause lead + pre-clamp magnitude (null when findings weren't
         # loaded for this row, or the file is clean). Additive; readers degrade.
         "primary_biomarker": lead.get("primary_biomarker") if lead else None,
@@ -608,11 +621,28 @@ async def list_health_files(
     page_paths = {m.file_path for m in page}
     findings = await crud.get_health_findings(session, repo_id)
     leads = _leads_by_file([f for f in findings if f.file_path in page_paths])
+    # Per-file performance signal for the map's performance lens: open perf-
+    # finding counts + whether a perf detector ran on the file's language. Colors
+    # the lens by findings/coverage instead of the uniformly-green [9,10] score.
+    perf_counts: dict[str, int] = {}
+    for fnd in findings:
+        if (getattr(fnd, "dimension", None) or "defect") == "performance":
+            perf_counts[fnd.file_path] = perf_counts.get(fnd.file_path, 0) + 1
+    lang_by_path = await crud.get_file_language_map(session, repo_id)
+    perf_langs = supported_perf_languages()
     return {
         "total": total,
         "offset": offset,
         "limit": limit,
-        "files": [_metric_to_dict(m, leads.get(m.file_path)) for m in page],
+        "files": [
+            _metric_to_dict(
+                m,
+                leads.get(m.file_path),
+                perf_findings=perf_counts.get(m.file_path, 0),
+                perf_analyzed=lang_by_path.get(m.file_path) in perf_langs,
+            )
+            for m in page
+        ],
     }
 
 

--- a/packages/types/src/health.ts
+++ b/packages/types/src/health.ts
@@ -179,6 +179,21 @@ export interface HealthFileMetric {
   maintainability_score?: number | null;
   performance_score?: number | null;
   /**
+   * Open performance-risk findings on this file. The performance lens on the
+   * code-health map colors by this count (+ `performance_analyzed`), not by the
+   * [9,10]-compressed `performance_score`, so a file with 40 N+1s reads
+   * differently from one with 1. Absent on payloads predating the perf pass.
+   */
+  performance_findings?: number | null;
+  /**
+   * Whether a performance detector actually ran on this file (its language has a
+   * registered perf dialect). `false` = unsupported language, the perf pass never
+   * looked — a silent 10.0 — so the map greys the file as "not analyzed" instead
+   * of green. High-precision / low-recall: green means "a detector ran and
+   * surfaced nothing", never "verified fast". `null`/absent on older payloads.
+   */
+  performance_analyzed?: boolean | null;
+  /**
    * Dominant-cause lead: the biomarker + reason of this file's worst finding, so
    * a low file can headline "the one reason" instead of a wall of markers. Null
    * when the row carries no findings or the payload predates this field.

--- a/packages/ui/__tests__/health/code-health-map.test.tsx
+++ b/packages/ui/__tests__/health/code-health-map.test.tsx
@@ -106,6 +106,35 @@ describe("CodeHealthMap", () => {
     expect(getByText("≥80%")).toBeInTheDocument();
   });
 
+  it("performance lens colors by findings + coverage, not the score", () => {
+    // Three files: covered-with-findings (heat), covered-clean (green), and an
+    // unsupported-language file the perf pass never ran on (grey, NOT green).
+    const files: CodeHealthMapFile[] = [
+      { ...f("core/hot.py", 120, "core"), performance_findings: 7, performance_analyzed: true },
+      { ...f("core/clean.py", 80, "core"), performance_findings: 0, performance_analyzed: true },
+      { ...f("core/leveldb.cc", 60, "core"), performance_findings: 0, performance_analyzed: false },
+    ];
+    const { container, getByText } = render(
+      <CodeHealthMap files={files} overlay="performance" />,
+    );
+    // Educational legend: findings-first, plus the "not analyzed" grey.
+    expect(getByText("5+ findings")).toBeInTheDocument();
+    expect(getByText("Not analyzed")).toBeInTheDocument();
+    expect(getByText("Analyzed, none found")).toBeInTheDocument();
+
+    const fillFor = (path: string) => {
+      const title = Array.from(container.querySelectorAll("title")).find((t) =>
+        t.textContent?.startsWith(path),
+      );
+      return (title?.parentElement as SVGCircleElement | undefined)?.getAttribute("fill");
+    };
+    // A file with findings burns red; a covered-clean file is green; an
+    // un-analyzed file is grey (tertiary) — never green.
+    expect(fillFor("core/hot.py")).toBe("var(--color-error)");
+    expect(fillFor("core/clean.py")).toBe("var(--color-success)");
+    expect(fillFor("core/leveldb.cc")).toBe("var(--color-text-tertiary)");
+  });
+
   it("fires onOverlayChange when a lens-switch button is clicked", () => {
     const onOverlayChange = vi.fn();
     const { getByRole } = render(

--- a/packages/ui/src/health/code-health-map.tsx
+++ b/packages/ui/src/health/code-health-map.tsx
@@ -14,8 +14,16 @@ export interface CodeHealthMapFile {
   has_test_file: boolean;
   /** Maintainability pillar score (1–10) — drives the maintainability overlay. */
   maintainability_score?: number | null;
-  /** Performance-risk pillar score (1–10) — drives the performance overlay. */
+  /** Performance-risk pillar score (1–10) — computed but NOT used to color the
+   *  performance overlay (it is compressed to [9,10] and reads uniformly green).
+   *  The performance lens colors by {@link performance_findings} + coverage. */
   performance_score?: number | null;
+  /** Open performance-risk findings on this file — drives the performance heat. */
+  performance_findings?: number | null;
+  /** Whether a perf detector ran on this file's language (has a dialect). `false`
+   *  → grey "not analyzed"; the pillar is high-precision / low-recall, so green
+   *  can only mean "a detector ran and surfaced nothing", never "verified fast". */
+  performance_analyzed?: boolean | null;
   /** 0–100 churn percentile — drives the churn overlay. */
   churn_percentile?: number | null;
   /** Reclaimable lines on this file — drives the dead-code overlay. */
@@ -109,6 +117,27 @@ function coverageFill(pct: number | null | undefined): string {
   return "var(--color-error)";
 }
 
+/**
+ * Performance lens fill — by findings + coverage state, NOT by the performance
+ * score. The score is capped to [9,10] so a score ramp paints the whole map
+ * green and hides where the risk actually is. Instead:
+ *   heat (yellow→red) = open perf findings, so 40 N+1s ≠ 1;
+ *   green            = a detector ran and surfaced nothing (NOT "verified fast");
+ *   grey             = no detector for this language ever ran ("not analyzed").
+ * This keeps the pillar's high-precision / low-recall honesty on the map.
+ */
+function perfFill(f: CodeHealthMapFile): string {
+  const n = f.performance_findings ?? 0;
+  if (n > 0) {
+    if (n >= 5) return "var(--color-error)";
+    if (n >= 2) return "var(--color-warning)";
+    return "var(--color-caution)";
+  }
+  // No findings: green only when a detector actually ran on this language;
+  // otherwise grey so an un-analyzed file never reads as "clean".
+  return f.performance_analyzed ? "var(--color-success)" : NEUTRAL_FILL;
+}
+
 /** Churn band: red = top-decile churn, green = quiet. */
 function churnFill(pctile: number | null | undefined): string {
   if (pctile == null) return NEUTRAL_FILL;
@@ -136,11 +165,14 @@ const OVERLAY_SPECS: Record<CodeHealthOverlay, OverlaySpec> = {
   },
   performance: {
     label: "Performance",
-    caption: "color = performance-risk score · grey = not measured",
-    fill: (f) => scoreFill(f.performance_score),
+    caption: "color = findings, not a score · grey = language not analyzed",
+    fill: perfFill,
     legend: [
-      ...BAND_LABEL.map((b) => ({ fill: BAND_FILL[b.band], label: b.label })),
-      { fill: NEUTRAL_FILL, label: "not measured" },
+      { fill: "var(--color-error)", label: "5+ findings" },
+      { fill: "var(--color-warning)", label: "2–4 findings" },
+      { fill: "var(--color-caution)", label: "1 finding" },
+      { fill: "var(--color-success)", label: "Analyzed, none found" },
+      { fill: NEUTRAL_FILL, label: "Not analyzed" },
     ],
   },
   coverage: {


### PR DESCRIPTION
## Problem

The performance category cap is `1.0`, so every file's `performance_score` lives in `[9, 10]`. The code-health map colors cells by score, so the performance lens painted the entire repo green regardless of where the risk actually is. A 10/10 is also easy to misread as "no issues" when the pillar is deliberately high-precision, low-recall: a green file can only ever mean "nothing surfaced," never "verified fast."

## Fix (presentation only, scoring untouched)

Recolor the performance lens by open finding count plus coverage state instead of the compressed score:

- **Grey = not analyzed** — no perf detector runs on this language (C++, Kotlin, and non-code files like markdown/json/config). Driven off the perf dialect set, so an un-analyzed file never reads as clean.
- **Green = analyzed, none found** — the legend says exactly that, not "healthy," to hold the high-precision/low-recall line.
- **Heat (yellow to red)** — by open finding count (1 / 2-4 / 5+), so a file with 40 N+1s no longer looks like one with 1.

The legend and caption now read "findings, not a score" and "language not analyzed," so a 10 is never mistaken for "no issues."

`/health/files` now emits `performance_findings` and `performance_analyzed` per file (the per-file open perf-finding count and whether the file's language has a registered perf dialect), reusing the coverage accounting the perf pass already computes. No change to `scoring.py` and the defect golden is unchanged.

## Verification

- Typecheck clean (types + ui); map unit tests extended to lock heat/green/grey; server suite passes with no regressions.
- Dogfood on this repo: 253 findings over 100 files render as heat (top file 15 findings burns red vs a 1-finding yellow), the majority green, and 208 non-code files grey rather than green.