### PR TITLE
fix(mcp): harden code-rationale git-grep for macOS and color configs

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/_code_rationale.py
+++ b/packages/server/src/repowise/server/mcp_server/_code_rationale.py
@@ -366,10 +366,14 @@ def grep_comment_candidates(
     noun_alt = "|".join(re.escape(n) for n in nouns)
     anchor_alt = "|".join(re.escape(a) for a in anchors)
     # A comment-leading line containing an anchor AND a content noun, in either
-    # order. ``git grep`` keeps the scan inside tracked files only.
+    # order. ``git grep`` keeps the scan inside tracked files only. Use the
+    # POSIX class ``[[:space:]]`` instead of ``\s``: ``\s`` is a GNU regex
+    # extension that git's ERE engine does not honor on macOS/BSD, so the
+    # pattern would silently match nothing there (and concept-anchoring would
+    # quietly disable itself).
     pat = (
-        rf"^\s*(#|//|--|\*).*({anchor_alt}).*({noun_alt})"
-        rf"|^\s*(#|//|--|\*).*({noun_alt}).*({anchor_alt})"
+        rf"^[[:space:]]*(#|//|--|\*).*({anchor_alt}).*({noun_alt})"
+        rf"|^[[:space:]]*(#|//|--|\*).*({noun_alt}).*({anchor_alt})"
     )
     try:
         proc = subprocess.run(
@@ -382,6 +386,10 @@ def grep_comment_candidates(
                 "git",
                 "--no-pager",
                 "grep",
+                # --no-color: this output is parsed, so a user's
+                # ``color.ui=always`` git config must not wrap paths in ANSI
+                # escapes (which would corrupt the path split below).
+                "--no-color",
                 "-n",
                 "-I",
                 "-i",


### PR DESCRIPTION
## Summary

`grep_comment_candidates()` in `mcp_server/_code_rationale.py` shells out to `git grep -E` and parses the result. The invocation was fragile in two environment-dependent ways, both invisible on Linux CI:

1. **`\s` is not portable in `git grep -E`.** `\s` is a GNU regex extension; macOS/BSD system git (e.g. Apple Git) does not honor it in ERE mode, so `^\s*(#|//|--|\*)...` never matches comment-leading lines with leading indentation. The function returns `[]`, silently disabling MCP concept-anchoring / in-code rationale on macOS.
2. **`git grep` output was not forced to `--no-color`.** With `color.ui=always` in a user's git config, git wraps each path in ANSI escapes (`\x1b[35m...enrichment.py\x1b[m`), which the `line.split(":")[0]` path parse captures verbatim, corrupting every returned candidate path.

Both are invisible in CI (Linux, default git config), so the two tests that cover this pass in CI while the feature is silently broken for macOS users and anyone running `color.ui=always`.

Fix: use the POSIX class `[[:space:]]` (portable across BSD/macOS and GNU/Linux git) and pass `--no-color` so the parsed output is stable regardless of git config. No behavior change on Linux.

## Related Issues

None filed.

## Test Plan

- [x] `uv run pytest tests/unit/server/mcp/test_code_rationale.py` -> 19 passed on macOS. Before this change, `test_grep_comment_candidates_ranks_number_bearing_file` and `test_concept_anchor_injects_winner_as_dominant` fail on macOS (they already pass on Linux/CI).
- [x] `ruff check` clean on the changed file.

Reproduced on macOS (Apple Git 2.50.1):

```
git grep -E '^\s*#.*caller'            # no match (\s unsupported in BSD git ERE)
git grep -E '^[[:space:]]*#.*caller'   # matches
# and with color.ui=always, paths return as \x1b[35m...\x1b[m unless --no-color is passed
```

## Checklist

- [x] Code follows the project's style
- [x] Existing tests still pass (and now also pass on macOS / with color.ui=always)
- [x] No new dependencies
- [x] No docs change needed
