### PR TITLE
test: fix two stale unit tests failing on main CI

### DIFF
--- a/tests/unit/persistence/test_crud_smoke.py
+++ b/tests/unit/persistence/test_crud_smoke.py
@@ -66,9 +66,18 @@ async def test_batch_upsert_graph_metrics_inserts_then_updates(async_session):
 @pytest.mark.asyncio
 async def test_batch_upsert_graph_edges_updates_existing(async_session):
     repo = await insert_repo(async_session)
-    edges = [{"source_node_id": "a", "target_node_id": "b", "edge_type": "imports"}]
+    edges = [
+        {
+            "source_node_id": "a",
+            "target_node_id": "b",
+            "edge_type": "imports",
+            "confidence": 0.7,
+        }
+    ]
     await batch_upsert_graph_edges(async_session, repo.id, edges)
-    # Re-upsert the same key with new optional fields → in-place update.
+    # Re-upsert the same key with new optional fields → in-place update, but
+    # confidence keeps the max on collision (a lower re-upsert must not lower
+    # it — the resolver can stamp a real call below the flow floor otherwise).
     await batch_upsert_graph_edges(
         async_session,
         repo.id,
@@ -88,7 +97,7 @@ async def test_batch_upsert_graph_edges_updates_existing(async_session):
     rows = list(result.scalars().all())
     assert len(rows) == 1
     assert rows[0].imported_names_json == '["foo"]'
-    assert rows[0].confidence == 0.5
+    assert rows[0].confidence == 0.7
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/mcp/test_answer_calibration.py
+++ b/tests/unit/server/mcp/test_answer_calibration.py
@@ -439,7 +439,7 @@ def _patch_anchor(monkeypatch, answer_mod, anchored: dict):
     """Force symbol anchoring to attach ``anchored`` to the top hit, as if the
     question named an indexed symbol whose defining file got promoted."""
 
-    async def _fake_anchor(session, repo_id, question_ids, hits):
+    async def _fake_anchor(session, repo_id, question_ids, hits, **kwargs):
         if hits:
             hits[0]["_anchor_symbols"] = [anchored]
         return hits, {"union": {}, "qualified_miss": []}


### PR DESCRIPTION
## What

Two unit tests have been failing deterministically on `main` across Python 3.11/3.12/3.13. Both are **stale tests**, not source regressions — the underlying behavior changes were intentional; the tests just weren't updated alongside them.

### 1. `test_batch_upsert_graph_edges_updates_existing`
`assert 1.0 == 0.5`

PR #807 (`fix(graph): keep max confidence on edge upsert`) made `_update_graph_edge` keep `max(existing, new)` confidence on collision, so a real call can't be stamped below the flow-calls floor by a later lower-confidence upsert. The test still asserted that a lower re-upsert (0.5) overwrites the default (1.0).

Fix: seed the edge at 0.7, re-upsert at 0.5, and assert confidence holds at **0.7** — directly covering the max-keep contract while still verifying the in-place `imported_names_json` update.

### 2. `test_hedged_but_named_body_served_holds_medium`
`assert 'low' == 'medium'`

PR #796 added `repo_root=` and `session_factory=` keyword args to the `_anchor_symbol_hits` call site. The test's `_fake_anchor` stub only accepted the four positional args, so the real call raised `TypeError` — swallowed by the `contextlib.suppress(Exception)` around it. Anchoring silently no-op'd, `_anchor_symbols` was never attached, `served_named_body` stayed `False`, and the hedged answer fell to `low` instead of `medium`.

Fix: the fake now accepts `**kwargs` so it matches the real signature.

## Test

Both files pass locally (55 tests):
```
tests/unit/persistence/test_crud_smoke.py .....
tests/unit/server/mcp/test_answer_calibration.py ..................................................
55 passed
```

Test-only change; no product code touched.