### PR TITLE
feat(decisions): remove code_comment harvest, source gating, sticky dismissals

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -439,7 +439,7 @@ repowise decision list [PATH]           # list decisions
 repowise decision show ID [PATH]        # full details
 repowise decision add [PATH]            # interactive add
 repowise decision confirm ID [PATH]     # confirm a proposal
-repowise decision dismiss ID [PATH]     # delete a proposal
+repowise decision dismiss ID [PATH]     # dismiss a proposal (sticky; never re-proposed)
 repowise decision deprecate ID [PATH]   # mark deprecated
 repowise decision health [PATH]         # health dashboard
 ```

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -172,6 +172,30 @@ mcp:
   `get_architecture`) are added automatically in workspace mode and ignored if
   named in single-repo mode. See [MCP_TOOLS.md](MCP_TOOLS.md#configuring-the-tool-surface).
 
+### The `decisions:` block
+
+Controls decision extraction. Each key under `sources:` names an index-time
+capture source; set it to `false` to skip that source on the next
+`init` / `update`. Unknown keys are ignored, and sources you don't mention
+stay enabled.
+
+```yaml
+decisions:
+  sources:
+    comment: false          # LLM comment archaeology (top central files)
+    # inline_marker: false  # WHY:/DECISION: markers
+    # git_archaeology: false
+    # readme_mining: false
+    # adr: false
+    # changelog: false
+    # pr: false
+```
+
+Dismissals are sticky: `repowise decision dismiss` keeps the record as a
+`dismissed` tombstone, so reindexing never re-proposes the same decision, and
+a confirmed (`active`) decision is never walked back to `proposed` by a
+re-extraction.
+
 ### The `refactoring:` block
 
 Controls the refactoring-intelligence layer: the structured Extract Class /

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -478,7 +478,7 @@ repowise decision list [PATH]          # List decisions
 repowise decision show ID [PATH]       # Show full details of a decision
 repowise decision add [PATH]           # Interactively add a new decision
 repowise decision confirm ID [PATH]    # Confirm a proposed decision (set to active)
-repowise decision dismiss ID [PATH]    # Delete a proposed decision
+repowise decision dismiss ID [PATH]    # Dismiss a proposal (sticky; never re-proposed)
 repowise decision deprecate ID [PATH]  # Mark as deprecated
 repowise decision health [PATH]        # Decision health dashboard
 ```

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1015,7 +1015,7 @@ repowise decision add        # interactive capture
 repowise decision list       # tabular list with filters
 repowise decision show <id>  # full detail
 repowise decision confirm    # proposed → active
-repowise decision dismiss    # delete proposed
+repowise decision dismiss    # dismiss proposed (sticky tombstone)
 repowise decision deprecate  # active → deprecated
 repowise decision health     # health summary
 ```

--- a/docs/architecture/deep-dives.md
+++ b/docs/architecture/deep-dives.md
@@ -557,7 +557,7 @@ CLI commands:
   repowise decision add        → creates with status "active"
   repowise decision confirm    → proposed → active
   repowise decision deprecate  → sets status "deprecated"
-  repowise decision dismiss    → deletes a proposed decision
+  repowise decision dismiss    → dismisses a proposal (sticky; never re-proposed)
   repowise decision health     → shows stale, ungoverned, proposed
 ```
 

--- a/packages/cli/src/repowise/cli/commands/decision_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/decision_cmd.py
@@ -13,7 +13,6 @@ from repowise.cli.helpers import (
     ensure_repowise_dir,
     get_db_url_for_repo,
     resolve_command_target,
-    resolve_repo_path,
     run_async,
 )
 
@@ -24,7 +23,6 @@ def _resolve_decision_repo(path: str | None):
     Honors workspace auto-detection: in workspace mode without an explicit
     path, targets the primary repo and prints a transparency notice.
     """
-    from pathlib import Path
 
     target = resolve_command_target(path=path)
     target.notice(console, command="decision")
@@ -40,6 +38,28 @@ def _resolve_decision_repo(path: str | None):
 @click.group("decision")
 def decision_group() -> None:
     """Manage architectural decision records."""
+
+
+async def _resolve_decision_id(session, decision_id: str) -> str | None:
+    """Expand a (possibly truncated) decision id to the full stored id.
+
+    ``decision list`` prints 8-char prefixes, so every id-taking subcommand
+    accepts a unique prefix. Returns None when nothing matches; raises on an
+    ambiguous prefix.
+    """
+    from sqlalchemy import select
+
+    from repowise.core.persistence.models import DecisionRecord
+
+    result = await session.execute(
+        select(DecisionRecord.id).where(DecisionRecord.id.like(f"{decision_id}%")).limit(2)
+    )
+    ids = [row[0] for row in result.all()]
+    if len(ids) > 1:
+        raise click.ClickException(
+            f"Decision id prefix {decision_id!r} is ambiguous; use more characters."
+        )
+    return ids[0] if ids else None
 
 
 # ---------------------------------------------------------------------------
@@ -129,7 +149,7 @@ def decision_add(path: str | None) -> None:
 @click.argument("path", required=False, default=None)
 @click.option(
     "--status",
-    type=click.Choice(["proposed", "active", "deprecated", "superseded", "all"]),
+    type=click.Choice(["proposed", "active", "deprecated", "superseded", "dismissed", "all"]),
     default="all",
 )
 @click.option(
@@ -203,6 +223,7 @@ def decision_list(
         "proposed": "yellow",
         "deprecated": "red",
         "superseded": "dim",
+        "dismissed": "dim",
     }
 
     for d in decisions:
@@ -249,7 +270,8 @@ def decision_show(decision_id: str, path: str | None) -> None:
         sf = create_session_factory(engine)
 
         async with get_session(sf) as session:
-            rec = await get_decision(session, decision_id)
+            full_id = await _resolve_decision_id(session, decision_id)
+            rec = await get_decision(session, full_id) if full_id else None
 
         await engine.dispose()
         return rec
@@ -328,7 +350,8 @@ def decision_confirm(decision_id: str, path: str | None) -> None:
         sf = create_session_factory(engine)
 
         async with get_session(sf) as session:
-            rec = await update_decision_status(session, decision_id, "active")
+            full_id = await _resolve_decision_id(session, decision_id)
+            rec = await update_decision_status(session, full_id, "active") if full_id else None
 
         await engine.dispose()
         return rec
@@ -349,20 +372,20 @@ def decision_confirm(decision_id: str, path: str | None) -> None:
 @click.argument("decision_id")
 @click.argument("path", required=False, default=None)
 def decision_dismiss(decision_id: str, path: str | None) -> None:
-    """Dismiss (delete) a proposed decision."""
+    """Dismiss a proposed decision (kept as a tombstone; never re-proposed)."""
     repo_path = _resolve_decision_repo(path)
 
-    if not click.confirm(f"Delete decision {decision_id[:8]}?"):
+    if not click.confirm(f"Dismiss decision {decision_id[:8]}?"):
         console.print("[yellow]Cancelled.[/yellow]")
         return
 
-    async def _delete():
+    async def _dismiss():
         from repowise.core.persistence import (
             create_engine,
             create_session_factory,
-            delete_decision,
             get_session,
             init_db,
+            update_decision_status,
         )
 
         url = get_db_url_for_repo(repo_path)
@@ -371,14 +394,18 @@ def decision_dismiss(decision_id: str, path: str | None) -> None:
         sf = create_session_factory(engine)
 
         async with get_session(sf) as session:
-            deleted = await delete_decision(session, decision_id)
+            full_id = await _resolve_decision_id(session, decision_id)
+            rec = await update_decision_status(session, full_id, "dismissed") if full_id else None
 
         await engine.dispose()
-        return deleted
+        return rec
 
-    deleted = run_async(_delete())
-    if deleted:
-        console.print(f"[green]Decision {decision_id[:8]} dismissed.[/green]")
+    rec = run_async(_dismiss())
+    if rec is not None:
+        console.print(
+            f"[green]Decision {rec.id[:8]} dismissed[/green] "
+            "[dim](kept as a tombstone; reindexing will not re-propose it)[/dim]"
+        )
     else:
         console.print(f"[red]Decision not found: {decision_id}[/red]")
 
@@ -411,8 +438,13 @@ def decision_deprecate(decision_id: str, path: str | None, superseded_by: str | 
         sf = create_session_factory(engine)
 
         async with get_session(sf) as session:
-            rec = await update_decision_status(
-                session, decision_id, "deprecated", superseded_by=superseded_by
+            full_id = await _resolve_decision_id(session, decision_id)
+            rec = (
+                await update_decision_status(
+                    session, full_id, "deprecated", superseded_by=superseded_by
+                )
+                if full_id
+                else None
             )
 
         await engine.dispose()

--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -429,6 +429,14 @@ async def _persist_full_update_async(
             # Decision records: new markers + harvested decisions, supersession
             # detection, staleness recompute.
             try:
+                # One-shot drain of proposals from the removed code_comment
+                # harvest (#751). Confirmed/dismissed rows are kept.
+                from repowise.core.persistence.crud import (
+                    purge_proposed_decisions_by_source,
+                )
+
+                await purge_proposed_decisions_by_source(session, repo_id, "code_comment")
+
                 decision_dicts: list[dict] = []
                 if new_decision_markers:
                     import dataclasses as _dc

--- a/packages/core/src/repowise/core/analysis/decisions/extractor.py
+++ b/packages/core/src/repowise/core/analysis/decisions/extractor.py
@@ -8,8 +8,14 @@ Capture sources (see ``decision_provenance.SOURCE_RANK`` for the trust ladder):
     5. CHANGELOG mining   (keep-a-changelog Changed/Removed/Deprecated)
     6. PR / squash-body mining (commit bodies captured in git indexing)
     7. Comment archaeology (LLM rationale prose on high-centrality code)
-    8. In-code rationale harvest (deterministic, repo-wide comment markers)
     + CLI capture (manual entry)
+
+Sources can be disabled per-repo via ``decisions.sources`` in
+``.repowise/config.yaml`` (see :data:`SOURCE_NAMES` /
+:meth:`DecisionExtractor.extract_all`). The former Source 8 (repo-wide
+deterministic rationale-comment harvest, ``code_comment``) was removed: the
+query-time live-grep miner (``mcp_server/_code_rationale.py``) serves the same
+comments fresh, so persisting them only flooded the proposed queue (#751).
 
 Determinism-first: ADR/CHANGELOG are parsed structurally before any LLM call.
 Every extracted decision passes an anti-hallucination substring gate
@@ -24,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -32,10 +39,6 @@ from typing import Any
 import structlog
 
 from repowise.core.analysis.decisions.gate import apply_substring_gate
-from repowise.core.analysis.decisions.rationale_comments import (
-    CODE_EXTENSIONS,
-    harvest_file_rationale,
-)
 
 from .prompts import (
     _SYSTEM_PROMPT,
@@ -105,6 +108,35 @@ class DecisionExtractionReport:
     total_found: int
     decisions: list[ExtractedDecision]
     by_source: dict[str, int]
+
+
+# Every index-time capture source, in progress order. The CLI derives its
+# progress-bar step count from this; the config gate validates against it.
+SOURCE_NAMES: tuple[str, ...] = (
+    "inline_marker",
+    "git_archaeology",
+    "readme_mining",
+    "adr",
+    "changelog",
+    "pr",
+    "comment",
+)
+
+
+def enabled_source_names(repo_config: dict[str, Any] | None) -> tuple[str, ...]:
+    """Resolve which capture sources are enabled for a repo.
+
+    Reads the ``decisions.sources`` mapping from a loaded
+    ``.repowise/config.yaml`` dict (``{source_name: bool}``). Sources absent
+    from the mapping default to enabled; unknown keys are ignored so a stale
+    config (e.g. the removed ``code_comment``) never breaks extraction.
+    """
+    cfg = repo_config or {}
+    decisions_cfg = cfg.get("decisions") or {}
+    sources_cfg = decisions_cfg.get("sources") if isinstance(decisions_cfg, dict) else {}
+    if not isinstance(sources_cfg, dict):
+        sources_cfg = {}
+    return tuple(name for name in SOURCE_NAMES if sources_cfg.get(name, True) is not False)
 
 
 # ---------------------------------------------------------------------------
@@ -282,20 +314,6 @@ _COMMENT_RATIONALE_CUES = (
     "intentionally",
 )
 _MAX_COMMENT_NODES = 30
-
-# Deterministic in-code rationale harvest (Source 8). Unlike comment
-# archaeology (LLM, top-30 central files, leading prose only) this is a
-# repo-wide, LLM-free scan of every comment block for rationale markers. It is
-# the index-time complement to the MCP live-grep miner: the same heuristics,
-# but harvested into the queryable decision corpus rather than mined per query.
-# Capped hard so a verbose file (or repo) can't flood the corpus, and emitted
-# at low confidence / ``proposed`` so these rank below real ADRs.
-_MAX_RATIONALE_PER_FILE = 3
-# Generous safety bound for a pathological repo — not a target. Causal-marker
-# gating keeps a typical repo well under this; if it is ever hit we LOG the
-# truncation rather than silently dropping the tail.
-_MAX_RATIONALE_TOTAL = 1500
-_RATIONALE_HARVEST_CONFIDENCE = 0.3
 
 # ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
@@ -1134,159 +1152,6 @@ class DecisionExtractor:
                 decisions.extend(result)
         return decisions
 
-    # ------------------------------------------------------------------
-    # Source 8: In-code rationale harvest (deterministic, repo-wide)
-    # ------------------------------------------------------------------
-
-    async def harvest_rationale_comments(self) -> list[ExtractedDecision]:
-        """Harvest rationale-bearing code comments into proposed decisions.
-
-        Deterministic (no LLM, no graph required): scans every indexed source
-        file for comment blocks carrying a rationale marker (``because``,
-        ``instead of``, ``workaround``, ``NOTE:`` …) and emits each as a
-        low-confidence ``proposed`` ``code_comment`` decision grounded by the
-        verbatim comment. Shares its heuristics with the MCP live-grep miner
-        (:mod:`repowise.core.analysis.decisions.rationale_comments`) so the
-        index-time and query-time paths never drift.
-
-        Hard precision guardrails live in ``harvest_file_rationale`` (marker
-        required, license / shebang headers dropped, commented-out code
-        dropped, thin comments dropped, per-file cap). The records are emitted
-        ``proposed`` at low confidence so they rank below real ADRs and stay
-        opt-in on high-signal surfaces. The substring gate is a no-op here —
-        every gated field is the verbatim comment — but the records still flow
-        through it for uniform verification stamping.
-        """
-        symbol_index = self._build_symbol_index()
-        decisions: list[ExtractedDecision] = []
-        truncated = False
-
-        for file_path in self._iter_source_files():
-            if len(decisions) >= _MAX_RATIONALE_TOTAL:
-                truncated = True
-                break
-            ext = file_path.suffix.lower().lstrip(".")
-            if ext not in CODE_EXTENSIONS:
-                continue
-            if not file_path.is_file():
-                continue
-            try:
-                text = file_path.read_text(encoding="utf-8", errors="replace")
-            except (OSError, UnicodeDecodeError):
-                continue
-
-            # require_causal=False: the guardrail wants any causal/INTENT
-            # connective (the broad RATIONALE_MARKERS set), not only textbook
-            # causal connectives. The canonical T4 comment that motivated this
-            # feature (tool_symbol.py "…can never blow up… round-trip count is
-            # what dominates token cost") is phrased with an intent marker, not
-            # "because"/"so that" — a causal-only gate would drop the very
-            # comment this exists to catch. Precision is held by the structural
-            # guardrails (no docstrings/license/code/thin + per-file cap).
-            harvested = harvest_file_rationale(
-                text,
-                ext,
-                max_per_file=_MAX_RATIONALE_PER_FILE,
-                require_causal=False,
-            )
-            if not harvested:
-                continue
-
-            try:
-                rel_path = str(file_path.relative_to(self._repo_path)).replace("\\", "/")
-            except ValueError:
-                rel_path = str(file_path)
-
-            for hc in harvested:
-                if len(decisions) >= _MAX_RATIONALE_TOTAL:
-                    truncated = True
-                    break
-                symbol = self._enclosing_symbol(symbol_index, rel_path, hc.start_line)
-                if symbol:
-                    context = f"In `{symbol}` ({rel_path}:{hc.start_line})"
-                else:
-                    context = f"{rel_path}:{hc.start_line}"
-                decisions.append(
-                    ExtractedDecision(
-                        # Title is the model-free one-line summary; ungated, so
-                        # always survives. decision/source_quote are the verbatim
-                        # comment, so the gate stamps them ``exact``.
-                        title=self._comment_title(hc.text),
-                        context=context,
-                        decision=hc.text,
-                        source="code_comment",
-                        status="proposed",
-                        confidence=_RATIONALE_HARVEST_CONFIDENCE,
-                        evidence_file=rel_path,
-                        evidence_line=hc.start_line,
-                        affected_files=[rel_path],
-                        affected_modules=self._infer_modules([rel_path]),
-                        tags=self._infer_tags(hc.text),
-                        source_quote=hc.text,
-                        source_text=hc.text,
-                    )
-                )
-
-        if truncated:
-            logger.warning(
-                "decision_extractor.code_comment_harvest_truncated",
-                cap=_MAX_RATIONALE_TOTAL,
-                note="rationale-comment harvest hit its safety cap; tail dropped",
-            )
-        return decisions
-
-    @staticmethod
-    def _comment_title(text: str) -> str:
-        """A short, single-line title for a harvested comment."""
-        first = text.strip().splitlines()[0] if text.strip() else text
-        first = re.sub(r"\s+", " ", first).strip()
-        return _truncate_title(first, 100)
-
-    def _build_symbol_index(self) -> dict[str, list[tuple[int, int, str]]]:
-        """Map each file's rel path → its symbols' ``(start, end, label)``.
-
-        Built once per harvest from ``parsed_files`` (empty when unavailable).
-        ``label`` is the qualified name when present, else the bare name.
-        """
-        index: dict[str, list[tuple[int, int, str]]] = {}
-        for pf in self._parsed_files:
-            fi = getattr(pf, "file_info", None)
-            path = getattr(fi, "path", None)
-            symbols = getattr(pf, "symbols", None)
-            if not path or not symbols:
-                continue
-            rel = str(path).replace("\\", "/")
-            entries: list[tuple[int, int, str]] = []
-            for sym in symbols:
-                start = getattr(sym, "start_line", None)
-                end = getattr(sym, "end_line", None)
-                if not isinstance(start, int) or not isinstance(end, int):
-                    continue
-                label = getattr(sym, "qualified_name", "") or getattr(sym, "name", "")
-                if label:
-                    entries.append((start, end, label))
-            if entries:
-                index[rel] = entries
-        return index
-
-    @staticmethod
-    def _enclosing_symbol(
-        index: dict[str, list[tuple[int, int, str]]],
-        rel_path: str,
-        line: int,
-    ) -> str | None:
-        """Return the innermost symbol whose line range contains ``line``."""
-        entries = index.get(rel_path)
-        if not entries:
-            return None
-        best: tuple[int, str] | None = None  # (span_width, label) — smallest wins
-        for start, end, label in entries:
-            if start <= line <= end:
-                width = end - start
-                if best is None or width < best[0]:
-                    best = (width, label)
-        return best[1] if best else None
-
     # Above this node count, skip the iterative PageRank solve and use degree
     # centrality (O(nodes)) instead — comment archaeology only needs a rough
     # "most depended-on files" ranking, not exact PageRank, and the iterative
@@ -1540,13 +1405,21 @@ class DecisionExtractor:
     # Main entry point
     # ------------------------------------------------------------------
 
-    async def extract_all(self, *, on_step: Any | None = None) -> DecisionExtractionReport:
+    async def extract_all(
+        self,
+        *,
+        on_step: Any | None = None,
+        enabled_sources: Collection[str] | None = None,
+    ) -> DecisionExtractionReport:
         """Run all capture sources in parallel. LLM failures are caught per-source.
 
         *on_step* is an optional callable invoked with the source name as each
-        sub-extractor finishes (``inline_marker``, ``git_archaeology``,
-        ``readme_mining``, ``adr``, ``changelog``, ``pr``, ``comment``,
-        ``code_comment``). Used by the CLI to surface per-source progress.
+        sub-extractor finishes (the names in :data:`SOURCE_NAMES`). Used by the
+        CLI to surface per-source progress.
+
+        *enabled_sources* restricts the run to the named sources (``None`` runs
+        everything). Callers derive it from ``decisions.sources`` in
+        ``.repowise/config.yaml`` via :func:`enabled_source_names`.
 
         Every extracted decision is then put through the anti-hallucination
         substring gate (:meth:`_apply_substring_gate`) before being returned —
@@ -1567,7 +1440,7 @@ class DecisionExtractor:
                     on_step(name)
 
         # (source name, bound coroutine factory) — order is the progress order.
-        sources: list[tuple[str, Any]] = [
+        all_sources: list[tuple[str, Any]] = [
             ("inline_marker", self.scan_inline_markers),
             ("git_archaeology", self.mine_git_archaeology),
             ("readme_mining", self.mine_readme_docs),
@@ -1575,8 +1448,15 @@ class DecisionExtractor:
             ("changelog", self.mine_changelog),
             ("pr", self.mine_pr_bodies),
             ("comment", self.mine_comment_archaeology),
-            ("code_comment", self.harvest_rationale_comments),
         ]
+        if enabled_sources is None:
+            sources = all_sources
+        else:
+            enabled = set(enabled_sources)
+            sources = [(name, fn) for name, fn in all_sources if name in enabled]
+            disabled = [name for name, _fn in all_sources if name not in enabled]
+            if disabled:
+                logger.info("decision_extractor.sources_disabled", sources=disabled)
 
         logger.info("decision_extractor.extract_all_start")
         results = await asyncio.gather(*[_safe_source(name, fn) for name, fn in sources])

--- a/packages/core/src/repowise/core/analysis/decisions/provenance.py
+++ b/packages/core/src/repowise/core/analysis/decisions/provenance.py
@@ -45,7 +45,7 @@ SOURCE_RANK: dict[str, int] = {
     "inline_marker": 4,  # # WHY: / # DECISION: code markers
     "comment": 3,  # LLM-curated rationale prose on high-centrality code
     "readme_mining": 3,  # implicit decisions in README/docs prose
-    "code_comment": 2,  # deterministic rationale-marker comment harvest (heuristic)
+    "code_comment": 2,  # legacy rows from the removed comment harvest (#751)
     "test_name": 2,  # placeholder — behaviour asserted by a test name
     "inferred": 1,  # placeholder — purely inferred, no verbatim source
     "llm_inferred": 1,  # Phase 2 LLM-docs harvest

--- a/packages/core/src/repowise/core/analysis/decisions/rationale_comments.py
+++ b/packages/core/src/repowise/core/analysis/decisions/rationale_comments.py
@@ -7,18 +7,12 @@ sits in a code comment instead::
     # We retry on 429 here rather than in the client because the client is
     # shared across tenants and a global backoff would starve everyone.
 
-Two consumers want exactly the same comment-extraction + rationale-marker
-heuristics, so they live here once:
-
-* the **index-time** decision-extractor pass
-  (:meth:`repowise.core.analysis.decisions.extractor.DecisionExtractor.harvest_rationale_comments`)
-  which harvests these into low-confidence ``proposed`` decision records so they
-  enter the queryable corpus with full retrieval/ranking/citation treatment, and
-* the **query-time** MCP live-grep miner (``mcp_server/_code_rationale.py``),
-  the best-effort recall backstop for un-indexed / just-edited files.
-
-Keeping one implementation here means the marker list and the comment tokenizer
-never drift between the two paths.
+The sole consumer is the **query-time** MCP live-grep miner
+(``mcp_server/_code_rationale.py``), which surfaces these comments fresh in
+``get_answer`` / ``get_why`` responses. (An index-time harvest into
+``code_comment`` decision records also consumed these heuristics until it was
+removed: it flooded the proposed-decision queue without adding information
+over the live miner; see #751.)
 
 This module is deliberately dependency-free (stdlib only) so both the core
 ingestion pipeline and the server layer can import it without a cycle.
@@ -117,9 +111,9 @@ RATIONALE_MARKERS: tuple[str, ...] = (
 
 # The strong subset: markers that state an actual *reason*, an alternative
 # rejected, or a deliberate choice — as opposed to a bare intent label
-# (``note:``, ``always``, ``we use``). The index-time decision harvest requires
-# one of these so a ``code_comment`` record always carries a genuine rationale;
-# the MCP recall miner uses the full ``RATIONALE_MARKERS`` set instead.
+# (``note:``, ``always``, ``we use``). Callers that want only genuine
+# rationale pass ``require_causal=True``; the MCP recall miner uses the full
+# ``RATIONALE_MARKERS`` set instead.
 CAUSAL_MARKERS: tuple[str, ...] = (
     "because",
     "instead of",
@@ -408,9 +402,7 @@ def extract_comment_blocks(
                 in_c_block = False
                 joined = " ".join(p for p in block_parts if p).strip()
                 if joined:
-                    blocks.append(
-                        CommentBlock(block_start, i, joined, tuple(block_parts), "block")
-                    )
+                    blocks.append(CommentBlock(block_start, i, joined, tuple(block_parts), "block"))
                 block_parts = []
             continue
 
@@ -423,9 +415,7 @@ def extract_comment_blocks(
                 in_pydoc = False
                 joined = " ".join(p for p in block_parts if p).strip()
                 if joined:
-                    blocks.append(
-                        CommentBlock(block_start, i, joined, tuple(block_parts), "doc")
-                    )
+                    blocks.append(CommentBlock(block_start, i, joined, tuple(block_parts), "doc"))
                 block_parts = []
             continue
 
@@ -586,16 +576,15 @@ def harvest_file_rationale(
 
     ``ext`` must name a known code extension; non-code files return ``[]``.
 
-    ``include_docstrings`` is ``False`` for the index-time decision harvest:
-    triple-quoted docstrings are the documented API surface (already mined by
-    the page generator / readme sources) and would flood the decision corpus.
-    The hidden rationale this targets lives in ``#`` / ``//`` / ``/* */``
-    comments. The MCP live-grep miner sets it ``True`` for maximum recall.
+    ``include_docstrings=False`` skips triple-quoted docstrings: they are the
+    documented API surface (already mined by the page generator / readme
+    sources); the hidden rationale this targets lives in ``#`` / ``//`` /
+    ``/* */`` comments. The MCP live-grep miner sets it ``True`` for maximum
+    recall.
 
-    ``require_causal`` (index-time default) demands a strong
-    :data:`CAUSAL_MARKERS` reason rather than any intent label, so every
-    ``code_comment`` decision carries a genuine rationale. The MCP recall miner
-    sets it ``False`` to surface any marker-bearing comment.
+    ``require_causal=True`` demands a strong :data:`CAUSAL_MARKERS` reason
+    rather than any intent label. The MCP recall miner sets it ``False`` to
+    surface any marker-bearing comment.
     """
     ext = ext.lower()
     if ext not in CODE_EXTENSIONS:

--- a/packages/core/src/repowise/core/persistence/crud/decisions.py
+++ b/packages/core/src/repowise/core/persistence/crud/decisions.py
@@ -11,14 +11,16 @@ from datetime import datetime
 from typing import Any
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from repowise.core.analysis.decision_provenance import compute_confidence, rank_for_source
 
 from ..decision_graph import sync_decision_node_links
 from ..models import (
+    DecisionEdge,
     DecisionEvidence,
+    DecisionNodeLink,
     DecisionRecord,
     GitMetadata,
     _new_uuid,
@@ -29,7 +31,29 @@ from ..models import (
 # DecisionRecord CRUD
 # ---------------------------------------------------------------------------
 
-_VALID_DECISION_STATUSES = frozenset({"proposed", "active", "deprecated", "superseded"})
+_VALID_DECISION_STATUSES = frozenset(
+    {"proposed", "active", "deprecated", "superseded", "dismissed"}
+)
+
+# Statuses a human (or the evolution judge) set deliberately. Re-extraction
+# must never walk one of these back to ``proposed``: a re-harvested source
+# ties or beats the stored rank, so without this guard a reindex would flip
+# confirmed decisions back into the review queue and resurrect dismissed ones
+# (#751). ``dismissed`` is terminal: the row is kept purely as a tombstone so
+# the same content never re-proposes.
+_PROTECTED_STATUSES = frozenset({"active", "deprecated", "superseded", "dismissed"})
+
+
+def _merge_status(existing: str, incoming: str) -> str:
+    """Resolve a re-extracted status against the stored one.
+
+    Extraction only ever emits ``proposed`` or ``active`` (ADR files can also
+    carry ``deprecated``/``superseded``). A protected stored status wins over
+    an incoming ``proposed``; anything else follows the incoming value.
+    """
+    if incoming == "proposed" and existing in _PROTECTED_STATUSES:
+        return existing
+    return incoming
 
 
 async def upsert_decision(
@@ -146,12 +170,18 @@ async def list_decisions(
     limit: int = 100,
     offset: int = 0,
 ) -> list[DecisionRecord]:
-    """Return decision records with optional filters."""
+    """Return decision records with optional filters.
+
+    Dismissed records are tombstones and only show up when explicitly asked
+    for via ``status="dismissed"``.
+    """
     q = select(DecisionRecord).where(DecisionRecord.repository_id == repository_id)
     if status is not None:
         q = q.where(DecisionRecord.status == status)
-    elif not include_proposed:
-        q = q.where(DecisionRecord.status != "proposed")
+    else:
+        q = q.where(DecisionRecord.status != "dismissed")
+        if not include_proposed:
+            q = q.where(DecisionRecord.status != "proposed")
     if source is not None:
         q = q.where(DecisionRecord.source == source)
     if tag is not None:
@@ -538,6 +568,12 @@ async def bulk_upsert_decisions(
                 rec = id_to_rec[match_id]
                 existing_by_norm[norm] = rec
 
+        # A dismissed record is a tombstone: leave it untouched (no headline
+        # promotion, no new evidence, not re-embedded, not in touched_ids) so
+        # dismissals survive every reindex.
+        if rec is not None and rec.status == "dismissed":
+            continue
+
         if rec is None:
             rec = DecisionRecord(
                 id=_new_uuid(),
@@ -566,7 +602,7 @@ async def bulk_upsert_decisions(
             # A new contributor at least as authoritative as the current
             # headline → promote its fields (provenance still accretes below).
             rec.title = headline.get("title", rec.title)
-            rec.status = headline.get("status", rec.status)
+            rec.status = _merge_status(rec.status, headline.get("status", rec.status))
             rec.context = headline.get("context") or rec.context
             rec.decision = headline.get("decision") or rec.decision
             rec.rationale = headline.get("rationale") or rec.rationale
@@ -674,6 +710,46 @@ async def bulk_upsert_decisions(
     return touched_ids
 
 
+async def purge_proposed_decisions_by_source(
+    session: AsyncSession,
+    repository_id: str,
+    source: str,
+) -> int:
+    """Delete still-``proposed`` records of *source* plus their child rows.
+
+    One-shot cleanup for retired extraction sources (today: the removed
+    ``code_comment`` harvest, #751). Only ``proposed`` rows go — anything the
+    user confirmed, deprecated, or dismissed is kept. Child rows are deleted
+    explicitly rather than trusting the FK cascade, which on SQLite depends on
+    the ``foreign_keys`` pragma. Returns the number of records deleted.
+    """
+    result = await session.execute(
+        select(DecisionRecord.id).where(
+            DecisionRecord.repository_id == repository_id,
+            DecisionRecord.source == source,
+            DecisionRecord.status == "proposed",
+        )
+    )
+    ids = [row[0] for row in result.all()]
+    if not ids:
+        return 0
+
+    await session.execute(delete(DecisionEvidence).where(DecisionEvidence.decision_id.in_(ids)))
+    await session.execute(
+        delete(DecisionEdge).where(
+            or_(
+                DecisionEdge.src_decision_id.in_(ids),
+                DecisionEdge.dst_decision_id.in_(ids),
+            )
+        )
+    )
+    await session.execute(delete(DecisionNodeLink).where(DecisionNodeLink.decision_id.in_(ids)))
+    await session.execute(delete(DecisionRecord).where(DecisionRecord.id.in_(ids)))
+    await session.flush()
+    structlog.get_logger(__name__).info("decision_purge_by_source", source=source, deleted=len(ids))
+    return len(ids)
+
+
 async def recompute_decision_staleness(
     session: AsyncSession,
     repository_id: str,
@@ -742,7 +818,14 @@ async def get_decision_health_summary(
     )
     all_decisions = list(result.scalars().all())
 
-    counts = {"active": 0, "proposed": 0, "deprecated": 0, "superseded": 0, "stale": 0}
+    counts = {
+        "active": 0,
+        "proposed": 0,
+        "deprecated": 0,
+        "superseded": 0,
+        "dismissed": 0,
+        "stale": 0,
+    }
     stale_decisions: list[DecisionRecord] = []
     proposed_decisions: list[DecisionRecord] = []
 

--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -654,5 +654,18 @@ async def persist_incremental_index(
                     await persist_kg(knowledge_graph_result, session, repo_id)
                 except Exception as exc:
                     _skip("Knowledge-graph persist", exc)
+
+            # One-shot drain of proposals from the removed code_comment
+            # harvest (#751). Runs on the index-only path too, because the
+            # post-commit hook's updates never reach the full decision
+            # persist. Confirmed/dismissed rows are kept.
+            try:
+                from repowise.core.persistence.crud import (
+                    purge_proposed_decisions_by_source,
+                )
+
+                await purge_proposed_decisions_by_source(session, repo_id, "code_comment")
+            except Exception as exc:
+                _skip("Decision purge", exc)
     finally:
         await engine.dispose()

--- a/packages/core/src/repowise/core/pipeline/persist.py
+++ b/packages/core/src/repowise/core/pipeline/persist.py
@@ -624,6 +624,16 @@ async def persist_analysis(result: Any, session: Any, repo_id: str) -> None:
             if harvested:
                 decision_dicts.extend(harvested)
 
+    # One-shot drain of proposals from the removed code_comment harvest;
+    # without this, DBs indexed before its removal keep a flooded review
+    # queue forever (#751). Confirmed/dismissed rows are kept.
+    try:
+        from repowise.core.persistence.crud import purge_proposed_decisions_by_source
+
+        await purge_proposed_decisions_by_source(session, repo_id, "code_comment")
+    except Exception as _purge_err:
+        logger.debug("decision_purge_skipped", error=str(_purge_err))
+
     if decision_dicts:
         # Reuse the run's shared vector store for semantic (paraphrase) dedup
         # and to make decisions searchable; title dedup still runs when None.

--- a/packages/core/src/repowise/core/pipeline/phases/analysis.py
+++ b/packages/core/src/repowise/core/pipeline/phases/analysis.py
@@ -97,9 +97,7 @@ def _build_pipeline_coverage(
         elif cfg.paths:
             report_paths = [repo_path / p for p in cfg.paths if (repo_path / p).is_file()]
         elif cfg.auto_discover:
-            report_paths = discover_artifacts(
-                repo_path, globs=cfg.artifacts or None
-            )
+            report_paths = discover_artifacts(repo_path, globs=cfg.artifacts or None)
         else:
             return {}, [], None
 
@@ -256,13 +254,18 @@ async def _run_decision_extraction(
 ) -> Any | None:
     """Extract architectural decisions from source and git history."""
     try:
-        from repowise.core.analysis.decision_extractor import DecisionExtractor
+        from repowise.core.analysis.decision_extractor import (
+            DecisionExtractor,
+            enabled_source_names,
+        )
+        from repowise.core.repo_config import load_repo_config
 
-        # Eight sources run concurrently inside extract_all(); drive a
-        # determinate bar so users see live progress.
-        decision_steps = 8
+        # Sources run concurrently inside extract_all(); drive a determinate
+        # bar so users see live progress. ``decisions.sources`` in the repo
+        # config can disable individual sources (#751).
+        enabled = enabled_source_names(load_repo_config(repo_path))
         if progress:
-            progress.on_phase_start("decisions", decision_steps)
+            progress.on_phase_start("decisions", len(enabled))
 
         extractor = DecisionExtractor(
             repo_path=repo_path,
@@ -277,7 +280,7 @@ async def _run_decision_extraction(
                 progress.on_item_done("decisions")
 
         report = await asyncio.wait_for(
-            extractor.extract_all(on_step=_decision_step),
+            extractor.extract_all(on_step=_decision_step, enabled_sources=enabled),
             timeout=DECISION_EXTRACTION_TIMEOUT_SECS,
         )
 
@@ -293,7 +296,6 @@ async def _run_decision_extraction(
                 f"{bs.get('pr', 0)} PR · "
                 f"{bs.get('git_archaeology', 0)} git · "
                 f"{bs.get('comment', 0)} comments · "
-                f"{bs.get('code_comment', 0)} code-comments · "
                 f"{bs.get('readme_mining', 0)} docs",
             )
 

--- a/packages/server/src/repowise/server/mcp_server/_code_rationale.py
+++ b/packages/server/src/repowise/server/mcp_server/_code_rationale.py
@@ -13,16 +13,13 @@ comments. The unbiased A/B (task T4) confirmed the gap — when the rationale
 was a code comment, get_answer returned low confidence and the agent fell
 back to Read+Grep, losing on tokens AND round-trips.
 
-This module is the **query-time recall backstop**. The durable fix is the
-index-time decision harvest (Source 8,
-:meth:`repowise.core.analysis.decisions.extractor.DecisionExtractor.harvest_rationale_comments`)
-which lands these comments in the queryable decision corpus. This miner only
-earns its keep for what the index can't cover: files edited since the last
-index, and comment shapes the index-time gate drops (trailing inline comments,
-intent-only markers, docstrings). The comment tokenizer and the rationale
-marker list are shared with that harvest — both import from
-:mod:`repowise.core.analysis.decisions.rationale_comments` so the two paths
-never drift.
+This module is the **query-time miner** that closes the gap, and since the
+removal of the index-time ``code_comment`` harvest (#751: it duplicated this
+miner while flooding the proposed-decision queue) it is the only consumer of
+the shared heuristics in
+:mod:`repowise.core.analysis.decisions.rationale_comments`. Mining live means
+the served comments are always fresh, including files edited since the last
+index.
 
 It is deliberately wired only into the LOW-confidence exits (get_answer's
 gated / hedged paths, get_why's no-decision fallback): when the confident
@@ -381,7 +378,20 @@ def grep_comment_candidates(
             # subprocess.run does NOT redirect stdin by default, so a pager / hook
             # that reads stdin would consume the protocol stream and deadlock the
             # whole server. Redirect it to /dev/null and disable the pager.
-            ["git", "--no-pager", "grep", "-n", "-I", "-i", "-E", pat, "--", "*.py", "*.ts", "*.tsx"],
+            [
+                "git",
+                "--no-pager",
+                "grep",
+                "-n",
+                "-I",
+                "-i",
+                "-E",
+                pat,
+                "--",
+                "*.py",
+                "*.ts",
+                "*.tsx",
+            ],
             cwd=str(root),
             capture_output=True,
             text=True,

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -155,7 +155,7 @@ def _is_readable_path(target: str) -> bool:
     if "/" in t or "\\" in t:
         return True
     dot = t.rfind(".")
-    ext = t[dot + 1:] if dot != -1 else ""
+    ext = t[dot + 1 :] if dot != -1 else ""
     return bool(ext) and ext.isalnum() and len(ext) <= 6
 
 
@@ -203,11 +203,10 @@ def _gather_code_rationale(ctx, hits: list[dict], fallback_targets: list[str], q
 def _drop_already_surfaced(rationale: list[dict], *surfaced: list[dict]) -> list[dict]:
     """Drop mined rationale comments already shown elsewhere in the response.
 
-    Track B harvests rationale comments into ``code_comment`` decision records at
-    index time; Track A mines them live here. Once both ship, the same comment
-    can appear twice — once as material already in the payload (a ``symbol_bodies``
-    block whose body contains the comment, a quote, or a line-ranged citation /
-    decision) and once as a ``code_rationale`` entry. Suppress the duplicate:
+    The same comment can reach the payload twice — once as material already in
+    the response (a ``symbol_bodies`` block whose body contains the comment, a
+    quote, a line-ranged citation, or a legacy ``code_comment`` decision) and
+    once as a live-mined ``code_rationale`` entry. Suppress the duplicate:
     drop any mined comment whose ``(path, line-range)`` overlaps an entry already
     surfaced. Entries without a ``(path, lines)`` pair are ignored.
     """
@@ -439,7 +438,8 @@ async def get_answer(
                 )
 
     fallback_targets = [
-        h["target_path"] for h in hits
+        h["target_path"]
+        for h in hits
         if h.get("target_path") and _is_readable_path(h["target_path"])
     ]
 

--- a/tests/unit/analysis/test_decision_rationale_comments.py
+++ b/tests/unit/analysis/test_decision_rationale_comments.py
@@ -1,14 +1,12 @@
-"""In-code rationale harvest — the shared miner + the index-time extractor pass.
+"""In-code rationale mining — the shared comment heuristics.
 
-Source 8 (``code_comment``) mines rationale-bearing source comments into
-low-confidence ``proposed`` decision records so the architectural intent that
-lives in comments (not ADRs) enters the queryable corpus. These tests cover the
-precision guardrails (the whole risk) and the extractor wiring.
+These heuristics feed the query-time MCP live-grep miner
+(``mcp_server/_code_rationale.py``). The precision guardrails are the whole
+risk, so they get the coverage. (The index-time ``code_comment`` harvest that
+also consumed them was removed; see #751.)
 """
 
 from __future__ import annotations
-
-from types import SimpleNamespace
 
 from repowise.core.analysis.decision_extractor import DecisionExtractor
 from repowise.core.analysis.decisions.rationale_comments import (
@@ -171,66 +169,18 @@ def test_require_causal_false_admits_intent_labels():
 
 
 # ---------------------------------------------------------------------------
-# Extractor pass (Source 8)
+# Extractor file walk (shared by inline markers)
 # ---------------------------------------------------------------------------
 
-
-async def test_harvest_rationale_comments_emits_grounded_proposed_record(tmp_path):
-    (tmp_path / "client.py").write_text(_RATIONALE_PY, encoding="utf-8")
-
-    ex = DecisionExtractor(repo_path=tmp_path)  # deterministic, no provider
-    decisions = await ex.harvest_rationale_comments()
-
-    assert len(decisions) == 1
-    d = decisions[0]
-    assert d.source == "code_comment"
-    assert d.status == "proposed"
-    assert d.confidence < 0.5  # ranks below real ADRs / inline markers
-    # Verbatim grounding: decision + source_quote are the comment itself.
-    assert "starve everyone" in d.decision
-    assert d.source_quote == d.decision
-    assert d.evidence_file == "client.py"
-    assert d.affected_files == ["client.py"]
-    assert d.title  # never title-only-empty; title is the comment's first line
+_WHY_PY = (
+    "def f():\n    # WHY: upstream API double-encodes, so we special-case here\n    return 1\n"
+)
 
 
-async def test_harvest_resolves_enclosing_symbol_from_parsed_files(tmp_path):
-    (tmp_path / "client.py").write_text(_RATIONALE_PY, encoding="utf-8")
-
-    # The rationale comment sits inside call_api() (lines ~7-9). Provide a
-    # parsed-file with that symbol so the harvest can attribute it.
-    parsed = SimpleNamespace(
-        file_info=SimpleNamespace(path="client.py"),
-        symbols=[
-            SimpleNamespace(
-                start_line=6, end_line=10, name="call_api", qualified_name="client.call_api"
-            )
-        ],
-    )
-    ex = DecisionExtractor(repo_path=tmp_path, parsed_files=[parsed])
-    decisions = await ex.harvest_rationale_comments()
-
-    assert len(decisions) == 1
-    assert "client.call_api" in decisions[0].context
-
-
-async def test_code_comment_records_pass_the_gate_in_extract_all(tmp_path):
-    (tmp_path / "client.py").write_text(_RATIONALE_PY, encoding="utf-8")
-
-    ex = DecisionExtractor(repo_path=tmp_path)
-    report = await ex.extract_all()
-
-    assert report.by_source["code_comment"] == 1
-    cc = [d for d in report.decisions if d.source == "code_comment"]
-    assert len(cc) == 1
-    # Verbatim comment → the substring gate stamps it exact, never rejects it.
-    assert cc[0].verification == "exact"
-
-
-async def test_harvest_skips_untracked_files_in_a_git_repo(tmp_path):
-    """In a git checkout the harvest scopes to tracked files: untracked /
-    excluded working dirs (local-stash, scratch dumps) must not produce records.
-    Gitless repos fall back to the full walk (the tmp_path tests above)."""
+async def test_source_walk_skips_untracked_files_in_a_git_repo(tmp_path):
+    """In a git checkout the extractor's file walk scopes to tracked files:
+    untracked / excluded working dirs (local-stash, scratch dumps) must not
+    produce records. Gitless repos fall back to the full walk."""
     import subprocess
 
     def _git(*args: str) -> None:
@@ -244,20 +194,15 @@ async def test_harvest_skips_untracked_files_in_a_git_repo(tmp_path):
     _git("config", "user.email", "t@t.t")
     _git("config", "user.name", "t")
 
-    (tmp_path / "tracked.py").write_text(_RATIONALE_PY, encoding="utf-8")
+    (tmp_path / "tracked.py").write_text(_WHY_PY, encoding="utf-8")
     _git("add", "tracked.py")
     _git("commit", "-m", "add tracked")
 
-    # An untracked file carrying a textbook rationale comment.
-    (tmp_path / "untracked.py").write_text(
-        "def f():\n"
-        "    # We special-case this because the upstream API double-encodes.\n"
-        "    return 1\n",
-        encoding="utf-8",
-    )
+    # An untracked file carrying the same explicit WHY: marker.
+    (tmp_path / "untracked.py").write_text(_WHY_PY, encoding="utf-8")
 
-    ex = DecisionExtractor(repo_path=tmp_path)
-    decisions = await ex.harvest_rationale_comments()
+    ex = DecisionExtractor(repo_path=tmp_path)  # no provider → raw markers
+    decisions = await ex.scan_inline_markers()
 
     files = {d.evidence_file for d in decisions}
     assert "tracked.py" in files

--- a/tests/unit/analysis/test_decision_sources.py
+++ b/tests/unit/analysis/test_decision_sources.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from repowise.core.analysis.decision_extractor import DecisionExtractor
+from repowise.core.analysis.decision_extractor import (
+    SOURCE_NAMES,
+    DecisionExtractor,
+    enabled_source_names,
+)
 
 _NYGARD_ADR = """\
 # 1. Use PostgreSQL for primary storage
@@ -137,3 +141,47 @@ async def test_extract_all_runs_deterministic_sources_and_gates(tmp_path):
     assert "changelog" in sources
     adr = next(d for d in report.decisions if d.source == "adr")
     assert adr.verification == "exact"
+    # The repo-wide code_comment harvest was removed (#751); extract_all must
+    # neither run it nor report it.
+    assert "code_comment" not in report.by_source
+    assert not any(d.source == "code_comment" for d in report.decisions)
+
+
+async def test_extract_all_honors_enabled_sources(tmp_path):
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "0001-use-postgres.md").write_text(_NYGARD_ADR, encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text(_CHANGELOG, encoding="utf-8")
+
+    ex = DecisionExtractor(repo_path=tmp_path)
+    seen: list[str] = []
+    report = await ex.extract_all(
+        on_step=seen.append,
+        enabled_sources=("adr", "inline_marker"),
+    )
+
+    assert set(seen) == {"adr", "inline_marker"}
+    assert set(report.by_source) == {"adr", "inline_marker"}
+    assert report.by_source["adr"] == 1
+    # The changelog file exists but its source was disabled.
+    assert not any(d.source == "changelog" for d in report.decisions)
+
+
+def test_enabled_source_names_defaults_and_overrides():
+    # No config → everything on.
+    assert enabled_source_names(None) == SOURCE_NAMES
+    assert enabled_source_names({}) == SOURCE_NAMES
+
+    cfg = {"decisions": {"sources": {"comment": False, "changelog": False}}}
+    enabled = enabled_source_names(cfg)
+    assert "comment" not in enabled
+    assert "changelog" not in enabled
+    assert "adr" in enabled and "inline_marker" in enabled
+
+    # Unknown / stale keys (e.g. the removed code_comment) are ignored.
+    assert enabled_source_names({"decisions": {"sources": {"code_comment": False}}}) == (
+        SOURCE_NAMES
+    )
+    # Malformed sections never break extraction.
+    assert enabled_source_names({"decisions": "nope"}) == SOURCE_NAMES
+    assert enabled_source_names({"decisions": {"sources": "nope"}}) == SOURCE_NAMES

--- a/tests/unit/persistence/test_decision_sticky_status.py
+++ b/tests/unit/persistence/test_decision_sticky_status.py
@@ -1,0 +1,161 @@
+"""Sticky decision statuses across reindexes (#751).
+
+``dismiss`` keeps a tombstone row instead of deleting, and
+``bulk_upsert_decisions`` must never walk a human-set status back to
+``proposed``: without these guards every reindex resurrected dismissed
+comment proposals and flipped confirmed decisions back into the review queue.
+Also covers the one-shot purge that drains still-proposed rows of a retired
+extraction source.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from repowise.core.persistence.crud import (
+    bulk_upsert_decisions,
+    get_decision_health_summary,
+    list_decision_evidence,
+    list_decisions,
+    purge_proposed_decisions_by_source,
+    update_decision_status,
+)
+from repowise.core.persistence.models import DecisionEvidence, DecisionRecord
+from tests.unit.persistence.helpers import insert_repo
+
+
+def _decision(title: str, *, source: str = "changelog", status: str = "proposed") -> dict:
+    return {
+        "title": title,
+        "decision": f"{title} because reasons",
+        "rationale": "",
+        "source": source,
+        "status": status,
+        "evidence_file": f"{title.lower().replace(' ', '_')}.py",
+        "confidence": 0.6,
+        "verification": "exact",
+        "source_quote": f"{title} because reasons",
+    }
+
+
+async def _only_row(session, repo_id) -> DecisionRecord:
+    result = await session.execute(
+        select(DecisionRecord).where(DecisionRecord.repository_id == repo_id)
+    )
+    rows = list(result.scalars().all())
+    assert len(rows) == 1
+    return rows[0]
+
+
+async def test_dismissed_decision_survives_reindex_untouched(async_session):
+    repo = await insert_repo(async_session)
+    await bulk_upsert_decisions(async_session, repo.id, [_decision("Use Redis")])
+    rec = await _only_row(async_session, repo.id)
+
+    dismissed = await update_decision_status(async_session, rec.id, "dismissed")
+    assert dismissed is not None and dismissed.status == "dismissed"
+    evidence_before = len(await list_decision_evidence(async_session, rec.id))
+
+    # The next reindex re-extracts the identical decision.
+    touched = await bulk_upsert_decisions(async_session, repo.id, [_decision("Use Redis")])
+
+    rec = await _only_row(async_session, repo.id)
+    assert rec.status == "dismissed"
+    assert rec.id not in touched
+    # Tombstones accrete nothing.
+    assert len(await list_decision_evidence(async_session, rec.id)) == evidence_before
+
+
+async def test_confirmed_decision_not_walked_back_to_proposed(async_session):
+    repo = await insert_repo(async_session)
+    await bulk_upsert_decisions(async_session, repo.id, [_decision("Use Redis")])
+    rec = await _only_row(async_session, repo.id)
+    await update_decision_status(async_session, rec.id, "active")
+
+    # Re-harvest ties the stored source rank, so the headline branch runs.
+    await bulk_upsert_decisions(async_session, repo.id, [_decision("Use Redis")])
+
+    rec = await _only_row(async_session, repo.id)
+    assert rec.status == "active"
+
+
+async def test_proposed_still_upgrades_to_active(async_session):
+    repo = await insert_repo(async_session)
+    await bulk_upsert_decisions(async_session, repo.id, [_decision("Use Redis")])
+
+    # An ADR marked accepted arrives for the same decision.
+    await bulk_upsert_decisions(
+        async_session, repo.id, [_decision("Use Redis", source="adr", status="active")]
+    )
+
+    rec = await _only_row(async_session, repo.id)
+    assert rec.status == "active"
+
+
+async def test_update_decision_status_accepts_dismissed(async_session):
+    repo = await insert_repo(async_session)
+    await bulk_upsert_decisions(async_session, repo.id, [_decision("Use Redis")])
+    rec = await _only_row(async_session, repo.id)
+    updated = await update_decision_status(async_session, rec.id, "dismissed")
+    assert updated is not None and updated.status == "dismissed"
+    with pytest.raises(ValueError):
+        await update_decision_status(async_session, rec.id, "nonsense")
+
+
+async def test_list_decisions_hides_dismissed_by_default(async_session):
+    repo = await insert_repo(async_session)
+    await bulk_upsert_decisions(
+        async_session, repo.id, [_decision("Use Redis"), _decision("Use Postgres")]
+    )
+    rows = await list_decisions(async_session, repo.id)
+    redis = next(r for r in rows if r.title == "Use Redis")
+    await update_decision_status(async_session, redis.id, "dismissed")
+
+    default_titles = {r.title for r in await list_decisions(async_session, repo.id)}
+    assert default_titles == {"Use Postgres"}
+    dismissed = await list_decisions(async_session, repo.id, status="dismissed")
+    assert {r.title for r in dismissed} == {"Use Redis"}
+
+    summary = (await get_decision_health_summary(async_session, repo.id))["summary"]
+    assert summary["dismissed"] == 1
+    assert all(
+        d.title != "Use Redis"
+        for d in (await get_decision_health_summary(async_session, repo.id))[
+            "proposed_awaiting_review"
+        ]
+    )
+
+
+async def test_purge_drains_proposed_rows_of_source_only(async_session):
+    repo = await insert_repo(async_session)
+    await bulk_upsert_decisions(
+        async_session,
+        repo.id,
+        [
+            _decision("Legacy comment one", source="code_comment"),
+            _decision("Legacy comment two", source="code_comment"),
+            _decision("Real changelog decision", source="changelog"),
+        ],
+    )
+    rows = await list_decisions(async_session, repo.id)
+    keeper = next(r for r in rows if r.title == "Legacy comment two")
+    await update_decision_status(async_session, keeper.id, "active")
+
+    deleted = await purge_proposed_decisions_by_source(async_session, repo.id, "code_comment")
+    assert deleted == 1
+
+    remaining = {r.title for r in await list_decisions(async_session, repo.id)}
+    assert remaining == {"Legacy comment two", "Real changelog decision"}
+
+    # Child evidence rows of the purged record are gone too.
+    orphan_evidence = await async_session.execute(
+        select(DecisionEvidence)
+        .join(
+            DecisionRecord,
+            DecisionEvidence.decision_id == DecisionRecord.id,
+            isouter=True,
+        )
+        .where(DecisionRecord.id.is_(None))
+    )
+    assert list(orphan_evidence.scalars().all()) == []


### PR DESCRIPTION
Closes #751.

## What changed

**Removed the index-time code_comment harvest (Source 8).** The repo-wide rationale-comment scan stored each matching comment verbatim as a proposed decision at floored confidence. The query-time live-grep miner already serves the same comments fresh inside get_answer and get_why, so the stored records added review burden without adding information: on a ~2.5k-file repo every reindex regenerated ~1,500 proposals. The shared heuristics module (rationale_comments.py) stays; the live miner is now its only consumer.

**One-shot drain of the legacy backlog.** Still-proposed code_comment rows (plus their evidence, edges, and node links) are deleted on the next init or update. This runs on all three persist paths, including index-only updates, so post-commit-hook users get the cleanup too. Confirmed and dismissed rows are kept.

**decisions.sources config gate.** Any remaining extraction source can be disabled per repo:

```yaml
decisions:
  sources:
    comment: false   # LLM comment archaeology
```

Unknown or stale keys are ignored. Documented in CONFIG.md.

**Sticky dismissals.** `repowise decision dismiss` now sets a terminal `dismissed` status instead of deleting the row, and `bulk_upsert_decisions` treats those rows as tombstones: no headline promotion, no evidence accretion, never re-proposed. The same guard stops a re-extraction from walking a confirmed `active` decision back to `proposed` (previously a re-harvest tied the stored source rank and flipped it). Dismissed rows are hidden from listings and dashboards unless explicitly requested.

**CLI id prefixes.** `decision show/confirm/dismiss/deprecate` now accept the 8-char id prefixes that `decision list` prints (they previously required the full 32-char id, which the CLI never displays).

## Validation

Dogfood on this repo: proposed queue dropped from 2,710 to 971 after one `repowise update`; zero code_comment rows or orphaned child rows remain; a dismissed decision stays dismissed and its tombstone is visible via `decision show`. Full unit suite green (6,921 passed), plus new tests for the source gate, sticky statuses, and the purge.