### PR TITLE
release: v0.30.0 — content-keyed page reuse, output languages, worktree auto-seed

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,18 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
-
-### Changed
-- **One dataflow parse per file.** The health pass's dataflow consumers (the Extract Method detector and the perf advisory-to-asserted promotion) now share a single lazily parsed per-file analysis instead of each re-reading and re-parsing the file, making the health pass measurably faster on large repos with identical output. The new per-function dataflow summary and point-lookup APIs this introduces are the foundation for upcoming dataflow-backed surfaces.
+## [0.30.0] — 2026-07-10
 
 ### Added
-- **First-class output-language support.** `repowise init --language <code>` (15 languages: en, ru, es, fr, de, zh, ja, ko, it, pt, nl, pl, tr, ar, hi) sets the natural language for generated wiki pages; advanced interactive mode now asks for it too (English default). The choice persists to `.repowise/config.yaml` so `update` regenerates changed pages in the same language, and the workspace init, workspace generate, and server regenerate paths now honor it instead of silently defaulting to English. Code, file paths, and symbol names stay untranslated. Previously this was config-file-only (#99).
-- **Worktrees just work.** `repowise init` and `repowise update` inside a linked git worktree now auto-detect the base checkout and seed the worktree's index from it, then catch up incrementally; no flags needed. `--seed-from <base>` remains as an explicit override and `--no-seed` forces a cold init. See [WORKTREES.md](WORKTREES.md). (#655 introduced the manual flag; this release makes it automatic.)
+- **First-class output-language support.** `repowise init --language <code>` (15 languages: en, ru, es, fr, de, zh, ja, ko, it, pt, nl, pl, tr, ar, hi) sets the natural language for generated wiki pages; advanced interactive mode now asks for it too (English default). The choice persists to `.repowise/config.yaml` so `update` regenerates changed pages in the same language, and the workspace init, workspace generate, and server regenerate paths now honor it instead of silently defaulting to English. Code, file paths, and symbol names stay untranslated. Previously this was config-file-only (#99). (#756)
+- **Worktrees just work.** `repowise init` and `repowise update` inside a linked git worktree now auto-detect the base checkout and seed the worktree's index from it, then catch up incrementally; no flags needed. `--seed-from <base>` remains as an explicit override and `--no-seed` forces a cold init. See [WORKTREES.md](WORKTREES.md). (#655 introduced the manual flag; #747 makes it automatic.)
+- **Ruby and Scala promoted to Full health tier.** Both languages now get the full complexity node map and performance-risk dialect, so health scores and perf findings match the depth Python/TypeScript/Go already had. (#745, #749)
+- **Git stats awards.** The contributor stats view gained biggest-commit, longest-streak, most-imported-file, and dependency awards. (#752)
+- **Workspace socket-contract detection.** Cross-repo analysis now detects socket-based service contracts alongside HTTP ones. (#710)
+- **Anonymous feedback panel.** The dashboard gained a lightweight feedback panel — no account or email required. (#763)
+- **Claude Code integration: session context + safer distill.** The augment hook now emits a per-session context block with live index freshness on session start, the distill rewrite hook learned two safe shell-syntax carve-outs, and `repowise doctor` checks hook registration. (#743)
+
+### Changed
+- **Unchanged wiki pages are reused across runs.** Cross-run page reuse now keys on the documented file's content plus the generation settings (template, language, style) instead of the exact rendered prompt — which embedded per-run retrieval context and practically never matched. A re-run over a repo where a handful of files changed now regenerates only those pages; changing the model, output language, or wiki style still regenerates everything it should. (#757)
+- **One dataflow parse per file.** The health pass's dataflow consumers (the Extract Method detector and the perf advisory-to-asserted promotion) now share a single lazily parsed per-file analysis instead of each re-reading and re-parsing the file, making the health pass measurably faster on large repos with identical output. The new per-function dataflow summary and point-lookup APIs this introduces are the foundation for upcoming dataflow-backed surfaces. (#755)
+- **Leaner MCP surface for agents.** An agent-lean tool profile with tool-search gating and registry-pinned docs, plus payload-precision trims across tools, cut the token cost of the MCP surface without removing capability. (#742, #744)
+- **Graph view cleanups.** The module view no longer collapses into a single blob, external nodes are hidden by default, and node info panels are layer-aware. (#754)
 
 ### Fixed
-- **Seeded worktree indexes no longer split in two.** Seeding now re-points the copied index at the worktree, so the first update reuses the seeded pages instead of minting a second repository entry and regenerating everything under it.
-- **`[workspace]` notices render again.** The one-line workspace auto-detect notice was being swallowed by console markup and printed without its prefix.
+- **Pages skipped by the update budget are labelled stale.** `repowise update` marks weakly-affected pages it chose not to regenerate as stale instead of leaving them claiming to be fresh, and `total_pages` is recomputed from the store. (#748)
+- **Dataflow CFG no longer flags reachable code as unreachable.** (#760)
+- **TypeScript object-literal shorthand properties count as reads**, fixing spurious unused-symbol findings. (#759)
+- **Cross-repo co-change is a bounded session-share signal**, preventing one shared session from dominating workspace coupling scores. (#758)
+- **Seeded worktree indexes no longer split in two.** Seeding now re-points the copied index at the worktree, so the first update reuses the seeded pages instead of minting a second repository entry and regenerating everything under it. (#747)
+- **`[workspace]` notices render again.** The one-line workspace auto-detect notice was being swallowed by console markup and printed without its prefix. (#747)
+
+### Documentation
+- User-facing docs restructured and refreshed (quickstart, user guide, CLI reference, config). (#741)
+- Plugin: the Claude Code plugin bundles the new SessionStart context hook. (#743)
 
 ---
 

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,18 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
-
-### Changed
-- **One dataflow parse per file.** The health pass's dataflow consumers (the Extract Method detector and the perf advisory-to-asserted promotion) now share a single lazily parsed per-file analysis instead of each re-reading and re-parsing the file, making the health pass measurably faster on large repos with identical output. The new per-function dataflow summary and point-lookup APIs this introduces are the foundation for upcoming dataflow-backed surfaces.
+## [0.30.0] — 2026-07-10
 
 ### Added
-- **First-class output-language support.** `repowise init --language <code>` (15 languages: en, ru, es, fr, de, zh, ja, ko, it, pt, nl, pl, tr, ar, hi) sets the natural language for generated wiki pages; advanced interactive mode now asks for it too (English default). The choice persists to `.repowise/config.yaml` so `update` regenerates changed pages in the same language, and the workspace init, workspace generate, and server regenerate paths now honor it instead of silently defaulting to English. Code, file paths, and symbol names stay untranslated. Previously this was config-file-only (#99).
-- **Worktrees just work.** `repowise init` and `repowise update` inside a linked git worktree now auto-detect the base checkout and seed the worktree's index from it, then catch up incrementally; no flags needed. `--seed-from <base>` remains as an explicit override and `--no-seed` forces a cold init. See [WORKTREES.md](WORKTREES.md). (#655 introduced the manual flag; this release makes it automatic.)
+- **First-class output-language support.** `repowise init --language <code>` (15 languages: en, ru, es, fr, de, zh, ja, ko, it, pt, nl, pl, tr, ar, hi) sets the natural language for generated wiki pages; advanced interactive mode now asks for it too (English default). The choice persists to `.repowise/config.yaml` so `update` regenerates changed pages in the same language, and the workspace init, workspace generate, and server regenerate paths now honor it instead of silently defaulting to English. Code, file paths, and symbol names stay untranslated. Previously this was config-file-only (#99). (#756)
+- **Worktrees just work.** `repowise init` and `repowise update` inside a linked git worktree now auto-detect the base checkout and seed the worktree's index from it, then catch up incrementally; no flags needed. `--seed-from <base>` remains as an explicit override and `--no-seed` forces a cold init. See [WORKTREES.md](WORKTREES.md). (#655 introduced the manual flag; #747 makes it automatic.)
+- **Ruby and Scala promoted to Full health tier.** Both languages now get the full complexity node map and performance-risk dialect, so health scores and perf findings match the depth Python/TypeScript/Go already had. (#745, #749)
+- **Git stats awards.** The contributor stats view gained biggest-commit, longest-streak, most-imported-file, and dependency awards. (#752)
+- **Workspace socket-contract detection.** Cross-repo analysis now detects socket-based service contracts alongside HTTP ones. (#710)
+- **Anonymous feedback panel.** The dashboard gained a lightweight feedback panel — no account or email required. (#763)
+- **Claude Code integration: session context + safer distill.** The augment hook now emits a per-session context block with live index freshness on session start, the distill rewrite hook learned two safe shell-syntax carve-outs, and `repowise doctor` checks hook registration. (#743)
+
+### Changed
+- **Unchanged wiki pages are reused across runs.** Cross-run page reuse now keys on the documented file's content plus the generation settings (template, language, style) instead of the exact rendered prompt — which embedded per-run retrieval context and practically never matched. A re-run over a repo where a handful of files changed now regenerates only those pages; changing the model, output language, or wiki style still regenerates everything it should. (#757)
+- **One dataflow parse per file.** The health pass's dataflow consumers (the Extract Method detector and the perf advisory-to-asserted promotion) now share a single lazily parsed per-file analysis instead of each re-reading and re-parsing the file, making the health pass measurably faster on large repos with identical output. The new per-function dataflow summary and point-lookup APIs this introduces are the foundation for upcoming dataflow-backed surfaces. (#755)
+- **Leaner MCP surface for agents.** An agent-lean tool profile with tool-search gating and registry-pinned docs, plus payload-precision trims across tools, cut the token cost of the MCP surface without removing capability. (#742, #744)
+- **Graph view cleanups.** The module view no longer collapses into a single blob, external nodes are hidden by default, and node info panels are layer-aware. (#754)
 
 ### Fixed
-- **Seeded worktree indexes no longer split in two.** Seeding now re-points the copied index at the worktree, so the first update reuses the seeded pages instead of minting a second repository entry and regenerating everything under it.
-- **`[workspace]` notices render again.** The one-line workspace auto-detect notice was being swallowed by console markup and printed without its prefix.
+- **Pages skipped by the update budget are labelled stale.** `repowise update` marks weakly-affected pages it chose not to regenerate as stale instead of leaving them claiming to be fresh, and `total_pages` is recomputed from the store. (#748)
+- **Dataflow CFG no longer flags reachable code as unreachable.** (#760)
+- **TypeScript object-literal shorthand properties count as reads**, fixing spurious unused-symbol findings. (#759)
+- **Cross-repo co-change is a bounded session-share signal**, preventing one shared session from dominating workspace coupling scores. (#758)
+- **Seeded worktree indexes no longer split in two.** Seeding now re-points the copied index at the worktree, so the first update reuses the seeded pages instead of minting a second repository entry and regenerating everything under it. (#747)
+- **`[workspace]` notices render again.** The one-line workspace auto-detect notice was being swallowed by console markup and printed without its prefix. (#747)
+
+### Documentation
+- User-facing docs restructured and refreshed (quickstart, user guide, CLI reference, config). (#741)
+- Plugin: the Claude Code plugin bundles the new SessionStart context hook. (#743)
 
 ---
 

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.29.0"
+__version__ = "0.30.0"

--- a/packages/web/src/components/dead-code/finding-row.tsx
+++ b/packages/web/src/components/dead-code/finding-row.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { GitBranch, Code2 } from "lucide-react";
+import { Button } from "@repowise-dev/ui/ui/button";
+import { Badge } from "@repowise-dev/ui/ui/badge";
+import { ConfirmDialog } from "@repowise-dev/ui/ui/confirm-dialog";
+import { RowActions } from "@repowise-dev/ui/shared/row-actions";
+import { formatConfidence } from "@repowise-dev/ui/lib/format";
+import { patchDeadCodeFinding } from "@/lib/api/dead-code";
+import { cn } from "@/lib/utils/cn";
+import type { DeadCodeFindingResponse } from "@/lib/api/types";
+import type { DeadCodeStatus } from "@repowise-dev/types/dead-code";
+
+const STATUS_LABELS: Record<string, { title: string; description: string; confirmLabel: string; destructive: boolean }> = {
+  resolved: {
+    title: "Resolve finding?",
+    description: "Mark this finding as resolved. You can undo from the toast.",
+    confirmLabel: "Resolve",
+    destructive: false,
+  },
+  acknowledged: {
+    title: "Acknowledge finding?",
+    description: "Mark this finding as acknowledged.",
+    confirmLabel: "Acknowledge",
+    destructive: false,
+  },
+  false_positive: {
+    title: "Mark as false positive?",
+    description: "This finding will be excluded from future analyses. You can undo from the toast.",
+    confirmLabel: "Mark FP",
+    destructive: true,
+  },
+};
+
+interface FindingRowProps {
+  finding: DeadCodeFindingResponse;
+  repoId: string;
+  selected: boolean;
+  onToggle: (id: string) => void;
+  onUpdate: (updated: DeadCodeFindingResponse) => void;
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  open: "bg-red-500/10 text-red-500 border-red-500/20",
+  acknowledged: "bg-yellow-500/10 text-yellow-500 border-yellow-500/20",
+  resolved: "bg-green-500/10 text-green-500 border-green-500/20",
+  false_positive: "bg-[var(--color-bg-elevated)] text-[var(--color-text-tertiary)] border-[var(--color-border-default)]",
+};
+
+export function FindingRow({ finding, repoId, selected, onToggle, onUpdate }: FindingRowProps) {
+  const [pending, setPending] = useState(false);
+  const [confirmStatus, setConfirmStatus] = useState<DeadCodeStatus | null>(null);
+
+  const previousStatus = finding.status;
+
+  const applyPatch = async (status: DeadCodeStatus) => {
+    setPending(true);
+    try {
+      const updated = await patchDeadCodeFinding(finding.id, { status });
+      onUpdate(updated);
+      setConfirmStatus(null);
+      toast.success(`Finding ${status.replace(/_/g, " ")}`, {
+        action: {
+          label: "Undo",
+          onClick: async () => {
+            try {
+              const reverted = await patchDeadCodeFinding(finding.id, { status: previousStatus });
+              onUpdate(reverted);
+            } catch (err) {
+              toast.error(
+                err instanceof Error ? `Couldn't undo: ${err.message}` : "Couldn't undo",
+              );
+            }
+          },
+        },
+        duration: 6000,
+      });
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? `Couldn't update finding: ${err.message}` : "Couldn't update finding",
+      );
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const requestPatch = (status: DeadCodeStatus) => setConfirmStatus(status);
+
+  const confirmConfig = confirmStatus ? STATUS_LABELS[confirmStatus] : null;
+
+  return (
+    <tr
+      className={cn(
+        "border-b border-[var(--color-border-default)] transition-colors last:border-0",
+        selected ? "bg-[var(--color-accent-muted)]" : "hover:bg-[var(--color-bg-elevated)]",
+      )}
+    >
+      <td className="px-4 py-2.5">
+        <input
+          type="checkbox"
+          checked={selected}
+          onChange={() => onToggle(finding.id)}
+          aria-label={`Select finding ${finding.file_path}`}
+          className="rounded border-[var(--color-border-default)]"
+        />
+      </td>
+      <td className="px-4 py-2.5 font-mono text-xs text-[var(--color-text-primary)] min-w-[200px] max-w-[480px]">
+        <span className="truncate block" title={finding.file_path}>{finding.file_path}</span>
+        {finding.symbol_name && (
+          <span className="block truncate text-[var(--color-text-tertiary)]" title={finding.symbol_name}>{finding.symbol_name}</span>
+        )}
+      </td>
+      <td className="px-4 py-2.5 text-xs text-[var(--color-text-secondary)] tabular-nums">
+        <span
+          className={cn(
+            "font-medium",
+            finding.confidence >= 0.8
+              ? "text-red-500"
+              : finding.confidence >= 0.6
+                ? "text-yellow-500"
+                : "text-[var(--color-text-secondary)]",
+          )}
+        >
+          {formatConfidence(finding.confidence)}
+        </span>
+      </td>
+      <td className="px-4 py-2.5 text-xs text-[var(--color-text-secondary)] hidden md:table-cell">
+        {finding.primary_owner ?? "—"}
+      </td>
+      <td className="px-4 py-2.5 text-xs text-[var(--color-text-tertiary)] tabular-nums hidden md:table-cell">
+        {finding.lines}
+      </td>
+      <td className="px-4 py-2.5 hidden sm:table-cell">
+        {finding.safe_to_delete ? (
+          <Badge variant="fresh">Candidate</Badge>
+        ) : (
+          <Badge
+            variant="default"
+            title={
+              finding.risk_factors && finding.risk_factors.length > 0
+                ? `Runtime-load risk (${finding.risk_factors.join(", ")}) — verify it isn't loaded outside static imports before deleting`
+                : "Lower confidence — verify before deleting"
+            }
+          >
+            Review
+          </Badge>
+        )}
+      </td>
+      <td className="px-4 py-2.5 hidden sm:table-cell">
+        <span
+          className={cn(
+            "inline-flex items-center rounded border px-2 py-0.5 text-xs font-medium",
+            STATUS_COLORS[finding.status] ?? STATUS_COLORS.open,
+          )}
+        >
+          {finding.status.replace(/_/g, " ")}
+        </span>
+      </td>
+      <td className="px-4 py-2.5">
+        <div className="flex items-center gap-1 flex-wrap justify-end">
+          <RowActions
+            actions={[
+              { icon: GitBranch, label: "Graph", href: `/repos/${repoId}/architecture?view=graph&node=${encodeURIComponent(finding.file_path)}` },
+              ...(finding.symbol_name ? [{ icon: Code2, label: "Symbol", href: `/repos/${repoId}/architecture?view=symbols` }] : []),
+            ]}
+          />
+        {finding.status === "open" && (
+          <div className="flex items-center gap-1 flex-wrap justify-end">
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={pending}
+              onClick={() => requestPatch("resolved")}
+              className="h-6 px-2 text-xs text-green-500 hover:text-green-400"
+              aria-label={`Resolve ${finding.file_path}`}
+            >
+              Resolve
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={pending}
+              onClick={() => requestPatch("acknowledged")}
+              className="h-6 px-2 text-xs"
+              aria-label={`Acknowledge ${finding.file_path}`}
+            >
+              Ack
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={pending}
+              onClick={() => requestPatch("false_positive")}
+              className="h-6 px-2 text-xs text-[var(--color-text-tertiary)]"
+              aria-label={`Mark ${finding.file_path} as false positive`}
+            >
+              FP
+            </Button>
+          </div>
+        )}
+        </div>
+      </td>
+      {confirmConfig && (
+        <ConfirmDialog
+          open={confirmStatus !== null}
+          onOpenChange={(o) => !o && setConfirmStatus(null)}
+          title={confirmConfig.title}
+          description={confirmConfig.description}
+          confirmLabel={confirmConfig.confirmLabel}
+          destructive={confirmConfig.destructive}
+          loading={pending}
+          onConfirm={() => applyPatch(confirmStatus!)}
+        />
+      )}
+    </tr>
+  );
+}

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
-## Unreleased
+## 0.30.0
 
 ### Added
 - Bundled `SessionStart` hook (`repowise-augment`, matcher `startup|resume|clear`):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.29.0"
+version = "0.30.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3056,7 +3056,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.29.0"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Cuts v0.30.0 with everything on main since v0.29.0 (21 commits). Headliners: cross-run wiki page reuse keyed on file content + generation settings (#757), first-class output-language support (#756), automatic worktree index seeding (#747/#655), Ruby & Scala promoted to the Full health tier (#745/#749), plus health-accuracy fixes (#758–#760), MCP surface trims (#742/#744), and the docs refresh (#741).

Release mechanics in this PR:
- Version bump to 0.30.0: `pyproject.toml`, the three package `__init__.py` files, `uv.lock` (regenerated via `uv lock`), and both Claude Code plugin manifests.
- `docs/CHANGELOG.md`: new 0.30.0 section (promoted + completed the Unreleased entries), bundled copy resynced.
- Plugin `CHANGELOG.md`: 0.30.0 entry for the bundled SessionStart hook (#743).
- Build fix required by the release gate: `finding-row.tsx` passed a plain `string` where `DeadCodePatchRequest` requires `DeadCodeStatus`, which failed `next build`'s type check. Regular CI never builds `packages/web`, so this sat on main undetected; typed the state + handlers.

## Test plan

- [x] Old-version drift grep clean (no `0.29.0` outside changelog history)
- [x] `uv lock` self-entry at 0.30.0
- [x] `uv build --wheel` — wheel built; 66 CLI command files, `.scm` queries (17) and `.j2` templates present; bundled changelog inside the wheel shows 0.30.0
- [x] `npm ci && npm run build --workspace packages/web` — green; standalone `server.js` produced; workspace-package code present in compiled chunks
- [x] `tests/unit/upgrade` (59 passed) incl. the bundled-changelog sync guard
- [x] Plugin MCP tool-surface grep — only live tools referenced
- [x] `repowise --version` → 0.30.0
- [ ] Squash-merge, then tag `v0.30.0` on the squash commit (triggers publish.yml)
- [ ] Post-release: workflow green, GitHub release assets, PyPI shows 0.30.0, tarball structure
- [ ] End-user smoke test (`pip install --upgrade repowise && repowise serve` in a fresh dir)

No store-format or parser-schema bump: everything this cycle is additive (new page/PriorPage fields ride the existing pickle-schema fingerprint; SQLite columns reconcile additively).