### PR TITLE
feat(health): deduct open performance findings from the performance score

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/scoring.py
+++ b/packages/core/src/repowise/core/analysis/health/scoring.py
@@ -313,10 +313,14 @@ _MAINTAINABILITY_HOME: frozenset[str] = frozenset(
 
 
 # ---------------------------------------------------------------------------
-# Performance dimension (PR3). Shipped at a small, ADVISORY weight - the whole
-# pillar is bounded by a single 1.0 category cap, so even a file riddled with
-# perf hits loses at most one health point on this dimension. Promotion to a
-# co-equal weight waits on PR4's cross-function precision study.
+# Performance dimension (PR3). Originally shipped at a small, ADVISORY weight
+# (a single 1.0 category cap), which left the pillar reading near-perfect even
+# on repos dense with open perf findings. With the cross-function pass landed
+# (PR4) and per-marker precision multipliers in place, the cap is raised to
+# 2.0 so open findings visibly move the score - still a deliberately
+# conservative ceiling for this first release (a file loses at most two
+# points regardless of hit count). Raising it further to a co-equal budget
+# waits on corpus precision data for the remaining advisory markers.
 # ---------------------------------------------------------------------------
 
 # Per-biomarker weight on the performance dimension. ``io_in_loop`` is the
@@ -339,7 +343,7 @@ _PERFORMANCE_WEIGHT_MULTIPLIER: dict[str, float] = {
     # Phase 6 dialect markers. Both are high-precision syntactic shapes (Go
     # `go vet`/`gocritic` ship defer-in-loop; the regex marker gates on a static
     # literal pattern in Java/Go/Rust). Ship advisory pending this session's
-    # test-repo gate; bounded by the 1.0 perf cap either way.
+    # test-repo gate; bounded by the perf category cap either way.
     "regex_compile_in_loop": 0.6,
     "defer_in_loop": 0.6,
     "resource_construction_in_loop": 0.7,
@@ -400,9 +404,13 @@ _PERFORMANCE_CATEGORY: dict[str, str] = {
     "sql_cartesian_join": "performance",
 }
 
-# One bounded performance category cap. ~1.0 keeps performance advisory.
+# One bounded performance category cap. 2.0 is a deliberately conservative
+# first-release ceiling: enough for open findings to register on the pillar,
+# small enough that an all-advisory marker set cannot crater a file. Upgrade
+# path: raise toward the defect-style multi-point budget once the remaining
+# advisory markers clear their corpus precision gates (MARKER_BACKLOG.md).
 _PERFORMANCE_CATEGORY_CAPS: dict[str, float] = {
-    "performance": 1.0,
+    "performance": 2.0,
 }
 
 # Perf biomarkers home to ``performance`` for display / per-pillar filtering.
@@ -565,7 +573,7 @@ def score_file(results: Iterable[BiomarkerResult]) -> tuple[dict[str, float | No
       identical to the pre-split ``score_file`` (the load-bearing guarantee).
       ``scores["performance"]`` is now measured (PR3): a file with no perf
       findings scores 10.0; the perf detectors deduct under a single bounded
-      ``performance`` cap. It is still capped low (advisory) and never blends
+      ``performance`` cap (2.0, a conservative ceiling). It never blends
       into ``defect``.
     - ``defect_deductions`` is each finding's contribution to the DEFECT score
       after category capping, parallel to *results*. It populates

--- a/packages/server/src/repowise/server/routers/code_health/files_routes.py
+++ b/packages/server/src/repowise/server/routers/code_health/files_routes.py
@@ -93,7 +93,7 @@ async def list_health_files(
     leads = _leads_by_file([f for f in findings if f.file_path in page_paths])
     # Per-file performance signal for the map's performance lens: open perf-
     # finding counts + whether a perf detector ran on the file's language. Colors
-    # the lens by findings/coverage instead of the uniformly-green [9,10] score.
+    # the lens by findings/coverage instead of the narrow-band [8,10] score.
     perf_counts: dict[str, int] = {}
     for fnd in findings:
         if (getattr(fnd, "dimension", None) or "defect") == "performance":

--- a/packages/ui/__tests__/health/biomarker-glossary.test.ts
+++ b/packages/ui/__tests__/health/biomarker-glossary.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Parity guard for the glossary's fallback category caps.
+ *
+ * `CATEGORY_CAP` is the TypeScript mirror of the category-cap tables in
+ * `packages/core/src/repowise/core/analysis/health/scoring.py`. The rendered
+ * cap always prefers the server-supplied value (see score-breakdown.tsx), so
+ * this constant only backstops older payloads — but a silent retune of one
+ * side without the other should still fail CI, the same way the band cutoffs
+ * are pinned in `packages/types/__tests__/health.test.ts` +
+ * `tests/unit/health/test_grading.py`. The Python half of this pin is the
+ * cap-bound behavior in `tests/unit/health/test_scoring_dimensions.py`
+ * (`test_perf_category_cap_bounds_dimension`).
+ */
+
+import { describe, expect, it } from "vitest";
+import { CATEGORY_CAP } from "../../src/health/biomarker-glossary.js";
+
+describe("CATEGORY_CAP parity", () => {
+  it("pins the performance cap to scoring.py's _PERFORMANCE_CATEGORY_CAPS", () => {
+    expect(CATEGORY_CAP.performance).toBe(2.0);
+  });
+});

--- a/packages/ui/src/health/biomarker-glossary.ts
+++ b/packages/ui/src/health/biomarker-glossary.ts
@@ -48,9 +48,10 @@ export const CATEGORY_CAP: Record<BiomarkerCategory, number> = {
   test_quality: 0.5,
   error_handling: 0.5,
   // One bounded performance category cap (mirrors `_PERFORMANCE_CATEGORY_CAPS`
-  // in scoring.py): the whole performance pillar deducts at most 1.0, keeping it
-  // advisory.
-  performance: 1.0,
+  // in scoring.py): the whole performance pillar deducts at most 2.0. Fallback
+  // only — a server-supplied cap always wins (see score-breakdown.tsx), so this
+  // constant matters just for payloads that predate the `cap` field.
+  performance: 2.0,
   // SQL smells deduct on the maintainability pillar only, bounded by the `sql`
   // cap in `_MAINTAINABILITY_CATEGORY_CAPS` (scoring.py).
   sql: 2.0,

--- a/packages/ui/src/health/code-health-map.tsx
+++ b/packages/ui/src/health/code-health-map.tsx
@@ -15,7 +15,7 @@ export interface CodeHealthMapFile {
   /** Maintainability pillar score (1–10) — drives the maintainability overlay. */
   maintainability_score?: number | null;
   /** Performance-risk pillar score (1–10) — computed but NOT used to color the
-   *  performance overlay (it is compressed to [9,10] and reads uniformly green).
+   *  performance overlay (it is compressed to [8,10] and reads uniformly green).
    *  The performance lens colors by {@link performance_findings} + coverage. */
   performance_score?: number | null;
   /** Open performance-risk findings on this file — drives the performance heat. */

--- a/packages/ui/src/health/score-breakdown.tsx
+++ b/packages/ui/src/health/score-breakdown.tsx
@@ -18,7 +18,10 @@ export interface ScoreBreakdownCategoryFinding {
 
 export interface ScoreBreakdownCategory {
   category: BiomarkerCategory | string;
-  cap: number;
+  /** Cap the scorer actually enforced. Optional only because payloads from
+   *  older servers predate the field; when present it always wins over the
+   *  glossary's `CATEGORY_CAP` fallback. */
+  cap?: number | null;
   raw_deduction: number;
   applied_deduction: number;
   capped: boolean;
@@ -58,23 +61,24 @@ export function ScoreBreakdown({
               return b.applied_deduction - a.applied_deduction;
             }
             const capA =
-              CATEGORY_CAP[a.category as BiomarkerCategory] ?? a.cap;
+              a.cap ?? CATEGORY_CAP[a.category as BiomarkerCategory] ?? 0;
             const capB =
-              CATEGORY_CAP[b.category as BiomarkerCategory] ?? b.cap;
+              b.cap ?? CATEGORY_CAP[b.category as BiomarkerCategory] ?? 0;
             return capB - capA;
           })
           .map((c) => {
           const label =
             CATEGORY_LABEL[c.category as BiomarkerCategory] ?? c.category;
-          // Only trust the glossary's caps for scaling the bar. A
-          // payload-supplied cap for an unknown category is often just the
-          // deduction echoed back at itself, which would render a
-          // meaningless always-full bar.
-          const knownCap = CATEGORY_CAP[c.category as BiomarkerCategory];
-          const cap = knownCap ?? c.cap;
+          // Prefer the server-supplied cap: it is the value the scorer
+          // actually enforced, so a cap retune in scoring.py renders
+          // correctly without a UI release. The glossary constant is only a
+          // fallback for older-server payloads that predate the `cap` field.
+          const cap = c.cap ?? CATEGORY_CAP[c.category as BiomarkerCategory];
           const pct = Math.min(
             100,
-            (Math.abs(c.applied_deduction) / Math.max(Math.abs(cap), 0.01)) * 100,
+            (Math.abs(c.applied_deduction) /
+              Math.max(Math.abs(cap ?? c.applied_deduction), 0.01)) *
+              100,
           );
           return (
             <div
@@ -89,19 +93,20 @@ export function ScoreBreakdown({
                   className="cursor-help tabular-nums text-[var(--color-text-tertiary)]"
                   title="The cap is the most this category is allowed to subtract from the 10-point score, no matter how many findings it has."
                 >
-                  −{c.applied_deduction.toFixed(2)} / cap −{cap.toFixed(1)}
+                  −{c.applied_deduction.toFixed(2)}
+                  {cap != null ? <> / cap −{cap.toFixed(1)}</> : null}
                   {c.capped ? <span className="ml-1 text-[var(--color-warning)]" title="Raw deductions exceeded the cap; only the cap was subtracted.">(capped)</span> : null}
                 </span>
               </div>
               <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-[var(--color-bg-muted)]">
                 <div
                   className={
-                    knownCap != null
+                    cap != null
                       ? "h-full bg-[var(--color-error)]/70"
                       : "h-full bg-[var(--color-text-tertiary)]/40"
                   }
                   title={
-                    knownCap == null
+                    cap == null
                       ? "No defined cap for this category — bar scale is approximate."
                       : undefined
                   }

--- a/tests/unit/health/test_scoring_dimensions.py
+++ b/tests/unit/health/test_scoring_dimensions.py
@@ -239,12 +239,25 @@ def test_perf_io_in_loop_deduction():
     assert scores["performance"] == 9.3
 
 
+def test_perf_two_medium_findings_deduct_uncapped():
+    """Two MEDIUM io_in_loop hits deduct in full (2 x 0.7 = 1.4, under the cap)."""
+    scores, _ = score_file([_r("io_in_loop", Severity.MEDIUM) for _ in range(2)])
+    assert scores["performance"] == 8.6
+
+
 def test_perf_category_cap_bounds_dimension():
-    """The single 1.0 performance cap bounds the whole pillar."""
+    """The single 2.0 performance cap bounds the whole pillar."""
     findings = [_r("io_in_loop", Severity.MEDIUM) for _ in range(10)]
     scores, _ = score_file(findings)
-    # 10 * 0.7 = 7.0 raw -> capped at 1.0 -> 9.0, never lower.
-    assert scores["performance"] == 9.0
+    # 10 * 0.7 = 7.0 raw -> capped at 2.0 -> 8.0, never lower.
+    assert scores["performance"] == 8.0
+
+
+def test_perf_cap_bounds_high_severity_pileup():
+    """Six HIGH hits (6 x 1.2 = 7.2 raw) still bottom out at the 2.0 cap."""
+    findings = [_r("io_in_loop", Severity.HIGH) for _ in range(6)]
+    scores, _ = score_file(findings)
+    assert scores["performance"] == 8.0
 
 
 def test_perf_bonus_markers_advisory_weight():


### PR DESCRIPTION
## Problem

The per-file `performance_score` was effectively pinned near 10: the whole performance dimension was bounded by a single **1.0** advisory category cap, so even a file riddled with open performance findings (I/O-in-loop / N+1, serial-await-in-loop, list-membership-in-loop, ...) lost at most one point, and the repo-level pillar (NLOC-weighted average of per-file scores) read 9.9–10/10 on repos with hundreds of open findings. A pillar that ignores its own findings reads as false.

The 1.0 cap was deliberate when the performance dimension first shipped ("promotion to a co-equal weight waits on the cross-function precision study"). That cross-function pass has since landed, along with per-marker precision multipliers, so the score can now honestly reflect the findings.

## Change

- Raise the single `performance` category cap from **1.0 → 2.0** in `packages/core/src/repowise/core/analysis/health/scoring.py`.
- Everything else reuses the existing scoring kernel unchanged: per-finding deduction = shared severity table (low 0.3 / medium 0.7 / high 1.2 / critical 2.0) × the per-marker precision multiplier (e.g. `io_in_loop` 1.0, `serial_await_in_loop` 0.4), summed and proportionally scaled down when the 2.0 cap binds, clamped to [1.0, 10.0]. Same algorithm, same constants, same capping discipline as the defect and maintainability dimensions.
- The **−2.0 ceiling is deliberately conservative for this first release**: enough for open findings to visibly move the pillar, small enough that a pile-up of advisory-weight markers cannot crater a file. The upgrade path (raising toward a defect-style multi-point budget once the remaining advisory markers clear their corpus precision gates) is noted in a code comment next to the cap.
- The defect and maintainability dimensions are untouched — perf markers still contribute to `performance` only, so the defect golden guarantee holds (locked by the existing legacy-golden test, which passes unchanged).
- **Shared UI**: the glossary's `CATEGORY_CAP.performance` mirror is updated to 2.0, and the score-breakdown component now prefers the **server-supplied cap** over the TS constant (`c.cap ?? CATEGORY_CAP[...]`), so a future cap retune in `scoring.py` renders correctly without a UI release. The TS constant remains only as a fallback for older-server payloads that predate the `cap` field. A parity test pins `CATEGORY_CAP.performance` to the scoring.py value, alongside the existing band-cutoff parity guards. The stale `[9,10]` score-band comment in `code-health-map.tsx` is updated to `[8,10]`.

## What changes and what does not

- **Per-file scores**: performance scores now range **[8,10]** instead of [9,10] — a file with open performance findings can lose up to 2 points on the pillar.
- **Repo-level pillar**: on large repos the headline number **remains ~9.9**. Roughly 95% of files carry no performance findings at all, and the KPI is an NLOC-weighted average of per-file scores, so doubling the per-file deduction ceiling barely moves the mean. Making the headline number reflect finding density would require changing the aggregation itself (a density/count-based KPI, or averaging only perf-analyzed files with findings in scope) — that is deliberately **out of scope** for this PR.

## Notes

- **Scores shift on the next index** (changelog-worthy): files with open performance findings can now score as low as 8.0 on the performance pillar (previously 9.0).
- **Finding statuses**: scoring happens at index time, where every finding is open. Acknowledged / resolved / false-positive statuses are serve-time overlays (`get_health_findings` filters on `status="open"` at query time) and take effect in the score on reindex — identical to how the defect pillar treats statuses today.
- **Health drawer**: the score-breakdown artifact is the defect-score explainer (its category rows sum to `10 − defect_score`, an identity the UI renders literally), so a performance row does not fit that format naturally and was not added. The files view already surfaces per-file open-perf-finding counts for the performance lens.

## Tests

- `tests/unit/health/test_scoring_dimensions.py`: two medium `io_in_loop` findings deduct in full (10 − 1.4 = 8.6); ten medium findings cap at 8.0 (not 3.0); six high findings (7.2 raw) still bottom out at 8.0; zero findings stay 10.0 (existing tests).
- `packages/ui/__tests__/health/biomarker-glossary.test.ts`: pins the TS `CATEGORY_CAP.performance` mirror to 2.0 (cross-language parity guard; the Python half is `test_perf_category_cap_bounds_dimension`).
- Full `tests/unit/health` passes (954 tests). Whole `tests/unit` suite: 5459 passed, 2 pre-existing failures in `tests/unit/server/mcp/test_code_rationale.py` that fail identically on unmodified `origin/main` (unrelated to this change). `@repowise-dev/ui` vitest (588 tests) and `tsc --noEmit` pass. `ruff check` and `ruff format --check` clean on touched files.
