### PR TITLE
fix(graph): keep max confidence on edge upsert

### DIFF
--- a/packages/core/src/repowise/core/persistence/crud/graph.py
+++ b/packages/core/src/repowise/core/persistence/crud/graph.py
@@ -39,7 +39,11 @@ def _update_graph_edge(existing: GraphEdge, edge_data: dict) -> None:
         existing.imported_names_json = imported
     confidence = edge_data.get("confidence")
     if confidence is not None:
-        existing.confidence = confidence
+        # Keep the max on collision, mirroring the in-memory resolver
+        # (_resolvers.py:504-505). A pair can carry several resolved calls of
+        # differing confidence; a last-write upsert could stamp a real call
+        # below _FLOW_CALLS_CONF_FLOOR (0.5) and drop it from flow-path answers.
+        existing.confidence = max(existing.confidence or 0.0, confidence)
 
 
 def _update_graph_metric(existing: GraphMetric, m: dict) -> None:

--- a/tests/unit/persistence/test_graph_edge_confidence_max.py
+++ b/tests/unit/persistence/test_graph_edge_confidence_max.py
@@ -1,0 +1,43 @@
+"""``graph_edges`` upserts must keep the max confidence on collision.
+
+A node pair can carry several resolved calls of differing confidence. The
+in-memory resolver keeps the highest (``_resolvers.py:504-505``); the persistence
+upsert historically did last-write, so a later low-confidence write could stamp a
+real call below ``_FLOW_CALLS_CONF_FLOOR`` (0.5) and drop it from flow-path
+answers. The upsert must mirror the resolver and keep the max.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from repowise.core.persistence import batch_upsert_graph_edges
+from repowise.core.persistence.models import GraphEdge
+from tests.unit.persistence.helpers import insert_repo
+
+
+async def _edge_conf(session, repo_id: str) -> float:
+    row = (
+        await session.execute(select(GraphEdge).where(GraphEdge.repository_id == repo_id))
+    ).scalar_one()
+    return row.confidence
+
+
+async def test_edge_upsert_keeps_max_confidence(async_session, tmp_path):
+    repo = await insert_repo(async_session)
+    edge = {"source_node_id": "a.py::f", "target_node_id": "b.py::g", "edge_type": "calls"}
+
+    await batch_upsert_graph_edges(async_session, repo.id, [{**edge, "confidence": 0.9}])
+    await async_session.commit()
+    assert await _edge_conf(async_session, repo.id) == 0.9
+
+    # A later, lower-confidence write for the same pair must not lower it below
+    # the flow-path floor.
+    await batch_upsert_graph_edges(async_session, repo.id, [{**edge, "confidence": 0.3}])
+    await async_session.commit()
+    assert await _edge_conf(async_session, repo.id) == 0.9
+
+    # A higher-confidence write still wins.
+    await batch_upsert_graph_edges(async_session, repo.id, [{**edge, "confidence": 0.95}])
+    await async_session.commit()
+    assert await _edge_conf(async_session, repo.id) == 0.95


### PR DESCRIPTION
## Problem

A node pair can carry several resolved calls of differing confidence. The in-memory resolver keeps the highest (`_resolvers.py:504-505`), but the persistence upsert (`_update_graph_edge`) did last-write: a later low-confidence write for the same pair overwrote a higher one. That can stamp a real call below `_FLOW_CALLS_CONF_FLOOR` (0.5, `_flow_path.py`) and drop it from flow-path answers.

## Fix

Mirror the resolver in the upsert: `max()` on collision instead of overwrite. One-line change plus a focused test that a lower-confidence re-upsert does not lower the stored value while a higher one still wins.

Follow-up to #806 (the flow-path floor directly benefits from this).