### PR TITLE
Fix CI: track widened augment matcher in hook config tests

### DIFF
--- a/tests/unit/cli/test_mcp_config.py
+++ b/tests/unit/cli/test_mcp_config.py
@@ -414,7 +414,7 @@ def test_install_claude_code_hooks_creates_missing_file(
     saved = json.loads(settings_path.read_text(encoding="utf-8"))
     assert "PreToolUse" not in saved["hooks"]
     assert _post_repowise_entries(saved) == [
-        ("Bash|PowerShell|Grep|Glob|Read|Edit|Write", "repowise-augment")
+        (claude_config._AUGMENT_MATCHER, "repowise-augment")
     ]
     assert _session_start_repowise_entries(saved) == [("startup|resume|clear", "repowise-augment")]
 
@@ -452,7 +452,7 @@ def test_install_claude_code_hooks_preserves_user_pretool_hooks(
     assert saved["hooks"]["PreToolUse"][0]["hooks"][0]["command"] == "echo read"
     # PostToolUse now has the repowise hook.
     assert _post_repowise_entries(saved) == [
-        ("Bash|PowerShell|Grep|Glob|Read|Edit|Write", "repowise-augment")
+        (claude_config._AUGMENT_MATCHER, "repowise-augment")
     ]
 
 
@@ -498,7 +498,7 @@ def test_install_claude_code_hooks_migrates_pre_0_6_1_command(
     saved = json.loads(settings_path.read_text(encoding="utf-8"))
     assert "PreToolUse" not in saved["hooks"]
     assert _post_repowise_entries(saved) == [
-        ("Bash|PowerShell|Grep|Glob|Read|Edit|Write", "repowise-augment")
+        (claude_config._AUGMENT_MATCHER, "repowise-augment")
     ]
 
 
@@ -538,7 +538,7 @@ def test_install_claude_code_hooks_migrates_pre_0_6_2_matcher(
     saved = json.loads(settings_path.read_text(encoding="utf-8"))
     assert "PreToolUse" not in saved["hooks"]
     assert _post_repowise_entries(saved) == [
-        ("Bash|PowerShell|Grep|Glob|Read|Edit|Write", "repowise-augment")
+        (claude_config._AUGMENT_MATCHER, "repowise-augment")
     ]
 
 
@@ -594,7 +594,7 @@ def test_migrate_claude_code_hooks_handles_full_legacy_payload(
     saved = json.loads(settings_path.read_text(encoding="utf-8"))
     assert "PreToolUse" not in saved["hooks"]
     assert _post_repowise_entries(saved) == [
-        ("Bash|PowerShell|Grep|Glob|Read|Edit|Write", "repowise-augment")
+        (claude_config._AUGMENT_MATCHER, "repowise-augment")
     ]
 
     # Idempotent: a second run finds nothing to do.
@@ -632,7 +632,7 @@ def test_migrate_claude_code_hooks_widens_legacy_matchers(
     assert claude_config.migrate_claude_code_hooks() is True
     saved = json.loads(settings_path.read_text(encoding="utf-8"))
     assert _post_repowise_entries(saved) == [
-        ("Bash|PowerShell|Grep|Glob|Read|Edit|Write", "repowise-augment")
+        (claude_config._AUGMENT_MATCHER, "repowise-augment")
     ]
 
 
@@ -720,7 +720,7 @@ def test_migrate_claude_code_hooks_noop_when_already_current(
         "hooks": {
             "PostToolUse": [
                 {
-                    "matcher": "Bash|PowerShell|Grep|Glob|Read|Edit|Write",
+                    "matcher": claude_config._AUGMENT_MATCHER,
                     "hooks": [{"type": "command", "command": "repowise-augment"}],
                 }
             ],


### PR DESCRIPTION
## Problem

CI's `Python 3.12 tests` job has been red on `main` across the last several commits (#778, #779, #780). Every run fails on the same 8 tests in `tests/unit/cli/test_mcp_config.py`:

```
AssertionError: assert [('Bash|PowerShell|Grep|Glob|Read|Edit|Write|mcp__.*[Rr]epowise.*__.*', 'repowise-augment')]
                    == [('Bash|PowerShell|Grep|Glob|Read|Edit|Write', 'repowise-augment')]
```

## Root cause

The augment PostToolUse matcher in `claude_config.py` was widened to append `mcp__.*[Rr]epowise.*__.*` (feeding the read-after-served ledger), and the old value was demoted into `_LEGACY_AUGMENT_MATCHERS` so existing installs migrate in place. The hook install/migrate tests still pinned the pre-widening literal as their expected output, and the "noop when already current" test still fed the old literal as its already-current input, so both drifted from the source.

## Fix

Assert against `claude_config._AUGMENT_MATCHER` instead of a hardcoded string for the expected-output rows, and point the noop test's already-current input at the same constant. Legacy-input matchers (the values migration is meant to widen) are left untouched. Test-only change.

```
tests/unit/cli/test_mcp_config.py | 14 +++++++-------
```

All 46 tests in the file pass locally.