### PR TITLE
fix(health): count TS object-literal shorthand properties as reads

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/dataflow/dialects/ts_js.py
+++ b/packages/core/src/repowise/core/analysis/health/dataflow/dialects/ts_js.py
@@ -60,6 +60,11 @@ class TsJsDefUseDialect(BaseDefUseDialect):
     language = "typescript"
     member_access_kinds = frozenset({"member_expression"})
     keyword_kinds = frozenset()  # object-property keys are not variable reads.
+    # ``shorthand_property_identifier`` is an object-literal read (``{ days }``
+    # reads the local ``days``). Its ``_pattern`` twin is the destructuring
+    # *binder*; the grammars (ts / tsx / js) never emit the non-pattern kind in
+    # a write-target position, so counting it as an identifier only adds reads.
+    identifier_kinds = frozenset({"identifier", "shorthand_property_identifier"})
 
     def _is_scope_boundary(self, node: Node) -> bool:
         return node.type in _SCOPE_BOUNDARIES

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **One dataflow parse per file.** The health pass's dataflow consumers (the Extract Method detector and the perf advisory-to-asserted promotion) now share a single lazily parsed per-file analysis instead of each re-reading and re-parsing the file, making the health pass measurably faster on large repos with identical output. The new per-function dataflow summary and point-lookup APIs this introduces are the foundation for upcoming dataflow-backed surfaces.
+
 ### Added
+- **First-class output-language support.** `repowise init --language <code>` (15 languages: en, ru, es, fr, de, zh, ja, ko, it, pt, nl, pl, tr, ar, hi) sets the natural language for generated wiki pages; advanced interactive mode now asks for it too (English default). The choice persists to `.repowise/config.yaml` so `update` regenerates changed pages in the same language, and the workspace init, workspace generate, and server regenerate paths now honor it instead of silently defaulting to English. Code, file paths, and symbol names stay untranslated. Previously this was config-file-only (#99).
 - **Worktrees just work.** `repowise init` and `repowise update` inside a linked git worktree now auto-detect the base checkout and seed the worktree's index from it, then catch up incrementally; no flags needed. `--seed-from <base>` remains as an explicit override and `--no-seed` forces a cold init. See [WORKTREES.md](WORKTREES.md). (#655 introduced the manual flag; this release makes it automatic.)
 
 ### Fixed

--- a/tests/unit/health/test_dataflow_langs.py
+++ b/tests/unit/health/test_dataflow_langs.py
@@ -300,6 +300,63 @@ def test_js_def_use_destructuring():
     assert {"items", "factor"} <= defs
 
 
+def test_ts_shorthand_object_literal_reads():
+    # ``{ days, limit }`` in a return reads both locals; ``shorthand_property_
+    # identifier`` must count as a use even though its ``_pattern`` twin is a
+    # destructuring def.
+    fn = _first(
+        "typescript",
+        """
+        function build(days: number, limit: number) {
+            const payload = compute(days);
+            return { days, limit, payload };
+        }
+        """,
+    )
+    uses = _use_names(fn)
+    assert {"days", "limit", "payload"} <= uses
+    # Reads never become defs.
+    defs = _def_names(fn)
+    assert defs == {"days", "limit", "payload"}  # params + the one declaration
+
+
+def test_ts_shorthand_mixed_with_destructuring_same_statement():
+    # LHS shorthand is a destructuring def; RHS shorthand is a read -- both on
+    # one statement.
+    fn = _first(
+        "typescript",
+        """
+        function f(source: { a: number }, b: number) {
+            const { a } = { ...source, b };
+            return a;
+        }
+        """,
+    )
+    assert "a" in _def_names(fn)
+    # On the destructuring line itself only ``a`` binds; the RHS shorthand
+    # ``b`` stays a read (its sole def is the parameter seed).
+    destructure_defs = {d.var for d in fn.def_use.definitions if d.line == 3}
+    assert destructure_defs == {"a"}
+    uses = _use_names(fn)
+    assert {"source", "b"} <= uses
+
+
+def test_js_shorthand_and_spread_reads():
+    # Plain JS pack: spread reads its identifier, shorthand reads its local.
+    fn = _first(
+        "javascript",
+        """
+        function merge(base, extra) {
+            const combined = { ...base, extra };
+            return combined;
+        }
+        """,
+    )
+    uses = _use_names(fn)
+    assert {"base", "extra"} <= uses
+    assert "extra" not in {d.var for d in fn.def_use.definitions if d.line > fn.start_line}
+
+
 _TS_PROCESS = """
 function process(records: number[], threshold: number): [number, number] {
     const results: number[] = [];


### PR DESCRIPTION
## Problem

The ts_js def/use dialect classifies only plain `identifier` nodes as variable reads. It knows `shorthand_property_identifier_pattern` (the destructuring binder, a def) but never counts `shorthand_property_identifier`, the object-literal read in `{ days, limit }`. Those reads were invisible to the dataflow layer.

Impact on shipped consumers:

- Extract Method IN/OUT inference on TS/JS can omit a variable a candidate span consumes via shorthand, producing a wrong parameter list.
- This violates the documented precision-first contract in defuse.py (unresolvable identifiers are reads).

Concrete repros: `packages/api-client/src/graph.ts::getHotFilesGraph` reported `days` and `limit` as unused parameters even though both are consumed at line 97 via shorthand; same for `providers.ts::setActiveProvider` (`provider`) and `packages/vscode/src/features/trees/shared.ts::section` (`key`, `label`).

## Fix

Extend the dialect's `identifier_kinds` with `shorthand_property_identifier`. Grammar introspection across the typescript, tsx, and javascript packs confirms the non-pattern kind only ever appears in read position (object literals); destructuring binders, including assignment-LHS destructuring, always parse as the `_pattern` variant. So this adds reads and can never introduce a false def.

## Tests

New fixtures in `tests/unit/health/test_dataflow_langs.py`:

- shorthand reads in a return object (`return { days, limit, payload }`)
- LHS destructuring def mixed with RHS shorthand read on the same statement (`const { a } = { ...source, b }`)
- spread plus shorthand on the plain JS grammar

Full health suite (921 tests) passes with no extract-method golden shifts. Full unit suite passes except the pre-existing `test_bundled_changelog_in_sync` failure, which is unrelated (bundled changelog drifted on main).

Rerunning the tree-wide dataflow sweep confirms the three shorthand false-positive repros above are gone.

Perf-neutral: the change adds one string to a frozenset consulted in an existing membership check.