### PR TITLE
test(server): align get_overview module-cap test with cap=8

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_overview.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_overview.py
@@ -256,7 +256,7 @@ async def _load_overview_page(session: Any, repository: Any) -> Page | None:
 async def _load_module_pages(
     session: Any, repository: Any, collector: OmissionCollector
 ) -> list[Page]:
-    """Module pages capped to 20; the remainder goes to the omission store."""
+    """Module pages capped to ``_MODULE_CAP``; the remainder goes to the omission store."""
     result = await session.execute(
         select(Page)
         .where(

--- a/tests/unit/server/mcp/test_budget.py
+++ b/tests/unit/server/mcp/test_budget.py
@@ -341,6 +341,7 @@ async def test_get_overview_module_cap_is_expandable(setup_mcp, session, repo_ro
     import repowise.server.mcp_server as mcp_mod
     from repowise.core.persistence.models import Page
     from repowise.server.mcp_server import get_overview
+    from repowise.server.mcp_server.tool_overview import _MODULE_CAP
 
     now = datetime(2026, 3, 19, tzinfo=UTC)
     for i in range(25):
@@ -367,11 +368,11 @@ async def test_get_overview_module_cap_is_expandable(setup_mcp, session, repo_ro
 
     mcp_mod._repo_path = str(repo_root)
     result = await get_overview()
-    assert len(result["key_modules"]) == 20
+    assert len(result["key_modules"]) == _MODULE_CAP
     omitted = result["_meta"]["omitted"]
     stored = "\n".join(_store_get(repo_root, r) or "" for r in omitted["refs"])
     # 27 module pages total, ordered by title — the tail is in the store.
-    assert "module pages beyond cap=20" in stored
+    assert f"module pages beyond cap={_MODULE_CAP}" in stored
     assert stored.count("Extra Module") + stored.count("Module") >= 7
 
 


### PR DESCRIPTION
## What

`test_get_overview_module_cap_is_expandable` was failing on `main` (asserted 20 `key_modules`, got 8). When the default `get_overview` module cap was compacted from 20 to 8, the test and the `_load_module_pages` docstring were left referencing 20.

## Fix

- Reference `_MODULE_CAP` from the test's assertions (count and the `beyond cap=N` message) instead of hardcoding a number, so the cap and its test can no longer drift.
- Correct the stale "capped to 20" docstring on `_load_module_pages`.

No behavior change; the expandable path (dropped tail goes to the omission store, retrievable via `expand`) is unchanged.

## Tests

`tests/unit/server/mcp/test_budget.py` and `test_overview_helpers.py` pass (27); lint clean.