### PR TITLE
fix(health): correct complexity-metric miscounts (elif nesting, params, comprehensions, NLOC)

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/complexity/ast_utils.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/ast_utils.py
@@ -181,14 +181,27 @@ def _count_parameters(fn_node: Node) -> int:
         # Dart: the parameter list lives on the preceding signature sibling.
         sig = _dart_signature_sibling(fn_node)
         if sig is not None:
-            params = next(
-                (c for c in sig.children if c.type == "formal_parameter_list"), None
-            )
+            params = next((c for c in sig.children if c.type == "formal_parameter_list"), None)
     if params is None:
         return 0
     count = 0
     for child in params.children:
-        if child.type in ("(", ")", ",", "self", "cls", ":", "*", "**"):
+        # A bare ``*`` (keyword-only marker) and a bare ``/`` (positional-only
+        # marker) parse as named ``keyword_separator`` / ``positional_separator``
+        # nodes but carry no arity, so they must be skipped alongside the
+        # ``*``/``**`` splat tokens and the punctuation.
+        if child.type in (
+            "(",
+            ")",
+            ",",
+            "self",
+            "cls",
+            ":",
+            "*",
+            "**",
+            "keyword_separator",
+            "positional_separator",
+        ):
             continue
         if child.is_named:
             count += 1

--- a/packages/core/src/repowise/core/analysis/health/complexity/cyclomatic.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/cyclomatic.py
@@ -48,6 +48,13 @@ _ELSE_IF_NODE_KINDS = frozenset(
     {"if_statement", "if_expression", "elif_clause", "if_let_expression"}
 )
 
+# Branch nodes that are a decision point (count toward CCN) but do NOT open a
+# nesting level: a comprehension filter (``[x for x in xs if a]``) and a match
+# ``case ... if guard:`` both parse as ``if_clause`` and sit inline, not as a
+# nested block. Treating them as flat keeps ``max_nesting`` / ``cognitive``
+# honest — they were only added to ``branch_kinds`` for the CCN count.
+_FLAT_BRANCH_KINDS = frozenset({"if_clause"})
+
 
 def _is_elif_continuation(node: Node) -> bool:
     """True when *node* is an ``else if`` / ``elif`` chain continuation.
@@ -271,11 +278,11 @@ def _walk_function_body(
             or node.type in lmap.catch_kinds
         ):
             ccn_increment = 1
-            # An ``else if`` / ``elif`` chain arm is a flat guard-clause
-            # continuation, not a genuinely nested block: charge the extra
-            # branch (ccn) but do not open a new nesting level for it. This
-            # parallels the flat-``switch``/``match`` special-case above.
-            if not _is_elif_continuation(node):
+            # An ``else if`` / ``elif`` chain arm and a comprehension /
+            # case-guard filter are flat: charge the extra branch (ccn) but do
+            # not open a new nesting level for them. This parallels the
+            # flat-``switch``/``match`` special-case above.
+            if node.type not in _FLAT_BRANCH_KINDS and not _is_elif_continuation(node):
                 nesting_increment = 1
             # Side-channel: count compound boolean ops in this
             # construct's condition. Does not affect ccn/cognitive

--- a/packages/core/src/repowise/core/analysis/health/complexity/cyclomatic.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/cyclomatic.py
@@ -41,6 +41,40 @@ _BODY_FIELD_NAMES = (
     "block",
 )
 
+# The ``if``-shaped node types that can appear as an ``else if`` / ``elif``
+# chain continuation. Ternaries / ``if_element`` collection-``if`` are
+# deliberately excluded — only statement-level if chains flatten.
+_ELSE_IF_NODE_KINDS = frozenset(
+    {"if_statement", "if_expression", "elif_clause", "if_let_expression"}
+)
+
+
+def _is_elif_continuation(node: Node) -> bool:
+    """True when *node* is an ``else if`` / ``elif`` chain continuation.
+
+    Such an arm is visually flat guard-clause dispatch but the grammar nests
+    each arm under the previous ``else`` / ``alternative`` slot. We recognise
+    the continuation so the walker charges it a branch point (CCN) without
+    opening a fresh nesting level — mirroring the flat-``switch``/``match``
+    special-case. The AST shape differs per grammar:
+
+    - Python: a dedicated ``elif_clause`` node (always a continuation).
+    - TypeScript / Rust / C++: the else-if is wrapped in an ``else_clause``.
+    - Java / Go / C# / Dart / Kotlin: the else-if node is the sibling that
+      immediately follows the parent ``if``'s ``else`` token.
+    """
+    if node.type not in _ELSE_IF_NODE_KINDS:
+        return False
+    if node.type == "elif_clause":
+        return True
+    parent = node.parent
+    if parent is None:
+        return False
+    if parent.type == "else_clause":
+        return True
+    prev = node.prev_sibling
+    return prev is not None and prev.type == "else"
+
 
 def _count_boolean_ops_in_condition(node: Node, lmap: LanguageNodeMap) -> int:
     """Count ``&&`` / ``||`` / ``and`` / ``or`` operators in a condition.
@@ -55,7 +89,10 @@ def _count_boolean_ops_in_condition(node: Node, lmap: LanguageNodeMap) -> int:
     stack: list[Node] = [node]
     while stack:
         cur = stack.pop()
-        if cur is not node and cur.type in lmap.function_kinds:
+        if cur is not node and (cur.type in lmap.function_kinds or cur.type in lmap.lambda_kinds):
+            # Lambdas / arrow functions used as condition values (sort keys,
+            # predicates) are a separate scope; their boolean operators are not
+            # part of the enclosing branch's own decision logic.
             continue
         if _is_boolean_operator(cur, lmap):
             count += 1
@@ -234,7 +271,12 @@ def _walk_function_body(
             or node.type in lmap.catch_kinds
         ):
             ccn_increment = 1
-            nesting_increment = 1
+            # An ``else if`` / ``elif`` chain arm is a flat guard-clause
+            # continuation, not a genuinely nested block: charge the extra
+            # branch (ccn) but do not open a new nesting level for it. This
+            # parallels the flat-``switch``/``match`` special-case above.
+            if not _is_elif_continuation(node):
+                nesting_increment = 1
             # Side-channel: count compound boolean ops in this
             # construct's condition. Does not affect ccn/cognitive
             # (boolean operators are still tallied independently by

--- a/packages/core/src/repowise/core/analysis/health/complexity/languages.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/languages.py
@@ -202,7 +202,11 @@ class LanguageNodeMap:
 _PY = LanguageNodeMap(
     function_kinds=frozenset({"function_definition", "async_function_definition"}),
     lambda_kinds=frozenset({"lambda"}),
-    branch_kinds=frozenset({"if_statement", "elif_clause", "conditional_expression"}),
+    # ``if_clause`` is a comprehension filter (``[x for x in xs if a if b]``);
+    # each filter is an independent branch point, so it belongs with the other
+    # branch kinds. The comprehension ``for`` (``for_in_clause``) is a generator,
+    # not a decision, so it is intentionally left out.
+    branch_kinds=frozenset({"if_statement", "elif_clause", "conditional_expression", "if_clause"}),
     loop_kinds=frozenset({"for_statement", "while_statement"}),
     try_kinds=frozenset({"try_statement"}),
     catch_kinds=frozenset({"except_clause"}),
@@ -453,9 +457,7 @@ _DART = LanguageNodeMap(
     # ``if_element`` is the collection-literal ``if`` (``[if (x) y]``);
     # ``conditional_expression`` is the ternary.
     branch_kinds=frozenset({"if_statement", "conditional_expression", "if_element"}),
-    loop_kinds=frozenset(
-        {"for_statement", "while_statement", "do_statement", "for_element"}
-    ),
+    loop_kinds=frozenset({"for_statement", "while_statement", "do_statement", "for_element"}),
     try_kinds=frozenset({"try_statement"}),
     # A bare ``on FormatException {}`` arm without ``catch`` has no
     # catch_clause node (the block hangs off try_statement directly), so it

--- a/packages/core/src/repowise/core/analysis/health/complexity/nloc.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/nloc.py
@@ -13,17 +13,45 @@ if TYPE_CHECKING:
     from tree_sitter import Node
 
 
+# A file's decoded lines are needed once per function, per class and per body
+# during a single walk; decoding + splitting the whole file on every call is
+# quadratic on the hot index path. Callers all pass the same ``source`` bytes
+# object within one file, so a one-entry identity cache hoists the decode to
+# once per file without changing any signatures.
+_LINES_CACHE_SOURCE: bytes | None = None
+_LINES_CACHE_LINES: list[str] = []
+
+
+def _source_lines(source: bytes) -> list[str]:
+    """Decoded, newline-split view of *source*, cached per source object."""
+    global _LINES_CACHE_SOURCE, _LINES_CACHE_LINES
+    if source is _LINES_CACHE_SOURCE:
+        return _LINES_CACHE_LINES
+    lines = source.decode("utf-8", errors="replace").splitlines()
+    _LINES_CACHE_SOURCE = source
+    _LINES_CACHE_LINES = lines
+    return lines
+
+
 def _is_docstring_stmt(node: Node) -> bool:
-    """True for a bare string-literal statement (a docstring / directive).
+    """True for a docstring: a bare string statement opening a function/class.
 
     A Python docstring is an ``expression_statement`` whose sole child is a
-    string. Such a statement carries no logic; its lines are documentation,
-    not code, so they are excluded from a function's / class's NLOC.
+    string AND which is the first statement of its enclosing body. Gating on
+    the leading position keeps a mid-body bare string (a rare no-op, but real
+    source) counted, while the documentation block is excluded from NLOC.
     """
     if node.type != "expression_statement":
         return False
     named = [c for c in node.children if c.is_named]
-    return len(named) == 1 and "string" in named[0].type
+    if len(named) != 1 or "string" not in named[0].type:
+        return False
+    parent = node.parent
+    if parent is None:
+        return False
+    first_stmt = next((c for c in parent.children if c.is_named), None)
+    # tree-sitter re-wraps nodes on each access, so identity is compared by id.
+    return first_stmt is not None and first_stmt.id == node.id
 
 
 def _code_line_numbers(node: Node, lines: list[str], *, drop_docstrings: bool) -> set[int]:
@@ -63,11 +91,7 @@ def _count_nloc(node: Node, source: bytes) -> int:
     end = node.end_point[0]
     if end < start:
         return 0
-    try:
-        lines = source.decode("utf-8", errors="replace").splitlines()
-    except Exception:
-        return end - start + 1
-    return len(_code_line_numbers(node, lines, drop_docstrings=True))
+    return len(_code_line_numbers(node, _source_lines(source), drop_docstrings=True))
 
 
 def _count_file_nloc(source: bytes) -> int:
@@ -85,10 +109,6 @@ def _count_file_nloc_tree(root_node: Node, source: bytes) -> int:
     Lines where all content is inside comment nodes are excluded; lines
     with real code plus a trailing comment still count.
     """
-    try:
-        lines = source.decode("utf-8", errors="replace").splitlines()
-    except Exception:
-        return 0
     # File-level NLOC keeps counting module/class docstrings (only comment-only
     # lines are dropped), so ``drop_docstrings`` stays off here.
-    return len(_code_line_numbers(root_node, lines, drop_docstrings=False))
+    return len(_code_line_numbers(root_node, _source_lines(source), drop_docstrings=False))

--- a/packages/core/src/repowise/core/analysis/health/complexity/nloc.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/nloc.py
@@ -13,17 +13,61 @@ if TYPE_CHECKING:
     from tree_sitter import Node
 
 
+def _is_docstring_stmt(node: Node) -> bool:
+    """True for a bare string-literal statement (a docstring / directive).
+
+    A Python docstring is an ``expression_statement`` whose sole child is a
+    string. Such a statement carries no logic; its lines are documentation,
+    not code, so they are excluded from a function's / class's NLOC.
+    """
+    if node.type != "expression_statement":
+        return False
+    named = [c for c in node.children if c.is_named]
+    return len(named) == 1 and "string" in named[0].type
+
+
+def _code_line_numbers(node: Node, lines: list[str], *, drop_docstrings: bool) -> set[int]:
+    """Line indexes in *node*'s subtree that carry a non-comment token.
+
+    Lines whose only content sits inside comment nodes are excluded; a line
+    with real code plus a trailing comment still counts. When *drop_docstrings*
+    is set, lines belonging to a bare string-literal statement (a docstring)
+    are excluded too.
+    """
+    code_lines: set[int] = set()
+    stack: list[Node] = [node]
+    while stack:
+        cur = stack.pop()
+        if "comment" in cur.type:
+            continue
+        if drop_docstrings and _is_docstring_stmt(cur):
+            continue
+        if not cur.children and cur.start_byte < cur.end_byte:
+            for line in range(cur.start_point[0], cur.end_point[0] + 1):
+                if line < len(lines) and lines[line].strip():
+                    code_lines.add(line)
+        else:
+            for child in cur.children:
+                stack.append(child)
+    return code_lines
+
+
 def _count_nloc(node: Node, source: bytes) -> int:
-    """Return the count of non-blank lines spanned by *node*."""
+    """Return the count of code lines spanned by *node*.
+
+    Blank, comment-only and docstring-only lines are excluded, so a function
+    or class NLOC measures substance the same way file-level NLOC does
+    (``_count_file_nloc_tree``), rather than counting documentation as code.
+    """
     start = node.start_point[0]
     end = node.end_point[0]
     if end < start:
         return 0
     try:
-        snippet = source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
+        lines = source.decode("utf-8", errors="replace").splitlines()
     except Exception:
         return end - start + 1
-    return sum(1 for line in snippet.splitlines() if line.strip())
+    return len(_code_line_numbers(node, lines, drop_docstrings=True))
 
 
 def _count_file_nloc(source: bytes) -> int:
@@ -45,17 +89,6 @@ def _count_file_nloc_tree(root_node: Node, source: bytes) -> int:
         lines = source.decode("utf-8", errors="replace").splitlines()
     except Exception:
         return 0
-    code_lines: set[int] = set()
-    stack = [root_node]
-    while stack:
-        node = stack.pop()
-        if "comment" in node.type:
-            continue
-        if not node.children and node.start_byte < node.end_byte:
-            for line in range(node.start_point[0], node.end_point[0] + 1):
-                if line < len(lines) and lines[line].strip():
-                    code_lines.add(line)
-        else:
-            for child in node.children:
-                stack.append(child)
-    return len(code_lines)
+    # File-level NLOC keeps counting module/class docstrings (only comment-only
+    # lines are dropped), so ``drop_docstrings`` stays off here.
+    return len(_code_line_numbers(root_node, lines, drop_docstrings=False))

--- a/tests/unit/health/test_ff_track_bch_complexity.py
+++ b/tests/unit/health/test_ff_track_bch_complexity.py
@@ -1,0 +1,184 @@
+"""Regression tests for complexity-metric miscounts that produced false flags.
+
+Each test drives the real project functions (``_walk_function_body``,
+``_count_nloc``, ``_count_parameters``) against a small parsed fixture — no
+metric logic is reimplemented here. Tests skip (rather than fail) when a
+tree-sitter language pack is unavailable, matching the sibling walker tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.analysis.health.complexity.ast_utils import (
+    _collect_function_nodes,
+    _count_parameters,
+)
+from repowise.core.analysis.health.complexity.cyclomatic import _walk_function_body
+from repowise.core.analysis.health.complexity.languages import get_language_map
+from repowise.core.analysis.health.complexity.nloc import _count_nloc
+
+
+def _parse(language: str, source: str):
+    """Parse *source* and return its function nodes + the language map.
+
+    Skips the test when the tree-sitter grammar for *language* is missing.
+    """
+    try:
+        from tree_sitter import Parser
+
+        from repowise.core.ingestion.parser import _get_language
+    except Exception:  # pragma: no cover - depends on optional deps
+        pytest.skip("tree-sitter not installed")
+
+    grammar = _get_language(language)
+    if grammar is None:
+        pytest.skip(f"tree-sitter language pack missing for {language}")
+    lmap = get_language_map(language)
+    tree = Parser(grammar).parse(source.encode())
+    fns = _collect_function_nodes(tree.root_node, lmap)
+    if not fns:
+        pytest.skip(f"no functions parsed for {language}")
+    return fns, lmap
+
+
+def _first_body(language: str, source: str):
+    fns, lmap = _parse(language, source)
+    fn = fns[0]
+    body = fn.child_by_field_name("body") or fn
+    return body, lmap
+
+
+def _walk(language: str, source: str):
+    body, lmap = _first_body(language, source)
+    return _walk_function_body(body, lmap)
+
+
+# --- M2: bare * / bare / separators are not parameters ---------------------
+
+
+def test_keyword_only_separator_not_counted_as_param():
+    src = (
+        "async def embed_top(*, limit=7000, concurrency=8, "
+        "batch_size=96, description_only=True):\n    pass\n"
+    )
+    fns, _ = _parse("python", src)
+    assert _count_parameters(fns[0]) == 4
+
+
+def test_positional_only_separator_not_counted_as_param():
+    fns, _ = _parse("python", "def h(a, b, /, c):\n    pass\n")
+    assert _count_parameters(fns[0]) == 3
+
+
+# --- R2: else-if / elif chains are flat, not nested ------------------------
+
+_FLAT_DISPATCH = {
+    "python": (
+        "def f(x):\n"
+        "    if x == 1:\n        return 1\n"
+        "    elif x == 2:\n        return 2\n"
+        "    elif x == 3:\n        return 3\n"
+        "    elif x == 4:\n        return 4\n"
+        "    elif x == 5:\n        return 5\n"
+        "    return 0\n"
+    ),
+    "typescript": (
+        "function f(x){"
+        " if(x==1){return 1;}"
+        " else if(x==2){return 2;}"
+        " else if(x==3){return 3;}"
+        " else if(x==4){return 4;}"
+        " else if(x==5){return 5;}"
+        " return 0; }"
+    ),
+    "java": (
+        "class C { int f(int x){"
+        " if(x==1){return 1;}"
+        " else if(x==2){return 2;}"
+        " else if(x==3){return 3;}"
+        " else if(x==4){return 4;}"
+        " else if(x==5){return 5;}"
+        " return 0; } }"
+    ),
+    "go": (
+        "func F(x int) int {\n"
+        " if x==1 { return 1 } else if x==2 { return 2 }"
+        " else if x==3 { return 3 } else if x==4 { return 4 }"
+        " else if x==5 { return 5 }\n return 0\n}"
+    ),
+}
+
+
+@pytest.mark.parametrize("language", ["python", "typescript", "java", "go"])
+def test_flat_elif_chain_is_not_nested(language):
+    ccn, max_nesting, _cognitive, _bumps, _conds = _walk(language, _FLAT_DISPATCH[language])
+    # A 5-arm flat dispatch is one branch deep, not five.
+    assert max_nesting == 1, f"{language}: expected max_nesting 1, got {max_nesting}"
+    # The extra branches still count toward CCN (base 1 + 5 arms).
+    assert ccn == 6, f"{language}: expected ccn 6, got {ccn}"
+
+
+def test_genuine_nested_ifs_still_report_depth():
+    _ccn, max_nesting, _cog, _b, _c = _walk(
+        "python",
+        "def g(a, b, c):\n"
+        "    if a:\n        if b:\n            if c:\n                return 1\n"
+        "    return 0\n",
+    )
+    assert max_nesting == 3
+
+
+# --- M4: boolean ops inside a lambda body do not leak into the condition ---
+
+
+def test_lambda_boolean_ops_excluded_from_condition_count():
+    _ccn, _mn, _cog, _b, conds = _walk(
+        "python",
+        "def f(items, other):\n"
+        "    if any(sorted(items, key=lambda x: x.a or x.b or x.c)) and other:\n"
+        "        return 1\n"
+        "    return 0\n",
+    )
+    assert conds, "expected a complex-condition record for the if"
+    # Only the `and other` operator belongs to the if's own condition; the two
+    # `or`s live inside the sort-key lambda.
+    assert conds[0].operator_count == 1
+
+
+# --- M11: comprehension filter clauses contribute CCN ----------------------
+
+
+def test_comprehension_filter_clauses_count_toward_ccn():
+    ccn, _mn, _cog, _b, _c = _walk(
+        "python",
+        "def f(items):\n    return [x for x in items if x > 0 if x < 100]\n",
+    )
+    # base path + two independent filter predicates.
+    assert ccn == 3
+
+
+# --- M5: function NLOC excludes docstring / comment-only lines --------------
+
+_LARGE_METHOD_THRESHOLD = 60
+
+
+def test_docstring_heavy_function_nloc_excludes_docs():
+    doc = "\n".join(f"    Rationale line {i}." for i in range(59))
+    source = (
+        "def f(a, b):\n"
+        '    """\n'
+        f"{doc}\n"
+        '    """\n'
+        "    # trailing note\n"
+        "    if a:\n"
+        "        b = 1\n"
+        "    return b\n"
+    )
+    body, _lmap = _first_body("python", source)
+    nloc = _count_nloc(body, source.encode())
+    # Only the three real statements count.
+    assert nloc == 3
+    # And so the function stays well under the large_method threshold despite
+    # spanning ~64 physical lines.
+    assert nloc < _LARGE_METHOD_THRESHOLD

--- a/tests/unit/health/test_ff_track_bch_complexity.py
+++ b/tests/unit/health/test_ff_track_bch_complexity.py
@@ -107,10 +107,15 @@ _FLAT_DISPATCH = {
         " else if x==3 { return 3 } else if x==4 { return 4 }"
         " else if x==5 { return 5 }\n return 0\n}"
     ),
+    "rust": (
+        "fn f(x: i32) -> i32 {"
+        " if x==1 {1} else if x==2 {2} else if x==3 {3}"
+        " else if x==4 {4} else if x==5 {5} else {0} }"
+    ),
 }
 
 
-@pytest.mark.parametrize("language", ["python", "typescript", "java", "go"])
+@pytest.mark.parametrize("language", ["python", "typescript", "java", "go", "rust"])
 def test_flat_elif_chain_is_not_nested(language):
     ccn, max_nesting, _cognitive, _bumps, _conds = _walk(language, _FLAT_DISPATCH[language])
     # A 5-arm flat dispatch is one branch deep, not five.
@@ -127,6 +132,19 @@ def test_genuine_nested_ifs_still_report_depth():
         "    return 0\n",
     )
     assert max_nesting == 3
+
+
+def test_else_block_with_nested_if_is_not_flattened():
+    # An ``else:`` opening a block that *contains* an if is genuine nesting
+    # (depth 2) — only a direct ``elif`` / ``else if`` continuation flattens.
+    _ccn, max_nesting, _cog, _b, _c = _walk(
+        "python",
+        "def f(a, b):\n"
+        "    if a:\n        return 1\n"
+        "    else:\n        if b:\n            return 2\n"
+        "    return 0\n",
+    )
+    assert max_nesting == 2
 
 
 # --- M4: boolean ops inside a lambda body do not leak into the condition ---
@@ -156,6 +174,39 @@ def test_comprehension_filter_clauses_count_toward_ccn():
     )
     # base path + two independent filter predicates.
     assert ccn == 3
+
+
+def test_comprehension_filter_does_not_inflate_nesting():
+    # A lone filtered comprehension is a branch, not a nested block.
+    ccn, max_nesting, cognitive, _b, _c = _walk(
+        "python",
+        "def f(xs):\n    return [x for x in xs if x > 0]\n",
+    )
+    assert (ccn, max_nesting, cognitive) == (2, 0, 1)
+    # And it must not add a level on top of genuine nesting.
+    _ccn, max_nesting_deep, _cog, _b, _c = _walk(
+        "python",
+        "def g(xs, a, b, c):\n"
+        "    if a:\n        if b:\n            if c:\n"
+        "                return [x for x in xs if x > 0]\n"
+        "    return 0\n",
+    )
+    assert max_nesting_deep == 3
+
+
+def test_match_case_guard_does_not_inflate_nesting():
+    # A ``case ... if guard:`` also parses as an ``if_clause``; the guard is a
+    # branch point but must not open a nesting level beyond match + case.
+    ccn, max_nesting, _cog, _b, _c = _walk(
+        "python",
+        "def f(v):\n"
+        "    match v:\n"
+        "        case 1 if v > 0:\n            return 1\n"
+        "        case _:\n            return 0\n",
+    )
+    assert max_nesting == 2
+    # The guard still counts toward CCN.
+    assert ccn >= 3
 
 
 # --- M5: function NLOC excludes docstring / comment-only lines --------------


### PR DESCRIPTION
## What this fixes

Corrects several miscounts in the shared complexity engine (the metrics many detectors read).

- **`elif` / `else if` chains no longer inflate nesting.** A flat guard-clause chain parses as nested AST in every grammar, so a 5-arm chain reported `max_nesting=5` (or 2 in Python) when the real depth is 1 — enough to trip `nested_complexity` HIGH/CRITICAL on code that isn't nested. Chains now count toward branch complexity (CCN) but not nesting/cognitive. Verified across Python, TypeScript, JavaScript, Java, Go, Rust, C++, C#, Kotlin, Dart; a genuine `else { if … }` block still counts real depth.
- **Parameter count** no longer counts a bare `*` or `/` separator (the keyword-only / positional-only markers) as a parameter — fixes an off-by-one that tipped clean signatures over the long-argument-list smell.
- **Boolean-operator condition count** no longer descends into lambda bodies, so operators inside a `key=lambda …` don't get attributed to the enclosing `if`.
- **Comprehension `if` filters** now contribute to CCN (they were an undercount), while — per the fix above — not inflating nesting.
- **Function/class length (NLOC)** now excludes comment- and docstring-only lines, matching how file-level NLOC is already measured, so a doc-heavy function isn't flagged as a large method on the strength of its docstring.

## Notes

- Line counting now decodes each file once (was re-decoding the whole file per function/class — a hot-path perf regression).

## Testing

New regression module (comprehension/guard nesting guards, non-flattening `else{if}`, cross-grammar `else if`, separators, lambda, NLOC). Full health suite: **824 passed**. Scoring snapshots unchanged. `ruff check` + `format --check` clean.
