### PR TITLE
Explain the agent-authorship share on the contributors strip

### DIFF
--- a/packages/ui/src/git/contributors-strip.tsx
+++ b/packages/ui/src/git/contributors-strip.tsx
@@ -1,5 +1,7 @@
 import { Users, Bot, ArrowRight } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { InfoTip } from "../shared/info-tip";
+import { AGENT_PCT_HINT } from "../stats/stat-callout";
 
 export interface StripOwner {
   name: string;
@@ -129,15 +131,18 @@ export function ContributorsStrip({
                 <Bot className="h-3 w-3" />
                 Authorship
               </span>
-              <a
-                href={commitsHref}
-                className="text-xs tabular-nums text-[var(--color-text-secondary)] hover:text-[var(--color-accent-primary)] transition-colors"
-              >
-                <span className="font-semibold text-[var(--color-accent-primary)]">
-                  {Math.round(provenance!.agentPct)}%
-                </span>{" "}
-                agent-written
-              </a>
+              <span className="flex items-center gap-1">
+                <a
+                  href={commitsHref}
+                  className="text-xs tabular-nums text-[var(--color-text-secondary)] hover:text-[var(--color-accent-primary)] transition-colors"
+                >
+                  <span className="font-semibold text-[var(--color-accent-primary)]">
+                    {Math.round(provenance!.agentPct)}%
+                  </span>{" "}
+                  agent-written
+                </a>
+                <InfoTip content={AGENT_PCT_HINT} label="How agent authorship is measured" />
+              </span>
             </div>
             <div className="flex h-2 w-full overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
               <div


### PR DESCRIPTION
## What

Adds an `InfoTip` next to the "% agent-written" figure in the Overview contributors strip's Authorship section (`packages/ui/src/git/contributors-strip.tsx`), reusing the canonical `AGENT_PCT_HINT` copy from `stats/stat-callout.tsx`:

> Share of commits with a verifiable agent signature: known bot identities, agent commit footers, or Co-authored-by agent trailers. Squash merges that drop trailers and agents committing under a human git identity can't be detected, so the true share may be higher.

This was the last agent-authorship surface without the methodology explanation — the stats teaser, By the Numbers tab, Growth tab, and size-class hero already carry `AGENT_PCT_HINT` / `NLOC_HINT` tooltips.

## Why

The bare percentage reads like a full census of agent-written code. It only counts commits whose git metadata identifies an agent, so it is a lower bound; the tooltip makes that explicit. `InfoTip` (rather than a native `title`) keeps the explanation reachable on touch devices and doesn't fight the label's link-to-commits hover behavior.

No new components or dependencies — `InfoTip` and the hint constant already live in this package.

## Verification

- `packages/ui` `tsc --noEmit`: no errors from package sources
- `packages/ui` `vitest run`: 93 files / 587 tests passed