### PR TITLE
test(vscode): fix flaky home-sidebar summary-failure assertion

### DIFF
--- a/packages/vscode/webview/src/views/home/App.test.tsx
+++ b/packages/vscode/webview/src/views/home/App.test.tsx
@@ -142,6 +142,9 @@ describe("Home sidebar", () => {
 
     expect(await screen.findByText("Knowledge Graph")).toBeTruthy();
     expect(screen.getByText("Server-ranked refactoring opportunities")).toBeTruthy();
-    expect(screen.getByText(/No health data yet/)).toBeTruthy();
+    // findByText, not getByText: the launcher renders before the summary
+    // promise rejection flushes, so on a slow runner the hero card can still
+    // be in its loading skeleton when the launcher assertions pass.
+    expect(await screen.findByText(/No health data yet/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
CI on the v0.30.0 squash push failed `Home sidebar > keeps the launcher usable when the summary fails` while the identical code was green on the release PR run — a timing flake, confirmed by the failure's DOM dump (launcher rendered, hero card still in its loading skeleton). The test asserted the summary-failure fallback with a synchronous `getByText` immediately after awaiting an unrelated element; on a slow runner the rejection hasn't flushed yet. Switched to `findByText` so the assertion waits for the error state. Full webview suite green locally (43/43).