### PR TITLE
release: v0.29.0 — code-health detector honesty + MCP payload/privacy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.28.1",
+      "version": "0.29.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.29.0] — 2026-07-09
+
+### Added
+- **Leverage-weighted health signals.** `get_health` now surfaces NLOC-weighting and per-file leverage, so the score points at where a fix buys the most. (#719)
+- **Wider agent-authorship detection.** Git indexing recognizes agent-written commits across more provenance channels. (#731)
+
+### Changed
+- **Leaner `get_overview` by default.** The `get_overview` MCP payload is compact by default, cutting the token cost of orienting an agent. (#729)
+- **Health scores reflect corrected findings.** Removing the false findings below raises some file and repo health scores — this is expected and desirable, not a regression. Broad `except Exception` catches are now detected completely (they were previously under-counted), so a few files surface additional — but honest — findings.
+
+### Fixed
+- **Honest exception-handling rationale.** A broad `except Exception` is no longer described as catching `KeyboardInterrupt`/`SystemExit` — only a genuine bare `except:` or `except BaseException:` carries that warning, and `except Exception` gets its own rationale. Go blank-identifier discards are only flagged when the discarded value sits in the error position, and Rust panic macros and `.unwrap()`/`.expect()` inside test code are no longer flagged as recoverable-error crashes. (#733)
+- **Accurate complexity counting.** `elif` / `else if` chains no longer read as deep nesting (a flat guard chain is flat); parameter counts ignore the bare `*` / `/` separators; comprehension filters now count toward complexity; and docstring- and comment-only lines no longer inflate a function's or class's measured length. (#734)
+- **Fewer false performance findings.** I/O-in-loop, defer-in-loop, blocking-I/O-under-lock and related markers no longer fire on a closure that is merely defined — not run — inside a loop or lock; a parenthesized `await` is recognized as awaited; `deque.insert(0, …)` is no longer flagged as quadratic; name-shadowing collisions in the Python and TypeScript detectors are resolved; and a semaphore-bounded goroutine worker pool is no longer called unbounded. (#735)
+- **Truthful structural findings.** A god-class finding cites the complexity of the actual brain method rather than the class-wide maximum; an `UPDATE`/`DELETE` bounded by a `LIMIT` is no longer said to touch every row; a flat `match`/`case` dispatch table is no longer flagged as a large method; and hidden-coupling severity is no longer overstated from a handful of shared commits. (#736)
+- **Cleaner, more private MCP output.** Contributor email addresses are never shown in overview output (display names only); extreme churn renders as a multiplier instead of a runaway percentage; search snippets no longer repeat a title-only decision; comment-derived decisions rank below real architecture decisions; file counts are labeled; and decision titles truncate on a word boundary with an ellipsis. (#737)
+- **Atomic update lock.** `repowise update`'s lock file is now written atomically with its contents, closing a creation race. (#720)
+
+---
+
 ## [0.28.1] — 2026-07-08
 
 ### Changed

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.28.1"
+__version__ = "0.29.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.28.1"
+__version__ = "0.29.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.29.0] — 2026-07-09
+
+### Added
+- **Leverage-weighted health signals.** `get_health` now surfaces NLOC-weighting and per-file leverage, so the score points at where a fix buys the most. (#719)
+- **Wider agent-authorship detection.** Git indexing recognizes agent-written commits across more provenance channels. (#731)
+
+### Changed
+- **Leaner `get_overview` by default.** The `get_overview` MCP payload is compact by default, cutting the token cost of orienting an agent. (#729)
+- **Health scores reflect corrected findings.** Removing the false findings below raises some file and repo health scores — this is expected and desirable, not a regression. Broad `except Exception` catches are now detected completely (they were previously under-counted), so a few files surface additional — but honest — findings.
+
+### Fixed
+- **Honest exception-handling rationale.** A broad `except Exception` is no longer described as catching `KeyboardInterrupt`/`SystemExit` — only a genuine bare `except:` or `except BaseException:` carries that warning, and `except Exception` gets its own rationale. Go blank-identifier discards are only flagged when the discarded value sits in the error position, and Rust panic macros and `.unwrap()`/`.expect()` inside test code are no longer flagged as recoverable-error crashes. (#733)
+- **Accurate complexity counting.** `elif` / `else if` chains no longer read as deep nesting (a flat guard chain is flat); parameter counts ignore the bare `*` / `/` separators; comprehension filters now count toward complexity; and docstring- and comment-only lines no longer inflate a function's or class's measured length. (#734)
+- **Fewer false performance findings.** I/O-in-loop, defer-in-loop, blocking-I/O-under-lock and related markers no longer fire on a closure that is merely defined — not run — inside a loop or lock; a parenthesized `await` is recognized as awaited; `deque.insert(0, …)` is no longer flagged as quadratic; name-shadowing collisions in the Python and TypeScript detectors are resolved; and a semaphore-bounded goroutine worker pool is no longer called unbounded. (#735)
+- **Truthful structural findings.** A god-class finding cites the complexity of the actual brain method rather than the class-wide maximum; an `UPDATE`/`DELETE` bounded by a `LIMIT` is no longer said to touch every row; a flat `match`/`case` dispatch table is no longer flagged as a large method; and hidden-coupling severity is no longer overstated from a handful of shared commits. (#736)
+- **Cleaner, more private MCP output.** Contributor email addresses are never shown in overview output (display names only); extreme churn renders as a multiplier instead of a runaway percentage; search snippets no longer repeat a title-only decision; comment-derived decisions rank below real architecture decisions; file counts are labeled; and decision titles truncate on a word boundary with an ellipsis. (#737)
+- **Atomic update lock.** `repowise update`'s lock file is now written atomically with its contents, closing a creation race. (#720)
+
+---
+
 ## [0.28.1] — 2026-07-08
 
 ### Changed

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.28.1"
+__version__ = "0.29.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.28.1"
+version = "0.29.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3056,7 +3056,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.28.1"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Release **v0.29.0** — the code-health detector honesty release.

This cycle's theme is trust in the health findings: a batch of detector false-flag fixes (audited, unit-tested, and verified end-to-end by reindexing repowise's own tree), plus MCP payload-quality and contributor-privacy fixes. Also folds in the leverage-weighted `get_health`, compact `get_overview`, wider agent-authorship detection, and the atomic update-lock fix that landed since 0.28.1.

Because false findings were removed and rationales corrected, **some health scores rise** — expected, not a regression (called out in the changelog). Broad `except Exception` detection is now complete (was under-counted), so a few files show additional but honest findings.

### Local validation
- [x] Version bumped in all 4 Python files + both plugin manifests; `uv.lock` self-entry → 0.29.0
- [x] Drift grep clean (only `httpx==0.28.1` dependency remains, unrelated)
- [x] Changelog written + bundled copy resynced (`test_bundled_changelog_sync.py` green)
- [x] Plugin parity: no MCP tool surface change this cycle; tool-name grep clean (`get_architecture_diagram` only in the plugin CHANGELOG's removal note)
- [x] `repowise --version` → 0.29.0
- [x] Wheel build clean — commands, `.scm` queries, `.j2` templates all present
- [x] End-to-end verified: reindexed repowise's own tree with the new engine vs the pre-fix baseline — no crashes, all scores equal-or-higher, targeted false flags gone
- [x] Web build hard gate (`npm ci && npm run build --workspace packages/web`) — clean, standalone server.js + workspace chunks present
- [ ] Browser smoke test — hand off to reviewer

### Post-merge (unchecked)
- [ ] Squash-merge, then tag `v0.29.0` on `main` and push (triggers `publish.yml`)
- [ ] Post-release sanity (PyPI version, release assets, tarball structure)
- [ ] Discord announcement
