### PR TITLE
release: v0.31.0 - coverage test intelligence, decisions from agent sessions, grounded get_answer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ headline, so the bug-predictive number stays clean.
 ```bash
 repowise health                       # KPIs + lowest-scoring files
 repowise coverage add cov.lcov   # ingest LCOV/Cobertura/Clover → untested-hotspot
+repowise impacted-tests HEAD~1   # run only the tests a diff actually exercises
 repowise health --refactoring-targets # ranked by impact / effort
 repowise health --trend               # snapshots + declining / predicted-decline alerts
 ```

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.31.0] — 2026-07-12
+
+### Added
+- **Coverage-backed test intelligence.** repowise now ingests per-test coverage to build a test-to-code map, and puts it to work two ways: a missing-test signal proven by that map (real gaps, not just heuristics), and a new `repowise impacted-tests` command that takes a diff and lists only the tests that actually exercise the changed code, so you can run the smallest relevant subset instead of the whole suite. (#789, #790, #792, #793)
+- **Decisions mined from your agent sessions.** A shared agent-transcript layer lets repowise mine durable architectural decisions out of Claude Code / agent session transcripts, then deliver them relevance-ranked at session start and at edit time with a usage-feedback loop. Agent co-authorship is detected and decision scope is derived from it. (#774, #775, #776, #803)
+- **Flow-shaped answers.** `get_answer` can now trace how something gets from one named endpoint to another by walking the graph path between them and narrating the flow. (#804)
+- **Shell parsed to a real AST.** Shell scripts now parse into functions, source edges, and complexity like every other supported language, instead of being treated as opaque text. (#768)
+- **Lean MCP-only Docker image.** A new `Dockerfile.mcp` builds a slim MCP-server-only image for MCP hosts and server directories. (#800)
+
+### Changed
+- **`get_answer` is grounded in what it serves.** Synthesis is grounded in the exact body the answer returns, data-shape questions are grounded in the field set mined from source (including alias keys the shape omits), homonym symbols are answered by union across their definitions, and low-confidence misses are slimmed. `get_symbol(id=...)` is forgiven and a hedged answer is re-grounded on the served body. (#778, #779, #780, #772, #783)
+- **Performance findings move the health score.** Open performance-risk findings are now deducted from the performance score, so the number reflects outstanding perf debt. (#801)
+- **Decision sources gated and stickier.** The code-comment decision harvest is gone, decision sources are gated, and dismissals stick so a dismissed suggestion stays dismissed. (#773)
+- **FAQ-weighted docs budget.** Generation tilts documentation depth toward the modules people actually ask about. (#781)
+- **Hardier MCP surface.** Session-survival hardening for the tool surface, plus a response budget clamped under the live MCP host token cap, keeps the server responsive under strict hosts. (#767, #771)
+- **Prose search leads with concept pages.** Hybrid search now leads prose queries with concept and wiki pages instead of raw symbol hits. (#797)
+- **Contributors strip explains agent authorship.** The contributors view now spells out the agent-authored share of commits. (#799)
+
+### Fixed
+- **Incremental updates persist graph and symbol data.** `repowise update` now persists `graph_edges` and `wiki_symbols` on incremental runs (both were dropped before), and edge upserts keep the maximum confidence instead of overwriting it. (#795, #806, #807)
+- **`get_answer` verifies live slices.** Symbol bounds are verified before serving a live slice, and non-path node ids are kept out of `fallback_targets`. (#796, #769)
+- **Honest search and symbol signals.** Zero-exact search and filename-only `get_symbol` carry honesty signals instead of implying a confident hit. (#770)
+- **Execution-flow picker on the module overview.** The module overview gained an execution-flow picker with hierarchical-layout guardrails so large graphs stay readable. (#805)
+
+### Documentation
+- New hooks guide plus a "learns from your usage" section explaining the adoption feedback loop. (#784)
+- Full AGPL-3.0 license text so GitHub detects the license correctly. (#794)
+
+---
+
 ## [0.30.0] — 2026-07-10
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.31.0] — 2026-07-12
+
+### Added
+- **Coverage-backed test intelligence.** repowise now ingests per-test coverage to build a test-to-code map, and puts it to work two ways: a missing-test signal proven by that map (real gaps, not just heuristics), and a new `repowise impacted-tests` command that takes a diff and lists only the tests that actually exercise the changed code, so you can run the smallest relevant subset instead of the whole suite. (#789, #790, #792, #793)
+- **Decisions mined from your agent sessions.** A shared agent-transcript layer lets repowise mine durable architectural decisions out of Claude Code / agent session transcripts, then deliver them relevance-ranked at session start and at edit time with a usage-feedback loop. Agent co-authorship is detected and decision scope is derived from it. (#774, #775, #776, #803)
+- **Flow-shaped answers.** `get_answer` can now trace how something gets from one named endpoint to another by walking the graph path between them and narrating the flow. (#804)
+- **Shell parsed to a real AST.** Shell scripts now parse into functions, source edges, and complexity like every other supported language, instead of being treated as opaque text. (#768)
+- **Lean MCP-only Docker image.** A new `Dockerfile.mcp` builds a slim MCP-server-only image for MCP hosts and server directories. (#800)
+
+### Changed
+- **`get_answer` is grounded in what it serves.** Synthesis is grounded in the exact body the answer returns, data-shape questions are grounded in the field set mined from source (including alias keys the shape omits), homonym symbols are answered by union across their definitions, and low-confidence misses are slimmed. `get_symbol(id=...)` is forgiven and a hedged answer is re-grounded on the served body. (#778, #779, #780, #772, #783)
+- **Performance findings move the health score.** Open performance-risk findings are now deducted from the performance score, so the number reflects outstanding perf debt. (#801)
+- **Decision sources gated and stickier.** The code-comment decision harvest is gone, decision sources are gated, and dismissals stick so a dismissed suggestion stays dismissed. (#773)
+- **FAQ-weighted docs budget.** Generation tilts documentation depth toward the modules people actually ask about. (#781)
+- **Hardier MCP surface.** Session-survival hardening for the tool surface, plus a response budget clamped under the live MCP host token cap, keeps the server responsive under strict hosts. (#767, #771)
+- **Prose search leads with concept pages.** Hybrid search now leads prose queries with concept and wiki pages instead of raw symbol hits. (#797)
+- **Contributors strip explains agent authorship.** The contributors view now spells out the agent-authored share of commits. (#799)
+
+### Fixed
+- **Incremental updates persist graph and symbol data.** `repowise update` now persists `graph_edges` and `wiki_symbols` on incremental runs (both were dropped before), and edge upserts keep the maximum confidence instead of overwriting it. (#795, #806, #807)
+- **`get_answer` verifies live slices.** Symbol bounds are verified before serving a live slice, and non-path node ids are kept out of `fallback_targets`. (#796, #769)
+- **Honest search and symbol signals.** Zero-exact search and filename-only `get_symbol` carry honesty signals instead of implying a confident hit. (#770)
+- **Execution-flow picker on the module overview.** The module overview gained an execution-flow picker with hierarchical-layout guardrails so large graphs stay readable. (#805)
+
+### Documentation
+- New hooks guide plus a "learns from your usage" section explaining the adoption feedback loop. (#784)
+- Full AGPL-3.0 license text so GitHub detects the license correctly. (#794)
+
+---
+
 ## [0.30.0] — 2026-07-10
 
 ### Added

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.31.0
+
+### Changed
+- Version bump to track the repowise 0.31.0 release. No command, skill, or MCP
+  tool-surface changes this cycle.
+
 ## 0.30.0
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.30.0"
+version = "0.31.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3056,7 +3056,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.30.0"
+version = "0.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -3085,6 +3085,7 @@ dependencies = [
     { name = "structlog" },
     { name = "tenacity" },
     { name = "tree-sitter" },
+    { name = "tree-sitter-bash" },
     { name = "tree-sitter-c-sharp" },
     { name = "tree-sitter-cpp" },
     { name = "tree-sitter-dart" },
@@ -3176,6 +3177,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9,<10" },
     { name = "time-machine", marker = "extra == 'dev'", specifier = ">=2.14,<3" },
     { name = "tree-sitter", specifier = ">=0.23,<1" },
+    { name = "tree-sitter-bash", specifier = ">=0.23,<1" },
     { name = "tree-sitter-c-sharp", specifier = ">=0.23,<1" },
     { name = "tree-sitter-cpp", specifier = ">=0.23,<1" },
     { name = "tree-sitter-dart", specifier = ">=0.1,<1" },
@@ -3959,6 +3961,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
     { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
     { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/0e/f0108be910f1eef6499eabce517e79fe3b12057280ed398da67ce2426cba/tree_sitter_bash-0.25.1.tar.gz", hash = "sha256:bfc0bdaa77bc1e86e3c6652e5a6e140c40c0a16b84185c2b63ad7cd809b88f14", size = 419703, upload-time = "2025-12-02T17:01:08.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/8e/37e7364d9c9c58da89e05c510671d8c45818afd7b31c6939ab72f8dc6c04/tree_sitter_bash-0.25.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0e6235f59e366d220dde7d830196bed597d01e853e44d8ccd1a82c5dd2500acf", size = 194160, upload-time = "2025-12-02T17:00:59.047Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bb/2d2cfbb1f89aaeb1ec892624f069d92d058d06bb66f16b9ec9fb5873ab60/tree_sitter_bash-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f4a34a6504c7c5b2a9b8c5c4065531dea19ca2c35026e706cf2eeeebe2c92512", size = 202659, upload-time = "2025-12-02T17:01:00.275Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f0/1bb25519be27460255d3899db677313cfa1e6306988fbf456a3d7e211bbb/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e76c4cfb20b076552406782b7f8c2a3946835993df0a44df006de54b7030c7dc", size = 230596, upload-time = "2025-12-02T17:01:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/22/9f70bc3d3b942ab9fc0f89c1dc9e087519a3a94f64ae6b7377aae3a7a0f0/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3f484c4bb8796cde7a87ca351e6116f09653edac0eb3c6d238566359dd28b117", size = 231981, upload-time = "2025-12-02T17:01:02.859Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c3/f1540e42cd41b323c6821e45e52e1aed6ed386209aad52db996f05703963/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5e76af6df46d958c7f5b6d5884c9743218e3902a00ccb493ec92728b1084430b", size = 228364, upload-time = "2025-12-02T17:01:03.997Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/c3050a6277dfcac8c480f514dc4fe49f3f65f0eac68b4702cbaca2584e85/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a3332d71c7b7d5f78259b19d02d0ea111fcb82b72712ee4a93aaa5b226d3f0a8", size = 230074, upload-time = "2025-12-02T17:01:05.05Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0f/203fe6b27211387f4b9ba8c4a321567ca4ded2624dae6ccdbd2b6e940e17/tree_sitter_bash-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:52a6802d9218f86278aa3e8b459c3abdad67eed0fde1f9f13aca5b6c634217a6", size = 195574, upload-time = "2025-12-02T17:01:06.412Z" },
+    { url = "https://files.pythonhosted.org/packages/47/75/4ca1a9fabd8fb5aea78cea70f7837ce4dbf2afae115f62051e5fa99cba1c/tree_sitter_bash-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:59115057ec2bae319e8082ff29559861045002964c3431ccb0fc92aa4bc9bccb", size = 191196, upload-time = "2025-12-02T17:01:07.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## release: v0.31.0

Version bump + changelog for the 0.31.0 PyPI release. Cut from latest `origin/main`.

### What's in this release
- **Coverage-backed test intelligence** - per-test coverage builds a test-to-code map, powering a coverage-proven missing-test signal and the new `repowise impacted-tests` command (run only the tests a diff exercises). (#789, #790, #792, #793)
- **Decisions mined from agent sessions** - shared agent-transcript layer, durable-decision mining, relevance-ranked delivery at session start and edit time. (#774, #775, #776, #803)
- **`get_answer` grounding** - synthesis grounded in the served body, data-shape answers grounded in source-mined fields, flow-shaped answers across the graph, homonym-by-union. (#778, #779, #780, #772, #783, #804)
- **Incremental-update graph fixes** - persist `graph_edges` / `wiki_symbols`, keep max confidence on edge upsert. (#795, #806, #807)
- **Shell parsed to a real AST** (#768), **lean MCP-only Docker image** (#800), **perf findings deducted from health score** (#801), and MCP session-survival hardening (#767, #771).

Full detail in `docs/CHANGELOG.md`.

### Version bump
Four Python files + `uv.lock` self-entry + both plugin manifests, all at `0.31.0`. Drift grep clean. Bundled changelog copy resynced. Codex plugin unchanged this cycle (stays 0.1.1). `server.json` MCP-registry descriptor intentionally not touched (separate publish path).

### Test plan
- [x] Version drift grep clean (no `0.30.0` in tracked release files)
- [x] `uv lock` regenerated (repowise self-entry 0.30.0 -> 0.31.0)
- [x] Bundled changelog sync guard passes
- [x] Plugin tool-surface parity (matches live `list_tools()`; no `get_architecture_diagram` outside historical CHANGELOG)
- [x] Hook matcher parity (`hooks.json` mirrors `claude_config.py`)
- [x] `uv build --wheel` clean - serve_cmd + 40 `.scm`/`.j2` data files present, `impacted-tests` included
- [x] `npm ci && npm run build --workspace packages/web` green (hard gate); workspace code transpiled into standalone bundle
- [ ] End-to-end `repowise serve` browser click-through (hand-off to reviewer)
- [ ] Tag `v0.31.0` on main after merge -> `publish.yml`

### Merge convention
**Regular merge commit - not squash.** The tag must point at a real merge commit carrying the bump-only diff for artifact provenance.
