### PR TITLE
fix(update): persist decay_only staleness and recompute total_pages from the DB

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -1021,7 +1021,7 @@ def run_update(
     if emitter is not None:
         emitter.stage("persist")
     try:
-        _persist_full_update(
+        db_total_pages = _persist_full_update(
             repo_path=repo_path,
             repo_name=repo_name,
             generated_pages=generated_pages,
@@ -1035,6 +1035,7 @@ def run_update(
             graph_builder=graph_builder,
             knowledge_graph_result=knowledge_graph_result,
             degraded=degraded,
+            decay_paths=affected.decay_only,
         )
     except Exception as exc:
         if emitter is not None:
@@ -1058,7 +1059,9 @@ def run_update(
             degraded.append(f"Knowledge-graph export: {exc}")
 
     state["last_sync_commit"] = head
-    state["total_pages"] = state.get("total_pages", 0) + len(generated_pages)
+    # Real DB total, not an accumulation: regeneration upserts existing pages,
+    # so adding len(generated_pages) every run inflated the count forever.
+    state["total_pages"] = db_total_pages
     state["config_fingerprint"] = config_fingerprint(repo_path)
     save_state(repo_path, state)
 

--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -291,7 +291,8 @@ def _persist_full_update(
     graph_builder: Any,
     knowledge_graph_result: Any | None,
     degraded: list[str],
-) -> None:
+    decay_paths: list[str] | None = None,
+) -> int:
     """Persist a full (LLM-regenerating) update in one transaction.
 
     Mirrors :func:`repowise.core.pipeline.incremental.persist_incremental_index`:
@@ -301,8 +302,13 @@ def _persist_full_update(
     Page upserts fail loudly — pages are the point of docs mode; every other
     step degrades into ``degraded`` with a logged warning. FTS indexing stays
     outside the transaction: it is rebuildable and non-transactional anyway.
+
+    Returns the repository's total page count after the write, so the caller
+    can stamp ``state["total_pages"]`` with the real DB total (regeneration
+    upserts existing pages, so accumulating ``len(generated_pages)`` inflates
+    the count forever).
     """
-    run_async(
+    return run_async(
         _persist_full_update_async(
             repo_path=repo_path,
             repo_name=repo_name,
@@ -317,6 +323,7 @@ def _persist_full_update(
             graph_builder=graph_builder,
             knowledge_graph_result=knowledge_graph_result,
             degraded=degraded,
+            decay_paths=decay_paths,
         )
     )
 
@@ -336,7 +343,8 @@ async def _persist_full_update_async(
     graph_builder: Any,
     knowledge_graph_result: Any | None,
     degraded: list[str],
-) -> None:
+    decay_paths: list[str] | None = None,
+) -> int:
     from repowise.cli.helpers import get_db_url_for_repo
     from repowise.core.persistence import (
         FullTextSearch,
@@ -378,6 +386,18 @@ async def _persist_full_update_async(
                 await mark_tombstone_pages(session, repo_id, tombstone_candidates(file_diffs))
             except Exception as exc:
                 _skip("Tombstone marking", exc)
+
+            # Weakly-affected pages (cascade overflow beyond the budget,
+            # co-change partners, 2-hop rename fallout) decay to 'stale' so
+            # the coverage view and get_stale_pages reflect them — the
+            # detector computed decay_only all along but it was never
+            # persisted.
+            try:
+                from repowise.core.pipeline.persist import mark_stale_pages
+
+                await mark_stale_pages(session, repo_id, decay_paths or [])
+            except Exception as exc:
+                _skip("Stale-page decay", exc)
 
             # Refreshed knowledge graph — same writers as the init pipeline
             # (full-replace layers/tour/curated meta).
@@ -526,6 +546,25 @@ async def _persist_full_update_async(
             except Exception as exc:
                 _skip("Generation job record", exc)
 
+            # Real page total for state.json — see _persist_full_update's
+            # docstring. Falls back to the upsert count if the count query
+            # itself degrades.
+            total_pages = len(generated_pages)
+            try:
+                from sqlalchemy import func as sa_func
+                from sqlalchemy import select as sa_select
+
+                from repowise.core.persistence.models import Page
+
+                count_result = await session.execute(
+                    sa_select(sa_func.count())
+                    .select_from(Page)
+                    .where(Page.repository_id == repo_id)
+                )
+                total_pages = int(count_result.scalar_one())
+            except Exception as exc:
+                _skip("Page count", exc)
+
         # FTS outside the transaction — rebuildable, and its writer manages
         # its own connection state.
         try:
@@ -535,6 +574,7 @@ async def _persist_full_update_async(
                 await fts.index(page.page_id, page.title, page.content)
         except Exception as exc:
             _skip("Full-text search indexing", exc)
+        return total_pages
     finally:
         await engine.dispose()
 

--- a/packages/core/src/repowise/core/pipeline/persist.py
+++ b/packages/core/src/repowise/core/pipeline/persist.py
@@ -80,6 +80,42 @@ async def mark_tombstone_pages(
     return marked
 
 
+async def mark_stale_pages(session: Any, repo_id: str, paths: list[str]) -> int:
+    """Decay weakly-affected file pages to ``freshness_status='stale'``.
+
+    ``ChangeDetector.get_affected_pages`` returns ``decay_only`` — pages hit
+    by the change cascade but beyond the regeneration budget (budget
+    overflow, co-change partners, 2-hop rename fallout). They keep serving
+    their existing content, but the stale bit makes the coverage view and
+    ``get_stale_pages`` truthful so the next docs run (or a reader) knows
+    they lag the code. Only ``fresh`` pages are downgraded — tombstoned or
+    already-stale pages keep their stronger status, and pages regenerated in
+    this run are never in ``decay_only`` by construction.
+
+    Returns the number of pages marked.
+    """
+    if not paths:
+        return 0
+    from sqlalchemy import update
+
+    from repowise.core.persistence.models import Page
+
+    page_ids = [f"file_page:{path}" for path in paths]
+    res = await session.execute(
+        update(Page)
+        .where(
+            Page.repository_id == repo_id,
+            Page.id.in_(page_ids),
+            Page.freshness_status == "fresh",
+        )
+        .values(freshness_status="stale")
+    )
+    marked = int(res.rowcount or 0)
+    if marked:
+        logger.info("pages_decayed_stale", repo_id=repo_id, count=marked)
+    return marked
+
+
 def _derive_entry_point_scores(graph_builder: Any) -> dict[str, float]:
     """Best-effort entry-point scores from the builder's execution-flow report.
 
@@ -540,9 +576,7 @@ async def persist_analysis(result: Any, session: Any, repo_id: str) -> None:
         # Resolved coverage rows, when a report was ingested this run.
         coverage_files = getattr(hr, "coverage_files", None)
         if coverage_files:
-            head_sha = getattr(result, "head_commit", None) or getattr(
-                result, "commit_sha", None
-            )
+            head_sha = getattr(result, "head_commit", None) or getattr(result, "commit_sha", None)
             await save_coverage_files(
                 session,
                 repo_id,

--- a/tests/unit/persistence/test_mark_stale_pages.py
+++ b/tests/unit/persistence/test_mark_stale_pages.py
@@ -1,0 +1,67 @@
+"""Decay marking for weakly-affected pages (ChangeDetector.decay_only).
+
+The detector computed decay_only on every update but nothing ever persisted
+it, so pages hit by the cascade beyond the regeneration budget stayed
+``fresh`` forever. ``mark_stale_pages`` closes that: coverage and
+``get_stale_pages`` must reflect the decay, without downgrading tombstones
+or touching unrelated pages.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from repowise.core.persistence.crud import get_stale_pages, upsert_page
+from repowise.core.pipeline.persist import mark_stale_pages
+from tests.unit.persistence.helpers import insert_repo, make_page_kwargs
+
+
+async def _seed_page(session, repo_id, path, **overrides):
+    kwargs = make_page_kwargs(
+        repo_id,
+        page_id=f"file_page:{path}",
+        target_path=path,
+        title=path,
+        **overrides,
+    )
+    page = await upsert_page(session, **kwargs)
+    await session.commit()
+    return page
+
+
+@pytest.mark.asyncio
+async def test_fresh_pages_decay_to_stale(async_session):
+    repo = await insert_repo(async_session)
+    await _seed_page(async_session, repo.id, "src/a.py")
+    await _seed_page(async_session, repo.id, "src/b.py")
+    untouched = await _seed_page(async_session, repo.id, "src/c.py")
+
+    marked = await mark_stale_pages(async_session, repo.id, ["src/a.py", "src/b.py"])
+    await async_session.commit()
+
+    assert marked == 2
+    stale = await get_stale_pages(async_session, repo.id)
+    assert sorted(p.target_path for p in stale) == ["src/a.py", "src/b.py"]
+    await async_session.refresh(untouched)
+    assert untouched.freshness_status == "fresh"
+
+
+@pytest.mark.asyncio
+async def test_tombstone_is_not_downgraded(async_session):
+    repo = await insert_repo(async_session)
+    page = await _seed_page(async_session, repo.id, "src/dead.py", freshness_status="tombstone")
+
+    marked = await mark_stale_pages(async_session, repo.id, ["src/dead.py"])
+    await async_session.commit()
+
+    assert marked == 0
+    await async_session.refresh(page)
+    assert page.freshness_status == "tombstone"
+
+
+@pytest.mark.asyncio
+async def test_missing_pages_and_empty_input_are_noops(async_session):
+    repo = await insert_repo(async_session)
+
+    assert await mark_stale_pages(async_session, repo.id, []) == 0
+    assert await mark_stale_pages(async_session, repo.id, ["src/never_indexed.py"]) == 0


### PR DESCRIPTION
## What

Two `repowise update` correctness fixes:

1. **decay_only pages are now actually marked stale.** `ChangeDetector.get_affected_pages` has always computed `decay_only` (pages hit by the change cascade beyond the regeneration budget: budget overflow, co-change partners, 2-hop rename fallout), but nothing persisted it, so those pages stayed `fresh` forever and the coverage view / `get_stale_pages` never reflected them. New `mark_stale_pages` in `pipeline/persist.py` (mirrors `mark_tombstone_pages`, `file_page:{path}` id scheme) downgrades only `fresh` pages, wired into `_persist_full_update` as a degradable step. `decay_only` is disjoint from `regenerate` by construction, so a just-regenerated page can never be marked stale.

2. **`state["total_pages"]` no longer inflates.** The update path accumulated `+= len(generated_pages)` on every run, but regeneration upserts existing pages, so the count grew without bound (surfaced in `repowise status`). `_persist_full_update` now returns the real DB page count (same-session count query, falls back to the upsert count if it degrades) and the state stamp uses that, matching how init computes it.

## Tests

New `tests/unit/persistence/test_mark_stale_pages.py`: fresh pages decay, tombstones are not downgraded, missing/empty inputs are no-ops. Persistence + tombstone suites pass (274 tests).
