### PR TITLE
feat(docker): lean MCP-only image for MCP hosts and directories

### DIFF
--- a/docker/Dockerfile.mcp
+++ b/docker/Dockerfile.mcp
@@ -1,0 +1,34 @@
+# =============================================================================
+# repowise — MCP server image (stdio)
+# =============================================================================
+# A lean image that runs ONLY the repowise MCP server, speaking JSON-RPC over
+# stdio. This is the image MCP hosts and directories (e.g. Glama) build to start
+# the server and run introspection (initialize + tools/list). It carries no web
+# UI and exposes no ports.
+#
+# Build:
+#   docker build -t repowise-mcp -f docker/Dockerfile.mcp .
+#
+# Run (mount a repo so the tools can serve it; tools/list works without one):
+#   docker run --rm -i -v /path/to/your/repo:/repo -w /repo repowise-mcp
+#
+# For the full API + Web UI stack, use docker/Dockerfile instead.
+# =============================================================================
+FROM python:3.12-slim
+
+# git is required at runtime (repowise reads git history via GitPython).
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the published package. The base install already ships `repowise mcp`.
+RUN pip install --no-cache-dir repowise
+
+# Run as a non-root user.
+RUN useradd -r -m -d /home/repowise -s /sbin/nologin repowise
+USER repowise
+WORKDIR /repo
+
+# The MCP server communicates over stdio; do not buffer stdout.
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["repowise", "mcp"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,11 @@
 # Docker
 
+Two images are provided:
+
+- **`Dockerfile`** runs the full repowise stack (API + Web UI) in a single container.
+- **`Dockerfile.mcp`** runs only the MCP server over stdio, for MCP hosts and
+  directories (see [MCP server image](#mcp-server-image) below).
+
 Run the full repowise stack (API + Web UI) in a single container.
 
 ## Prerequisites
@@ -44,3 +50,20 @@ docker compose up
 | `GEMINI_API_KEY` | — | Gemini API key (for chat + embeddings) |
 | `PORT_BACKEND` | `7337` | API server port |
 | `PORT_FRONTEND` | `3000` | Web UI port |
+
+## MCP server image
+
+`Dockerfile.mcp` is a lean image that runs only the MCP server, speaking
+JSON-RPC over stdio. It carries no Web UI and exposes no ports. This is the
+image to point MCP hosts and directories at.
+
+```bash
+# Build
+docker build -t repowise-mcp -f docker/Dockerfile.mcp .
+
+# Run against a repo (mount it and set it as the working dir).
+# tools/list works without an index; the query tools serve a mounted .repowise.
+docker run --rm -i -v /path/to/your/repo:/repo -w /repo repowise-mcp
+```
+
+The container communicates over stdin/stdout, so run it with `-i` and no `-t`.


### PR DESCRIPTION
## What

Adds `docker/Dockerfile.mcp`, a lean image that runs only the repowise MCP server over stdio. No web UI, no exposed ports.

This is the image MCP hosts and directories (e.g. Glama) build to start the server and run introspection. The existing `docker/Dockerfile` builds the full API + Web UI stack, which is not what a stdio MCP host wants.

## Contents

- `docker/Dockerfile.mcp` - `python:3.12-slim`, installs the published `repowise` package, runs as a non-root user, `ENTRYPOINT ["repowise", "mcp"]`.
- `docker/README.md` - documents the new image alongside the full-stack one.

## Verified

Built the image and ran the MCP handshake against the running container:

```
initialize -> OK (protocol 2024-11-05)
tools/list -> OK, 11 tools (get_answer, get_context, get_health, get_risk, get_why, search_codebase, ...)
```

`tools/list` works with no index present, which is all an MCP directory's introspection check needs. Confirmed a base `pip install repowise` (no extras) is enough for the server to start and list tools.

## Run

```bash
docker build -t repowise-mcp -f docker/Dockerfile.mcp .
docker run --rm -i -v /path/to/your/repo:/repo -w /repo repowise-mcp
```
