### PR TITLE
feat(risk): split test-file breakage out of will_break (#672)

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -282,7 +282,7 @@ Modification risk assessment for files or a set of changed files.
 
 **Returns:** Per-file risk score (0–10), hotspot status, dependent count, co-change partners, blast radius, recommended reviewers, test gap analysis, security signals. In workspace mode, enriched with cross-repo co-change partners and contract dependencies.
 
-When `changed_files` is passed, the response leads with a `directive` block. In workspace mode that directive also carries the cross-repo fallout of the changed repo:
+When `changed_files` is passed, the response leads with a `directive` block. Its core lists are the local blast radius: `will_break` (production files that depend on the diff and are likely to break), `will_break_tests` (test files impacted the same way, kept separate so a burst of broken tests doesn't crowd production impact out of the capped list), `missing_cochanges` (historical co-changers absent from the diff), and `missing_tests` (changed files without test coverage). In workspace mode that directive also carries the cross-repo fallout of the changed repo:
 
 - `will_break_consumers`: services in *other* repos that depend on this one (structural impact), each with `repo`, `service`, `distance`, `score`, and the edge kinds carrying the impact.
 - `missing_cross_repo_cochanges`: services in other repos that historically co-change with this one but aren't in the diff.

--- a/packages/server/src/repowise/server/mcp_server/tool_risk/directives.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/directives.py
@@ -44,6 +44,11 @@ _BC_CONSUMER_LIMIT = 5
 _CF_VIOLATION_LIMIT = 5
 _CF_CYCLE_LIMIT = 3
 
+#: Caps on the will-break split. Production impact leads the directive, so it
+#: keeps the larger budget; test fallout is a secondary signal capped tighter.
+_WILL_BREAK_LIMIT = 5
+_WILL_BREAK_TESTS_LIMIT = 3
+
 
 def _breaking_change_directive(repo_alias: str) -> list[dict[str, Any]]:
     """Breaking-change half of the PR directive: incompatible provider changes.
@@ -269,6 +274,7 @@ def _build_pr_directive(
     exclude_spec: Any,
     collector: OmissionCollector,
     governance_risk: list[dict[str, Any]],
+    test_paths: set[str],
     alias: str,
 ) -> None:
     """Assemble PR-mode output: trim co-change lists + blast radius, then build
@@ -295,10 +301,13 @@ def _build_pr_directive(
     # entry is a file path (string), never a dossier. Designed to answer
     # "what should I do about this PR" in three lines.
 
-    will_break = filter_path_list(
+    affected = filter_path_list(
         [p for p in (_as_path(e) for e in trimmed_blast.get("transitive_affected", [])) if p],
         exclude_spec,
-    )[:5]
+    )
+    will_break = [p for p in affected if p not in test_paths][:_WILL_BREAK_LIMIT]
+    will_break_tests = [p for p in affected if p in test_paths][:_WILL_BREAK_TESTS_LIMIT]
+
     missing_cochanges = filter_path_list(
         [p for p in (_as_path(e) for e in trimmed_blast.get("cochange_warnings", [])) if p],
         exclude_spec,
@@ -364,6 +373,7 @@ def _build_pr_directive(
 
     response["directive"] = {
         "will_break": will_break,
+        "will_break_tests": will_break_tests,
         "missing_cochanges": missing_cochanges,
         "missing_tests": missing_tests,
         "will_break_consumers": will_break_consumers,
@@ -376,6 +386,7 @@ def _build_pr_directive(
         "summary": (
             f"PR touches {len(changed_files)} file(s). "
             f"~{len(will_break)} downstream file(s) likely affected, "
+            f"{len(will_break_tests)} test(s) likely broken, "
             f"{len(missing_cochanges)} historical co-changer(s) missing, "
             f"{len(missing_tests)} file(s) without tests."
             f"{gov_suffix}{xr_suffix}{bc_suffix}{cf_suffix}"

--- a/packages/server/src/repowise/server/mcp_server/tool_risk/get_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_risk/get_risk.py
@@ -80,6 +80,7 @@ async def get_risk(
             select(GraphNode).where(GraphNode.repository_id == repo_id)
         )
         node_meta = {n.node_id: n for n in node_res.scalars().all()}
+        test_paths = {nid for nid, n in node_meta.items() if n.is_test}
 
         # Team size is repo-wide — compute once, share across targets
         # (small-team calibration for bus-factor-risk, issue #361).
@@ -160,6 +161,7 @@ async def get_risk(
             exclude_spec,
             collector,
             governance_risk,
+            test_paths,
             ctx.alias,
         )
     else:

--- a/tests/unit/server/mcp/conftest.py
+++ b/tests/unit/server/mcp/conftest.py
@@ -325,6 +325,20 @@ async def populated_db(session: AsyncSession, repo_id: str) -> str:
             community_id=2,
             created_at=_NOW,
         ),
+        GraphNode(
+            id="gn4",
+            repository_id=rid,
+            node_id="tests/test_service.py",
+            node_type="file",
+            language="python",
+            symbol_count=1,
+            is_test=True,
+            is_entry_point=False,
+            pagerank=0.1,
+            betweenness=0.0,
+            community_id=1,
+            created_at=_NOW,
+        ),
     ]
     for n in nodes:
         session.add(n)
@@ -343,6 +357,14 @@ async def populated_db(session: AsyncSession, repo_id: str) -> str:
             id="ge2",
             repository_id=rid,
             source_node_id="src/auth/middleware.py",
+            target_node_id="src/auth/service.py",
+            imported_names_json='["AuthService"]',
+            created_at=_NOW,
+        ),
+        GraphEdge(
+            id="ge3",
+            repository_id=rid,
+            source_node_id="tests/test_service.py",
             target_node_id="src/auth/service.py",
             imported_names_json='["AuthService"]',
             created_at=_NOW,

--- a/tests/unit/server/mcp/test_risk.py
+++ b/tests/unit/server/mcp/test_risk.py
@@ -91,6 +91,27 @@ async def test_get_risk_stable_file(setup_mcp):
     assert t["risk_type"] == "stable"
 
 
+@pytest.mark.asyncio
+async def test_get_risk_pr_directive_splits_test_breakage(setup_mcp):
+    """PR mode splits test-file fallout out of will_break into will_break_tests (#672)."""
+    from repowise.server.mcp_server import get_risk
+
+    # Pass changed_files to trigger PR mode + blast-radius directive.
+    result = await get_risk(["src/auth/service.py"], changed_files=["src/auth/service.py"])
+    directive = result["directive"]
+
+    # middleware.py imports service.py → production breakage.
+    assert "src/auth/middleware.py" in directive["will_break"]
+    assert "src/auth/middleware.py" not in directive["will_break_tests"]
+
+    # test_service.py imports service.py but is is_test=True → segmented out.
+    assert "tests/test_service.py" in directive["will_break_tests"]
+    assert "tests/test_service.py" not in directive["will_break"]
+
+    # Summary reflects the test count.
+    assert "test(s) likely broken" in directive["summary"]
+
+
 # ---- _classify_risk_type small-team calibration (issue #361) ---------------
 
 


### PR DESCRIPTION
## Summary

- In `get_risk` PR mode, the `will_break` directive list mixed production and test files, so a burst of broken tests could crowd real structural impact out of the capped list.
- Segments test files into a new `will_break_tests` field, reusing the `is_test` flag already loaded into `node_meta` (no new query). Partitioning happens **before** the per-list cap, so production impact keeps its full budget of 5 even when many tests break.
- The directive `summary` now reports the test-breakage count. Additive change — no consumer relied on test files being inside `will_break`, so it's low risk.

## Related Issues

Closes #672

## Test Plan

Added `test_get_risk_pr_directive_splits_test_breakage`, which drives a diff whose transitive impact includes both a production importer and a test importer and asserts each lands in the correct bucket (`will_break` vs `will_break_tests`).

- [x] Tests pass (`pytest tests/unit/server/mcp/test_risk.py` — 10/10)
- [x] Lint passes (`ruff check` on changed files — clean)
- [x] Web build passes — N/A, no frontend changes

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation
