### PR TITLE
fix(mcp): keep non-path node ids out of get_answer fallback_targets

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -140,6 +140,25 @@ def _cache_entry_expired(created_at) -> bool:
     return (datetime.now(UTC) - ts) > timedelta(days=_ANSWER_CACHE_TTL_DAYS)
 
 
+def _is_readable_path(target: str) -> bool:
+    """Whether a fallback_target is a file the agent can actually Read.
+
+    Non-file graph nodes (community/SCC nodes, architectural layers) can ride in
+    on retrieval hits with a ``target_path`` like ``"scc-607"`` or
+    ``"layer:application"``: internal ids with no path separator and no file
+    extension. An agent handed one in ``fallback_targets`` will try to Read it and
+    dead-end, so keep only path-shaped entries (2026-07-10 dogfood finding).
+    """
+    t = (target or "").strip()
+    if not t:
+        return False
+    if "/" in t or "\\" in t:
+        return True
+    dot = t.rfind(".")
+    ext = t[dot + 1:] if dot != -1 else ""
+    return bool(ext) and ext.isalnum() and len(ext) <= 6
+
+
 def _gather_code_rationale(ctx, hits: list[dict], fallback_targets: list[str], question: str):
     """Mine in-code rationale comments for a low-confidence answer.
 
@@ -419,7 +438,10 @@ async def get_answer(
                     session, repo_id, hits, ctx, question_ids=question_ids
                 )
 
-    fallback_targets = [h["target_path"] for h in hits if h.get("target_path")]
+    fallback_targets = [
+        h["target_path"] for h in hits
+        if h.get("target_path") and _is_readable_path(h["target_path"])
+    ]
 
     if not hits:
         return {

--- a/tests/unit/server/mcp/test_answer_payload.py
+++ b/tests/unit/server/mcp/test_answer_payload.py
@@ -13,7 +13,33 @@ from types import SimpleNamespace
 
 import pytest
 
+from repowise.server.mcp_server.tool_answer.answer import _is_readable_path
 from repowise.server.mcp_server.tool_answer.retrieval import serialize_hits
+
+# ---------------------------------------------------------------------------
+# fallback_targets must be Read-able paths, never internal graph node ids
+# (2026-07-10 dogfood finding: "scc-607" / "layer:application" leaked in)
+# ---------------------------------------------------------------------------
+
+
+class TestIsReadablePath:
+    @pytest.mark.parametrize(
+        "target,expected",
+        [
+            ("src/flask/app.py", True),
+            ("app.py", True),
+            ("pkg/sub/mod.py", True),
+            ("cluster-config/x.py", True),   # hyphen in a real dir must not trip it
+            ("scc-607", False),              # community/SCC node id
+            ("layer:application", False),    # architectural-layer scheme token
+            ("comm-12", False),
+            ("README", False),              # no separator, no extension
+            ("", False),
+        ],
+    )
+    def test_filters_node_ids_keeps_paths(self, target, expected) -> None:
+        assert _is_readable_path(target) is expected
+
 
 # ---------------------------------------------------------------------------
 # serialize_hits unit tests


### PR DESCRIPTION
## What

`get_answer` returns a `fallback_targets` list of files the agent should Read. Retrieval hits for non-file graph nodes (community/SCC nodes, architectural layers) can carry a `target_path` that is an internal id rather than a path, for example `scc-607` or `layer:application`. Those ids were passed straight into `fallback_targets`, so an agent that tries to Read one dead-ends on something that is not a file.

## Fix

Filter `fallback_targets` to path-shaped entries only. The predicate keys on path shape (a separator, or a file extension) instead of a fixed id denylist, so it also catches leak forms beyond the originally observed `scc-NNN`, such as `layer:application`. Real hyphenated paths like `cluster-config/x.py` are kept.

## Test

Adds `TestIsReadablePath` covering the leak ids, real paths, and edge cases. Full `test_answer_payload.py` and `test_answer_calibration.py` pass (63 tests).

## Found via

Dogfooding the MCP tools against microdot and the repowise index; recorded in the 2026-07-10 dogfood notes.