### PR TITLE
fix(health): recurse into Python with statement bodies

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/complexity/languages.py
+++ b/packages/core/src/repowise/core/analysis/health/complexity/languages.py
@@ -180,12 +180,21 @@ class LanguageNodeMap:
     #     (``throw``) edge to the function exit; ``break`` / ``continue`` edge to
     #     the enclosing loop's exit / header. A language that omits one simply
     #     records that statement as a plain straight-line node (no special edge).
+    #   * ``with_kinds`` -- structured resource/context-management statements
+    #     whose bodies execute as a normal statement sequence (Python
+    #     ``with_statement``; analogous constructs in other languages such as
+    #     C# ``using`` or Java try-with-resources where applicable). Unlike
+    #     ``if`` or ``loop`` statements, these do not introduce a control-flow
+    #     split themselves; instead, the CFG builder recursively processes the
+    #     body so nested branches, loops, and early exits create their normal
+    #     basic-block structure.
     if_kinds: frozenset[str] = frozenset()
     block_kinds: frozenset[str] = frozenset()
     return_kinds: frozenset[str] = frozenset()
     raise_kinds: frozenset[str] = frozenset()
     break_kinds: frozenset[str] = frozenset()
     continue_kinds: frozenset[str] = frozenset()
+    with_kinds: frozenset[str] = frozenset()
     #   * ``statement_wrapper_kinds`` -- statement node(s) that merely wrap the
     #     node the CFG builder should classify, as their last named child.
     #     Expression-oriented grammars need this: tree-sitter-rust parses every
@@ -230,6 +239,7 @@ _PY = LanguageNodeMap(
     raise_kinds=frozenset({"raise_statement"}),
     break_kinds=frozenset({"break_statement"}),
     continue_kinds=frozenset({"continue_statement"}),
+    with_kinds=frozenset({"with_statement"}),
 )
 
 _TS = LanguageNodeMap(

--- a/packages/core/src/repowise/core/analysis/health/dataflow/cfg.py
+++ b/packages/core/src/repowise/core/analysis/health/dataflow/cfg.py
@@ -308,6 +308,8 @@ class _CFGBuilder:
                 cur = self._build_loop(st, cur)
             elif t in self.lmap.try_kinds:
                 cur = self._build_try(st, cur)
+            elif t in self.lmap.with_kinds:
+                cur = self._build_with(st, cur)
             elif t in self.lmap.return_kinds or t in self.lmap.raise_kinds:
                 self._record_stmt(cur, st)
                 self._edge(cur, self.exit_block)
@@ -325,6 +327,22 @@ class _CFGBuilder:
             else:
                 self._record_stmt(cur, st)
         return cur
+
+    def _build_with(self, with_node: Node, cur: BasicBlock) -> BasicBlock:
+        self._record_head(cur, with_node)
+        join = self._new("join")
+
+        body_entry = self._new()
+        self._edge(cur, body_entry)
+
+        body_out = self._process_seq(
+            self._body_stmts(with_node.child_by_field_name("body")), body_entry
+        )
+
+        if body_out is not None:
+            self._edge(body_out, join)
+
+        return join
 
     def _build_if(self, if_node: Node, cur: BasicBlock) -> BasicBlock:
         cur.kind = "branch"

--- a/tests/unit/health/test_dataflow_cfg.py
+++ b/tests/unit/health/test_dataflow_cfg.py
@@ -260,6 +260,97 @@ def test_try_except_finally_convergence():
     assert cfg.exit_id in cfg.reachable_ids()
 
 
+# ----with statements------------------------------------------------------------------
+def test_with_body_builds_nested_cfg():
+    cfg = _cfg(
+        """
+        def f(ctx, cond):
+            with ctx.push():
+                if cond:
+                    result = 1
+                else:
+                    result = 2
+            return result
+        """
+    )
+
+    # The if inside the with should still produce a branch.
+    assert len(_by_kind(cfg, "branch")) == 1
+
+    # The branch should still merge.
+    branches = _by_kind(cfg, "branch")
+    assert len(branches) == 1
+    assert len(branches[0].successors) == 2
+    assert cfg.exit_id in cfg.reachable_ids()
+
+
+def test_unreachable_inside_with():
+    cfg = _cfg(
+        """
+        def f(ctx):
+            with ctx:
+                return
+                dead = 1
+        """
+    )
+
+    unreachable = _by_kind(cfg, "unreachable")
+    assert len(unreachable) == 1
+    assert unreachable[0].id not in cfg.reachable_ids()
+
+
+def test_loop_inside_with():
+    cfg = _cfg(
+        """
+        def f(ctx, xs):
+            with ctx:
+                for x in xs:
+                    print(x)
+        """
+    )
+
+    assert len(_by_kind(cfg, "loop_header")) == 1
+    assert cfg.back_edges()
+
+
+def test_with_preserves_if_structure():
+    outside = _cfg(
+        """
+        def f(cond):
+            if cond:
+                x = 1
+            else:
+                x = 2
+            return x
+        """
+    )
+
+    inside = _cfg(
+        """
+        def f(ctx, cond):
+            with ctx:
+                if cond:
+                    x = 1
+                else:
+                    x = 2
+            return x
+        """
+    )
+
+    outside_branches = _by_kind(outside, "branch")
+    inside_branches = _by_kind(inside, "branch")
+
+    # Wrapping an if in a with must not change the nested branch structure.
+    assert len(outside_branches) == len(inside_branches)
+    assert len(outside_branches) == 1
+    assert len(outside_branches[0].successors) == 2
+    assert len(inside_branches[0].successors) == 2
+
+    # Both CFGs should reach the function exit.
+    assert outside.exit_id in outside.reachable_ids()
+    assert inside.exit_id in inside.reachable_ids()
+
+
 # -- early return ---------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Add CFG support for Python `with_statement` nodes by introducing `with_kinds` to `LanguageNodeMap`
- Process `with` bodies through the existing statement-sequence recursion so nested control flow (`if`, `for`, `while`, `return`, etc.) is represented correctly in the CFG
- Add regression tests covering nested branches, loops, unreachable code, and preservation of CFG structure inside `with` statements

## Related Issues

Partially addresses #<issue-number>.

This PR implements the `with_statement` CFG recursion described in the issue. The related `except` → `finally` CFG edge is intentionally left out of this change.

## Test Plan

- [x] Tests pass (`pytest`)
- [ ] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(not applicable – backend-only change)*

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed