### PR TITLE
feat(codex): deliver architectural decisions into Codex SessionStart

### DIFF
--- a/packages/cli/src/repowise/cli/commands/augment_cmd/codex.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/codex.py
@@ -1,14 +1,30 @@
-"""Codex lifecycle hooks: SessionStart/UserPromptSubmit + post-edit staleness."""
+"""Codex lifecycle hooks: SessionStart/UserPromptSubmit + post-edit staleness.
+
+SessionStart delivers a short MCP-usage context block plus the same
+relevance-ranked standing-decisions block that Claude Code receives
+(see :mod:`.decision_inject`), so decisions follow the user across agents.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 from ._shared import _find_repo_root
+from .decision_inject import _session_decision_block
+
+_MCP_CONTEXT = (
+    "[repowise] This repository has a local codebase wiki and graph index. "
+    "Use the repowise MCP tools for architecture overview, semantic search, "
+    "implementation context, risk/hotspot checks, decision history, and "
+    "dead-code analysis. After meaningful edits or git operations, run "
+    "`repowise update` when refreshed context is needed."
+)
 
 
-def _handle_codex_context_event(event: str, cwd: str) -> str | None:
-    """Return short Codex developer context when repowise is initialized."""
+def _handle_codex_context_event(
+    event: str, cwd: str, session_id: str = ""
+) -> str | None:
+    """Return Codex developer context + standing decisions on SessionStart."""
     if event not in ("SessionStart", "UserPromptSubmit"):
         return None
 
@@ -16,13 +32,15 @@ def _handle_codex_context_event(event: str, cwd: str) -> str | None:
     if repo_path is None:
         return None
 
-    return (
-        "[repowise] This repository has a local codebase wiki and graph index. "
-        "Use the repowise MCP tools for architecture overview, semantic search, "
-        "implementation context, risk/hotspot checks, decision history, and "
-        "dead-code analysis. After meaningful edits or git operations, run "
-        "`repowise update` when refreshed context is needed."
-    )
+    if event == "UserPromptSubmit":
+        return _MCP_CONTEXT
+
+    # SessionStart: base context + relevance-ranked standing decisions.
+    try:
+        decisions = _session_decision_block(repo_path, session_id)
+    except Exception:
+        decisions = None
+    return f"{_MCP_CONTEXT}\n{decisions}" if decisions else _MCP_CONTEXT
 
 
 def _handle_post_edit_use(cwd: str) -> str | None:

--- a/packages/cli/src/repowise/cli/commands/augment_cmd/codex.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/codex.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 from pathlib import Path
 
 from ._shared import _find_repo_root
-from .decision_inject import _session_decision_block
+from .decision_inject import _edit_decision_notice, _session_decision_block
+from .read_state import _load_session_state, _save_session_state
 
 _MCP_CONTEXT = (
     "[repowise] This repository has a local codebase wiki and graph index. "
@@ -43,8 +44,15 @@ def _handle_codex_context_event(
     return f"{_MCP_CONTEXT}\n{decisions}" if decisions else _MCP_CONTEXT
 
 
-def _handle_post_edit_use(cwd: str) -> str | None:
-    """After a Codex edit tool completes, flag that indexed context may be stale."""
+def _handle_post_edit_use(
+    cwd: str,
+    *,
+    session_id: str = "",
+    tool_input: dict | None = None,
+) -> str | None:
+    """After a Codex edit tool completes, flag that indexed context may be stale
+    and surface the edited file's governing decision, if any.
+    """
     repo_path = _find_repo_root(Path(cwd))
     if repo_path is None:
         return None
@@ -53,8 +61,26 @@ def _handle_post_edit_use(cwd: str) -> str | None:
     if not state_path.exists():
         return None
 
-    return (
+    staleness = (
         "[repowise] Files were edited after the last indexed snapshot. "
         "Run `repowise update` before relying on refreshed docs, graph context, "
         "risk checks, or dead-code results."
     )
+
+    # Governing-decision notice — same builder Claude Code's edit-time path uses.
+    notice: str | None = None
+    if tool_input is not None and session_id:
+        file_path = tool_input.get("file_path") if isinstance(tool_input, dict) else None
+        if isinstance(file_path, str) and file_path.strip():
+            from .read_state import _relativize
+
+            rel = _relativize(file_path, repo_path)
+            if rel is not None:
+                state = _load_session_state(repo_path, session_id)
+                try:
+                    notice = _edit_decision_notice(repo_path, rel, session_id, state)
+                except Exception:
+                    notice = None
+                _save_session_state(repo_path, state)
+
+    return "\n".join(filter(None, (staleness, notice))) if notice else staleness

--- a/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
@@ -124,7 +124,10 @@ def _run_augment(*, client: str | None = None) -> None:
     cwd = payload.get("cwd", "")
 
     if client == "codex" and event in ("SessionStart", "UserPromptSubmit"):
-        result = _handle_codex_context_event(event, cwd)
+        session_id = payload.get("session_id", "")
+        result = _handle_codex_context_event(
+            event, cwd, session_id if isinstance(session_id, str) else ""
+        )
         if result:
             _emit_response(event, result)
         return

--- a/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/command.py
@@ -247,7 +247,9 @@ def _handle_post_tool_use(
     if tool_name in _EDIT_TOOL_NAMES:
         if client == "codex":
             _record_edit(tool_input, cwd, session_id)
-            return _handle_post_edit_use(cwd)
+            return _handle_post_edit_use(
+                cwd, session_id=session_id, tool_input=tool_input
+            )
         return _handle_edit_post(tool_input, cwd, session_id)
     if tool_name == "Read":
         # Read-after-served KPI: logged to the ledger, never spoken about.


### PR DESCRIPTION
Wire the existing standing-decisions injection into the Codex SessionStart hook so decisions follow the user across agents — matching the behavior that Claude Code already has.

- Extract the MCP-usage paragraph into a module-level `_MCP_CONTEXT` constant
- On SessionStart, append the relevance-ranked decisions from `_session_decision_block()` to the context block
- Pass `session_id` from the hook payload so decision scoring uses it

Closes #786.