### PR TITLE
feat(stats): biggest commit, longest streak, dependencies, most-imported award

### DIFF
--- a/packages/server/src/repowise/server/routers/stats.py
+++ b/packages/server/src/repowise/server/routers/stats.py
@@ -14,6 +14,9 @@ overview-summary contract.
 from __future__ import annotations
 
 import json
+import re
+from datetime import timedelta
+from itertools import pairwise
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -24,8 +27,10 @@ from repowise.core.ingestion.git_indexer import build_identity_resolver
 from repowise.core.persistence import crud
 from repowise.core.persistence.models import (
     DecisionRecord,
+    ExternalSystem,
     GitCommit,
     GitMetadata,
+    GraphMetric,
     GraphNode,
     Page,
     WikiSymbol,
@@ -66,6 +71,13 @@ def _size_class(total_nloc: int) -> dict[str, Any]:
 
 def _iso(dt: Any) -> str | None:
     return dt.isoformat() if dt is not None else None
+
+
+# Test-path convention shared with analysis (communities / execution_flows):
+# catches conftest, fixtures, and spec files the `is_test` flag misses.
+_TEST_PATH_RE = re.compile(
+    r"(test[s_/]|_test\.|\.test\.|\.spec\.|__tests__|conftest|fixture[s]?[/.])"
+)
 
 
 async def _scale(session: AsyncSession, repo_id: str, metrics: list[Any]) -> dict[str, Any]:
@@ -123,7 +135,12 @@ async def _activity(session: AsyncSession, repo_id: str) -> dict[str, Any]:
 
     Buckets the bounded ``git_commits`` table in Python so it is portable
     across SQLite/Postgres date functions (same approach as the agent-trend
-    endpoint)."""
+    endpoint).
+
+    Also derives the ``biggest_commit`` and ``longest_streak`` awards on the
+    same pass — they need per-commit rows anyway, and riding along here keeps
+    the endpoint at a single scan of the commits table. The caller moves them
+    into the superlatives payload."""
     rows = (
         await session.execute(
             select(
@@ -132,13 +149,18 @@ async def _activity(session: AsyncSession, repo_id: str) -> dict[str, Any]:
                 GitCommit.author_email,
                 GitCommit.agent_name,
                 GitCommit.is_fix,
+                GitCommit.sha,
+                GitCommit.subject,
+                GitCommit.lines_added,
+                GitCommit.lines_deleted,
+                GitCommit.files_changed,
             ).where(GitCommit.repository_id == repo_id)
         )
     ).all()
 
     # Fold GitHub noreply variants and same-name real+noreply emails to one
     # identity so the same person isn't counted as several contributors.
-    resolve = build_identity_resolver([(name, email) for _, name, email, _, _ in rows])
+    resolve = build_identity_resolver([(name, email) for _, name, email, *_ in rows])
 
     total = 0
     agent_total = 0
@@ -147,9 +169,17 @@ async def _activity(session: AsyncSession, repo_id: str) -> dict[str, Any]:
     agent_names: dict[str, int] = {}
     contributors: set[str] = set()
     first_at: Any = None
+    first_sha: str | None = None
     last_at: Any = None
+    commit_days: set[Any] = set()
+    # Top-2 commits by churn: the repo's very first commit is excluded from
+    # the "biggest commit" award (every import/initial commit would win), so
+    # two candidates are enough to survive dropping it.
+    top_commits: list[dict[str, Any]] = []
 
-    for committed_at, author_name, author_email, agent_name, is_fix in rows:
+    for row in rows:
+        committed_at, author_name, author_email, agent_name, is_fix = row[:5]
+        sha, subject, lines_added, lines_deleted, files_changed = row[5:]
         total += 1
         if author_email or author_name:
             key = resolve(author_name, author_email)
@@ -160,16 +190,48 @@ async def _activity(session: AsyncSession, repo_id: str) -> dict[str, Any]:
         if agent_name:
             agent_total += 1
             agent_names[agent_name] = agent_names.get(agent_name, 0) + 1
+        churn = int(lines_added or 0) + int(lines_deleted or 0)
+        if churn > 0:
+            top_commits.append(
+                {
+                    "sha": sha,
+                    "subject": subject or "",
+                    "lines_changed": churn,
+                    "files_changed": int(files_changed or 0),
+                }
+            )
+            top_commits.sort(key=lambda c: -c["lines_changed"])
+            del top_commits[2:]
         if committed_at is not None:
             if first_at is None or committed_at < first_at:
                 first_at = committed_at
+                first_sha = sha
             if last_at is None or committed_at > last_at:
                 last_at = committed_at
+            commit_days.add(committed_at.date())
             key = committed_at.strftime("%Y-%m")
             b = months.setdefault(key, {"total": 0, "agent": 0})
             b["total"] += 1
             if agent_name:
                 b["agent"] += 1
+
+    biggest_commit = next((c for c in top_commits if c["sha"] != first_sha), None)
+
+    longest_streak: dict[str, Any] | None = None
+    if commit_days:
+        days_sorted = sorted(commit_days)
+        best_len = run_len = 1
+        best_end = days_sorted[0]
+        for prev, cur in pairwise(days_sorted):
+            run_len = run_len + 1 if (cur - prev).days == 1 else 1
+            if run_len > best_len:
+                best_len, best_end = run_len, cur
+        if best_len >= 2:
+            longest_streak = {
+                "days": best_len,
+                "start": (best_end - timedelta(days=best_len - 1)).isoformat(),
+                "end": best_end.isoformat(),
+            }
 
     monthly = [
         {"month": m, "total": b["total"], "agent": b["agent"]} for m, b in sorted(months.items())
@@ -193,6 +255,8 @@ async def _activity(session: AsyncSession, repo_id: str) -> dict[str, Any]:
             ({"name": k, "count": v} for k, v in agent_names.items()),
             key=lambda x: -x["count"],
         ),
+        "biggest_commit": biggest_commit,
+        "longest_streak": longest_streak,
     }
 
 
@@ -353,17 +417,52 @@ async def _superlatives(
             "first_commit_at": _iso(oldest.first_commit_at),
         }
 
-    # Most central file (highest PageRank file node)
-    central = (
+    # Most imported file — highest fan-in among non-test file nodes, the
+    # legible version of "most central". External and test nodes are excluded
+    # so the award names real project source; the `is_test` flag misses
+    # conftest/fixture files, so the top candidates are re-checked against the
+    # test-path convention used across analysis. Falls back to the PageRank
+    # pick when graph metrics were not materialized for this repo.
+    candidates = (
         await session.execute(
-            select(GraphNode.node_id, GraphNode.pagerank)
-            .where(GraphNode.repository_id == repo_id, GraphNode.node_type == "file")
-            .order_by(GraphNode.pagerank.desc())
-            .limit(1)
+            select(GraphMetric.node_id, GraphMetric.in_degree, GraphMetric.pagerank)
+            .join(
+                GraphNode,
+                (GraphNode.repository_id == GraphMetric.repository_id)
+                & (GraphNode.node_id == GraphMetric.node_id),
+            )
+            .where(
+                GraphMetric.repository_id == repo_id,
+                GraphNode.node_type == "file",
+                GraphNode.is_test.is_(False),
+                GraphNode.external_system_id.is_(None),
+                ~GraphNode.node_id.like("external:%"),
+            )
+            .order_by(GraphMetric.in_degree.desc())
+            .limit(10)
         )
-    ).first()
-    if central is not None and (central[1] or 0) > 0:
-        out["most_central_file"] = {"path": central[0], "pagerank": round(float(central[1]), 4)}
+    ).all()
+    imported = next((c for c in candidates if not _TEST_PATH_RE.search(c[0])), None)
+    if imported is not None and (imported[1] or 0) > 0:
+        out["most_central_file"] = {
+            "path": imported[0],
+            "pagerank": round(float(imported[2] or 0.0), 4),
+            "import_count": int(imported[1]),
+        }
+    else:
+        central = (
+            await session.execute(
+                select(GraphNode.node_id, GraphNode.pagerank)
+                .where(GraphNode.repository_id == repo_id, GraphNode.node_type == "file")
+                .order_by(GraphNode.pagerank.desc())
+                .limit(1)
+            )
+        ).first()
+        if central is not None and (central[1] or 0) > 0:
+            out["most_central_file"] = {
+                "path": central[0],
+                "pagerank": round(float(central[1]), 4),
+            }
 
     # Strongest hidden coupling pair (max co-change count across files)
     best_pair: dict[str, Any] | None = None
@@ -381,6 +480,40 @@ async def _superlatives(
         out["strongest_coupling"] = best_pair
 
     return out
+
+
+async def _dependencies(session: AsyncSession, repo_id: str) -> dict[str, Any] | None:
+    """Third-party dependency rollup from the manifest-derived rows."""
+    rows = (
+        await session.execute(
+            select(ExternalSystem.ecosystem, ExternalSystem.is_dev_dep, func.count())
+            .where(ExternalSystem.repository_id == repo_id)
+            .group_by(ExternalSystem.ecosystem, ExternalSystem.is_dev_dep)
+        )
+    ).all()
+    if not rows:
+        return None
+
+    total = runtime = dev = 0
+    ecosystems: dict[str, int] = {}
+    for eco, is_dev, n in rows:
+        total += n
+        if is_dev:
+            dev += n
+        else:
+            runtime += n
+        key = eco or "other"
+        ecosystems[key] = ecosystems.get(key, 0) + n
+
+    return {
+        "total": total,
+        "runtime": runtime,
+        "dev": dev,
+        "ecosystems": sorted(
+            ({"name": k, "count": v} for k, v in ecosystems.items()),
+            key=lambda x: -x["count"],
+        ),
+    }
 
 
 @router.get("/{repo_id}/stats/highlights")
@@ -416,6 +549,15 @@ async def stats_highlights(
         or 0
     )
 
+    activity = await _activity(session, repo_id)
+    superlatives = await _superlatives(session, repo_id, metrics, all_meta)
+    # Computed on _activity's commit scan for performance, but they are awards
+    # so they belong under superlatives in the payload.
+    for key in ("biggest_commit", "longest_streak"):
+        value = activity.pop(key, None)
+        if value:
+            superlatives[key] = value
+
     return {
         "repo": {
             "id": repo.id,
@@ -424,12 +566,13 @@ async def stats_highlights(
             "head_commit": repo.head_commit,
         },
         "scale": await _scale(session, repo_id, metrics),
-        "activity": await _activity(session, repo_id),
+        "activity": activity,
         "people": await _people(session, repo_id, all_meta),
         "quality": await _quality(session, repo_id, metrics),
         "knowledge": {
             "decision_count": decision_count,
             "active_decision_count": active_decisions,
         },
-        "superlatives": await _superlatives(session, repo_id, metrics, all_meta),
+        "dependencies": await _dependencies(session, repo_id),
+        "superlatives": superlatives,
     }

--- a/packages/types/src/stats.ts
+++ b/packages/types/src/stats.ts
@@ -133,8 +133,31 @@ export interface StatsSuperlatives {
   most_complex_symbol?: { name: string; file_path: string; complexity: number };
   most_changed_file?: { path: string; commit_count: number };
   oldest_file?: { path: string; first_commit_at: string | null };
-  most_central_file?: { path: string; pagerank: number };
+  /** `import_count` present when graph metrics were materialized — the award
+   *  is then "most imported"; without it, it degrades to the PageRank pick. */
+  most_central_file?: { path: string; pagerank: number; import_count?: number };
   strongest_coupling?: { a: string; b: string; count: number };
+  /** Largest non-initial commit by churn (added + deleted lines). */
+  biggest_commit?: {
+    sha: string;
+    subject: string;
+    lines_changed: number;
+    files_changed: number;
+  };
+  /** Longest run of consecutive days with at least one commit (UTC dates). */
+  longest_streak?: { days: number; start: string; end: string };
+}
+
+export interface StatsEcosystem {
+  name: string;
+  count: number;
+}
+
+export interface StatsDependencies {
+  total: number;
+  runtime: number;
+  dev: number;
+  ecosystems: StatsEcosystem[];
 }
 
 export interface StatsRepo {
@@ -151,5 +174,7 @@ export interface StatsHighlights {
   people: StatsPeople;
   quality: StatsQuality;
   knowledge: StatsKnowledge;
+  /** Optional so older payloads (hosted exporters) degrade gracefully. */
+  dependencies?: StatsDependencies | null;
   superlatives: StatsSuperlatives;
 }

--- a/packages/ui/src/stats/superlatives-grid.tsx
+++ b/packages/ui/src/stats/superlatives-grid.tsx
@@ -1,14 +1,16 @@
 import * as React from "react";
 import {
   FileText,
+  Flame,
   GitCommitHorizontal,
   Hourglass,
   Network,
   Workflow,
   Boxes,
+  Zap,
 } from "lucide-react";
 import type { StatsSuperlatives } from "@repowise-dev/types/stats";
-import { formatNumber, formatRelativeTimeOrNull, truncatePath } from "../lib/format";
+import { formatDate, formatNumber, formatRelativeTimeOrNull, truncatePath } from "../lib/format";
 
 interface AwardRow {
   key: string;
@@ -60,12 +62,38 @@ function buildAwards(s: StatsSuperlatives): AwardRow[] {
     });
   }
   if (s.most_central_file) {
+    const central = s.most_central_file;
     rows.push({
       key: "central",
       icon: Network,
-      title: "Most central file",
-      primary: truncatePath(s.most_central_file.path, 42),
-      detail: `PageRank ${s.most_central_file.pagerank.toFixed(4)}`,
+      title: central.import_count != null ? "Most imported file" : "Most central file",
+      primary: truncatePath(central.path, 42),
+      detail:
+        central.import_count != null
+          ? `imported by ${formatNumber(central.import_count)} files · PageRank ${central.pagerank.toFixed(4)}`
+          : `PageRank ${central.pagerank.toFixed(4)}`,
+    });
+  }
+  if (s.biggest_commit) {
+    rows.push({
+      key: "biggest-commit",
+      icon: Zap,
+      title: "Biggest commit",
+      primary: s.biggest_commit.subject || s.biggest_commit.sha.slice(0, 10),
+      detail: `${formatNumber(s.biggest_commit.lines_changed)} lines across ${formatNumber(
+        s.biggest_commit.files_changed,
+      )} files — in one commit`,
+    });
+  }
+  if (s.longest_streak) {
+    rows.push({
+      key: "streak",
+      icon: Flame,
+      title: "Longest streak",
+      primary: `${formatNumber(s.longest_streak.days)} consecutive days`,
+      detail: `commits every day, ${formatDate(s.longest_streak.start)} – ${formatDate(
+        s.longest_streak.end,
+      )}`,
     });
   }
   if (s.strongest_coupling) {

--- a/packages/web/src/components/stats/by-the-numbers-tab.tsx
+++ b/packages/web/src/components/stats/by-the-numbers-tab.tsx
@@ -1,4 +1,4 @@
-import { Bot, CalendarClock, Users, ShieldCheck, Trash2, HeartPulse } from "lucide-react";
+import { Bot, CalendarClock, Users, ShieldCheck, Trash2, HeartPulse, Package } from "lucide-react";
 import type { StatsHighlights } from "@repowise-dev/types/stats";
 import {
   SizeClassHero,
@@ -9,9 +9,18 @@ import {
 } from "@repowise-dev/ui/stats";
 import { formatNumber, formatLOC, formatAgeDays, formatDate } from "@repowise-dev/ui/lib/format";
 
+const ECOSYSTEM_NAMES: Record<string, string> = {
+  npm: "npm",
+  pypi: "PyPI",
+  go: "Go",
+  cargo: "crates.io",
+  nuget: "NuGet",
+};
+
 export function ByTheNumbersTab({ data }: { data: StatsHighlights }) {
   const { scale, activity, quality, people, superlatives } = data;
   const da = quality.defect_accuracy;
+  const deps = data.dependencies;
 
   return (
     <div className="space-y-5">
@@ -65,7 +74,7 @@ export function ByTheNumbersTab({ data }: { data: StatsHighlights }) {
         )}
       </div>
 
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <StatCallout
           label="Lines of code"
           value={formatLOC(scale.total_nloc)}
@@ -88,6 +97,18 @@ export function ByTheNumbersTab({ data }: { data: StatsHighlights }) {
             quality.dead_code.total_findings,
           )} dead-code findings`}
         />
+        {deps && deps.total > 0 && (
+          <StatCallout
+            label="Dependencies"
+            value={formatNumber(deps.total)}
+            icon={<Package className="h-4 w-4" />}
+            sub={`standing on ${formatNumber(deps.runtime)} runtime + ${formatNumber(
+              deps.dev,
+            )} dev shoulders across ${deps.ecosystems
+              .map((e) => ECOSYSTEM_NAMES[e.name] ?? e.name)
+              .join(", ")}`}
+          />
+        )}
       </div>
 
       <div>

--- a/tests/unit/server/test_stats_superlatives.py
+++ b/tests/unit/server/test_stats_superlatives.py
@@ -1,0 +1,71 @@
+"""Ride-along awards on the /stats/highlights activity scan.
+
+``biggest_commit`` must skip the repo's very first commit (every initial
+import would win otherwise) and ``longest_streak`` counts consecutive UTC
+days with at least one commit.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+
+from repowise.core.persistence.crud import upsert_git_commits_bulk
+from repowise.core.persistence.database import get_session
+from repowise.server.routers.stats import _activity
+from tests.unit.server.conftest import create_test_repo
+
+_DAY = 86400
+
+
+def _commit(sha: str, ts: int, added: int, deleted: int = 0, files: int = 1) -> dict:
+    return {
+        "sha": sha,
+        "author_name": "Jane Doe",
+        "author_email": "jane@company.com",
+        "committed_at": datetime.fromtimestamp(ts, tz=UTC),
+        "subject": f"commit {sha}",
+        "lines_added": added,
+        "lines_deleted": deleted,
+        "files_changed": files,
+        "dirs_changed": 1,
+        "subsystems_changed": 1,
+        "entropy": 0.1,
+        "is_fix": False,
+        "change_risk_score": 1.0,
+        "change_risk_level": "low",
+    }
+
+
+@pytest.mark.asyncio
+async def test_biggest_commit_skips_initial_and_streak_counts_days(
+    client: AsyncClient, app
+) -> None:
+    repo = await create_test_repo(client)
+    rows = [
+        # Initial commit is the largest by churn but must not win the award.
+        _commit("a1", 1000, added=50_000, files=300),
+        # Days 2-4 form a 3-day streak; day 2's commit is the rightful winner.
+        _commit("b1", 1000 + _DAY, added=900, deleted=100, files=12),
+        _commit("c1", 1000 + 2 * _DAY, added=10),
+        _commit("d1", 1000 + 3 * _DAY, added=10),
+        # A gap, then a lone day — streak stays 4 (day 1 chains into days 2-4).
+        _commit("e1", 1000 + 10 * _DAY, added=10),
+    ]
+    async with get_session(app.state.session_factory) as session:
+        await upsert_git_commits_bulk(session, repo["id"], rows)
+
+    async with get_session(app.state.session_factory) as session:
+        activity = await _activity(session, repo["id"])
+
+    biggest = activity["biggest_commit"]
+    assert biggest is not None
+    assert biggest["sha"] == "b1"
+    assert biggest["lines_changed"] == 1000
+    assert biggest["files_changed"] == 12
+
+    streak = activity["longest_streak"]
+    assert streak is not None
+    assert streak["days"] == 4


### PR DESCRIPTION
Adds four pieces of informative-but-fun content to the By the Numbers page. Everything is stitched from rows the indexer already writes; no new analysis and no schema changes.

## What's new

- **Biggest commit** award: the largest commit by churn (added + deleted lines), skipping the repo's very first commit so every initial import doesn't win by default.
- **Longest streak** award: the longest run of consecutive days with at least one commit (UTC dates).
- **Dependencies** callout: total third-party dependencies with the runtime/dev split and ecosystems, from `external_systems`.
- **Most imported file**: the "most central" award now leads with graph fan-in ("imported by N files") and demotes PageRank to the detail line. External nodes and test/conftest/fixture paths are excluded so the award names real project source; falls back to the PageRank pick when graph metrics were not materialized.

## Performance

The highlights endpoint stays at a single scan of the bounded `git_commits` table: biggest commit and streak ride along on the existing `_activity` pass (extra columns on the same select). The only new queries are one indexed `LIMIT 10` join on `graph_metrics` and one `GROUP BY` over `external_systems`.

## Compatibility

All new payload fields are optional in `@repowise-dev/types`, so consumers on older payloads (hosted exporters) degrade gracefully. UI additions live in `packages/ui` (`SuperlativesGrid` grew three award types); the web tab only adds one callout.

## Testing

- New unit test covering skip-initial-commit and streak counting
- Full server unit suite passes (847 tests)
- Verified all four stats against a live index: biggest commit, 25-day streak, 184 deps, and most-imported file all resolve to sensible values
- ruff, tsc, and ESLint clean
