### PR TITLE
fix(update-lock): make lock creation atomic to stop double-acquire

### DIFF
--- a/packages/core/src/repowise/core/update_lock.py
+++ b/packages/core/src/repowise/core/update_lock.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -32,12 +33,13 @@ def try_acquire_update_lock(repo_path: Path, target_commit: str | None) -> dict[
     """Atomically acquire the update lock. ``None`` means acquired.
 
     Returns the live owner's payload when another update already holds the
-    lock, so the caller can report who it lost to and bail. The check and
-    the write are one exclusive create (``O_EXCL``) — the previous
-    read-then-write pair left a window where two updates racing past the
-    read would both "acquire" and then race on save_state, the exact
-    failure the lock exists to prevent. A stale lock (dead or recycled PID,
-    or past the wall-clock ceiling) is cleared and the create retried.
+    lock, so the caller can report who it lost to and bail. The payload is
+    written to a private temp file and hard-linked into place, so the lock
+    only ever becomes visible with its full content — an exclusive create
+    followed by a write leaves a window where a contender reads the still
+    empty file, mistakes it for a corrupt lock, and deletes the winner's
+    live lock (two "winners"). A stale lock (dead or recycled PID, or past
+    the wall-clock ceiling) is cleared and the create retried.
 
     The payload contains the PID and target commit so the augment hook can
     decide whether a stale-wiki warning is redundant, plus the writing
@@ -57,22 +59,30 @@ def try_acquire_update_lock(repo_path: Path, target_commit: str | None) -> dict[
         "started_at": time.time(),
     }
     data = json.dumps(payload)
+    tmp_path = lock_path.with_name(
+        f"{UPDATE_LOCK_FILENAME}.{os.getpid()}.{threading.get_ident()}.tmp"
+    )
     for _ in range(2):
         try:
             lock_path.parent.mkdir(parents=True, exist_ok=True)
-            fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+            tmp_path.write_text(data, encoding="utf-8")
+            # Atomic create-with-content: the lock either doesn't exist or
+            # holds a complete payload — contenders can never read a
+            # half-written file.
+            os.link(tmp_path, lock_path)
         except FileExistsError:
             existing = read_update_lock(repo_path)
             if existing is not None:
                 return existing
-            # Stale or corrupt lock: clear it and retry the exclusive create.
+            # Stale lock: clear it and retry the exclusive create.
             with contextlib.suppress(OSError):
                 lock_path.unlink(missing_ok=True)
             continue
         except OSError:
             return None
-        with contextlib.suppress(OSError), os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(data)
+        finally:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink(missing_ok=True)
         return None
     # Lost the create race twice in a row: someone else just acquired a
     # fresh lock — report it. A still-unreadable lock degrades to acquired.


### PR DESCRIPTION
try_acquire_update_lock created the lock file with O_EXCL and wrote the JSON payload afterward. A second updater hitting FileExistsError in that window would read the still-empty file, decide the lock was corrupt, delete the winner's live lock, and acquire it too. Under contention this produced multiple winners — it's what made test_concurrent_acquire_has_exactly_one_winner flake in CI (locally it failed about 1 run in 3).

The payload is now written to a private temp file and hard-linked into place, so the lock either doesn't exist or is complete — there is no empty-file window to misread. The stale-lock recovery path (dead PID, wall-clock ceiling) is unchanged.

Ran the concurrency test 50 times on the old code (18 failures) and 80 times on this change (0 failures); the rest of the lock/persistence suites pass unchanged.