### PR TITLE
feat(web): anonymous feedback panel in dashboard

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -21,6 +21,7 @@
     "./dead-code": "./src/dead-code.ts",
     "./decisions": "./src/decisions.ts",
     "./external-systems": "./src/external-systems.ts",
+    "./feedback": "./src/feedback.ts",
     "./files": "./src/files.ts",
     "./git": "./src/git.ts",
     "./graph": "./src/graph.ts",

--- a/packages/api-client/src/feedback.ts
+++ b/packages/api-client/src/feedback.ts
@@ -1,0 +1,27 @@
+/**
+ * In-app feedback. The web app POSTs to the local server's `/api/feedback`,
+ * which forwards the message to the hosted Repowise backend (tagged as OSS).
+ */
+
+import { apiPost } from "./client";
+
+/** Feedback categories. Mirrors the server-side `_CATEGORIES` set. */
+export type FeedbackCategory = "ui_ux" | "bug" | "feature_request" | "other";
+
+export interface FeedbackInput {
+  category: FeedbackCategory;
+  message: string;
+  /** Optional reply-to address, so the maintainers can follow up. */
+  email?: string;
+  /** The dashboard page the feedback was sent from. */
+  pageUrl?: string;
+}
+
+export async function submitFeedback(input: FeedbackInput): Promise<{ ok: boolean }> {
+  return apiPost<{ ok: boolean }>("/api/feedback", {
+    category: input.category,
+    message: input.message,
+    ...(input.email && { email: input.email }),
+    ...(input.pageUrl && { page_url: input.pageUrl }),
+  });
+}

--- a/packages/server/src/repowise/server/app.py
+++ b/packages/server/src/repowise/server/app.py
@@ -41,6 +41,7 @@ from repowise.server.routers import (
     dead_code,
     decisions,
     external_systems,
+    feedback,
     files,
     git,
     graph,
@@ -447,5 +448,6 @@ def create_app() -> FastAPI:
     app.include_router(stats.router)
     app.include_router(files.router)
     app.include_router(external_systems.router)
+    app.include_router(feedback.router)
 
     return app

--- a/packages/server/src/repowise/server/routers/feedback.py
+++ b/packages/server/src/repowise/server/routers/feedback.py
@@ -1,0 +1,75 @@
+"""``/api/feedback``: forward in-app feedback from the OSS dashboard to the
+hosted Repowise backend.
+
+The self-hosted dashboard has no database or mail transport of its own, so the
+local server acts as a thin, server-side relay: the browser POSTs here, and we
+forward the message to the hosted feedback endpoint (which persists it and
+emails the maintainers). The submission is tagged ``source="oss"`` and carries
+the running server version so OSS feedback is distinguishable from hosted, and
+triageable by version.
+
+This is an explicit, user-initiated action (they typed a message and clicked
+send), so it is not gated on the telemetry opt-out. Forwarding server-side
+(rather than a direct browser call) keeps the web app talking only to its local
+origin and sidesteps cross-origin restrictions on the hosted API.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from repowise.server import __version__
+from repowise.server.deps import verify_api_key
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/feedback", tags=["feedback"], dependencies=[Depends(verify_api_key)])
+
+#: Hosted feedback sink. Persists the row and emails the maintainer list. No
+#: localhost override: feedback is only useful when it reaches the maintainers.
+_HOSTED_FEEDBACK_URL = "https://api.repowise.dev/feedback"
+
+_CATEGORIES = frozenset({"ui_ux", "bug", "feature_request", "other"})
+
+
+class FeedbackRequest(BaseModel):
+    category: str = Field(..., description="One of ui_ux, bug, feature_request, other")
+    message: str = Field(..., min_length=1, max_length=4000)
+    email: str | None = Field(default=None, max_length=320)
+    page_url: str | None = Field(default=None, max_length=2048)
+
+
+class FeedbackResponse(BaseModel):
+    ok: bool
+
+
+@router.post("", response_model=FeedbackResponse)
+async def submit_feedback(body: FeedbackRequest) -> FeedbackResponse:
+    """Relay one feedback message to the hosted backend, tagged as OSS."""
+    category = body.category if body.category in _CATEGORIES else "other"
+    payload = {
+        "category": category,
+        "message": body.message.strip(),
+        "email": (body.email or "").strip() or None,
+        "page_url": body.page_url,
+        "source": "oss",
+        "client_version": __version__,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(_HOSTED_FEEDBACK_URL, json=payload)
+        resp.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.warning("feedback_forward_failed: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="Couldn't reach the feedback service. Please try again.",
+        ) from exc
+
+    logger.info("feedback_forwarded category=%s has_email=%s", category, bool(payload["email"]))
+    return FeedbackResponse(ok=True)

--- a/packages/web/src/components/layout/feedback-button.tsx
+++ b/packages/web/src/components/layout/feedback-button.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { MessageSquarePlus } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@repowise-dev/ui/ui/dialog";
+import { Button } from "@repowise-dev/ui/ui/button";
+import { toast } from "sonner";
+import { submitFeedback, type FeedbackCategory } from "@/lib/api/feedback";
+
+const CATEGORIES: { value: FeedbackCategory; label: string }[] = [
+  { value: "ui_ux", label: "UI / UX" },
+  { value: "bug", label: "Bug" },
+  { value: "feature_request", label: "Feature request" },
+  { value: "other", label: "Other" },
+];
+
+const MAX_LENGTH = 4000;
+
+/**
+ * Sidebar-footer feedback entry point for the self-hosted dashboard. Opens a
+ * categorised dialog; submissions POST to the local server's `/api/feedback`,
+ * which forwards them to the Repowise maintainers. Works without an account.
+ */
+export function FeedbackButton() {
+  const [open, setOpen] = useState(false);
+  const [category, setCategory] = useState<FeedbackCategory>("ui_ux");
+  const [message, setMessage] = useState("");
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = () => {
+    setCategory("ui_ux");
+    setMessage("");
+    setEmail("");
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (submitting) return;
+    setOpen(next);
+    if (!next) reset();
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = message.trim();
+    if (!trimmed) {
+      toast.error("Please enter your feedback.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await submitFeedback({
+        category,
+        message: trimmed,
+        ...(email.trim() && { email: email.trim() }),
+        ...(typeof window !== "undefined" && { pageUrl: window.location.href }),
+      });
+      toast.success("Thanks for the feedback!");
+      setOpen(false);
+      reset();
+    } catch {
+      toast.error("Couldn't send feedback. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Send feedback"
+        className="flex w-full items-center gap-1.5 text-xs text-[var(--color-text-tertiary)] transition-colors hover:text-[var(--color-text-secondary)]"
+      >
+        <MessageSquarePlus className="h-3.5 w-3.5 shrink-0" />
+        <span>Send feedback</span>
+      </button>
+
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Send feedback</DialogTitle>
+            <DialogDescription>
+              Found a bug or have an idea? It goes straight to the maintainers. We read every
+              message.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            {/* Category */}
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-[var(--color-text-tertiary)]">
+                Category
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {CATEGORIES.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setCategory(option.value)}
+                    className={`cursor-pointer rounded-full border px-3 py-1.5 text-xs font-medium transition-colors ${
+                      category === option.value
+                        ? "border-[var(--color-accent-primary)] bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
+                        : "border-[var(--color-border-default)] text-[var(--color-text-secondary)] hover:border-[var(--color-text-tertiary)]"
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Message */}
+            <div>
+              <label
+                htmlFor="feedback-message"
+                className="mb-1.5 block text-xs font-medium text-[var(--color-text-tertiary)]"
+              >
+                Your feedback
+              </label>
+              <textarea
+                id="feedback-message"
+                rows={5}
+                autoFocus
+                maxLength={MAX_LENGTH}
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder="Tell us what's working, what's broken, or what you'd love to see..."
+                className="w-full resize-none rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2.5 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-tertiary)] focus:border-[var(--color-accent-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent-primary)]"
+              />
+              <p className="mt-1 text-right text-[11px] text-[var(--color-text-tertiary)]">
+                {message.length}/{MAX_LENGTH}
+              </p>
+            </div>
+
+            {/* Optional email — so the maintainers can reply */}
+            <div>
+              <label
+                htmlFor="feedback-email"
+                className="mb-1.5 block text-xs font-medium text-[var(--color-text-tertiary)]"
+              >
+                Email{" "}
+                <span className="font-normal text-[var(--color-text-tertiary)]">
+                  (optional, if you&apos;d like a reply)
+                </span>
+              </label>
+              <input
+                id="feedback-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                className="w-full rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-tertiary)] focus:border-[var(--color-accent-primary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent-primary)]"
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button onClick={handleSubmit} disabled={submitting || !message.trim()}>
+              {submitting ? "Sending…" : "Send feedback"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/packages/web/src/components/layout/mobile-nav.tsx
+++ b/packages/web/src/components/layout/mobile-nav.tsx
@@ -17,6 +17,7 @@ import { ScrollArea } from "@repowise-dev/ui/ui/scroll-area";
 import { Separator } from "@repowise-dev/ui/ui/separator";
 import { AddRepoDialog } from "@/components/repos/add-repo-dialog";
 import { VersionFooter } from "./version-footer";
+import { FeedbackButton } from "./feedback-button";
 import { cn } from "@/lib/utils/cn";
 import {
   GLOBAL_NAV,
@@ -241,7 +242,8 @@ export function MobileNav({ repos = [], workspace }: MobileNavProps) {
             </div>
           </ScrollArea>
 
-          <div className="border-t border-[var(--color-border-default)] px-4 py-3">
+          <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
+            <FeedbackButton />
             <VersionFooter />
           </div>
         </SheetContent>

--- a/packages/web/src/components/layout/sidebar.tsx
+++ b/packages/web/src/components/layout/sidebar.tsx
@@ -25,6 +25,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@repowise-dev/ui/ui/too
 import { ThemeToggle } from "@repowise-dev/ui/shared/theme-toggle";
 import { AddRepoDialog } from "@/components/repos/add-repo-dialog";
 import { VersionFooter } from "./version-footer";
+import { FeedbackButton } from "./feedback-button";
 import type { RepoResponse, WorkspaceResponse } from "@/lib/api/types";
 
 interface SidebarProps {
@@ -390,6 +391,7 @@ export function Sidebar({ repos = [], activeRepoId, workspace }: SidebarProps) {
       {!isIconOnly && (
         <div className="flex flex-col gap-3 border-t border-[var(--color-border-default)] px-4 py-3">
           <ThemeToggle className="w-full justify-between" />
+          <FeedbackButton />
           <VersionFooter />
         </div>
       )}

--- a/packages/web/src/lib/api/feedback.ts
+++ b/packages/web/src/lib/api/feedback.ts
@@ -1,0 +1,3 @@
+import "./client";
+
+export * from "@repowise-dev/api-client/feedback";


### PR DESCRIPTION
## What

Adds a low-friction, anonymous feedback panel to the shipped dashboard. A "Send feedback" button in the sidebar and mobile-nav footers opens a categorised dialog (UI/UX, bug, feature request, other) with a message box and an optional reply email. No account required.

## How it reaches us

The self-hosted dashboard has no database or mail transport of its own, so the local server acts as a thin relay:

```
browser -> local Next server -> local FastAPI /api/feedback -> hosted feedback endpoint
```

The new `/api/feedback` route forwards each submission server-side (httpx) to the hosted backend, tagged with `source="oss"` and the running server version. Forwarding server-side keeps the web app talking only to its local origin and avoids cross-origin restrictions on the hosted API. It is an explicit user action, so it is not gated on the telemetry opt-out.

## Changes

- `packages/server/.../routers/feedback.py` (new) + registered in `app.py`
- `packages/api-client/src/feedback.ts` (new) + package export; `packages/web/src/lib/api/feedback.ts` re-export
- `packages/web/src/components/layout/feedback-button.tsx` (new); mounted in `sidebar.tsx` and `mobile-nav.tsx` footers

The hosted sink is rate limited per IP. Backend changes to accept `source`/`client_version` ship separately.

## Verification

- `ruff` clean, server imports resolve
- `type-check` passes for `@repowise-dev/api-client` and `repowise-web`