### PR TITLE
release: v0.28.1 — graph overlay visibility, decisions/health presentation fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.28.1] — 2026-07-08
+
+### Changed
+- **Performance map colors by findings.** The performance code map now colors by open findings and detector coverage instead of the bounded score, so hot spots read at a glance. (#716)
+
+### Fixed
+- **Graph overlays show their nodes.** The full dependency graph reserves part of its node budget for dead-code files, hotspots, and execution-flow members instead of selecting purely by PageRank — the Dead/Hot overlays and flow highlighting no longer come up empty on large repos. The view says how many flagged files are in view ("12 of 37 dead files"), and empty overlays explain whether the repo has none or they fell outside the loaded set. (#714)
+- **Graph controls explain themselves.** The hierarchical layout says why it won't run above 500 nodes instead of silently doing nothing; the Execution Flows panel gained a close button and Escape handling, and warns when a selected flow has out-of-view nodes; the Dead/Hot toggle pair became an exclusive All / Hot / Dead control. (#714)
+- **Honest health drawer and stats labels.** Missing structural metrics render "not measured" instead of 0; score-breakdown bars scale against real category caps with a tooltip explaining the cap; the lines-of-code and agent-authorship stats now say exactly what they measure. (#715)
+- **Decisions page polish.** Missing decision dates render a dash instead of "Invalid Date"; the decision graph bounds its layout so large decision sets can't hang the page; Confirm/Dismiss/Deprecate explain what they do; and a new "Enforce this decision" button generates a paste-ready agent prompt that audits governed code for compliance. (#715)
+- **Honest performance coverage.** Dead performance markers are wired up and performance coverage is reported honestly. (#711)
+
+---
+
 ## [0.28.0] — 2026-07-07
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.28.0"
+__version__ = "0.28.1"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.28.0"
+__version__ = "0.28.1"

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.28.0"
+__version__ = "0.28.1"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.28.0"
+version = "0.28.1"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3056,7 +3056,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.28.0"
+version = "0.28.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Patch release carrying the fixes merged since v0.28.0.

## Ships
- **#714** — graph: reserved node-cap slots for dead/hot/flow nodes + overlay coverage counts; layout-skip notice; Execution Flows close affordance; exclusive All/Hot/Dead filter.
- **#715** — decisions date guard + bounded decision graph + "Enforce this decision" prompt; honest stats labels; health-drawer "not measured" cards and real cap bars.
- **#711** — dead perf markers wired, honest perf coverage reporting.
- **#716** — performance map colors by findings/coverage instead of the bounded score.
- (#712/#713 cancel out — omitted from the changelog.)

## Release checklist
- [x] Version bump: `pyproject.toml`, cli/core/server `__init__.py`, both plugin manifests (codex plugin unchanged this cycle, left at 0.1.1)
- [x] `uv.lock` regenerated (self-entry → 0.28.1)
- [x] `docs/CHANGELOG.md` entry for 0.28.1 (OSS-facing only)
- [x] Plugin tool-surface grep guard run — no MCP/CLI/hook surface changes this cycle, version bump only
- [x] Wheel builds clean: `dist/repowise-0.28.1-py3-none-any.whl` (45 CLI command files; `.scm`/`.j2` package data present)
- [x] Web standalone builds clean (compiled + 11 static pages; `server.js` present; workspace-package code verified in compiled chunks)
- [ ] Post-merge: tag the squash commit on `main` as `v0.28.1` and push (triggers `publish.yml`)
- [ ] Post-merge: verify GitHub release assets + PyPI shows 0.28.1
- [ ] Hosted: repin `@repowise-dev/ui` / `@repowise-dev/types` to the internal build published from the final main sha

**Merge note:** repo is squash-only; squash-merge this PR and the tag goes on the squash commit (same as v0.17.0 onward).