### PR TITLE
chore(glama): add glama.json to claim the MCP server listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "RaghavChamadiya"
+  ]
+}


### PR DESCRIPTION
## What

Adds `glama.json` at the repo root so the repowise MCP server listing on [Glama](https://glama.ai/mcp/servers/repowise-dev/repowise) can be claimed and maintained.

Glama requires this manifest to claim a server that belongs to an organization. Claiming the page enables:
- Updating the server description
- Configuring the Docker build instructions (pointing Glama at `docker/Dockerfile.mcp`, added in #800)
- Review notifications

## Contents

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["RaghavChamadiya"]
}
```

The schema defines a single property, `maintainers` (GitHub usernames allowed to maintain the listing).
