### PR TITLE
feat(coverage): per-test contexts ingestion substrate (test-to-code map)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/coverage_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/coverage_cmd.py
@@ -54,7 +54,9 @@ def coverage_group() -> None:
 
 @coverage_group.command("add")
 @click.argument("paths", nargs=-1, type=click.Path(exists=True, dir_okay=False))
-@click.option("--path", "repo", default=None, help="Repo path (defaults to cwd / workspace primary).")
+@click.option(
+    "--path", "repo", default=None, help="Repo path (defaults to cwd / workspace primary)."
+)
 @click.option(
     "--format",
     "coverage_format",
@@ -125,8 +127,7 @@ def coverage_add(paths: tuple[str, ...], repo: str | None, coverage_format: str 
             repo_keys = await _repo_file_keys(session, repo_row.id)
             if not repo_keys:
                 console.print(
-                    "[yellow]No indexed files found — run `repowise init` "
-                    "first.[/yellow]"
+                    "[yellow]No indexed files found — run `repowise init` first.[/yellow]"
                 )
                 return
 
@@ -176,8 +177,112 @@ def coverage_add(paths: tuple[str, ...], repo: str | None, coverage_format: str 
     run_async(_do())
 
 
+@coverage_group.command("contexts")
+@click.argument("paths", nargs=-1, type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--path", "repo", default=None, help="Repo path (defaults to cwd / workspace primary)."
+)
+@click.option("--limit", type=int, default=20, help="Max per-test records to print.")
+def coverage_contexts(paths: tuple[str, ...], repo: str | None, limit: int) -> None:
+    """Preview the per-test coverage map from a context-carrying report.
+
+    Opt-in and read-only: reads a coverage.py ``.coverage`` sqlite (written
+    with ``coverage run --contexts=test``) or a per-test lcov, then prints
+    "test T covers N lines of file F". Nothing is persisted - this is the
+    Phase 0 substrate surface, not the ingest path.
+
+    A report produced without contexts degrades loudly rather than showing
+    an empty map:
+
+        repowise coverage contexts .coverage
+        repowise coverage contexts coverage/per-test.lcov
+    """
+    repo_path = _resolve_coverage_repo(repo)
+
+    from repowise.core.analysis.health.coverage import (
+        parse_contexts_file,
+        resolve_test_reports,
+    )
+
+    if paths:
+        report_paths = [Path(p) for p in paths]
+    else:
+        default = repo_path / ".coverage"
+        if not default.exists():
+            console.print(
+                "[yellow]No report given and no .coverage found.[/yellow] "
+                "Generate one with [cyan]coverage run --contexts=test[/cyan] "
+                "then pass its path:\n"
+                "  [cyan]repowise coverage contexts .coverage[/cyan]"
+            )
+            return
+        report_paths = [default]
+
+    for report_path in report_paths:
+        report = parse_contexts_file(report_path)
+        if not report.has_contexts:
+            console.print(
+                f"[yellow]{report_path.name}: no contexts - aggregate only, "
+                f"per-test features unavailable.[/yellow] Regenerate with "
+                f"[cyan]coverage run --contexts=test[/cyan] (or per-test lcov)."
+            )
+            continue
+
+        async def _resolve(rep=report) -> None:
+            from repowise.core.persistence import (
+                create_engine,
+                create_session_factory,
+                get_session,
+            )
+            from repowise.core.persistence.crud import get_repository_by_path
+
+            engine = create_engine(get_db_url_for_repo(repo_path))
+            sf = create_session_factory(engine)
+            async with get_session(sf) as session:
+                repo_row = await get_repository_by_path(session, str(repo_path))
+                repo_keys = await _repo_file_keys(session, repo_row.id) if repo_row else set()
+            _print_context_records(rep, repo_keys, resolve_test_reports, limit)
+
+        run_async(_resolve())
+
+
+def _print_context_records(report, repo_keys, resolve_test_reports, limit: int) -> None:
+    """Resolve (when an index exists) and print per-test coverage records."""
+    if repo_keys:
+        resolved = resolve_test_reports(report, repo_keys)
+        records = resolved.records
+        header = (
+            f"[bold]{len(records)} record(s)[/bold] "
+            f"({resolved.matched_exact} exact, {resolved.matched_suffix} resolved, "
+            f"{resolved.test_files_resolved} test-file(s) mapped)"
+        )
+        skipped = resolved.unmatched + resolved.ambiguous
+    else:
+        records = report.records
+        header = f"[bold]{len(records)} record(s)[/bold] (raw paths, no index to resolve against)"
+        skipped = []
+
+    console.print(f"{header} from [cyan]{report.source_format}[/cyan] contexts:")
+    for rec in records[:limit]:
+        via = f"  [dim](test file: {rec.test_file})[/dim]" if rec.test_file else ""
+        console.print(
+            f"  [green]{rec.test_id}[/green] covers "
+            f"{len(rec.covered_lines)} line(s) of [cyan]{rec.file_path}[/cyan]{via}"
+        )
+    if len(records) > limit:
+        console.print(f"  [dim]... {len(records) - limit} more[/dim]")
+    if skipped:
+        sample = ", ".join(skipped[:5])
+        console.print(
+            f"[yellow]{len(skipped)} source path(s) did not map to the repo "
+            f"tree[/yellow] (e.g. {sample})."
+        )
+
+
 @coverage_group.command("status")
-@click.option("--path", "repo", default=None, help="Repo path (defaults to cwd / workspace primary).")
+@click.option(
+    "--path", "repo", default=None, help="Repo path (defaults to cwd / workspace primary)."
+)
 def coverage_status(repo: str | None) -> None:
     """Show the coverage currently ingested for this repo."""
     repo_path = _resolve_coverage_repo(repo)

--- a/packages/core/src/repowise/core/analysis/health/coverage/__init__.py
+++ b/packages/core/src/repowise/core/analysis/health/coverage/__init__.py
@@ -4,24 +4,39 @@ from __future__ import annotations
 
 from .clover import parse_clover
 from .cobertura import parse_cobertura
+from .contexts import (
+    parse_contexts_file,
+    parse_coverage_sqlite,
+    parse_lcov_contexts,
+)
 from .detector import detect_format, is_test_file, paired_test_file, parse
 from .discovery import (
     CoverageConfig,
     ResolvedCoverage,
+    ResolvedTestCoverage,
     build_coverage_map,
     discover_artifacts,
     normalize_report_path,
     resolve_reports,
+    resolve_test_reports,
 )
 from .lcov import parse_lcov
-from .model import CoverageReport, FileCoverage
+from .model import (
+    ContextCoverageReport,
+    CoverageReport,
+    FileCoverage,
+    TestCoverage,
+)
 from .repowise_json import parse_repowise_json
 
 __all__ = [
+    "ContextCoverageReport",
     "CoverageConfig",
     "CoverageReport",
     "FileCoverage",
     "ResolvedCoverage",
+    "ResolvedTestCoverage",
+    "TestCoverage",
     "build_coverage_map",
     "detect_format",
     "discover_artifacts",
@@ -31,7 +46,11 @@ __all__ = [
     "parse",
     "parse_clover",
     "parse_cobertura",
+    "parse_contexts_file",
+    "parse_coverage_sqlite",
     "parse_lcov",
+    "parse_lcov_contexts",
     "parse_repowise_json",
     "resolve_reports",
+    "resolve_test_reports",
 ]

--- a/packages/core/src/repowise/core/analysis/health/coverage/contexts.py
+++ b/packages/core/src/repowise/core/analysis/health/coverage/contexts.py
@@ -1,0 +1,214 @@
+"""Per-test coverage readers (the test-to-code substrate).
+
+The standard parsers (:mod:`.lcov`, :mod:`.cobertura`, ...) collapse every
+test into one hit-wins aggregate per file - they know a file is covered,
+never by *which* test. These readers keep the test dimension instead,
+emitting one :class:`TestCoverage` per ``(test, file)`` pair.
+
+Two sources carry per-test data today:
+
+- **coverage.py ``.coverage`` sqlite** written with
+  ``coverage run --contexts=test`` (static) or ``dynamic_context =
+  test_function`` (dynamic). The ``context`` table names each test; the
+  ``line_bits`` / ``arc`` rows are keyed by ``(file_id, context_id)``.
+- **lcov ``TN:`` records** - the test-name line, blank in most merged lcov
+  but populated by per-test lcov output.
+
+Both degrade loudly: a report produced *without* contexts (a plain lcov, or
+``coverage run`` with no ``--contexts``) yields ``records=[]`` and
+``has_contexts=False`` so callers report "aggregate only, per-test features
+unavailable" rather than silently emitting nothing.
+
+These readers are opt-in and standalone: nothing in the default ingest path
+calls them (that is Phase 1+). They only parse; persistence, the reverse
+index, and any downstream feature live above this layer.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from .lcov import _normalize_path
+from .model import ContextCoverageReport, TestCoverage
+
+# coverage.py sqlite files start with the standard SQLite magic header.
+_SQLITE_MAGIC = b"SQLite format 3\x00"
+
+
+def parse_lcov_contexts(text: str) -> ContextCoverageReport:
+    """Parse per-test records from an lcov report's ``TN:`` names.
+
+    Each ``end_of_record`` block carries at most one ``TN`` (test name) and
+    one ``SF`` (source file); a covered ``DA`` line (hits > 0) becomes part
+    of that test's line set. Blocks with a blank ``TN`` carry no test
+    dimension and are skipped. If *no* block names a test, the report is
+    aggregate-only and comes back with ``has_contexts=False``.
+    """
+    records: list[TestCoverage] = []
+    has_contexts = False
+
+    current_test: str | None = None
+    current_path: str | None = None
+    covered: set[int] = set()
+
+    def flush() -> None:
+        nonlocal current_test, current_path, covered, has_contexts
+        if current_test and current_path and covered:
+            has_contexts = True
+            records.append(
+                TestCoverage(
+                    test_id=current_test,
+                    file_path=current_path,
+                    covered_lines=sorted(covered),
+                    source_format="lcov",
+                )
+            )
+        current_test = None
+        current_path = None
+        covered = set()
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line == "end_of_record":
+            flush()
+            continue
+        if ":" not in line:
+            continue
+        tag, _, rest = line.partition(":")
+        if tag == "TN":
+            name = rest.strip()
+            if name:
+                current_test = name
+        elif tag == "SF":
+            current_path = _normalize_path(rest)
+        elif tag == "DA":
+            parts = rest.split(",")
+            if len(parts) >= 2:
+                try:
+                    line_no = int(parts[0])
+                    hits = int(parts[1])
+                except ValueError:
+                    continue
+                if hits > 0:
+                    covered.add(line_no)
+
+    # Some reports omit the final end_of_record.
+    flush()
+    return ContextCoverageReport(source_format="lcov", records=records, has_contexts=has_contexts)
+
+
+def _numbits_to_lines(numbits: bytes) -> list[int]:
+    """Decode a coverage.py ``numbits`` blob to the line numbers it sets.
+
+    ``numbits`` is coverage.py's bitmap encoding: line number ``n`` is bit
+    ``n`` (byte ``n // 8``, bit ``n % 8``). We decode inline rather than
+    importing ``coverage.numbits`` so the reader has no runtime dependency
+    on coverage.py being importable.
+    """
+    lines: list[int] = []
+    for byte_i, byte in enumerate(numbits):
+        if not byte:
+            continue
+        for bit_i in range(8):
+            if (byte >> bit_i) & 1:
+                lines.append(byte_i * 8 + bit_i)
+    return lines
+
+
+def parse_coverage_sqlite(db_path: str | Path) -> ContextCoverageReport:
+    """Parse per-test records from a coverage.py ``.coverage`` sqlite file.
+
+    Reads the ``file`` / ``context`` / ``line_bits`` tables (falling back to
+    ``arc`` endpoints when the db was written in branch/arc mode). Only
+    non-empty contexts become records; a db written without ``--contexts``
+    has a single empty context and comes back ``has_contexts=False``.
+    """
+    path = Path(db_path)
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    except sqlite3.Error:
+        # Not openable as sqlite (e.g. an lcov file handed here by mistake).
+        return ContextCoverageReport(source_format="coverage.py", has_contexts=False)
+
+    try:
+        contexts = {cid: ctx for cid, ctx in conn.execute("SELECT id, context FROM context")}
+        named = {cid: ctx for cid, ctx in contexts.items() if ctx}
+        if not named:
+            # Ran without --contexts: one empty context, aggregate only.
+            return ContextCoverageReport(source_format="coverage.py", has_contexts=False)
+
+        files = {fid: _normalize_path(p) for fid, p in conn.execute("SELECT id, path FROM file")}
+
+        # (file_id, context_id) -> covered line set. line_bits is the common
+        # (line-mode) source; arc rows fill in for branch-mode dbs.
+        covered: dict[tuple[int, int], set[int]] = {}
+        for file_id, ctx_id, numbits in conn.execute(
+            "SELECT file_id, context_id, numbits FROM line_bits"
+        ):
+            if ctx_id not in named or file_id not in files:
+                continue
+            covered.setdefault((file_id, ctx_id), set()).update(_numbits_to_lines(numbits))
+
+        if not covered and _has_table(conn, "arc"):
+            for file_id, ctx_id, fromno, tono in conn.execute(
+                "SELECT file_id, context_id, fromno, tono FROM arc"
+            ):
+                if ctx_id not in named or file_id not in files:
+                    continue
+                lines = covered.setdefault((file_id, ctx_id), set())
+                # Arc endpoints are line numbers; <= 0 are synthetic
+                # (module entry/exit), not real lines.
+                if fromno and fromno > 0:
+                    lines.add(fromno)
+                if tono and tono > 0:
+                    lines.add(tono)
+    except sqlite3.Error:
+        return ContextCoverageReport(source_format="coverage.py", has_contexts=False)
+    finally:
+        conn.close()
+
+    records = [
+        TestCoverage(
+            test_id=named[ctx_id],
+            file_path=files[file_id],
+            covered_lines=sorted(line_set),
+            source_format="coverage.py",
+        )
+        for (file_id, ctx_id), line_set in covered.items()
+        if line_set
+    ]
+    return ContextCoverageReport(
+        source_format="coverage.py", records=records, has_contexts=bool(records)
+    )
+
+
+def _has_table(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def parse_contexts_file(path: str | Path) -> ContextCoverageReport:
+    """Parse a per-test report, sniffing coverage.py sqlite vs lcov text.
+
+    coverage.py ``.coverage`` files are sqlite (binary magic header);
+    everything else is read as lcov text. Unreadable files degrade to an
+    empty aggregate-only report rather than raising.
+    """
+    p = Path(path)
+    try:
+        with p.open("rb") as fh:
+            head = fh.read(len(_SQLITE_MAGIC))
+    except OSError:
+        return ContextCoverageReport(source_format="unknown", has_contexts=False)
+
+    if head == _SQLITE_MAGIC:
+        return parse_coverage_sqlite(p)
+    try:
+        return parse_lcov_contexts(p.read_text(encoding="utf-8"))
+    except OSError:
+        return ContextCoverageReport(source_format="unknown", has_contexts=False)

--- a/packages/core/src/repowise/core/analysis/health/coverage/discovery.py
+++ b/packages/core/src/repowise/core/analysis/health/coverage/discovery.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from .detector import parse as parse_coverage
-from .model import CoverageReport, FileCoverage
+from .model import ContextCoverageReport, CoverageReport, FileCoverage, TestCoverage
 
 # Default glob patterns, relative to the repo root. Ordered roughly by how
 # canonical/common the location is. Kept curated (not a blind ``**/*.info``)
@@ -343,6 +343,104 @@ def resolve_reports(
         }
     result.files = list(by_key.values())
     return result
+
+
+@dataclass
+class ResolvedTestCoverage:
+    """Outcome of resolving a :class:`ContextCoverageReport` against the tree.
+
+    Mirrors :class:`ResolvedCoverage` but keeps the test dimension: every
+    record's ``file_path`` (and, best-effort, ``test_file``) is rewritten to
+    a canonical repo key. ``has_contexts`` propagates the loud-degradation
+    signal so a report with no contexts stays visibly empty.
+    """
+
+    records: list[TestCoverage] = field(default_factory=list)
+    source_format: str | None = None
+    has_contexts: bool = False
+    matched_exact: int = 0
+    matched_suffix: int = 0
+    # Report source paths that did not map to an indexed file.
+    unmatched: list[str] = field(default_factory=list)
+    ambiguous: list[str] = field(default_factory=list)
+    # How many records had their test's own file resolved to a repo key.
+    test_files_resolved: int = 0
+
+    @property
+    def matched(self) -> int:
+        return self.matched_exact + self.matched_suffix
+
+
+# Extensions that make a test-id prefix look like a real source path (rather
+# than a bare suite name), so we only try to resolve path-shaped ids.
+_CODE_EXTS = (".py", ".ts", ".tsx", ".js", ".jsx", ".go", ".rb", ".java", ".scala")
+
+
+def _extract_test_file(test_id: str) -> str | None:
+    """Pull a resolvable source path out of a raw test id, or ``None``.
+
+    coverage.py contexts look like ``path/to/test_x.py::Class::test|run``:
+    the file lives before ``::`` (and any ``|phase`` suffix). lcov ``TN:``
+    names are often bare suite labels with no path, which we skip.
+    """
+    head = test_id.split("::", 1)[0].split("|", 1)[0].strip()
+    if not head:
+        return None
+    looks_pathy = "/" in head or "\\" in head or head.endswith(_CODE_EXTS)
+    return head if looks_pathy else None
+
+
+def resolve_test_reports(
+    report: ContextCoverageReport,
+    repo_keys: set[str],
+    *,
+    strip_prefix: str | None = None,
+    path_prefix: str | None = None,
+) -> ResolvedTestCoverage:
+    """Resolve per-test records against the indexed tree.
+
+    Reuses the aggregate path resolver (:func:`normalize_report_path` +
+    :func:`_match_key`) for *both* the source path and the test's own file,
+    so no second resolver is introduced. Records whose source path does not
+    map to the tree are dropped and counted in ``unmatched`` / ``ambiguous``.
+    """
+    suffix_index = _build_suffix_index(repo_keys)
+    out = ResolvedTestCoverage(source_format=report.source_format, has_contexts=report.has_contexts)
+    for rec in report.records:
+        norm = normalize_report_path(
+            rec.file_path, strip_prefix=strip_prefix, path_prefix=path_prefix
+        )
+        key, ambiguous = _match_key(norm, repo_keys, suffix_index)
+        if key is None:
+            if ambiguous:
+                out.ambiguous.append(rec.file_path)
+            else:
+                out.unmatched.append(rec.file_path)
+            continue
+        if norm == key:
+            out.matched_exact += 1
+        else:
+            out.matched_suffix += 1
+
+        test_key: str | None = None
+        head = _extract_test_file(rec.test_id)
+        if head:
+            tnorm = normalize_report_path(head, strip_prefix=strip_prefix, path_prefix=path_prefix)
+            tkey, _ = _match_key(tnorm, repo_keys, suffix_index)
+            if tkey is not None:
+                test_key = tkey
+                out.test_files_resolved += 1
+
+        out.records.append(
+            TestCoverage(
+                test_id=rec.test_id,
+                file_path=key,
+                covered_lines=list(rec.covered_lines),
+                source_format=rec.source_format,
+                test_file=test_key,
+            )
+        )
+    return out
 
 
 def build_coverage_map(

--- a/packages/core/src/repowise/core/analysis/health/coverage/model.py
+++ b/packages/core/src/repowise/core/analysis/health/coverage/model.py
@@ -35,3 +35,45 @@ class CoverageReport:
     source_format: str
     files: list[FileCoverage] = field(default_factory=list)
     commit_sha: str | None = None
+
+
+@dataclass
+class TestCoverage:
+    """One ``(test, file, lines)`` fact — the per-test coverage substrate.
+
+    Where :class:`FileCoverage` collapses every test into one hit-wins
+    aggregate, this keeps the *test dimension*: a record says "test
+    ``test_id`` covered ``covered_lines`` of ``file_path``". It is the raw
+    material for the test-to-code map (run-only-affected-tests, real
+    ``missing_tests``, etc.) and is produced only when a report actually
+    carries contexts.
+
+    ``test_id`` is the report's raw test identifier (coverage.py context
+    ``module::qualname|phase`` or an lcov ``TN:`` name). ``file_path`` is the
+    raw source path from the report until :func:`resolve_test_reports`
+    rewrites it to a canonical repo key. ``test_file`` is the canonical key
+    of the test's *own* source file, filled in best-effort by the resolver
+    (``None`` when the test id is not path-shaped or does not resolve).
+    """
+
+    test_id: str
+    file_path: str
+    covered_lines: list[int] = field(default_factory=list)
+    source_format: str = "unknown"
+    test_file: str | None = None
+
+
+@dataclass
+class ContextCoverageReport:
+    """Per-test records parsed from one context-carrying report.
+
+    ``has_contexts`` is the loud-degradation signal: a report run *without*
+    contexts (a plain lcov, or ``coverage run`` with no ``--contexts``)
+    parses to ``records=[]`` and ``has_contexts=False`` so callers can say
+    "aggregate only, per-test features unavailable" instead of silently
+    emitting nothing.
+    """
+
+    source_format: str
+    records: list[TestCoverage] = field(default_factory=list)
+    has_contexts: bool = False

--- a/tests/unit/health/test_coverage_contexts.py
+++ b/tests/unit/health/test_coverage_contexts.py
@@ -1,0 +1,232 @@
+"""Per-test coverage readers + resolver (the test-to-code substrate).
+
+Covers the two context-carrying sources (coverage.py ``.coverage`` sqlite
+and lcov ``TN:`` records), their loud degradation when a report has no
+contexts, and the resolver's reuse of the aggregate path matcher for both
+the source path and the test's own file.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from repowise.core.analysis.health.coverage import (
+    parse_contexts_file,
+    parse_coverage_sqlite,
+    parse_lcov_contexts,
+    resolve_test_reports,
+)
+
+# --- coverage.py sqlite fixture builders -----------------------------------
+
+
+def _numbits(lines: list[int]) -> bytes:
+    """Encode line numbers into coverage.py's numbits bitmap (line n -> bit n)."""
+    if not lines:
+        return b""
+    buf = bytearray((max(lines) // 8) + 1)
+    for n in lines:
+        buf[n // 8] |= 1 << (n % 8)
+    return bytes(buf)
+
+
+def _write_coverage_db(
+    path: Path,
+    files: dict[int, str],
+    contexts: dict[int, str],
+    line_bits: list[tuple[int, int, list[int]]],
+    *,
+    with_arc_table: bool = True,
+) -> None:
+    """Write a minimal coverage.py-shaped sqlite db (line-mode)."""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE file (id integer primary key, path text, unique(path));
+        CREATE TABLE context (id integer primary key, context text, unique(context));
+        CREATE TABLE line_bits (file_id integer, context_id integer, numbits blob,
+            unique(file_id, context_id));
+        """
+    )
+    if with_arc_table:
+        conn.execute(
+            "CREATE TABLE arc (file_id integer, context_id integer, fromno integer, "
+            "tono integer, unique(file_id, context_id, fromno, tono))"
+        )
+    conn.executemany("INSERT INTO file (id, path) VALUES (?, ?)", files.items())
+    conn.executemany("INSERT INTO context (id, context) VALUES (?, ?)", contexts.items())
+    conn.executemany(
+        "INSERT INTO line_bits (file_id, context_id, numbits) VALUES (?, ?, ?)",
+        [(fid, cid, _numbits(lines)) for fid, cid, lines in line_bits],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _write_arc_db(path: Path) -> None:
+    """A branch/arc-mode db: no line_bits rows, covered lines live in arcs."""
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE file (id integer primary key, path text, unique(path));
+        CREATE TABLE context (id integer primary key, context text, unique(context));
+        CREATE TABLE line_bits (file_id integer, context_id integer, numbits blob,
+            unique(file_id, context_id));
+        CREATE TABLE arc (file_id integer, context_id integer, fromno integer,
+            tono integer, unique(file_id, context_id, fromno, tono));
+        """
+    )
+    conn.execute("INSERT INTO file (id, path) VALUES (1, 'src/mod.py')")
+    conn.execute("INSERT INTO context (id, context) VALUES (1, 'tests/test_mod.py::test_a|run')")
+    # Synthetic module entry (-1) and real line arcs 3->5, 5->7.
+    conn.executemany(
+        "INSERT INTO arc (file_id, context_id, fromno, tono) VALUES (?, ?, ?, ?)",
+        [(1, 1, -1, 3), (1, 1, 3, 5), (1, 1, 5, 7)],
+    )
+    conn.commit()
+    conn.close()
+
+
+# --- coverage.py sqlite reader ---------------------------------------------
+
+
+def test_sqlite_emits_per_test_records(tmp_path: Path) -> None:
+    db = tmp_path / ".coverage"
+    _write_coverage_db(
+        db,
+        files={1: "src/foo.py", 2: "src/bar.py"},
+        contexts={1: "", 2: "tests/test_foo.py::test_a|run", 3: "tests/test_foo.py::test_b|run"},
+        line_bits=[
+            (1, 2, [1, 3, 5]),  # test_a covers foo lines 1,3,5
+            (2, 2, [10]),  # test_a also covers bar line 10
+            (1, 3, [1, 2]),  # test_b covers foo lines 1,2
+        ],
+    )
+    report = parse_coverage_sqlite(db)
+    assert report.has_contexts is True
+    assert report.source_format == "coverage.py"
+
+    by_key = {(r.test_id, r.file_path): r for r in report.records}
+    assert by_key[("tests/test_foo.py::test_a|run", "src/foo.py")].covered_lines == [1, 3, 5]
+    assert by_key[("tests/test_foo.py::test_a|run", "src/bar.py")].covered_lines == [10]
+    assert by_key[("tests/test_foo.py::test_b|run", "src/foo.py")].covered_lines == [1, 2]
+    # The empty context (id 1) never produces a record.
+    assert all(r.test_id for r in report.records)
+
+
+def test_sqlite_without_contexts_degrades_loudly(tmp_path: Path) -> None:
+    db = tmp_path / ".coverage"
+    _write_coverage_db(
+        db,
+        files={1: "src/foo.py"},
+        contexts={1: ""},  # ran without --contexts
+        line_bits=[(1, 1, [1, 2, 3])],
+    )
+    report = parse_coverage_sqlite(db)
+    assert report.has_contexts is False
+    assert report.records == []
+
+
+def test_sqlite_falls_back_to_arcs(tmp_path: Path) -> None:
+    db = tmp_path / ".coverage"
+    _write_arc_db(db)
+    report = parse_coverage_sqlite(db)
+    assert report.has_contexts is True
+    rec = report.records[0]
+    assert rec.file_path == "src/mod.py"
+    # Synthetic -1 dropped; real endpoints 3,5,7 kept.
+    assert rec.covered_lines == [3, 5, 7]
+
+
+def test_sqlite_missing_db_degrades(tmp_path: Path) -> None:
+    report = parse_coverage_sqlite(tmp_path / "does-not-exist.coverage")
+    assert report.has_contexts is False
+    assert report.records == []
+
+
+def test_non_sqlite_file_degrades(tmp_path: Path) -> None:
+    junk = tmp_path / ".coverage"
+    junk.write_text("i am not a database", encoding="utf-8")
+    report = parse_coverage_sqlite(junk)
+    assert report.has_contexts is False
+    assert report.records == []
+
+
+# --- lcov TN reader --------------------------------------------------------
+
+
+def test_lcov_contexts_from_tn_records() -> None:
+    text = (
+        "TN:test_alpha\nSF:src/foo.py\nDA:1,1\nDA:2,0\nDA:3,1\nend_of_record\n"
+        "TN:test_beta\nSF:src/bar.py\nDA:10,1\nend_of_record\n"
+    )
+    report = parse_lcov_contexts(text)
+    assert report.has_contexts is True
+    by_test = {r.test_id: r for r in report.records}
+    assert by_test["test_alpha"].file_path == "src/foo.py"
+    assert by_test["test_alpha"].covered_lines == [1, 3]  # line 2 had 0 hits
+    assert by_test["test_beta"].covered_lines == [10]
+
+
+def test_lcov_without_tn_degrades_loudly() -> None:
+    # Aggregate lcov: blank/absent TN means no test dimension.
+    text = "TN:\nSF:src/foo.py\nDA:1,1\nend_of_record\nSF:src/bar.py\nDA:2,1\nend_of_record\n"
+    report = parse_lcov_contexts(text)
+    assert report.has_contexts is False
+    assert report.records == []
+
+
+# --- sniffing dispatcher ---------------------------------------------------
+
+
+def test_parse_contexts_file_sniffs_sqlite(tmp_path: Path) -> None:
+    db = tmp_path / ".coverage"
+    _write_coverage_db(
+        db,
+        files={1: "src/foo.py"},
+        contexts={1: "tests/test_foo.py::test_a|run"},
+        line_bits=[(1, 1, [1, 2])],
+    )
+    report = parse_contexts_file(db)
+    assert report.source_format == "coverage.py"
+    assert report.has_contexts is True
+
+
+def test_parse_contexts_file_sniffs_lcov(tmp_path: Path) -> None:
+    lcov = tmp_path / "per-test.lcov"
+    lcov.write_text("TN:test_x\nSF:src/foo.py\nDA:1,1\nend_of_record\n", encoding="utf-8")
+    report = parse_contexts_file(lcov)
+    assert report.source_format == "lcov"
+    assert report.has_contexts is True
+
+
+# --- resolver reuse --------------------------------------------------------
+
+
+def test_resolve_test_reports_maps_source_and_test_paths() -> None:
+    text = (
+        "TN:tests/test_foo.py::test_a|run\nSF:/abs/build/src/foo.py\n"
+        "DA:1,1\nDA:3,1\nend_of_record\n"
+    )
+    report = parse_lcov_contexts(text)
+    repo_keys = {"packages/app/src/foo.py", "packages/app/tests/test_foo.py"}
+    resolved = resolve_test_reports(report, repo_keys)
+
+    assert resolved.has_contexts is True
+    assert resolved.matched == 1
+    assert resolved.test_files_resolved == 1
+    rec = resolved.records[0]
+    assert rec.file_path == "packages/app/src/foo.py"  # suffix-resolved source
+    assert rec.test_file == "packages/app/tests/test_foo.py"  # test path resolved too
+    assert rec.covered_lines == [1, 3]
+
+
+def test_resolve_test_reports_reports_unmatched() -> None:
+    text = "TN:suite_only\nSF:vendor/unknown.py\nDA:1,1\nend_of_record\n"
+    report = parse_lcov_contexts(text)
+    resolved = resolve_test_reports(report, {"src/foo.py"})
+    assert resolved.records == []
+    assert resolved.unmatched == ["vendor/unknown.py"]
+    # A bare suite name (no path shape) leaves test_file unresolved.
+    assert resolved.test_files_resolved == 0


### PR DESCRIPTION
## What

Adds the read layer that keeps the test dimension coverage has always dropped: **which test covered which lines of which file**. Today's parsers collapse every test into one hit-wins `FileCoverage` aggregate, so a file is known to be covered but never by *which* test. This adds a per-test read layer alongside it, opt-in and read-only.

## Changes

- **model**: new `TestCoverage(test_id, file_path, covered_lines, source_format, test_file)` and `ContextCoverageReport(source_format, records, has_contexts)`. The aggregate `FileCoverage` path is untouched.
- **contexts.py** (new): readers for the two sources that carry per-test data today:
  - coverage.py `.coverage` sqlite (per-test contexts via `line_bits`, numbits decoded inline with no coverage.py runtime dependency, `arc` fallback for branch-mode dbs)
  - lcov `TN:` (test-name) records
  - plus `parse_contexts_file()` which sniffs sqlite magic vs lcov text
  - all degrade loudly: a report with no contexts yields `records=[]` and `has_contexts=False`, so callers report "aggregate only, per-test data unavailable" rather than silently emitting nothing.
- **discovery**: `resolve_test_reports()` + `ResolvedTestCoverage`, reusing the existing longest-suffix path matcher for both the source path and the test's own file. No new resolver.
- **cli**: `repowise coverage contexts [PATHS]` previews the map ("test T covers N lines of file F"). Off by default, nothing persisted.

## Verification

- New unit tests `tests/unit/health/test_coverage_contexts.py` (11 cases; sqlite fixture built inline, no coverage.py test dependency). Full coverage suite: 958 passed.
- Verified end-to-end on a real `coverage run --cov-context=test` db: each test resolves to the exact lines it exercised, and an untested function shows no coverage.
- Reports without contexts (a plain lcov, or `coverage run` with no contexts) correctly report `has_contexts=False`.