### PR TITLE
fix(ui): make empty doc state friendlier

### DIFF
--- a/packages/ui/src/files/file-doc-tab.tsx
+++ b/packages/ui/src/files/file-doc-tab.tsx
@@ -29,8 +29,8 @@ export function FileDocTab({ wikiPage, docSlot, wikiHref }: FileDocTabProps) {
     return (
       <EmptyState
         icon={<BookOpen className="h-8 w-8" />}
-        title="No documentation yet"
-        description="This file hasn't been documented. Run a sync to generate its wiki page."
+        title="This page didn't make the cut"
+        description="Not every file gets its own documentation page, and that's perfectly normal."
       />
     );
   }


### PR DESCRIPTION
## Summary

- Replace the file Doc tab's misleading sync prompt with warmer, clearer copy
- Clarify that files without documentation are an expected state
- Leave repository-wide empty states unchanged because they represent a different condition

## Related Issues

Closes #811

## Test Plan

- [x] UI type-check passes (`npm run type-check --workspace=@repowise-dev/ui`)
- [x] UI tests pass — 595/595 (`npm run test --workspace=@repowise-dev/ui`)

## Checklist

- [x] My code follows the project's code style
- [x] Tests were not added because this is a copy-only change
- [x] All existing tests pass
- [x] Documentation updates are not needed