### PR TITLE
docs: hooks guide + "learns from your usage" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 <p align="center"><sub>
   <a href="#the-five-layers">Layers</a> ·
+  <a href="#learns-from-how-you-actually-use-it">Learns from you</a> ·
   <a href="#-code-health-the-layer-nobody-else-nails">Code Health</a> ·
   <a href="#refactoring-intelligence">Refactoring</a> ·
   <a href="#benchmarks">Benchmarks</a> ·
@@ -96,6 +97,31 @@ dead code, CLAUDE.md generation): **[docs/INTELLIGENCE_LAYERS.md →](docs/INTEL
 
 ---
 
+## Learns from how you actually use it
+
+repowise doesn't just index once and go stale, it watches how you and your agent
+work in the repo and tilts itself toward that. All local, all deterministic, no
+extra LLM calls, and it feeds back through the [hooks](docs/HOOKS.md) at zero
+agent effort:
+
+- **Decisions mined from your own sessions.** repowise reads your Claude Code
+  transcripts for the corrections and conventions you actually enforce ("new
+  endpoints go through the auth middleware", "use the shared HTTP client, not
+  raw requests"), turns the durable ones into tracked decisions, then delivers
+  the relevant ones back: a compact block at session start, and a one-line
+  *"governed by"* notice the moment your agent edits a file that decision
+  governs. If a later session contradicts a decision, it stops being injected.
+- **Docs that follow your questions.** The wiki generation budget tilts toward
+  the modules you and your agent ask about most (from `get_answer` and
+  `search_codebase` history), so depth lands where you actually work instead of
+  spreading evenly. Silent and byte-identical on a fresh repo with no history.
+
+It is a flywheel: **use it → it mines what mattered → it delivers that back on
+the next session.** How the hooks carry it: **[docs/HOOKS.md →](docs/HOOKS.md)** ·
+decision layer: **[docs/INTELLIGENCE_LAYERS.md →](docs/INTELLIGENCE_LAYERS.md)**
+
+---
+
 ## ★ Code Health: the layer nobody else nails
 
 Code health is repowise's deepest differentiator: the one layer with no real
@@ -108,27 +134,26 @@ refactoring plan your agent can execute.
 <img src=".github/assets/health-loop.svg" alt="repowise code-health loop: 25 deterministic markers fan into three signals (defect risk, maintainability, performance), the graph and git history locate where risk concentrates, and refactoring intelligence emits concrete plans (Extract Class, Extract Helper, Move Method, Break Cycle, Split File, Extract Method) your agent executes" width="100%" />
 </div>
 
-repowise scores **every file 1–10** from **25 deterministic markers**:
-McCabe complexity, deep nesting, brain methods, class cohesion (LCOM4), god
-classes, native Rabin–Karp clone detection, untested hotspots, function-level
-churn, code-age volatility, ownership dispersion, change entropy, co-change
-scatter, prior-defect history, test-quality smells, and more.
+repowise scores **every file 1–10** from **25 deterministic markers**, McCabe
+complexity, brain methods, class cohesion (LCOM4), god classes, native
+Rabin–Karp clone detection, untested hotspots, change entropy, prior-defect
+history, and more, split into **three signals**:
 
-**Three signals, one index.** The headline 1–10 is **defect risk**: the
-defect-calibrated, bug-predictive score in the table below. From the same
-marker stream, repowise surfaces two co-equal companion views:
-**maintainability** (cohesion, brain methods, DRY and god-class smells that
-raise change-cost without predicting bugs) and **performance** (static N+1 /
-I/O-in-loop risk, followed across files through the call graph: file-local
-linters found 0 of those cross-function cases on a 12k-file benchmark where
-repowise surfaced 557). They are separate lenses, never blended into the defect
+- **Defect risk** is the headline 1–10: the defect-calibrated, bug-predictive
+  score in the table below.
+- **Maintainability** (cohesion, brain methods, DRY and god-class smells) flags
+  what raises change-cost without predicting bugs.
+- **Performance** (static N+1 / I/O-in-loop risk) is followed across files
+  through the call graph: file-local linters found 0 of those cross-function
+  cases on a 12k-file benchmark where repowise surfaced 557.
+
+The companion signals are separate lenses, never blended into the defect
 headline, so the bug-predictive number stays clean.
 
-> **Zero LLM calls. Zero cloud requirement. Zero new runtime dependencies.**
-> Pure Python over tree-sitter + git data, finishing in **under 30 seconds** on
-> a 3,000-file repo. The marker weights are **calibrated against a real defect
-> corpus, not hand-tuned**; only the learned constants ship and the runtime
-> stays fully deterministic.
+> **Zero LLM calls, zero cloud, zero new runtime dependencies.** Pure Python
+> over tree-sitter + git data, **under 30 seconds** on a 3,000-file repo. The
+> marker weights are **calibrated against a real defect corpus, not hand-tuned**;
+> only the learned constants ship and the runtime stays fully deterministic.
 
 ```bash
 repowise health                       # KPIs + lowest-scoring files
@@ -163,26 +188,23 @@ User guide & per-marker reference: **[docs/CODE_HEALTH.md](docs/CODE_HEALTH.md)*
 
 ### Refactoring intelligence
 
-A health score tells you a file is in trouble. Every other tool stops there, or
-prints the same static sentence for every god class in every repo. repowise names
-the **specific** fix, computed deterministically from the graph, the class model,
-and git co-change: **Extract Class**, **Extract Helper**, **Move Method**,
-**Break Cycle**, **Split File**, and **Extract Method**. Each plan names the
-exact methods, edges, or symbols that move, and carries its **blast radius**
-(the callers and co-changing files that must move with it). Extract Method goes
-deepest: an intra-procedural dataflow pass (CFG + def/use + reaching
-definitions) finds the exact line span to lift out of an oversized method and
-infers the helper's parameters and return value, so the plan is
-behavior-preserving by construction. Ranking is **graph-aware** (`impact ×
-call-graph centrality × blast radius`), so a fix on a central hub outranks the
-same fix on a leaf. That is the wedge: CodeScene's AI refactoring stays within a
-single function, where repowise names the cross-file move and the dependents it
-ripples to.
+A health score tells you a file is in trouble; every other tool stops there, or
+prints the same static sentence for every god class. repowise names the
+**specific** fix, computed deterministically from the graph, the class model, and
+git co-change: **Extract Class**, **Extract Helper**, **Move Method**, **Break
+Cycle**, **Split File**, **Extract Method**. Each plan names the exact methods,
+edges, or symbols that move and carries its **blast radius** (the callers and
+co-changing files that must move with it), ranked **graph-aware** (`impact ×
+call-graph centrality × blast radius`) so a fix on a central hub outranks the
+same fix on a leaf. That is the wedge: CodeScene's AI refactoring stays inside a
+single function; repowise names the cross-file move and the dependents it ripples
+to. Extract Method goes deepest, an intra-procedural dataflow pass (CFG + def/use
++ reaching definitions) lifts the exact line span and infers the helper's
+signature, behavior-preserving by construction.
 
 The deterministic plan is the product; an optional LLM step (never in the
-indexing path, only on explicit request) expands any plan into generated code
-plus a unified diff, fed the graph and co-change context a bare codegen tool
-throws away.
+indexing path, only on request) expands any plan into generated code plus a
+unified diff, fed the graph and co-change context a bare codegen tool throws away.
 
 ```bash
 repowise health --refactoring-targets    # ranked plans; get_health(include=["refactoring"]) over MCP
@@ -451,7 +473,7 @@ Ready for the full picture? Run `repowise init --provider …` for the generated
 semantic search, or skip key management entirely with the hosted tier at
 [repowise.dev](https://www.repowise.dev). Full walkthrough: [docs/QUICKSTART.md](docs/QUICKSTART.md).
 
-**Docs:** [Quickstart](docs/QUICKSTART.md) · [User Guide](docs/USER_GUIDE.md) · [CLI Reference](docs/CLI_REFERENCE.md) · [Codex](docs/CODEX.md) · [MCP Tools](docs/MCP_TOOLS.md) · [Distill](docs/DISTILL.md) · [Workspaces](docs/WORKSPACES.md) · [Auto-Sync](docs/AUTO_SYNC.md) · [Upgrading](docs/UPGRADING.md) · [Config](docs/CONFIG.md)
+**Docs:** [Quickstart](docs/QUICKSTART.md) · [User Guide](docs/USER_GUIDE.md) · [CLI Reference](docs/CLI_REFERENCE.md) · [Codex](docs/CODEX.md) · [MCP Tools](docs/MCP_TOOLS.md) · [Hooks](docs/HOOKS.md) · [Distill](docs/DISTILL.md) · [Workspaces](docs/WORKSPACES.md) · [Auto-Sync](docs/AUTO_SYNC.md) · [Upgrading](docs/UPGRADING.md) · [Config](docs/CONFIG.md)
 
 ---
 
@@ -491,6 +513,7 @@ Worked example (*"Add rate limiting to all API endpoints"* in 5 calls instead of
 | MCP server for AI agents | ✅ 9 tools | ❌ | ✅ 3 tools | ✅ | ✅ |
 | Proactive agent hooks | ✅ Claude + Codex hooks | ❌ | ❌ | ❌ | ❌ |
 | Auto-generated AI instructions (`CLAUDE.md`, `AGENTS.md`) | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Learns from your usage (session-mined decisions, demand-weighted docs) | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Code health score (1–10) | ✅ 25 markers | ❌ | ❌ | ❌ | ✅ 25–30 |
 | Brain Method / LCOM4 / god class | ✅ | ❌ | ❌ | ❌ | ✅ |
 | Test-coverage intelligence | ✅ LCOV/Cobertura/Clover | ❌ | ❌ | ❌ | ❌ |

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,0 +1,222 @@
+# Hooks
+
+repowise installs a set of lightweight hooks so context reaches your agent, and
+your index stays fresh, with zero effort on your part. They fall into two
+families:
+
+- **Git hooks** keep the wiki and graph in sync with your code.
+- **Agent hooks** feed graph, git, health, and decision context into Claude Code
+  and Codex at the exact moments the agent needs it.
+
+Every agent hook shares the same guarantees: **no LLM calls, no network**, only
+local SQLite (`wiki.db`) and `git` reads. They are import-isolated (cold start
+under ~500ms), and any failure exits `0` silently, so a broken environment never
+crashes or blocks your agent.
+
+---
+
+## At a glance
+
+| Hook | Family | Installed by | Fires on | What it does |
+|------|--------|--------------|----------|--------------|
+| **Post-commit auto-sync** | git | `repowise hook install` (or the `repowise init` prompt) | every `git commit` | Runs `repowise update` in the background so the wiki tracks your code |
+| **SessionStart context** | Claude Code | `repowise init` | session `startup` / `resume` / `clear` | Live index-freshness line, core-tool trust rule, and the standing decisions relevant to this session |
+| **PostToolUse enrichment** | Claude Code | `repowise init` | `Grep` / `Glob` / `Read` / `Edit` / `Write` / `Bash` / `PowerShell` / repowise MCP calls | Graph context on searches, git/edit freshness, read-intelligence notices, and edit-time "governed by" decision notices |
+| **Command-rewrite (distill)** | Claude Code | `repowise hook rewrite install` (opt-in) | `Bash` / `PowerShell` | Rewrites noisy commands to `repowise distill <cmd>`, pending your approval |
+| **Codex context + staleness** | Codex | `repowise init --codex` | SessionStart / UserPromptSubmit / edit / Bash | Reminds Codex to use the MCP tools and flags stale context after edits |
+
+---
+
+## Git hook: post-commit auto-sync
+
+The wiki, graph, and health scores are only as current as your last index. The
+post-commit hook closes that gap: after every commit it runs `repowise update`
+in the background, so documentation, dependency edges, and code-health follow
+your code without you thinking about it. Your terminal is never blocked.
+
+```bash
+repowise hook install              # install for the current repo
+repowise hook install --workspace  # install for all repos in the workspace
+repowise hook status               # check whether the hook is installed
+repowise hook uninstall            # remove it
+```
+
+The hook is **marker-delimited**, so it coexists safely with other tools' hooks
+(linters, formatters, commit-msg checks) in the same `post-commit` file: repowise
+only ever touches the block between its own markers. See
+[AUTO_SYNC.md](AUTO_SYNC.md) for the full sync model, including how git worktrees
+seed from the base checkout.
+
+> Prefer to keep updates manual? Skip this hook and run `repowise update`
+> yourself. The agent hooks below will remind you when the index falls behind.
+
+---
+
+## Claude Code agent hooks
+
+Installed automatically during `repowise init` into your global
+`~/.claude/settings.json`. Existing user hooks are always preserved, and legacy
+repowise entries are migrated in place on the next `init` / `update`. All of them
+route through the `repowise-augment` console script (a standalone entry point
+that does not load the full CLI).
+
+### SessionStart, live freshness + relevant decisions
+
+The generated `CLAUDE.md` is static between reindexes, so it can't say whether
+the index is current *right now*. This hook adds a short per-session block so the
+agent starts with calibrated trust instead of discovering staleness mid-task:
+
+- **Index current** → one line saying so, plus the core-tool pointer.
+- **Update running** → a positive "catching up" notice (never a stale scare).
+- **Index behind** → indexed vs `HEAD` with a changed-file count, and the
+  target-scoped trust rule (a `stale_warning` fires only when a file a response
+  actually served has changed).
+
+It also carries the **relevance-ranked standing decisions** for this session.
+repowise scores the repo's active decisions against the session's likely working
+set (dirty and staged files, files changed on the branch vs `main`, the previous
+session's edited files, and branch-name tokens), expanded one hop through import
+edges and co-change partners. The top few land under a hard ~400-token cap.
+Relevance or silence: nothing clears the floor, nothing is injected, and
+decisions are never shown just for being high-confidence. Repo-wide rules mined
+from your own corrections are the one exception: a rule like "use the shared
+logger, not print" applies everywhere rather than to specific files, so it
+competes at a flat base relevance.
+
+### PostToolUse, enrichment on every tool call
+
+One hook covers several jobs, matched on
+`Grep`, `Glob`, `Read`, `Edit`, `Write`, `Bash`, `PowerShell`, and repowise MCP
+calls:
+
+**Grep/Glob enrichment.** When Claude Code runs a broad or zero-result search,
+repowise appends focused context pulled straight from `wiki.db`:
+
+| Field | What it tells the agent |
+|-------|------------------------|
+| **Symbols** | Functions, classes, and methods defined in the file |
+| **Imported by** | Which files depend on this file (reverse dependency) |
+| **Depends on** | What this file imports (forward dependency) |
+| **Git signals** | Hotspot status, bus factor, and owner |
+
+So an agent that greps for `PageGenerator` immediately knows what depends on it,
+what it depends on, and that it is a hotspot, without a separate MCP call:
+
+```
+[repowise] 2 related file(s) found:
+
+  packages/core/.../page_generator.py
+    Symbols: function:_now_iso, class:PageGenerator, method:__init__
+    Imported by: init_cmd.py, update_cmd.py, generation/__init__.py
+    Depends on: context_assembler.py, base.py, models.py
+    Git: HOTSPOT, bus-factor=1, owner=RaghavChamadiya
+```
+
+**Git/edit freshness.** After a successful `git commit`, `merge`, `rebase`,
+`cherry-pick`, or `pull`, repowise compares `HEAD` against the last indexed commit
+in `.repowise/state.json` and, if the wiki is behind, reminds the agent to run
+`repowise update` so it never silently works from outdated docs.
+
+**Read-intelligence.** On `Read` of an indexed file, repowise can nudge the agent
+toward the cheaper `get_context(..., include=["skeleton"])` for structure-level
+questions, and emit a per-file stale-read notice when the file changed after
+indexing.
+
+**Edit-time "governed by" decisions.** When the agent edits a file governed by an
+architectural decision (via `decision_node_links`), it gets a one-line notice
+with the rationale, at most once per session per decision and only a few times
+per session total. This is how a decision reaches the agent at the moment it is
+about to violate (or honor) it.
+
+Every injected decision id is recorded locally in
+`.repowise/sessions/sessions.db`. On the next `repowise update`, the session miner
+checks whether the guidance was followed or contradicted by your corrections in
+that session, and relaxes or bumps the decision's staleness accordingly, so
+guidance that stops being true stops being injected. This is the feedback loop
+behind "learns from your sessions" (see the [README](../README.md) and
+[decisions layer](INTELLIGENCE_LAYERS.md)).
+
+---
+
+## Command-rewrite hook (distill), opt-in
+
+Most of what an agent reads from a shell command is noise: 300 lines of passing
+tests around 4 failures, full commit bodies for "what changed recently". The
+rewrite hook intercepts noisy `Bash` / `PowerShell` commands and rewrites them to
+[`repowise distill <cmd>`](DISTILL.md), which compresses the output errors-first
+before the agent reads it, exit code preserved and every omission reversible.
+
+```bash
+repowise hook rewrite install     # or answer Yes at the `repowise init` prompt
+repowise hook rewrite status
+repowise hook rewrite uninstall
+```
+
+- Defaults to **`ask`**, so you approve every rewritten command before it runs.
+- Never rewrites pipes, compound commands, or watch modes.
+- Installing also adds `Bash(repowise distill:*)` / `PowerShell(repowise distill:*)`
+  to `permissions.allow`, so an already-approved command family doesn't start
+  re-prompting just because its string changed.
+
+Per-repo behavior lives under `distill.commands` in `.repowise/config.yaml`
+([CONFIG.md](CONFIG.md)). Track what it saved with `repowise saved`.
+
+---
+
+## Codex hooks
+
+Written to project-local `.codex/hooks.json` by `repowise init --codex` (they do
+not touch your global `~/.codex/config.toml`):
+
+- **SessionStart / UserPromptSubmit** → a short developer note reminding Codex to
+  use the repowise MCP tools for architecture, search, risk, decisions, and
+  dead-code analysis.
+- **PostToolUse** (`Bash`, `apply_patch` / `Edit` / `Write`) → flags that indexed
+  context may be stale after edits or git operations, pointing at `repowise
+  update`.
+
+Full Codex setup: [CODEX.md](CODEX.md).
+
+---
+
+## What gets written where
+
+`repowise init` writes these entries into `~/.claude/settings.json` (Claude Code)
+and `.codex/hooks.json` (Codex when `--codex` is passed):
+
+| Client | Hook type | Matcher | Command |
+|--------|-----------|---------|---------|
+| Claude Code | `SessionStart` | `startup\|resume\|clear` | `repowise-augment` |
+| Claude Code | `PostToolUse` | `Bash\|PowerShell\|Grep\|Glob\|Read\|Edit\|Write\|mcp__.*[Rr]epowise.*__.*` | `repowise-augment` |
+| Claude Code | `PreToolUse` (opt-in) | `Bash\|PowerShell` | `repowise-rewrite` |
+| Codex | `SessionStart` / `UserPromptSubmit` | lifecycle | context reminder |
+| Codex | `PostToolUse` | `Bash`, `apply_patch\|Edit\|Write` | staleness check |
+
+`SessionStart` deliberately excludes `compact`: the block usually survives
+compaction in the summary, and re-emitting it there would double it up. `init`
+also sets `env.ENABLE_TOOL_SEARCH=true` so the MCP tool schemas load on demand
+rather than sitting in every session's standing context (an existing value you
+set, including a deliberate `false`, is left untouched).
+
+For manual debugging, the underlying entry points can be run directly:
+
+```bash
+repowise-augment    # invoked by the agent hooks; prints what it would inject
+repowise augment    # equivalent Click subcommand
+```
+
+---
+
+## Hooks vs MCP tools
+
+The two are complementary:
+
+- **Hooks** are passive, automatic, and cost the agent nothing. They fire on
+  every search, edit, or session start whether or not the agent is thinking about
+  graph context.
+- **[MCP tools](MCP_TOOLS.md)** are active and on-demand, with richer output.
+  Reach for them when the agent needs full documentation, a risk assessment,
+  decision history, or dependency tracing.
+
+For most day-to-day coding, the hooks supply enough context on their own; the MCP
+tools are there for deeper investigation.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -834,93 +834,19 @@ Once connected, your AI editor can:
 
 ## Proactive Context Enrichment (Hooks)
 
-Repowise installs lightweight AI-agent hooks during editor setup. Claude Code hooks are installed during `repowise init`; Codex hooks are written by `repowise init --codex`.
+Repowise installs lightweight AI-agent hooks during editor setup so graph, git,
+health, and decision context reaches your agent (and your index stays fresh) with
+zero effort. They fire from editor lifecycle and tool-use events, never call an
+LLM or the network, and fail silently.
 
-Unlike MCP tools, hooks are passive reminders that fire from editor lifecycle events and tool-use events. They do not call an LLM or the network.
+The full inventory, the SessionStart freshness + relevant-decisions block, the
+PostToolUse Grep/Glob enrichment, git/edit freshness, read-intelligence, and
+edit-time "governed by" notices, the opt-in distill command-rewrite hook, the
+Codex hooks, and the exact `settings.json` entries, lives in a dedicated guide:
+**[HOOKS.md →](HOOKS.md)**.
 
-### How it works
-
-#### Claude Code PostToolUse Hook, Grep/Glob enrichment
-
-When Claude Code runs a broad or zero-result `Grep` or `Glob`, repowise can query the local `wiki.db` and append focused context:
-
-| Field | What it tells the agent |
-|-------|------------------------|
-| **Symbols** | Functions, classes, and methods defined in the file |
-| **Imported by** | Which files depend on this file (reverse dependency) |
-| **Depends on** | What this file imports (forward dependency) |
-| **Git signals** | Hotspot status, bus factor, and owner |
-
-No LLM calls, no network requests, pure local SQLite queries against `wiki.db`.
-
-#### PostToolUse Hook, Git/edit freshness detection
-
-After a successful `git commit`, `git merge`, `git rebase`, `git cherry-pick`, or `git pull`, repowise checks whether the wiki is stale by comparing `HEAD` against the last indexed commit in `.repowise/state.json`. Codex edit hooks also remind the agent that indexed context may be stale after edits.
-
-```
-Wiki is stale, run `repowise update` to refresh
-```
-
-This ensures agents are never silently working from outdated documentation.
-
-#### Decision injection, relevance-ranked
-
-The decision layer reaches the agent at the two moments it matters, with no LLM calls and indexed SQLite lookups only:
-
-- **Session start.** Repowise scores the repo's active decisions against the session's likely working set: dirty and staged files, files changed on the branch vs main, the previous session's edited files, and branch-name tokens, expanded one hop through import edges and co-change partners. The top few land in a compact block under a hard ~400-token cap. Nothing clears the relevance floor, nothing is injected; decisions are never injected just for being high-confidence. Repo-wide rules mined from your own corrections (see session decision mining in the CLI reference) are the exception: they apply everywhere, so they compete at a flat base relevance.
-- **Edit time.** When the agent edits a file governed by a decision (via `decision_node_links`), it gets a one-line "governed by" notice with the rationale, once per session per decision and at most a few times per session.
-
-Injected decision ids are recorded locally in `.repowise/sessions/sessions.db`. On the next `repowise update`, the session miner checks whether the guidance was followed or contradicted by your corrections in that session, relaxing or bumping the decision's staleness accordingly, so guidance that stops being true stops being injected.
-
-### Configuration
-
-Claude Code hooks are written to `~/.claude/settings.json` automatically during `repowise init`. Codex hooks are written to `.codex/hooks.json` by `repowise init --codex`.
-
-| Hook type | Matcher | Action |
-|-----------|---------|--------|
-| Claude `SessionStart` | `startup\|resume\|clear` | Inject live index freshness (current / behind with a changed-file count / update in progress), the core-tool trust rule, and the standing decisions relevant to the session's working set |
-| Claude `PostToolUse` | `Bash\|PowerShell\|Grep\|Glob\|Read\|Edit\|Write` | Check git freshness, add search rescue/triage context, emit Read-intelligence notices, and surface the governing decision when a governed file is edited |
-| Codex `SessionStart` / `UserPromptSubmit` | lifecycle | Remind Codex to use Repowise MCP tools |
-| Codex `PostToolUse` | `Bash`, `apply_patch\|Edit\|Write` | Check git/edit freshness |
-
-Both hooks call the `repowise-augment` console script, a standalone, import-isolated entry point that does not load the full `repowise` CLI. This keeps cold start under the 500ms target and ensures a broken environment (missing optional dep, corrupt DB, etc.) never crashes the agent: any failure exits 0 silently. The equivalent `repowise augment` Click subcommand still exists for manual debugging.
-
-### CLI command
-
-```bash
-repowise-augment    # Not meant to be called manually, invoked by AI-agent hooks
-repowise augment    # Equivalent Click subcommand, useful for manual debugging
-```
-
-### Sample enrichment output
-
-When an agent runs `Grep` or `Glob`, it sees its normal results followed by context like this:
-
-```
-[repowise] 2 related file(s) found:
-
-  packages/core/.../page_generator.py
-    Symbols: function:_now_iso, class:PageGenerator, method:__init__
-    Imported by: init_cmd.py, update_cmd.py, generation/__init__.py
-    Depends on: context_assembler.py, base.py, models.py
-    Git: HOTSPOT, bus-factor=1, owner=RaghavChamadiya
-
-  packages/cli/.../init_cmd.py
-    Symbols: function:_resolve_embedder, function:_register_mcp_with_claude
-    Imported by: reindex_cmd.py, search_cmd.py, main.py
-    Depends on: update_cmd.py, cost_estimator.py
-```
-
-This means an agent that searches for `"PageGenerator"` immediately knows which files depend on it, what it depends on, and that it is a hotspot, without making a separate MCP tool call.
-
-### Relationship to MCP tools
-
-Hooks and MCP tools are complementary:
-
-- **Hooks**, passive, automatic, zero agent effort. Fire on every search regardless of whether the agent is thinking about graph context.
-- **MCP tools**, active, on-demand, richer output. Used when the agent needs full documentation, risk assessment, architectural decisions, or dependency tracing.
-
-For most day-to-day coding tasks, hooks provide sufficient context automatically. MCP tools remain the right choice for deeper investigation.
+The post-commit git hook that auto-syncs the wiki is documented under
+[`repowise hook`](#repowise-hook) above and in [AUTO_SYNC.md](AUTO_SYNC.md).
 
 ---
 


### PR DESCRIPTION
## What

- **New `docs/HOOKS.md`** documenting the full hook inventory in one place:
  - Post-commit auto-sync git hook (`repowise hook install`)
  - Claude Code `SessionStart` block (live index freshness + relevance-ranked standing decisions)
  - Claude Code `PostToolUse` hooks (Grep/Glob graph enrichment, git/edit freshness, read-intelligence notices, edit-time "governed by" decision notices)
  - Opt-in distill command-rewrite hook (`repowise hook rewrite install`)
  - Codex context + staleness hooks
  - The exact `settings.json` matchers/commands, safety guarantees, and hooks-vs-MCP framing
- **README:** new "Learns from how you actually use it" section (session-mined decisions delivered at session start and edit time; demand-weighted docs budget), a top-nav anchor, and a matching comparison-table row.
- **README:** trimmed repetition in the Code Health and Refactoring Intelligence prose. The CodeScene head-to-head table, the defect-validation numbers, and every distinguishing refactoring claim are kept intact.
- **User Guide:** collapsed the old inline hooks section into a pointer to the new guide, and linked HOOKS.md from the README docs list.

## Why

The hook surface has grown enough (five distinct hooks across two agents) to warrant a dedicated guide instead of a User Guide subsection. The session-learning behavior was undocumented on the README despite being a real differentiator.

Docs only; no code or behavior changes.