### PR TITLE
feat(mcp): agent-lean tool profile, tool-search gating, registry-pinned docs

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -773,7 +773,7 @@ If `PATH` is omitted, `repowise mcp` first walks upward from the current directo
 |------|-------------|
 | `--transport` | `stdio` (default, for editors), `streamable-http` (for HTTP clients), or `sse` (legacy) |
 | `--port` | Port for HTTP/SSE transports (default: 7338) |
-| `--tools` | Override which tools are exposed. A comma-separated list is an explicit allowlist; prefix names with `+`/`-` to adjust the default set (e.g. `+get_dependency_path,-get_dead_code`). Overrides the `mcp.tools` config block. |
+| `--tools` | Override which tools are exposed. A comma-separated list is an explicit allowlist; prefix names with `+`/`-` to adjust the default set (e.g. `+get_dependency_path,-get_dead_code`); `lean` selects the five-tool agent-lean profile. Overrides the `mcp.tools` config block. |
 | `--all` | Expose every available tool, including opt-in and workspace tools |
 
 ```bash
@@ -781,6 +781,7 @@ repowise mcp --transport stdio           # for Claude Code, Codex, Cursor, etc.
 repowise mcp --transport streamable-http # for HTTP clients
 repowise mcp --transport sse --port 7338 # legacy SSE
 repowise mcp --tools "+get_dependency_path,-get_dead_code"
+repowise mcp --tools lean
 repowise mcp --all
 ```
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -140,7 +140,7 @@ distill:
 ### The `mcp:` block
 
 Controls which tools the MCP server advertises. The default surface is curated
-(10 tools in single-repo mode, plus 3 workspace-only tools in workspace mode);
+(11 tools in single-repo mode, plus 3 workspace-only tools in workspace mode);
 this block lets you opt extra tools in or trim the set down. The `repowise mcp
 --tools` / `--all` flags override it for a single launch.
 
@@ -149,10 +149,14 @@ mcp:
   tools: ["+get_execution_flows", "-get_dead_code"]   # adjust the default set
   # tools: ["get_answer", "get_context"]              # or an explicit allowlist
   # tools: all                                        # or everything available
+  # tools: lean                                       # or the agent-lean profile
 ```
 
 - `+name` / `-name` entries add to or remove from the default set; an
   unprefixed list is treated as an explicit allowlist.
+- `lean` selects the agent-lean profile: `get_answer`, `get_context`,
+  `get_symbol`, `search_codebase`, `get_risk` (plus `list_repos` in workspace
+  mode), small enough that Claude Code can keep every schema always loaded.
 - Opt-in tools are `get_dependency_path` and `get_execution_flows`.
 - Workspace-only tools (`get_blast_radius`, `get_conformance`,
   `get_architecture`) are added automatically in workspace mode and ignored if

--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -42,7 +42,7 @@ The default surface is deliberately small: fewer, richer tools mean fewer round-
 - **Default (workspace):** those 11 plus `get_architecture`, `get_blast_radius`, and `get_conformance`, added automatically when the server starts inside a workspace. They are never advertised outside one.
 - **Opt-in tools:** `get_dependency_path` and `get_execution_flows` are registered but off by default everywhere. Turn them on per repo.
 
-**Configure it in `.repowise/config.yaml`** under an `mcp.tools` key. Three shapes are supported:
+**Configure it in `.repowise/config.yaml`** under an `mcp.tools` key. Four shapes are supported:
 
 ```yaml
 # Adjust the default set with + / - deltas (the common case):
@@ -56,6 +56,10 @@ mcp:
 # Or enable everything available in the current mode:
 mcp:
   tools: all
+
+# Or select the agent-lean profile (see below):
+mcp:
+  tools: lean
 ```
 
 **Or per launch on the CLI**, which overrides the config block:
@@ -63,10 +67,13 @@ mcp:
 ```bash
 repowise mcp --tools "+get_execution_flows"          # default set plus one
 repowise mcp --tools "get_answer,get_context"         # explicit allowlist
+repowise mcp --tools lean                             # agent-lean profile
 repowise mcp --all                                    # every available tool
 ```
 
 Workspace-only tools named explicitly in single-repo mode are ignored (they cannot do useful work there). Unknown tool names are ignored with a warning.
+
+**The `lean` profile** is the agent-lean surface: `get_answer`, `get_context`, `get_symbol`, `search_codebase`, and `get_risk`, plus `list_repos` in workspace mode (where repo aliases must be discoverable). It advertises ~1.8k tokens of schema versus ~4.1k for the default surface. That is small enough to keep always loaded, so when a repo has `mcp.tools: lean` configured, `repowise init` skips the tool-search recommendation (the `ENABLE_TOOL_SEARCH` setting that defers MCP schemas behind a lookup round trip) for Claude Code; the five schemas the agent actually reaches for stay in context on every turn. init never turns an existing `ENABLE_TOOL_SEARCH` setting off, since it applies to every MCP server, not just repowise.
 
 **Or from the dashboard:** the Settings page lists every tool with its description and a per-repo toggle, and writes the same `mcp.tools` config for you.
 

--- a/packages/cli/src/repowise/cli/commands/mcp_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/mcp_cmd.py
@@ -90,8 +90,9 @@ def _print_network_startup(
     help=(
         "Override which tools are exposed. A comma-separated list is an "
         "explicit allowlist; prefix names with + or - to adjust the default "
-        "set (e.g. '+get_dependency_path,-get_dead_code'). Overrides the "
-        "mcp.tools config block."
+        "set (e.g. '+get_dependency_path,-get_dead_code'); 'lean' selects "
+        "the five-tool agent-lean profile. Overrides the mcp.tools config "
+        "block."
     ),
 )
 @click.option(
@@ -126,6 +127,7 @@ def mcp_command(
         repowise mcp                     # stdio, current directory
         repowise mcp /path/to/repo       # stdio, specific repo
         repowise mcp --tools +get_execution_flows  # default set plus one
+        repowise mcp --tools lean        # five-tool agent-lean profile
         repowise mcp --all               # every available tool
         repowise mcp --transport streamable-http  # HTTP on port 7338
     """

--- a/packages/cli/src/repowise/cli/editor_integrations/claude.py
+++ b/packages/cli/src/repowise/cli/editor_integrations/claude.py
@@ -67,7 +67,12 @@ class ClaudeCodeSetup:
                 "  [green]✓[/green] Claude Code hooks registered (PostToolUse, SessionStart)"
             )
 
-        if enable_tool_search_in_claude_code():
+        if _uses_lean_tool_surface(repo_path):
+            console_obj.print(
+                "  [dim]Lean MCP tool surface configured; skipping tool-search"
+                " deferral so the core schemas stay always loaded.[/dim]"
+            )
+        elif enable_tool_search_in_claude_code():
             console_obj.print(
                 "  [green]✓[/green] Claude Code tool-search enabled (defers MCP tool schemas)"
             )
@@ -83,6 +88,30 @@ class ClaudeCodeSetup:
         if not _claude_md_enabled(repo_path):
             return
         run_async(_write_claude_md_async(repo_path))
+
+
+def _uses_lean_tool_surface(repo_path: Path) -> bool:
+    """True when the repo's ``mcp.tools`` config selects the lean profile.
+
+    The lean surface (~1.8k tokens of schema) is cheap enough to keep always
+    loaded, so init skips the tool-search (schema deferral) recommendation for
+    it; deferral would reintroduce the schema-load round trip the profile
+    exists to remove. Mirrors the "lean" token the selection layer resolves
+    (see ``repowise.server.mcp_server._tool_selection.LEAN``), read here via
+    the lightweight config loader so init does not import the server stack.
+    """
+    try:
+        from repowise.core.repo_config import load_repo_config
+
+        mcp_cfg = load_repo_config(str(repo_path)).get("mcp") or {}
+        tools = mcp_cfg.get("tools") if isinstance(mcp_cfg, dict) else None
+    except Exception:
+        return False
+    if isinstance(tools, str):
+        return tools.strip().lower() == "lean"
+    if isinstance(tools, (list, tuple)) and len(tools) == 1:
+        return str(tools[0]).strip().lower() == "lean"
+    return False
 
 
 def _prompt_claude_md_enabled(console_obj: Any) -> bool:

--- a/packages/server/src/repowise/server/mcp_server/_tool_selection.py
+++ b/packages/server/src/repowise/server/mcp_server/_tool_selection.py
@@ -35,6 +35,14 @@ _log = logging.getLogger("repowise.mcp")
 # usable in the current mode, including opt-in and workspace-only tools.
 ALL = "all"
 
+# A value of "lean" enables the agent-lean profile: the five pre-edit tools a
+# coding agent actually reaches for, small enough that every schema can stay
+# always-loaded instead of deferred behind a tool-search round trip. list_repos
+# joins it in workspace mode only, where repo aliases must be discoverable.
+LEAN = "lean"
+LEAN_TOOLS = frozenset({"get_answer", "get_context", "get_symbol", "search_codebase", "get_risk"})
+_LEAN_WORKSPACE_EXTRAS = frozenset({"list_repos"})
+
 # Snapshot of every tool registered on the server, captured once after the
 # registry applies them and before any selection trims the live set. Selection
 # rebuilds the advertised set from this snapshot, so it is idempotent and can
@@ -88,6 +96,7 @@ def resolve_enabled_tools(
 
     - ``None`` / empty: the curated default surface.
     - ``"all"`` (or ``["all"]``): every tool usable in the current mode.
+    - ``"lean"``: the agent-lean profile (see :data:`LEAN_TOOLS`).
     - all tokens prefixed ``+``/``-``: deltas applied to the default surface.
     - otherwise: an explicit allowlist (only the named tools).
 
@@ -107,6 +116,10 @@ def resolve_enabled_tools(
 
     if len(tokens) == 1 and tokens[0].lower() == ALL:
         return {name for name, e in catalog.items() if usable(e)}
+
+    if len(tokens) == 1 and tokens[0].lower() == LEAN:
+        names = LEAN_TOOLS | (_LEAN_WORKSPACE_EXTRAS if is_workspace else frozenset())
+        return {n for n in names if n in catalog and usable(catalog[n])}
 
     def resolve_name(raw: str) -> str | None:
         entry = catalog.get(raw)

--- a/tests/unit/cli/test_editor_setup.py
+++ b/tests/unit/cli/test_editor_setup.py
@@ -644,6 +644,52 @@ def test_claude_client_registration_uses_existing_claude_setup(
     assert "tool-search enabled" in text
 
 
+def test_lean_tool_surface_skips_tool_search_recommendation(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """A repo configured with the lean profile keeps schemas always loaded."""
+    calls: list[str] = []
+    monkeypatch.setattr(claude_config, "register_with_claude_desktop", lambda p: None)
+    monkeypatch.setattr(claude_config, "register_with_claude_code", lambda p: None)
+    monkeypatch.setattr(claude_config, "install_claude_code_hooks", lambda: None)
+    monkeypatch.setattr(
+        claude_config,
+        "enable_tool_search_in_claude_code",
+        lambda: calls.append("tool_search"),
+    )
+
+    (tmp_path / ".repowise").mkdir()
+    (tmp_path / ".repowise" / "config.yaml").write_text("mcp:\n  tools: lean\n", encoding="utf-8")
+
+    output = StringIO()
+    console = Console(file=output, force_terminal=False)
+    ClaudeCodeSetup().register_client(console, tmp_path)
+
+    assert calls == []
+    assert "Lean MCP tool surface configured" in output.getvalue()
+
+
+def test_uses_lean_tool_surface_shapes(tmp_path: Path) -> None:
+    from repowise.cli.editor_integrations.claude import _uses_lean_tool_surface
+
+    config = tmp_path / ".repowise" / "config.yaml"
+    config.parent.mkdir()
+
+    assert _uses_lean_tool_surface(tmp_path) is False  # no config
+
+    for text, expected in [
+        ("mcp:\n  tools: lean\n", True),
+        ("mcp:\n  tools: LEAN\n", True),
+        ("mcp:\n  tools: [lean]\n", True),
+        ("mcp:\n  tools: ['+get_execution_flows']\n", False),
+        ("mcp:\n  tools: all\n", False),
+        ("mcp:\n  tools: [lean, get_health]\n", False),
+    ]:
+        config.write_text(text, encoding="utf-8")
+        assert _uses_lean_tool_surface(tmp_path) is expected, text
+
+
 def test_enable_tool_search_sets_env_idempotently(tmp_path: Path, monkeypatch: Any) -> None:
     settings = tmp_path / ".claude" / "settings.json"
     monkeypatch.setattr(claude_config, "_claude_code_settings_path", lambda: settings)

--- a/tests/unit/server/mcp/test_mcp_docs_drift.py
+++ b/tests/unit/server/mcp/test_mcp_docs_drift.py
@@ -1,0 +1,68 @@
+"""docs/MCP_TOOLS.md must track the live MCP tool registry.
+
+The doc's tool inventory (headings) and surface counts used to be hand-edited
+and could silently drift from the registered surface; this pins both, the same
+way test_tool_table_drift.py pins the CLAUDE.md tool table.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from repowise.core.registry import mcp_tool_registry
+from repowise.server.mcp_server._tool_selection import LEAN_TOOLS
+
+DOC = Path(__file__).parents[4] / "docs" / "MCP_TOOLS.md"
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    return DOC.read_text(encoding="utf-8")
+
+
+def _entries():
+    import repowise.server.mcp_server  # noqa: F401  (registers the tools)
+
+    return mcp_tool_registry.entries()
+
+
+def test_every_registered_tool_has_a_doc_section(doc_text: str):
+    documented = set(re.findall(r"^#{2,4} `(\w+)`", doc_text, flags=re.MULTILINE))
+    registered = {e.name for e in _entries()}
+    missing = registered - documented
+    assert not missing, f"registered tools without a MCP_TOOLS.md section: {missing}"
+    ghosts = documented - registered
+    assert not ghosts, f"MCP_TOOLS.md sections for unregistered tools: {ghosts}"
+
+
+def test_surface_counts_match_registry(doc_text: str):
+    entries = _entries()
+    total = len(entries)
+    single_default = sum(1 for e in entries if e.default and not e.requires_workspace)
+    workspace_only = sum(1 for e in entries if e.default and e.requires_workspace)
+
+    m = re.search(
+        r"(\d+) tools are registered in total\. A single-repo server advertises "
+        r"(\d+) by default.*?Workspace mode adds (\d+) more automatically, for (\d+)",
+        doc_text,
+        flags=re.DOTALL,
+    )
+    assert m, "MCP_TOOLS.md surface-count paragraph not found (wording changed?)"
+    assert [int(g) for g in m.groups()] == [
+        total,
+        single_default,
+        workspace_only,
+        single_default + workspace_only,
+    ], "MCP_TOOLS.md surface counts drifted from the registry"
+
+
+def test_lean_profile_paragraph_names_the_lean_tools(doc_text: str):
+    m = re.search(r"\*\*The `lean` profile\*\*.*?(?=\n\n)", doc_text, flags=re.DOTALL)
+    assert m, "MCP_TOOLS.md lean-profile paragraph not found"
+    paragraph = m.group(0)
+    missing = {name for name in LEAN_TOOLS if f"`{name}`" not in paragraph}
+    assert not missing, f"lean tools missing from the profile paragraph: {missing}"
+    assert "`list_repos`" in paragraph

--- a/tests/unit/server/mcp/test_tool_selection.py
+++ b/tests/unit/server/mcp/test_tool_selection.py
@@ -73,6 +73,34 @@ def test_all_enables_everything_usable():
     }
 
 
+def test_lean_profile_single_repo():
+    # Intersected with the catalog: only the lean tools this registry has.
+    enabled = resolve_enabled_tools(CATALOG, is_workspace=False, override="lean")
+    assert enabled == {"get_answer", "get_context"}
+
+
+def test_lean_profile_workspace_adds_list_repos():
+    enabled = resolve_enabled_tools(CATALOG, is_workspace=True, override="LEAN")
+    assert enabled == {"get_answer", "get_context", "list_repos"}
+
+
+def test_lean_profile_full_registry():
+    """Against the real registry, lean is exactly the five agent-lean tools."""
+    import repowise.server.mcp_server  # noqa: F401  (registers the tools)
+    from repowise.core.registry import mcp_tool_registry
+    from repowise.server.mcp_server._tool_selection import LEAN_TOOLS
+
+    enabled = resolve_enabled_tools(
+        mcp_tool_registry.entries(), is_workspace=False, override="lean"
+    )
+    assert enabled == LEAN_TOOLS
+
+    workspace = resolve_enabled_tools(
+        mcp_tool_registry.entries(), is_workspace=True, override="lean"
+    )
+    assert workspace == LEAN_TOOLS | {"list_repos"}
+
+
 def test_workspace_only_named_explicitly_is_dropped_single_repo():
     enabled = resolve_enabled_tools(
         CATALOG, is_workspace=False, override="get_answer,get_blast_radius"


### PR DESCRIPTION
## What

### `lean` tool profile

A new named profile for the MCP tool surface, selectable as a single token anywhere an override is accepted:

```bash
repowise mcp --tools lean
```

```yaml
mcp:
  tools: lean
```

It resolves to the five tools a coding agent actually reaches for in the pre-edit phase: `get_answer`, `get_context`, `get_symbol`, `search_codebase`, `get_risk`, plus `list_repos` in workspace mode (where repo aliases must be discoverable). Resolution follows the same shape as the existing `all` token, so config, CLI, and the dashboard tool-surface endpoints all pick it up with no schema changes.

Measured with tiktoken (cl100k_base) against the live server: the lean surface advertises 1,829 tokens of schema versus 4,059 for the default 11-tool surface, a 55% cut in the always-on cost.

### Tool-search recommendation gated on the profile

`repowise init` recommends `ENABLE_TOOL_SEARCH` for Claude Code, which defers MCP tool schemas behind a lookup round trip. That is the right trade for the 4k-token default surface, but the lean profile exists to remove exactly that round trip: at ~1.8k tokens the schemas are cheap enough to keep always loaded. init now skips the recommendation when the repo's config selects the lean profile, and prints why. It never flips an existing `ENABLE_TOOL_SEARCH` value, since the setting applies to every MCP server, not just repowise.

The check reads `.repowise/config.yaml` through the lightweight config loader rather than the server's selection layer, because importing the server package pulls FastMCP and every tool module into `repowise init`.

### docs/MCP_TOOLS.md pinned to the registry

New drift test (`test_mcp_docs_drift.py`) that fails when the doc and the live tool registry diverge:

- every registered tool must have a heading section, and no section may name an unregistered tool
- the surface-count paragraph (total registered / single-repo default / workspace additions) must match totals computed from the registry metadata
- the lean-profile paragraph must name every tool in the profile

Same pattern as the existing CLAUDE.md tool-table drift test. Also documents the profile in MCP_TOOLS.md, CONFIG.md, and CLI_REFERENCE.md, and fixes a stale "10 tools" default-surface count in CONFIG.md (it has been 11 since `generate_refactoring_code` joined the default set).

## Testing

- New: lean-profile resolution cases in `test_tool_selection.py` (representative catalog + full live registry, case-insensitivity, workspace `list_repos`), `test_mcp_docs_drift.py`, init gating cases in `test_editor_setup.py` (lean repo skips the recommendation; config-shape matrix for the detector)
- Full `tests/unit/server/mcp` (347 passed) and `tests/unit/cli` (725 passed, 1 skipped) suites green
