### PR TITLE
fix(go): detect function references in go to rescue FPs on dead-code 

### DIFF
--- a/packages/core/src/repowise/core/ingestion/queries/go.scm
+++ b/packages/core/src/repowise/core/ingestion/queries/go.scm
@@ -77,6 +77,20 @@
   arguments: (argument_list) @call.arguments
 ) @call.site
 
+; Package-qualified function value passed as call argument: f(pkg.Handler, ...)
+; Rescues functions used as first-class values — passed as callbacks, middleware,
+; or handlers rather than called directly. Without this, pkg.Func referenced
+; only in argument position (never in function: position) has no call edges
+; and is incorrectly flagged as an unused export.
+(call_expression
+  arguments: (argument_list
+    (selector_expression
+      operand: (_) @call.receiver
+      field: (field_identifier) @call.target
+    )
+  )
+) @call.site
+
 ; ---------------------------------------------------------------------------
 ; Type references — drive file-level ``type_use`` edges
 ; ---------------------------------------------------------------------------

--- a/tests/fixtures/go_sample/cmd/app/main.go
+++ b/tests/fixtures/go_sample/cmd/app/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"example.com/gosample/service"
 	"example.com/gosample/store"
+	"example.com/gosample/transform"
 )
 
 // run wires the concrete store into a service. Naming *store.MemStore (a
@@ -13,6 +14,12 @@ func run(st *store.MemStore) *service.Service {
 	return service.New(st)
 }
 
+// apply accepts a transform function as a value — exercises the pkg.Func
+// argument-position capture that rescues functions passed as arguments.
+func apply(fn func(string) string) {}
+
 func main() {
 	run(store.NewMemStore()).Run()
+	apply(transform.Upper)
+	apply(transform.Lower)
 }

--- a/tests/fixtures/go_sample/transform/transform.go
+++ b/tests/fixtures/go_sample/transform/transform.go
@@ -1,0 +1,16 @@
+// Package transform provides string transformation functions.
+package transform
+
+import "strings"
+
+// Upper returns s converted to upper case.
+// Passed as a function value to Apply — never called directly.
+func Upper(s string) string {
+	return strings.ToUpper(s)
+}
+
+// Lower returns s converted to lower case.
+// Passed as a function value to Apply — never called directly.
+func Lower(s string) string {
+	return strings.ToLower(s)
+}

--- a/tests/integration/test_go_dead_code.py
+++ b/tests/integration/test_go_dead_code.py
@@ -69,6 +69,14 @@ class TestGoSampleNoFalsePositives:
         for live in ("Store", "Config", "New", "NewMemStore", "MemStore"):
             assert live not in exports, f"{live} wrongly flagged unused_export"
 
+    def test_func_value_as_argument_not_flagged(self, go_report) -> None:
+        exports = _names(go_report, DeadCodeKind.UNUSED_EXPORT)
+        # Upper and Lower are passed as pkg.Func argument values to apply()
+        # — never called directly. The selector_expression in argument_list
+        # position must produce a call edge so they are not flagged as unused.
+        for live in ("Upper", "Lower"):
+            assert live not in exports, f"{live} wrongly flagged unused_export (function value passed as argument)"
+
     def test_sibling_helper_not_flagged_internal(self, go_report) -> None:
         internals = _names(go_report, DeadCodeKind.UNUSED_INTERNAL)
         # greeting() is private but called from the sibling service.go.


### PR DESCRIPTION
## Summary

 - Functions passed as references in arguments, flagged as `unused_export` with 100% confidence. 
 
 - Added `selector_expression` query in `go.scm` to capture `pkg.Func` references passed as call arguments
 
## Related Issues

closes https://github.com/repowise-dev/repowise/issues/814

## Test Plan

- [x] Verified on a real repo, 2 FPs gone
- [x] Added regression test (`test_func_value_as_argument_not_flagged`): Confirmed fails against pre-fix code (flagged `unused_export`) and passes with the fix.

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
