### PR TITLE
fix: handle Anthropic thinking blocks

### DIFF
--- a/packages/core/src/repowise/core/providers/llm/anthropic.py
+++ b/packages/core/src/repowise/core/providers/llm/anthropic.py
@@ -219,8 +219,15 @@ class AnthropicProvider(BaseProvider):
             raise ProviderError("anthropic", str(exc), status_code=exc.status_code) from exc
 
         cached = getattr(response.usage, "cache_read_input_tokens", 0) or 0
+
+        text_content = ""
+        for block in response.content:
+            if hasattr(block, "text"):
+                text_content = block.text
+                break
+
         result = GeneratedResponse(
-            content=response.content[0].text,
+            content=text_content,
             input_tokens=response.usage.input_tokens,
             output_tokens=response.usage.output_tokens,
             cached_tokens=cached,

--- a/tests/unit/test_providers/test_anthropic_provider.py
+++ b/tests/unit/test_providers/test_anthropic_provider.py
@@ -11,6 +11,8 @@ import pytest
 
 pytest.importorskip("anthropic", reason="anthropic SDK not installed")
 
+from anthropic.types import TextBlock, ThinkingBlock
+
 from repowise.core.providers.llm.anthropic import AnthropicProvider
 from repowise.core.providers.llm.base import GeneratedResponse, ProviderError, RateLimitError
 
@@ -156,6 +158,29 @@ async def test_generate_sends_correct_params():
     assert kw["temperature"] == 0.1
     assert kw["system"] == "system msg"
     assert kw["messages"] == [{"role": "user", "content": "user msg"}]
+
+
+async def test_generate_skips_thinking_block_before_text():
+    provider = AnthropicProvider(api_key="sk-ant-test")
+    mock_response = _make_mock_response()
+    mock_response.content = [
+        ThinkingBlock(
+            type="thinking",
+            thinking="Internal reasoning",
+            signature="test-signature",
+        ),
+        TextBlock(
+            type="text",
+            text="Hello after thinking",
+        ),
+    ]
+
+    with patch("anthropic.AsyncAnthropic") as mock_client:
+        mock_client.return_value.messages.create = AsyncMock(return_value=mock_response)
+        provider._client = mock_client.return_value
+        result = await provider.generate("sys", "user")
+
+    assert result.content == "Hello after thinking"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Updates `AnthropicProvider` to scan `response.content` for the first block carrying text instead of assuming that the first content block is always a `TextBlock`.
- Prevents generation from crashing when Anthropic or Anthropic-compatible endpoints return a `ThinkingBlock` before the final text response.
- Adds a regression test using a mocked `[ThinkingBlock, TextBlock]` response.

## Related Issues

Fixes #750

Related to #740

## Implementation Details

Anthropic responses can contain different content block types. When extended thinking is enabled, or when an Anthropic-compatible endpoint returns reasoning content, a `ThinkingBlock` may appear before the final `TextBlock`.

Previously, the provider accessed the first content block directly:

```python
response.content[0].text
```

This caused an `AttributeError` when the first block did not expose a `text` attribute.

The provider now iterates through `response.content` and selects the first block that carries text:

```python
text_content = ""
for block in response.content:
    if hasattr(block, "text"):
        text_content = block.text
        break
```

This preserves the existing behavior for standard Anthropic responses while supporting responses where thinking or reasoning blocks appear before the text.

## Test Plan

- [x] Added a regression test with `[ThinkingBlock, TextBlock]` content.
- [x] Anthropic provider unit tests pass (`13 passed`).
- [x] Ruff lint passes for the modified files.
- [x] Ruff formatting check passes for the modified files.
- [x] `git diff --check` passes.
- [x] Web build is not applicable because there are no frontend changes.

The full `make test-fast` run completed with 7,069 passing tests and 11 failures in unrelated CLI, update, and code-rationale tests. Representative failures also reproduce when executed independently and do not exercise the Anthropic provider changes.

## Checklist

- [x] My code follows the project's code style.
- [x] I have added tests for the reported bug.
- [ ] All existing tests still pass.
- [x] Documentation changes are not required for this bug fix.
- [x] The changes are limited to the scope of issue #750.