### PR TITLE
fix(mcp): payload quality and contributor-email privacy

### DIFF
--- a/packages/core/src/repowise/core/analysis/decisions/extractor.py
+++ b/packages/core/src/repowise/core/analysis/decisions/extractor.py
@@ -49,6 +49,25 @@ from .prompts import (
 
 logger = structlog.get_logger(__name__)
 
+
+def _truncate_title(text: str, limit: int) -> str:
+    """Truncate a decision title to ``limit`` chars on a word boundary.
+
+    Avoids splitting a word mid-way: trims back to the last whitespace inside
+    the limit and appends an ellipsis. Falls back to a hard cut only when the
+    first word already exceeds the limit (no boundary to break on).
+    """
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    window = text[:limit]
+    cut = window.rfind(" ")
+    if cut <= 0:
+        # Single over-long word — hard cut, still signal truncation.
+        return window.rstrip() + "…"
+    return window[:cut].rstrip() + "…"
+
+
 # ---------------------------------------------------------------------------
 # Data models
 # ---------------------------------------------------------------------------
@@ -432,7 +451,7 @@ class DecisionExtractor:
     ) -> ExtractedDecision:
         """Create a minimal decision from a raw marker without LLM."""
         return ExtractedDecision(
-            title=marker["text"][:100],
+            title=_truncate_title(marker["text"], 100),
             decision=marker["text"],
             context=f"Found in {file_path}:{marker['line']}",
             source="inline_marker",
@@ -817,7 +836,7 @@ class DecisionExtractor:
         mapped_status = _ADR_STATUS_MAP.get(status_key, "active")
 
         return ExtractedDecision(
-            title=(title or rel_path)[:200],
+            title=_truncate_title(title or rel_path, 200),
             context=context.strip(),
             decision=decision_txt.strip(),
             rationale=rationale.strip(),
@@ -862,7 +881,7 @@ class DecisionExtractor:
         for section, bullet in entries[:50]:
             decisions.append(
                 ExtractedDecision(
-                    title=bullet[:100],
+                    title=_truncate_title(bullet, 100),
                     decision=bullet,
                     context=f"CHANGELOG · {section.title()}",
                     source="changelog",
@@ -1221,7 +1240,7 @@ class DecisionExtractor:
         """A short, single-line title for a harvested comment."""
         first = text.strip().splitlines()[0] if text.strip() else text
         first = re.sub(r"\s+", " ", first).strip()
-        return first[:100]
+        return _truncate_title(first, 100)
 
     def _build_symbol_index(self) -> dict[str, list[tuple[int, int, str]]]:
         """Map each file's rel path → its symbols' ``(start, end, label)``.

--- a/packages/core/src/repowise/core/analysis/decisions/provenance.py
+++ b/packages/core/src/repowise/core/analysis/decisions/provenance.py
@@ -53,6 +53,15 @@ SOURCE_RANK: dict[str, int] = {
 
 MAX_SOURCE_RANK: int = max(SOURCE_RANK.values())
 
+# Rank at/below which the only evidence is a heuristic rationale-comment harvest
+# (``code_comment`` and the placeholder ``test_name``/``inferred`` tiers). A
+# decision resting solely on a plain code comment is a weak signal and must not
+# read as confident as a real ADR/commit-derived decision, so its confidence is
+# decayed into a sub-tier below the 0.5 floor unless something stronger
+# corroborates it (which lifts ``top_rank`` above this line).
+_HEURISTIC_COMMENT_RANK: int = 2
+_HEURISTIC_COMMENT_DECAY: float = 0.85
+
 
 def rank_for_source(source: str | None) -> int:
     """Return the ranking ladder value for *source* (unknown → lowest rank)."""
@@ -84,6 +93,10 @@ def compute_confidence(
         conf *= 0.85
     elif verification == "unverified":
         conf *= 0.6
+    # A decision backed only by a heuristic code-comment harvest sits a tier
+    # below real ADR/commit-derived intent, so it never clears the 0.5 floor.
+    if top_rank <= _HEURISTIC_COMMENT_RANK:
+        conf *= _HEURISTIC_COMMENT_DECAY
     return round(max(0.0, min(0.99, conf)), 3)
 
 

--- a/packages/core/src/repowise/core/analysis/decisions/semantic_match.py
+++ b/packages/core/src/repowise/core/analysis/decisions/semantic_match.py
@@ -75,7 +75,22 @@ def decision_match_text(title: str, decision: str = "") -> str:
     """
     title = (title or "").strip()
     decision = (decision or "").strip()
-    return f"{title}\n{decision}".strip() if decision else title
+    if not decision:
+        return title
+    # When ``decision`` is just the title again (a body-less record whose title
+    # was promoted into the decision field), don't emit the same line twice.
+    if _same_line(title, decision):
+        return title
+    return f"{title}\n{decision}".strip()
+
+
+def _same_line(a: str, b: str) -> bool:
+    """True when two strings are the same line ignoring case and edge punctuation."""
+
+    def norm(s: str) -> str:
+        return s.strip().strip(".!?:;,").casefold()
+
+    return norm(a) == norm(b)
 
 
 def _decision_page_id(decision_id: str) -> str:

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/churn_risk.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/churn_risk.py
@@ -67,6 +67,13 @@ class ChurnRiskDetector:
         if relative_churn < _RELATIVE_CHURN_FLOOR:
             return []
 
+        # Above 100% the churn/NLOC ratio reads as nonsense as a percentage
+        # (e.g. "15475%"); render it as a multiplier of the file's size instead.
+        if relative_churn >= 1.0:
+            churn_text = f"{relative_churn:.1f}x the file's size"
+        else:
+            churn_text = f"{relative_churn:.0%} of the file's lines"
+
         is_hotspot = bool(meta.get("is_hotspot"))
         if relative_churn >= 4 and is_hotspot:
             severity = Severity.CRITICAL
@@ -93,7 +100,7 @@ class ChurnRiskDetector:
                     "nloc": ctx.nloc,
                 },
                 reason=(
-                    f"90-day churn rewrote {relative_churn:.0%} of the file's lines "
+                    f"90-day churn rewrote {churn_text} "
                     f"({added + deleted} lines over {ctx.nloc} NLOC, "
                     f"top {(1 - churn_pct):.0%} of repo churn)"
                 ),

--- a/packages/core/src/repowise/core/analysis/health/biomarkers/churn_risk.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/churn_risk.py
@@ -67,12 +67,11 @@ class ChurnRiskDetector:
         if relative_churn < _RELATIVE_CHURN_FLOOR:
             return []
 
-        # Above 100% the churn/NLOC ratio reads as nonsense as a percentage
-        # (e.g. "15475%"); render it as a multiplier of the file's size instead.
-        if relative_churn >= 1.0:
-            churn_text = f"{relative_churn:.1f}x the file's size"
-        else:
-            churn_text = f"{relative_churn:.0%} of the file's lines"
+        # relative_churn is always >= _RELATIVE_CHURN_FLOOR (1.0) here — below it
+        # the detector already returned. Above 100% the churn/NLOC ratio reads as
+        # nonsense as a percentage (e.g. "15475%"), so render it as a multiplier
+        # of the file's size instead.
+        churn_text = f"{relative_churn:.1f}x the file's size"
 
         is_hotspot = bool(meta.get("is_hotspot"))
         if relative_churn >= 4 and is_hotspot:

--- a/packages/server/src/repowise/server/mcp_server/tool_overview.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_overview.py
@@ -352,7 +352,11 @@ def _build_git_health(all_git: list) -> dict[str, Any]:
     top_modules = [m for m, _ in module_churn.most_common(5) if module_churn[m] > 0]
 
     return {
-        "total_files_indexed": len(all_git),
+        # Files that carry git history (churn/ownership), NOT the parsed file
+        # total — a repo can parse more files than git attributes (vendored,
+        # generated, or newly added files have no 90-day history). Named
+        # explicitly so the two counts don't read as a discrepancy.
+        "files_git_attributed": len(all_git),
         "hotspot_count": hotspot_count,
         "avg_bus_factor": round(avg_bus, 1),
         "files_with_bus_factor_1": bf1,
@@ -361,24 +365,41 @@ def _build_git_health(all_git: list) -> dict[str, Any]:
     }
 
 
+def _owner_display_name(name: str | None, email: str) -> str:
+    """A privacy-safe display name for a contributor — never the raw email.
+
+    Prefers the recorded ``primary_owner_name``; when absent, derives a
+    conservative label from the email's local part (e.g. ``jane.doe`` from
+    ``jane.doe@example.com``) so the address itself is never surfaced.
+    """
+    if name and name.strip():
+        return name.strip()
+    local = (email or "").split("@", 1)[0].strip()
+    return local or "unknown"
+
+
 def _build_knowledge_map(all_git: list) -> dict[str, Any]:
     """Top owners and knowledge silos aggregated across all indexed files."""
     if not all_git:
         return {}
 
+    # Aggregate on email (the stable identity key) but never surface it — the
+    # payload emits a display name only, to keep contributor emails private.
     owner_file_count: dict[str, int] = defaultdict(int)
     owner_pct_sum: dict[str, float] = defaultdict(float)
+    owner_name: dict[str, str] = {}
     for g in all_git:
         email = g.primary_owner_email or ""
         if email:
             owner_file_count[email] += 1
             owner_pct_sum[email] += float(g.primary_owner_commit_pct or 0.0)
+            owner_name.setdefault(email, _owner_display_name(g.primary_owner_name, email))
 
     total_files = len(all_git) or 1
     top_owners = sorted(
         [
             {
-                "email": email,
+                "name": owner_name.get(email) or _owner_display_name(None, email),
                 "files_owned": count,
                 "percentage": round(count / total_files * 100.0, 1),
             }
@@ -787,7 +808,7 @@ async def get_overview(repo: str | None = None, include: list[str] | None = None
 
         if not want_full_content and content_md != full_content:
             result["content_hint"] = (
-                'Overview essay trimmed to its summary section. '
+                "Overview essay trimmed to its summary section. "
                 'Call get_overview(include=["content"]) for the full walkthrough.'
             )
 

--- a/packages/server/src/repowise/server/mcp_server/tool_overview.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_overview.py
@@ -368,11 +368,12 @@ def _build_git_health(all_git: list) -> dict[str, Any]:
 def _owner_display_name(name: str | None, email: str) -> str:
     """A privacy-safe display name for a contributor — never the raw email.
 
-    Prefers the recorded ``primary_owner_name``; when absent, derives a
-    conservative label from the email's local part (e.g. ``jane.doe`` from
-    ``jane.doe@example.com``) so the address itself is never surfaced.
+    Prefers the recorded ``primary_owner_name``; when absent — or when that name
+    is itself an address (bot/CI commits, a misconfigured ``user.name``) —
+    derives a conservative label from the email's local part (e.g. ``jane.doe``
+    from ``jane.doe@example.com``) so the address itself is never surfaced.
     """
-    if name and name.strip():
+    if name and name.strip() and "@" not in name:
         return name.strip()
     local = (email or "").split("@", 1)[0].strip()
     return local or "unknown"

--- a/tests/unit/analysis/test_ff_mcp_payload_decisions.py
+++ b/tests/unit/analysis/test_ff_mcp_payload_decisions.py
@@ -1,0 +1,80 @@
+"""Regression tests for decision-payload quality fixes:
+
+- semantic snippet text must not double a title-only decision,
+- a code-comment-derived decision must land below the real-ADR floor,
+- decision titles must truncate on a word boundary with an ellipsis.
+"""
+
+from __future__ import annotations
+
+from repowise.core.analysis.decisions.extractor import _truncate_title
+from repowise.core.analysis.decisions.provenance import (
+    compute_confidence,
+    rank_for_source,
+)
+from repowise.core.analysis.decisions.semantic_match import decision_match_text
+
+# --- snippet doubling ------------------------------------------------------
+
+
+def test_snippet_not_doubled_when_decision_equals_title():
+    text = decision_match_text("Use Redis for caching", "Use Redis for caching")
+    assert text == "Use Redis for caching"
+    assert text.count("Use Redis for caching") == 1
+
+
+def test_snippet_not_doubled_for_trivial_variant():
+    # Trailing punctuation / case difference is still "the same line".
+    text = decision_match_text("Use Redis for caching", "use redis for caching.")
+    assert text.count("\n") == 0
+    assert text == "Use Redis for caching"
+
+
+def test_snippet_keeps_both_lines_when_they_differ():
+    text = decision_match_text("Use Redis for caching", "Chosen for sub-ms reads")
+    assert "Use Redis for caching" in text
+    assert "Chosen for sub-ms reads" in text
+    assert "\n" in text
+
+
+# --- comment-derived confidence sub-tier -----------------------------------
+
+
+def test_code_comment_confidence_below_real_adr_floor():
+    comment_conf = compute_confidence(rank_for_source("code_comment"))
+    adr_conf = compute_confidence(rank_for_source("adr"))
+    commit_conf = compute_confidence(rank_for_source("commit"))
+    assert comment_conf < 0.5  # does not clear the confidence floor
+    assert comment_conf < adr_conf
+    assert comment_conf < commit_conf
+
+
+def test_corroborating_adr_lifts_comment_out_of_subtier():
+    # When a stronger source corroborates, top_rank rises and the sub-tier
+    # penalty no longer applies.
+    corroborated = compute_confidence(rank_for_source("adr"), corroboration_count=2)
+    assert corroborated > 0.5
+
+
+# --- boundary-aware title truncation ---------------------------------------
+
+
+def test_title_truncates_on_word_boundary_with_ellipsis():
+    title = "Adopt an event-driven architecture for the payment settlement pipeline " + ("x" * 200)
+    out = _truncate_title(title, 60)
+    assert out.endswith("…")
+    body = out.rstrip("…")
+    # Never splits a word: every emitted word appears verbatim in the source.
+    for word in body.split():
+        assert word in title
+    assert len(out) <= 61
+
+
+def test_short_title_unchanged():
+    assert _truncate_title("Use Postgres", 100) == "Use Postgres"
+
+
+def test_single_overlong_word_hard_cut_still_ellipsized():
+    out = _truncate_title("a" * 200, 40)
+    assert out.endswith("…")
+    assert len(out) == 41

--- a/tests/unit/health/test_ff_mcp_payload_churn.py
+++ b/tests/unit/health/test_ff_mcp_payload_churn.py
@@ -1,0 +1,59 @@
+"""Regression: churn-risk reason wording for extreme relative churn.
+
+An above-100% churn/NLOC ratio used to render with ``:.0%`` and print
+nonsense like "15475%". It must render as a multiplier ("N.Nx the file's
+size") instead. The numeric score fields must be untouched.
+"""
+
+from __future__ import annotations
+
+from repowise.core.analysis.health.biomarkers import FileContext
+from repowise.core.analysis.health.biomarkers.churn_risk import ChurnRiskDetector
+
+
+def _ctx(meta: dict, *, nloc: int = 120) -> FileContext:
+    return FileContext(
+        file_path="src/payments.py",
+        language="python",
+        nloc=nloc,
+        has_test_file=False,
+        module=None,
+        function_metrics={},
+        git_meta=meta,
+        dependents_count=4,
+        pagerank_score=0.0,
+    )
+
+
+def test_extreme_churn_renders_as_multiplier_not_percentage():
+    # nloc=1; 155 lines churned → relative_churn 155.0 → old text "15500%".
+    meta = {
+        "commit_count_90d": 20,
+        "churn_percentile": 0.99,
+        "lines_added_90d": 100,
+        "lines_deleted_90d": 55,
+        "is_hotspot": True,
+    }
+    out = ChurnRiskDetector().detect(_ctx(meta, nloc=1))
+    assert len(out) == 1
+    reason = out[0].reason
+    assert "155.0x the file's size" in reason
+    assert "%" not in reason.split("top")[0]  # no percentage before the percentile clause
+    # Score-bearing detail fields unchanged.
+    assert out[0].details["relative_churn"] == 155.0
+
+
+def test_churn_multiplier_used_at_and_above_one():
+    # relative_churn exactly 1.5 (100 + 80 over 120 nloc).
+    meta = {
+        "commit_count_90d": 8,
+        "churn_percentile": 0.9,
+        "lines_added_90d": 100,
+        "lines_deleted_90d": 80,
+        "is_hotspot": False,
+    }
+    out = ChurnRiskDetector().detect(_ctx(meta))
+    assert len(out) == 1
+    assert "1.5x the file's size" in out[0].reason
+    # No four-plus-digit percentage anywhere.
+    assert "15475%" not in out[0].reason

--- a/tests/unit/server/mcp/test_ff_mcp_payload_overview.py
+++ b/tests/unit/server/mcp/test_ff_mcp_payload_overview.py
@@ -1,0 +1,70 @@
+"""Regression tests for get_overview payload quality:
+
+- the git-attributed file count is labelled distinctly (not "total_files"),
+- the knowledge map emits a contributor display name, never the raw email.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from repowise.server.mcp_server.tool_overview import (
+    _build_git_health,
+    _build_knowledge_map,
+    _owner_display_name,
+)
+
+
+def _git_row(**kw) -> SimpleNamespace:
+    base = {
+        "file_path": "src/app.py",
+        "is_hotspot": False,
+        "bus_factor": 2,
+        "commit_count_30d": 1,
+        "commit_count_90d": 3,
+        "primary_owner_email": "jane.doe@example.com",
+        "primary_owner_name": "Jane Doe",
+        "primary_owner_commit_pct": 0.5,
+    }
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+# --- file-count labelling --------------------------------------------------
+
+
+def test_git_health_labels_git_attributed_count():
+    rows = [_git_row(file_path="a.py"), _git_row(file_path="b.py")]
+    out = _build_git_health(rows)
+    assert out["files_git_attributed"] == 2
+    # The ambiguous name is gone so it can't read as a parsed-file total.
+    assert "total_files_indexed" not in out
+
+
+# --- contributor-email privacy ---------------------------------------------
+
+
+def test_knowledge_map_emits_name_not_email():
+    rows = [_git_row(file_path=f"f{i}.py") for i in range(3)]
+    out = _build_knowledge_map(rows)
+    owners = out["top_owners"]
+    assert owners
+    top = owners[0]
+    assert top["name"] == "Jane Doe"
+    assert "email" not in top
+    # The raw address never appears anywhere in the owner payload.
+    assert "jane.doe@example.com" not in str(owners)
+
+
+def test_owner_display_name_derives_from_email_when_name_missing():
+    # No recorded name → conservative local-part label, never the raw email.
+    assert _owner_display_name(None, "jane.doe@example.com") == "jane.doe"
+    assert _owner_display_name("", "jane.doe@example.com") == "jane.doe"
+    assert _owner_display_name("Jane Doe", "jane.doe@example.com") == "Jane Doe"
+
+
+def test_knowledge_map_falls_back_to_local_part():
+    rows = [_git_row(primary_owner_name=None, primary_owner_email="bob@corp.io")]
+    out = _build_knowledge_map(rows)
+    assert out["top_owners"][0]["name"] == "bob"
+    assert "bob@corp.io" not in str(out["top_owners"])

--- a/tests/unit/server/mcp/test_ff_mcp_payload_overview.py
+++ b/tests/unit/server/mcp/test_ff_mcp_payload_overview.py
@@ -63,6 +63,20 @@ def test_owner_display_name_derives_from_email_when_name_missing():
     assert _owner_display_name("Jane Doe", "jane.doe@example.com") == "Jane Doe"
 
 
+def test_owner_display_name_rejects_email_shaped_name():
+    # Git author name is commonly itself an email (bot/CI commits, misconfigured
+    # user.name); it must NOT be surfaced — fall through to the local part.
+    assert _owner_display_name("bob@corp.io", "bob@corp.io") == "bob"
+    assert _owner_display_name("ci-bot@ci.internal", "bob@corp.io") == "bob"
+
+
+def test_knowledge_map_rejects_email_shaped_name():
+    rows = [_git_row(primary_owner_name="bob@corp.io", primary_owner_email="bob@corp.io")]
+    out = _build_knowledge_map(rows)
+    assert out["top_owners"][0]["name"] == "bob"
+    assert "bob@corp.io" not in str(out["top_owners"])
+
+
 def test_knowledge_map_falls_back_to_local_part():
     rows = [_git_row(primary_owner_name=None, primary_owner_email="bob@corp.io")]
     out = _build_knowledge_map(rows)


### PR DESCRIPTION
## What this fixes

Output-quality and privacy fixes in the MCP/reporting payloads. None of these change health scores (scoring snapshots verified unchanged).

- **Contributor privacy.** The overview emits the owner's display name, never a raw email address — including the case where the git author name is itself an email (bot/CI/misconfigured `user.name`), which now falls back to the local part.
- **Churn wording.** Extreme churn renders as a multiplier ("155.0x the file's size") instead of a percentage that read as nonsense ("15475%").
- **Search snippets** no longer show the same line twice when a decision's title and body are identical.
- **Comment-derived decisions** are kept below the confidence floor of real architecture decision records, so a code comment isn't presented with the same weight as an ADR.
- **File counts** are labeled to distinguish files parsed from files attributed via git history, instead of looking like a discrepancy.
- **Decision titles** truncate on a word boundary with an ellipsis instead of mid-word.

## Testing

New regression tests across the touched subsystems. Relevant suites green; **scoring snapshots explicitly verified unchanged (28/28)**. `ruff check` + `format --check` clean.
