### PR TITLE
feat(git): extend agent-provenance detection channels

### DIFF
--- a/packages/core/src/repowise/core/ingestion/git_commit_index.py
+++ b/packages/core/src/repowise/core/ingestion/git_commit_index.py
@@ -29,6 +29,52 @@ if TYPE_CHECKING:
 logger = structlog.get_logger(__name__)
 
 
+def load_git_ai_note_agents(repo: object, commit_limit: int) -> dict[str, str]:
+    """Map ``commit_sha → agent`` from git-ai authorship notes (``refs/notes/ai``).
+
+    Returns an empty dict when the ref is absent — the common case, gated by a
+    single cheap ``for-each-ref`` so 99.9% of repos pay nothing and add no git
+    pass. Only repos actually using git-ai incur the one bounded
+    ``git log --notes=ai`` walk here, whose ``sha → agent`` result the commit
+    walk then reads by-key (no re-parse per touched file). Any failure returns
+    ``{}`` — a notes read must never break the git index. See the git-ai
+    standard v3.0.0 for the note format.
+    """
+    from .git_indexer import _FIELD_SEP, _RECORD_SEP
+    from .git_indexer.agent_provenance import _agent_from_git_ai_note
+
+    try:
+        if not repo.git.for_each_ref("refs/notes/ai"):  # type: ignore[attr-defined]
+            return {}
+    except Exception:
+        return {}
+
+    try:
+        # ``%N`` is the note body; the leading ``%x00``/``%x1f`` mirror the main
+        # walk's record/field separators so multi-line notes parse unambiguously.
+        raw = repo.git.log(  # type: ignore[attr-defined]
+            f"-{commit_limit}",
+            "--no-merges",
+            "--notes=ai",
+            "--format=%x00%H%x1f%N",
+        )
+    except Exception as exc:
+        logger.warning("git_ai_notes_load_failed", error=str(exc))
+        return {}
+
+    agents: dict[str, str] = {}
+    for chunk in raw.split(_RECORD_SEP):
+        if not chunk.strip():
+            continue
+        sha, sep, note = chunk.partition(_FIELD_SEP)
+        if not sep:
+            continue
+        agent = _agent_from_git_ai_note(note)
+        if agent:
+            agents[sha.strip()] = agent
+    return agents
+
+
 def load_commit_index(
     repo: object,
     commit_limit: int,
@@ -105,6 +151,9 @@ def load_commit_index(
     if not raw:
         return {}
 
+    # git-ai authorship notes for this window (``{}`` unless the repo uses them).
+    note_agents = load_git_ai_note_agents(repo, commit_limit)
+
     bucket: dict[str, list[_CommitRec]] = {}
     commits_parsed = 0
 
@@ -134,6 +183,7 @@ def load_commit_index(
             header["committer_name"],
             header["committer_email"],
             f"{header['subject']}\n{header['body']}",
+            note_agent=note_agents.get(header["sha"]),
         )
 
         # Full change footprint of this commit (every file, not just the
@@ -280,6 +330,9 @@ def load_deep_commit_index(
     if not raw:
         return {}
 
+    # git-ai notes across the deep region (``{}`` unless the repo uses them).
+    note_agents = load_git_ai_note_agents(repo, skip + deep_limit)
+
     bucket: dict[str, list[_CommitRec]] = {}
     commits_parsed = 0
 
@@ -329,6 +382,7 @@ def load_deep_commit_index(
                     header["committer_name"],
                     header["committer_email"],
                     f"{header['subject']}\n{header['body']}",
+                    note_agent=note_agents.get(header["sha"]),
                 )
 
             records.append(

--- a/packages/core/src/repowise/core/ingestion/git_indexer/agent_provenance.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/agent_provenance.py
@@ -16,6 +16,16 @@ LLM), in strip-resistance order:
        pushed/amended a human-driven change — deliberately NOT tier 1)
   Tier 3 (assisted — an agent contributed, a human authored):
      * ``Co-authored-by:`` trailer naming a known agent service identity
+     * an ``Assisted-by:`` trailer naming a recognized agent (the Fedora /
+       OpenInfra AI-attribution standard)
+
+Two cross-cutting channels ride the same rule set:
+  * a **git-ai authorship note** (``refs/notes/ai``, the git-ai standard) —
+    an explicit, line-level attestation attached to the commit. Read out of
+    band (see :mod:`git_commit_index`) and passed in pre-resolved as
+    ``note_agent``; classified Tier 2 (``git_ai_note`` channel).
+  * a ``Generated-by:`` trailer (Apache's AI-attribution footer) naming a
+    recognized agent — Tier 2 (``generated_by_trailer`` channel).
 
 Precedence is tier order (1 > 2 > 3); first match wins. A commit with no
 match is human (``None``). Every pattern is anchored to a *service identity*
@@ -48,6 +58,7 @@ rides the existing commit-index walk — it adds no git subprocess and no I/O.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 
@@ -58,6 +69,7 @@ logger = structlog.get_logger(__name__)
 __all__ = [
     "AgentProvenance",
     "AgentProvenanceClassifier",
+    "_agent_from_git_ai_note",
     "classifier_from_repo_config",
 ]
 
@@ -74,11 +86,33 @@ _BOT_LOGINS: dict[str, str] = {
     "cursor": "cursor",
     "cursoragent": "cursor",
     "google-labs-jules": "jules",
+    "gemini-code-assist": "gemini",
     "codegen-sh": "codegen",
     "openhands-ai": "openhands",
     "sweep-ai": "sweep",
     "claude": "claude",
 }
+
+# Agent name/tool aliases → canonical label. Substring match (first hit wins),
+# so ``GitHub Copilot`` → ``copilot`` and ``claude-code`` → ``claude``. Used to
+# resolve free-text values in ``Assisted-by:`` / ``Generated-by:`` trailers and
+# the ``agent_id.tool`` field of git-ai notes. ``chatgpt`` precedes ``gpt`` so
+# the more specific token wins first.
+_AGENT_ALIASES: list[tuple[str, str]] = [
+    ("claude", "claude"),
+    ("cursor", "cursor"),
+    ("copilot", "copilot"),
+    ("chatgpt", "chatgpt"),
+    ("gpt", "chatgpt"),
+    ("codex", "codex"),
+    ("gemini", "gemini"),
+    ("windsurf", "windsurf"),
+    ("opencode", "opencode"),
+    ("devin", "devin"),
+    ("aider", "aider"),
+    ("jules", "jules"),
+    ("llama", "llama"),
+]
 
 # Exact service e-mails → (agent, tier) for commit identity fields.
 _SERVICE_EMAILS: dict[str, tuple[str, int]] = {
@@ -91,8 +125,19 @@ _FOOTER_PATTERNS: list[tuple[str, str]] = [
     (r"generated with \[?claude code\]?", "claude"),
     (r"generated with \[?opencode\]?", "opencode"),
     (r"generated with \[?(?:openai )?codex\]?", "codex"),
+    (r"generated with \[?cursor\]?", "cursor"),
+    (r"<!--\s*cursor\s*-->", "cursor"),
     (r"^\s*aider wrote this", "aider"),
 ]
+
+# AI-attribution trailers (Fedora/OpenInfra ``Assisted-by``, Apache
+# ``Generated-by``). The trailer KEY is the anchor — a standardized AI marker —
+# but the agent identity comes from the value, so these fire only when the
+# value resolves to a recognized agent (``allow_slug=False``): a bare human
+# name in a misused ``Assisted-by`` must never mint a phantom agent. Generated =
+# agent wrote it (T2); Assisted = human wrote it, agent helped (T3).
+_GENERATED_BY_RE = re.compile(r"^\s*generated-by:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+_ASSISTED_BY_RE = re.compile(r"^\s*assisted-by:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
 
 # ``Co-authored-by:`` trailers → agent. Anchored to the trailer position AND
 # the agent's service identity — a name alone is not enough (see module doc).
@@ -112,6 +157,62 @@ _COAUTHOR_PATTERNS: list[tuple[str, str]] = [
 ]
 
 _AIDER_NAME_RE = re.compile(r"\(aider\)\s*$")
+
+
+def _normalize_agent_token(value: str, *, allow_slug: bool) -> str | None:
+    """Resolve a free-text tool/agent name to a canonical label.
+
+    Matches *value* against :data:`_AGENT_ALIASES` (substring, first hit wins).
+    With ``allow_slug`` the unmatched remainder is slugified and returned (used
+    for git-ai notes, whose ``refs/notes/ai`` ref is AI-specific by
+    construction, so an unknown tool is still a genuine agent). Without it, an
+    unrecognized value returns ``None`` — the precision-first path for
+    free-text trailers where a bare human name must not become an agent.
+    """
+    v = (value or "").strip().lower()
+    if not v:
+        return None
+    for needle, canon in _AGENT_ALIASES:
+        if needle in v:
+            return canon
+    if not allow_slug:
+        return None
+    slug = re.sub(r"[^a-z0-9]+", "-", v).strip("-")
+    return slug or None
+
+
+def _agent_from_git_ai_note(note: str) -> str | None:
+    """Resolve the dominant agent from a git-ai authorship note.
+
+    A note (``refs/notes/ai``, git-ai standard v3.0.0) is
+    ``<attestation>\\n---\\n<json metadata>``. We read
+    ``sessions.<id>.agent_id.tool`` from the JSON metadata and return the tool
+    owning the most sessions, normalized to our agent label. A tie between
+    distinct tools returns ``None`` (ambiguous — precision-first; per-line
+    dominance from the attestation section is the upgrade path). Any parse
+    failure returns ``None``: a malformed note is never a signal.
+    """
+    if not note:
+        return None
+    try:
+        lines = note.splitlines()
+        div = max((i for i, ln in enumerate(lines) if ln.strip() == "---"), default=-1)
+        if div < 0:
+            return None
+        data = json.loads("\n".join(lines[div + 1 :]))
+        counts: dict[str, int] = {}
+        for sess in (data.get("sessions") or {}).values():
+            tool = ((sess or {}).get("agent_id") or {}).get("tool")
+            agent = _normalize_agent_token(str(tool), allow_slug=True) if tool else None
+            if agent:
+                counts[agent] = counts.get(agent, 0) + 1
+        if not counts:
+            return None
+        top = max(counts.values())
+        leaders = [a for a, c in counts.items() if c == top]
+        return leaders[0] if len(leaders) == 1 else None
+    except Exception:
+        return None
 
 
 @dataclass(frozen=True)
@@ -182,25 +283,47 @@ class AgentProvenanceClassifier:
         committer_name: str,
         committer_email: str,
         message: str,
+        note_agent: str | None = None,
     ) -> AgentProvenance:
         """Classify one commit from local metadata. *message* is the full
         commit message (subject + body) — trailers and footers live in the
-        body, so passing the subject alone silently disables two channels."""
+        body, so passing the subject alone silently disables several channels.
+        *note_agent* is the pre-resolved agent from this commit's git-ai
+        authorship note (``refs/notes/ai``), or ``None`` when absent — read out
+        of band by the caller so classification stays a pure function."""
         # T1 — agent service identity AUTHORED the commit.
         hit = self._identity_match(author_email)
         if hit:
             return AgentProvenance(hit[0], hit[1], "service_email", "high")
+        # T2 — git-ai authorship note: an explicit line-level attestation on
+        # this commit. Below T1 (a bot service account is more autonomous) but
+        # above the message-derived channels.
+        if note_agent:
+            return AgentProvenance(note_agent, 2, "git_ai_note", "high")
         # T2 — message footer / aider author-name suffix.
         for pat, agent in self._footers:
             if pat.search(message):
                 return AgentProvenance(agent, 2, "message_footer", "high")
         if _AIDER_NAME_RE.search(author_name or ""):
             return AgentProvenance("aider", 2, "author_name_aider", "high")
+        # T2 — ``Generated-by:`` AI-attribution trailer (agent generated it).
+        m = _GENERATED_BY_RE.search(message)
+        if m:
+            agent = _normalize_agent_token(m.group(1), allow_slug=False)
+            if agent:
+                return AgentProvenance(agent, 2, "generated_by_trailer", "high")
         # T2 — service identity as COMMITTER over a human author: the agent
         # pushed/amended a human-driven change. Deliberately tier 2, not 1.
         hit = self._identity_match(committer_email)
         if hit:
             return AgentProvenance(hit[0], max(hit[1], 2), "service_committer", "high")
+        # T3 — ``Assisted-by:`` AI-attribution trailer (human wrote it, agent
+        # helped). Below the committer channel to keep tier order intact.
+        m = _ASSISTED_BY_RE.search(message)
+        if m:
+            agent = _normalize_agent_token(m.group(1), allow_slug=False)
+            if agent:
+                return AgentProvenance(agent, 3, "assisted_by_trailer", "high")
         # T3 — co-author trailer naming an agent service identity.
         for pat, agent in self._coauthors:
             if pat.search(message):

--- a/tests/unit/ingestion/test_agent_provenance.py
+++ b/tests/unit/ingestion/test_agent_provenance.py
@@ -12,9 +12,13 @@ import json
 import time
 from unittest.mock import MagicMock
 
-from repowise.core.ingestion.git_commit_index import load_commit_index
+from repowise.core.ingestion.git_commit_index import (
+    load_commit_index,
+    load_git_ai_note_agents,
+)
 from repowise.core.ingestion.git_indexer.agent_provenance import (
     AgentProvenanceClassifier,
+    _agent_from_git_ai_note,
 )
 from repowise.core.ingestion.git_indexer.commit_rows import build_commit_rows
 from repowise.core.ingestion.git_indexer.file_history import index_file
@@ -23,8 +27,28 @@ from repowise.core.ingestion.git_indexer.records import _CommitRec
 CLF = AgentProvenanceClassifier()
 
 
-def _classify(an="Dev", ae="dev@x.com", cn="Dev", ce="dev@x.com", msg="feat: thing"):
-    return CLF.classify(an, ae, cn, ce, msg)
+def _classify(an="Dev", ae="dev@x.com", cn="Dev", ce="dev@x.com", msg="feat: thing", note_agent=None):
+    return CLF.classify(an, ae, cn, ce, msg, note_agent=note_agent)
+
+
+def _git_ai_note(*tools: str) -> str:
+    """A minimal git-ai note (v3.0.0): one session per tool, valid metadata."""
+    sessions = {
+        f"s_{i:014x}": {"agent_id": {"tool": t, "id": f"id{i}", "model": "m"}}
+        for i, t in enumerate(tools)
+    }
+    attestation = "src/a.py\n" + "\n".join(
+        f"  s_{i:014x}::t_{i:014x} {i + 1}-{i + 5}" for i in range(len(tools))
+    )
+    meta = json.dumps(
+        {
+            "schema_version": "authorship/3.0.0",
+            "base_commit_sha": "deadbeef",
+            "prompts": {},
+            "sessions": sessions,
+        }
+    )
+    return f"{attestation}\n---\n{meta}"
 
 
 # ---------------------------------------------------------------------------
@@ -113,6 +137,110 @@ def test_devin_service_trailer_matches() -> None:
     )
     prov = _classify(msg=msg)
     assert (prov.agent, prov.autonomy_tier) == ("devin", 3)
+
+
+# ---------------------------------------------------------------------------
+# Assisted-by / Generated-by AI-attribution trailers
+# ---------------------------------------------------------------------------
+
+
+def test_generated_by_trailer_is_tier2() -> None:
+    prov = _classify(msg="feat: x\n\nGenerated-by: Claude")
+    assert (prov.agent, prov.autonomy_tier, prov.channel) == ("claude", 2, "generated_by_trailer")
+
+
+def test_assisted_by_trailer_is_tier3() -> None:
+    prov = _classify(msg="feat: x\n\nAssisted-by: GitHub Copilot")
+    assert (prov.agent, prov.autonomy_tier, prov.channel) == ("copilot", 3, "assisted_by_trailer")
+
+
+def test_assisted_by_chatgpt_normalizes() -> None:
+    assert _classify(msg="fix: y\n\nAssisted-by: ChatGPTv5").agent == "chatgpt"
+
+
+def test_assisted_by_bare_human_name_is_not_an_agent() -> None:
+    """The trailer key is an AI marker, but an unrecognized value must not mint
+    a phantom agent — a project misusing Assisted-by for a human stays human."""
+    prov = _classify(msg="feat: pairing\n\nAssisted-by: Jane Smith")
+    assert prov.agent is None
+
+
+def test_generated_by_beats_assisted_by_on_tier() -> None:
+    """A commit with both trailers is classified at the stronger T2."""
+    msg = "feat: x\n\nGenerated-by: Cursor\nAssisted-by: Claude"
+    assert _classify(msg=msg).autonomy_tier == 2
+
+
+# ---------------------------------------------------------------------------
+# Cursor commit-local signals
+# ---------------------------------------------------------------------------
+
+
+def test_cursor_html_marker_is_detected() -> None:
+    assert _classify(msg="feat: x\n\n<!-- Cursor -->").agent == "cursor"
+
+
+def test_generated_with_cursor_footer_is_detected() -> None:
+    assert _classify(msg="feat: x\n\nGenerated with Cursor").agent == "cursor"
+
+
+# ---------------------------------------------------------------------------
+# git-ai authorship notes (refs/notes/ai)
+# ---------------------------------------------------------------------------
+
+
+def test_git_ai_note_single_tool() -> None:
+    assert _agent_from_git_ai_note(_git_ai_note("cursor")) == "cursor"
+
+
+def test_git_ai_note_tool_alias_maps_to_label() -> None:
+    assert _agent_from_git_ai_note(_git_ai_note("claude-code")) == "claude"
+
+
+def test_git_ai_note_dominant_tool_wins() -> None:
+    assert _agent_from_git_ai_note(_git_ai_note("cursor", "cursor", "claude")) == "cursor"
+
+
+def test_git_ai_note_tie_is_ambiguous() -> None:
+    assert _agent_from_git_ai_note(_git_ai_note("cursor", "claude")) is None
+
+
+def test_git_ai_note_malformed_is_no_signal() -> None:
+    assert _agent_from_git_ai_note("") is None
+    assert _agent_from_git_ai_note("no divider here") is None
+    assert _agent_from_git_ai_note("attestation\n---\nnot json") is None
+
+
+def test_git_ai_note_classified_tier2() -> None:
+    prov = _classify(note_agent="cursor")
+    assert (prov.agent, prov.autonomy_tier, prov.channel) == ("cursor", 2, "git_ai_note")
+
+
+def test_bot_author_beats_git_ai_note() -> None:
+    """T1 service-account authorship outranks a note (more autonomous)."""
+    prov = _classify(
+        an="Cursor Agent",
+        ae="cursoragent@cursor.com",
+        note_agent="claude",
+    )
+    assert (prov.agent, prov.autonomy_tier) == ("cursor", 1)
+
+
+def test_load_git_ai_note_agents_absent_ref_is_empty_no_log() -> None:
+    """The common path: ref absent → {} without ever spawning the notes walk."""
+    repo = MagicMock()
+    repo.git.for_each_ref.return_value = ""
+    assert load_git_ai_note_agents(repo, 100) == {}
+    repo.git.log.assert_not_called()
+
+
+def test_load_git_ai_note_agents_parses_present_ref() -> None:
+    repo = MagicMock()
+    repo.git.for_each_ref.return_value = "abc123 commit\trefs/notes/ai"
+    note = _git_ai_note("cursor")
+    repo.git.log.return_value = f"\x00sha_agent\x1f{note}\n\x00sha_human\x1f\n"
+    agents = load_git_ai_note_agents(repo, 100)
+    assert agents == {"sha_agent": "cursor"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Extends the deterministic agent-provenance classifier in the git indexer with three new AI-authorship detection channels. All are zero-LLM, local-history only, and layered onto the existing precision-first tier model without changing the shared commit-record format.

### 1. git-ai authorship notes (`refs/notes/ai`)
Reads the [git-ai standard v3.0.0](https://github.com/git-ai-project/git-ai/blob/main/specs/git_ai_standard_v3.0.0.md) authorship notes attached to commits. The note's `sessions.<id>.agent_id.tool` metadata resolves to the dominant agent for that commit (`git_ai_note` channel, tier 2). A tie between distinct tools stays unlabelled.

Read out of band via a ref-gated pass: repos without the ref do a single `for-each-ref` and add no git pass, so the common case pays nothing. Only repos that actually use git-ai walk the notes.

### 2. Assisted-by / Generated-by attribution trailers
Matches the Fedora/OpenInfra `Assisted-by:` and Apache `Generated-by:` commit trailers. The trailer key is a standardized AI marker, but the agent identity comes from the value, so these fire only when the value maps to a recognized agent. A bare human name in a misused trailer never mints a phantom agent. `Generated-by` is tier 2, `Assisted-by` tier 3.

### 3. Cursor commit-local markers + registry refresh
Adds the Cursor HTML-comment marker and "Generated with Cursor" footer, plus the `gemini-code-assist` bot login.

## Validation

Ran the classifier over two real histories:

| Repo | Commits | Attributed | Notable |
|---|---|---|---|
| This repo (false-positive check) | 569 | 5 (claude 4, copilot 1) | all via genuine `Co-authored-by`; 0 git-ai notes; no false positives |
| git-ai project (true-positive) | 4041 | 1652 (41%) | 335 commits carry real ai notes; new `git_ai_note` channel attributes 326, the rest deferring correctly to higher-precedence bot-identity channels |

Agent breakdown on the git-ai repo: claude 1286, devin 206, codex 107, copilot 29, cursor 24. Note tools present: codex 107, claude 196, devin 11, cursor 21.

## Tests

Adds coverage for the note parser (single tool, alias mapping, dominant-tool, tie ambiguity, malformed input), the two trailer channels, the bare-human-name precision guard, Cursor markers, tier precedence, and the ref-gated notes loader (absent ref never spawns the walk). Full git-indexer suites pass.