### PR TITLE
fix(stats): report true project age, commit and contributor counts (#730)

### DIFF
--- a/packages/api-client/src/__fixtures__/hosted/stats-highlights.json
+++ b/packages/api-client/src/__fixtures__/hosted/stats-highlights.json
@@ -60,6 +60,7 @@
     "fix_pct": 10.2,
     "contributor_count": 568,
     "first_commit_at": "2015-06-06T04:25:41+00:00",
+    "first_commit_author": "Armin Ronacher",
     "last_commit_at": "2026-05-31T14:42:46+00:00",
     "age_days": 4012,
     "busiest_month": {

--- a/packages/core/alembic/versions/0037_repo_git_totals.py
+++ b/packages/core/alembic/versions/0037_repo_git_totals.py
@@ -1,0 +1,58 @@
+"""repositories: whole-history git totals (commit count, age, contributors, founder).
+
+The per-commit ``git_commits`` table is bounded to the newest N commits (churn
+and co-change analysis need no deeper history), so the stats page derived
+project age, total-commit count, and contributor count from that sample and
+reported a multi-year repo as a few months old with a few hundred commits and
+only its recent authors (issue #730).
+
+Adds four nullable repo-level columns the git indexer fills with cheap
+``git rev-list``/``shortlog`` calls at index time: ``total_commit_count``,
+``first_commit_at`` (root commit date, i.e. project age), ``first_commit_author``
+(the founder), and ``total_contributor_count`` (all-time mailmap-folded authors).
+Nullable so existing rows and non-git indexes degrade gracefully until the next
+index writes them.
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-07-14
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers
+revision: str = "0037"
+down_revision: str | None = "0036"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "repositories",
+        sa.Column("total_commit_count", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "repositories",
+        sa.Column("first_commit_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "repositories",
+        sa.Column("total_contributor_count", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "repositories",
+        sa.Column("first_commit_author", sa.String(255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("repositories", "first_commit_author")
+    op.drop_column("repositories", "total_contributor_count")
+    op.drop_column("repositories", "first_commit_at")
+    op.drop_column("repositories", "total_commit_count")

--- a/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
@@ -32,7 +32,7 @@ from .co_change import compute_co_changes, compute_co_changes_and_entropy
 from .enrich import compute_percentiles
 from .file_history import index_file
 from .prior_defects import compute_prior_defects
-from .records import GitIndexSummary, _CommitRec, _should_skip_index
+from .records import GitIndexSummary, _CommitRec, _should_skip_index, capture_repo_totals
 from .tiers import GitIndexTier
 
 logger = structlog.get_logger(__name__)
@@ -292,6 +292,10 @@ class GitIndexer:
             stable_files=stable,
             duration_seconds=duration,
             commit_rows=commit_rows,
+            # Whole-history totals from cheap git calls on the still-open repo —
+            # true project age / commit / contributor counts for the stats page,
+            # which must not read them off the depth-capped sample (issue #730).
+            repo_totals=capture_repo_totals(repo),
         )
         repo.close()
 
@@ -481,6 +485,25 @@ class GitIndexer:
             return []
         finally:
             repo.close()
+
+    def capture_repo_totals(self) -> Any:
+        """Whole-history :class:`RepoTotals` for this repo (opens its own repo).
+
+        The incremental counterpart to the capture ``index_repo`` runs inline:
+        ``repowise update`` calls this so true project age / commit / contributor
+        counts stay fresh between full re-indexes. Returns an all-``None``
+        ``RepoTotals`` when git is unavailable rather than raising.
+        """
+        from .records import RepoTotals
+
+        repo = self._get_repo()
+        if repo is None:
+            return RepoTotals()
+        try:
+            return capture_repo_totals(repo)
+        finally:
+            with contextlib.suppress(Exception):
+                repo.close()
 
     # ------------------------------------------------------------------
     # Internal methods

--- a/packages/core/src/repowise/core/ingestion/git_indexer/records.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/records.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from ._constants import _CODE_EXTENSIONS
 
@@ -13,10 +15,12 @@ __all__ = [
     "_LOG_FORMAT",
     "_RECORD_SEP",
     "GitIndexSummary",
+    "RepoTotals",
     "_CommitRec",
     "_extract_rename_paths",
     "_parse_commit_record",
     "_should_skip_index",
+    "capture_repo_totals",
 ]
 
 # Git log record/field separators (NUL byte + US 0x1f) — chosen so they can't
@@ -129,6 +133,12 @@ class GitIndexSummary:
     # for ``upsert_git_commits_bulk``. Empty in rename-tracking mode (which uses
     # the per-file walk instead of the batched commit index).
     commit_rows: list[dict] = field(default_factory=list)
+    # Whole-history git totals captured via cheap ``git rev-list``/``shortlog``
+    # calls that ignore ``commit_limit`` (unlike ``commit_rows``). Persisted to
+    # the Repository row so the stats page reports true project age / commit /
+    # contributor counts instead of deriving them from the bounded sample
+    # (issue #730). None when git is unavailable or the repo has no commits.
+    repo_totals: RepoTotals | None = None
 
 
 _RENAME_RE = re.compile(r"\{(.*?) => (.*?)\}")
@@ -161,6 +171,64 @@ def _extract_rename_paths(stat_path: str, known_paths: set[str]) -> tuple[str | 
         known_paths.add(new_path)
         return old_path, new_path
     return None, None
+
+
+@dataclass
+class RepoTotals:
+    """Whole-history git facts, captured independently of ``commit_limit``.
+
+    Every field degrades to ``None`` on its own so a partial capture still
+    persists what succeeded. See :func:`capture_repo_totals`.
+    """
+
+    total_commit_count: int | None = None
+    first_commit_at: datetime | None = None
+    total_contributor_count: int | None = None
+    first_commit_author: str | None = None
+
+
+def capture_repo_totals(repo: Any) -> RepoTotals:
+    """Whole-history stats for *repo* via a handful of cheap git calls.
+
+    All three git calls are O(1) in subprocess count and independent of the
+    indexer's ``commit_limit``, so they stay cheap no matter how deep the
+    history is:
+
+    - ``git rev-list --count HEAD`` — the true total commit count.
+    - the root commit(s) — earliest committed date (project age) and the
+      founding author's name. Multiple roots (merged histories) use the
+      earliest root.
+    - ``git shortlog -sn HEAD`` — one line per mailmap-folded author, so its
+      line count is the true all-time contributor count. Passing ``HEAD``
+      keeps shortlog from blocking on stdin.
+
+    Each field is captured under its own ``try`` so one failure (empty/unborn
+    HEAD, detached state, git unavailable) never voids the others.
+    """
+    totals = RepoTotals()
+
+    try:
+        totals.total_commit_count = int(repo.git.rev_list("--count", "HEAD").strip())
+    except Exception:
+        pass
+
+    try:
+        roots = repo.git.rev_list("--max-parents=0", "HEAD").split()
+        root_commits = [repo.commit(sha) for sha in roots if sha]
+        if root_commits:
+            oldest = min(root_commits, key=lambda c: c.committed_datetime)
+            totals.first_commit_at = oldest.committed_datetime
+            totals.first_commit_author = (oldest.author.name or None) if oldest.author else None
+    except Exception:
+        pass
+
+    try:
+        out = repo.git.shortlog("-sn", "HEAD")
+        totals.total_contributor_count = sum(1 for line in out.splitlines() if line.strip())
+    except Exception:
+        pass
+
+    return totals
 
 
 def _should_skip_index(file_path: str) -> bool:

--- a/packages/core/src/repowise/core/persistence/crud/repository.py
+++ b/packages/core/src/repowise/core/persistence/crud/repository.py
@@ -7,6 +7,7 @@ every public name, so existing imports are unaffected.
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 from sqlalchemy import select
@@ -125,6 +126,41 @@ def _read_head_commit(local_path: str) -> str | None:
             return None
         return None
     return head or None
+
+
+async def update_repo_git_totals(
+    session: AsyncSession,
+    repo_id: str,
+    *,
+    total_commit_count: int | None = None,
+    first_commit_at: datetime | None = None,
+    total_contributor_count: int | None = None,
+    first_commit_author: str | None = None,
+) -> None:
+    """Store a repo's whole-history git totals, captured at index time (#730).
+
+    The per-commit ``git_commits`` table is bounded to the newest N commits, so
+    the stats page must read true project age / commit / contributor counts from
+    these repo-level fields instead of that sample. Each argument is applied
+    only when non-``None`` so a partial capture never blanks a value a previous
+    index stored. No-ops on a missing repo or all-``None`` input.
+    """
+    updates = {
+        "total_commit_count": total_commit_count,
+        "first_commit_at": first_commit_at,
+        "total_contributor_count": total_contributor_count,
+        "first_commit_author": first_commit_author,
+    }
+    if all(v is None for v in updates.values()):
+        return
+    repo = await session.get(Repository, repo_id)
+    if repo is None:
+        return
+    for attr, value in updates.items():
+        if value is not None:
+            setattr(repo, attr, value)
+    repo.updated_at = _now_utc()
+    await session.flush()
 
 
 async def get_repository(session: AsyncSession, repo_id: str) -> Repository | None:

--- a/packages/core/src/repowise/core/persistence/models.py
+++ b/packages/core/src/repowise/core/persistence/models.py
@@ -49,6 +49,22 @@ class Repository(Base):
     local_path: Mapped[str] = mapped_column(Text, nullable=False)
     default_branch: Mapped[str] = mapped_column(String(255), nullable=False, default="main")
     head_commit: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    # Whole-history git totals captured at index time via cheap ``git rev-list``
+    # calls. The per-commit ``git_commits`` table is deliberately bounded to the
+    # newest N commits (churn/co-change need no more), so project age and total
+    # commit count must be read from these repo-level fields rather than derived
+    # from that sample — otherwise a multi-year repo reads as a few months old
+    # (issue #730). NULL until the first index writes them / for non-git repos.
+    total_commit_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    first_commit_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # All-time unique authors (mailmap-folded) and the founding author's name.
+    # Contributor count shares the #730 bug when read off the bounded sample;
+    # the founder rides along free (the root commit is already loaded for the
+    # first-commit date). Both NULL until the first index writes them.
+    total_contributor_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    first_commit_author: Mapped[str | None] = mapped_column(String(255), nullable=True)
     settings_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_now_utc

--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -503,6 +503,7 @@ async def persist_incremental_commits(session: Any, repo_id: str, repo_path: Any
     from repowise.core.ingestion.git_indexer import GitIndexer
     from repowise.core.persistence.crud import (
         get_latest_commit_committed_at,
+        update_repo_git_totals,
         upsert_git_commits_bulk,
     )
     from repowise.core.repo_config import load_repo_config
@@ -525,6 +526,19 @@ async def persist_incremental_commits(session: Any, repo_id: str, repo_path: Any
     rows = await asyncio.to_thread(indexer.capture_new_commit_rows, since_ts=since_ts)
     if rows:
         await upsert_git_commits_bulk(session, repo_id, rows)
+
+    # Refresh the repo-level whole-history totals so age / commit / contributor
+    # counts keep growing between full re-indexes (#730). Cheap git calls, and
+    # cheap to run every update since they don't touch the bounded sample.
+    totals = await asyncio.to_thread(indexer.capture_repo_totals)
+    await update_repo_git_totals(
+        session,
+        repo_id,
+        total_commit_count=totals.total_commit_count,
+        first_commit_at=totals.first_commit_at,
+        total_contributor_count=totals.total_contributor_count,
+        first_commit_author=totals.first_commit_author,
+    )
 
 
 async def persist_incremental_index(

--- a/packages/core/src/repowise/core/pipeline/persist.py
+++ b/packages/core/src/repowise/core/pipeline/persist.py
@@ -651,6 +651,7 @@ async def persist_git(result: Any, session: Any, repo_id: str) -> None:
     ``(repo_id, sha)`` — safe to call incrementally and on resume.
     """
     from repowise.core.persistence.crud import (
+        update_repo_git_totals,
         upsert_git_commits_bulk,
         upsert_git_metadata_bulk,
     )
@@ -658,10 +659,26 @@ async def persist_git(result: Any, session: Any, repo_id: str) -> None:
     if result.git_metadata_list:
         await upsert_git_metadata_bulk(session, repo_id, result.git_metadata_list)
 
+    summary = getattr(result, "git_summary", None)
+
     # Per-commit rows + change-risk ride on the git summary.
-    commit_rows = getattr(getattr(result, "git_summary", None), "commit_rows", None)
+    commit_rows = getattr(summary, "commit_rows", None)
     if commit_rows:
         await upsert_git_commits_bulk(session, repo_id, commit_rows)
+
+    # Whole-history totals (true age / commit / contributor counts) also ride on
+    # the summary — stamp them on the Repository row so the stats page reads them
+    # instead of deriving them from the bounded ``git_commits`` sample (#730).
+    totals = getattr(summary, "repo_totals", None)
+    if totals is not None:
+        await update_repo_git_totals(
+            session,
+            repo_id,
+            total_commit_count=totals.total_commit_count,
+            first_commit_at=totals.first_commit_at,
+            total_contributor_count=totals.total_contributor_count,
+            first_commit_author=totals.first_commit_author,
+        )
 
 
 async def persist_analysis(result: Any, session: Any, repo_id: str) -> None:

--- a/packages/server/src/repowise/server/routers/stats.py
+++ b/packages/server/src/repowise/server/routers/stats.py
@@ -130,12 +130,19 @@ async def _scale(session: AsyncSession, repo_id: str, metrics: list[Any]) -> dic
     }
 
 
-async def _activity(session: AsyncSession, repo_id: str) -> dict[str, Any]:
+async def _activity(session: AsyncSession, repo_id: str, repo: Any) -> dict[str, Any]:
     """Commit volume, project age, agent-vs-human split, and a monthly series.
 
     Buckets the bounded ``git_commits`` table in Python so it is portable
     across SQLite/Postgres date functions (same approach as the agent-trend
     endpoint).
+
+    Headline totals (commit count, project age, contributor count, founder)
+    prefer the whole-history values captured on the ``Repository`` row at index
+    time — the ``git_commits`` table is bounded to the newest N commits, so
+    deriving them from it undercounts a long-lived repo badly (issue #730). The
+    bounded scan still drives the *sample* signals (agent/fix ratios, monthly
+    series, awards) that are meaningful on the recent window.
 
     Also derives the ``biggest_commit`` and ``longest_streak`` awards on the
     same pass — they need per-commit rows anyway, and riding along here keeps
@@ -237,16 +244,29 @@ async def _activity(session: AsyncSession, repo_id: str) -> dict[str, Any]:
         {"month": m, "total": b["total"], "agent": b["agent"]} for m, b in sorted(months.items())
     ]
     busiest = max(monthly, key=lambda r: r["total"], default=None)
-    age_days = (last_at - first_at).days if (first_at and last_at) else None
+
+    # Prefer the whole-history values stamped on the repo at index time; fall
+    # back to the bounded sample when they're absent (older index, non-git
+    # repo). Age runs from the true first commit to the latest commit we have.
+    true_total = getattr(repo, "total_commit_count", None)
+    true_first = getattr(repo, "first_commit_at", None)
+    true_contributors = getattr(repo, "total_contributor_count", None)
+    effective_total = true_total if true_total is not None else total
+    effective_first = true_first if true_first is not None else first_at
+    effective_contributors = (
+        true_contributors if true_contributors is not None else len(contributors)
+    )
+    age_days = (last_at - effective_first).days if (effective_first and last_at) else None
 
     return {
-        "total_commits": total,
+        "total_commits": effective_total,
         "agent_commits": agent_total,
         "agent_pct": round(agent_total / total * 100.0, 1) if total else 0.0,
         "fix_commits": fix_total,
         "fix_pct": round(fix_total / total * 100.0, 1) if total else 0.0,
-        "contributor_count": len(contributors),
-        "first_commit_at": _iso(first_at),
+        "contributor_count": effective_contributors,
+        "first_commit_at": _iso(effective_first),
+        "first_commit_author": getattr(repo, "first_commit_author", None),
         "last_commit_at": _iso(last_at),
         "age_days": age_days,
         "busiest_month": busiest,
@@ -549,7 +569,7 @@ async def stats_highlights(
         or 0
     )
 
-    activity = await _activity(session, repo_id)
+    activity = await _activity(session, repo_id, repo)
     superlatives = await _superlatives(session, repo_id, metrics, all_meta)
     # Computed on _activity's commit scan for performance, but they are awards
     # so they belong under superlatives in the payload.

--- a/packages/types/src/stats.ts
+++ b/packages/types/src/stats.ts
@@ -48,6 +48,8 @@ export interface StatsActivity {
   fix_pct: number;
   contributor_count: number;
   first_commit_at: string | null;
+  /** Founding author (root commit). Null for older indexes / non-git repos. */
+  first_commit_author: string | null;
   last_commit_at: string | null;
   age_days: number | null;
   busiest_month: StatsMonthlyBucket | null;

--- a/packages/web/src/components/stats/by-the-numbers-tab.tsx
+++ b/packages/web/src/components/stats/by-the-numbers-tab.tsx
@@ -43,7 +43,9 @@ export function ByTheNumbersTab({ data }: { data: StatsHighlights }) {
           icon={<CalendarClock className="h-4 w-4" />}
           sub={
             activity.first_commit_at
-              ? `since ${formatDate(activity.first_commit_at)}`
+              ? `since ${formatDate(activity.first_commit_at)}${
+                  activity.first_commit_author ? ` · started by ${activity.first_commit_author}` : ""
+                }`
               : "first commit date unknown"
           }
         />

--- a/tests/unit/ingestion/test_git_commit_rows_integration.py
+++ b/tests/unit/ingestion/test_git_commit_rows_integration.py
@@ -87,6 +87,52 @@ async def test_capture_new_commit_rows_bounds_by_since_ts(tmp_path) -> None:
     assert idx.capture_new_commit_rows(since_ts=int(newest_ts)) == []
 
 
+def _configure_author(repo, name: str, email: str) -> None:
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", name)
+        cw.set_value("user", "email", email)
+
+
+@pytest.mark.asyncio
+async def test_index_repo_captures_whole_history_totals(tmp_path) -> None:
+    """``index_repo`` stamps true whole-history totals on the summary, and a
+    small ``commit_limit`` must NOT bound them (issue #730)."""
+    import git as gitpython
+
+    repo = gitpython.Repo.init(tmp_path)
+    _configure_author(repo, "Ada Lovelace", "ada@example.com")
+    _commit(repo, tmp_path / "a.py", "x = 1\n", "feat: add a")
+    _commit(repo, tmp_path / "b.py", "y = 2\n", "feat: add b")
+    _commit(repo, tmp_path / "c.py", "w = 4\n", "feat: add c")
+
+    # commit_limit far below the true count: the sample bounds, the totals don't.
+    idx = GitIndexer(tmp_path, tier=GitIndexTier.FULL, commit_limit=1)
+    summary, _results = await idx.index_repo("repo1")
+
+    totals = summary.repo_totals
+    assert totals is not None
+    assert totals.total_commit_count == 3
+    assert totals.total_contributor_count == 1
+    assert totals.first_commit_author == "Ada Lovelace"
+    assert totals.first_commit_at is not None
+
+
+def test_capture_repo_totals_method(tmp_path) -> None:
+    """The public capture (used by the incremental update path) opens its own
+    repo and returns the same whole-history record."""
+    import git as gitpython
+
+    repo = gitpython.Repo.init(tmp_path)
+    _configure_author(repo, "Grace Hopper", "grace@example.com")
+    _commit(repo, tmp_path / "a.py", "x = 1\n", "feat: add a")
+    _commit(repo, tmp_path / "b.py", "y = 2\n", "feat: add b")
+
+    totals = GitIndexer(tmp_path, tier=GitIndexTier.FULL).capture_repo_totals()
+    assert totals.total_commit_count == 2
+    assert totals.total_contributor_count == 1
+    assert totals.first_commit_author == "Grace Hopper"
+
+
 @pytest.mark.asyncio
 async def test_capture_new_commit_rows_empty_in_rename_mode(tmp_path) -> None:
     import git as gitpython

--- a/tests/unit/server/test_stats_contributors.py
+++ b/tests/unit/server/test_stats_contributors.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime
 import pytest
 from httpx import AsyncClient
 
-from repowise.core.persistence.crud import upsert_git_commits_bulk
+from repowise.core.persistence.crud import get_repository, upsert_git_commits_bulk
 from repowise.core.persistence.database import get_session
 from repowise.server.routers.stats import _activity
 from tests.unit.server.conftest import create_test_repo
@@ -52,7 +52,44 @@ async def test_contributor_count_folds_noreply_and_same_name(client: AsyncClient
         await upsert_git_commits_bulk(session, repo["id"], rows)
 
     async with get_session(app.state.session_factory) as session:
-        activity = await _activity(session, repo["id"])
+        repo_row = await get_repository(session, repo["id"])
+        activity = await _activity(session, repo["id"], repo_row)
 
+    # No whole-history totals stored on the repo, so the count folds the
+    # bounded sample's author identities (Jane + Bob, not 4).
     assert activity["total_commits"] == 4
-    assert activity["contributor_count"] == 2  # Jane + Bob, not 4
+    assert activity["contributor_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_activity_prefers_whole_history_totals(client: AsyncClient, app) -> None:
+    """When the repo carries index-time totals, the headline reads those, not
+    the bounded ``git_commits`` sample (issue #730)."""
+    repo = await create_test_repo(client)
+    # Two sampled commits from one author, ~1 day apart.
+    rows = [
+        _commit("a1", "Jane Doe", "jane@company.com", 1_600_000_000),
+        _commit("a2", "Jane Doe", "jane@company.com", 1_600_086_400),
+    ]
+    async with get_session(app.state.session_factory) as session:
+        await upsert_git_commits_bulk(session, repo["id"], rows)
+
+    # Stamp true whole-history values on the repo, far larger than the sample.
+    async with get_session(app.state.session_factory) as session:
+        repo_row = await get_repository(session, repo["id"])
+        repo_row.total_commit_count = 5000
+        repo_row.total_contributor_count = 42
+        repo_row.first_commit_at = datetime.fromtimestamp(1_300_000_000, tz=UTC)
+        repo_row.first_commit_author = "Ada Lovelace"
+        await session.flush()
+
+    async with get_session(app.state.session_factory) as session:
+        repo_row = await get_repository(session, repo["id"])
+        activity = await _activity(session, repo["id"], repo_row)
+
+    assert activity["total_commits"] == 5000
+    assert activity["contributor_count"] == 42
+    assert activity["first_commit_author"] == "Ada Lovelace"
+    # Age runs from the true first commit to the latest sampled commit, so it is
+    # far larger than the ~1 day the sample alone would show.
+    assert activity["age_days"] > 3000

--- a/tests/unit/server/test_stats_superlatives.py
+++ b/tests/unit/server/test_stats_superlatives.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime
 import pytest
 from httpx import AsyncClient
 
-from repowise.core.persistence.crud import upsert_git_commits_bulk
+from repowise.core.persistence.crud import get_repository, upsert_git_commits_bulk
 from repowise.core.persistence.database import get_session
 from repowise.server.routers.stats import _activity
 from tests.unit.server.conftest import create_test_repo
@@ -58,7 +58,8 @@ async def test_biggest_commit_skips_initial_and_streak_counts_days(
         await upsert_git_commits_bulk(session, repo["id"], rows)
 
     async with get_session(app.state.session_factory) as session:
-        activity = await _activity(session, repo["id"])
+        repo_row = await get_repository(session, repo["id"])
+        activity = await _activity(session, repo["id"], repo_row)
 
     biggest = activity["biggest_commit"]
     assert biggest is not None


### PR DESCRIPTION
Fixes #730.

## Problem

The By the Numbers page derived project age, total commits, and contributor count from the `git_commits` table, which is intentionally bounded to the newest N commits (default 500) because churn and co-change analysis need no deeper history. As a result a multi-year repo with thousands of commits showed up as a few months old, with a few hundred commits and only its most recent authors.

## Fix

Capture the whole-history facts at index time with a handful of cheap git calls that ignore the commit limit, and stamp them on the repository row:

- `git rev-list --count HEAD` for the true commit count
- the root commit's date and author for project age and the founder
- `git shortlog -sn HEAD` for the true all-time contributor count (mailmap-folded)

The stats endpoint now prefers these true totals and falls back to the bounded sample only when they are absent (older index, non-git repo). The bounded scan still drives the sample-only signals that are meaningful on the recent window (agent/fix ratios, monthly series, awards).

The contributor count shared the same bug, so it is fixed the same way. The founding author rides along for free (the root commit is already loaded for the first-commit date) and is surfaced as "started by X" on the project-age tile.

## No reindex needed

The four new columns are nullable, so the additive schema reconciler backfills them on any repo-db open, and the values are refreshed on the next file-changing `repowise update`. The single-repo and workspace update paths both route through the same incremental persist, so existing indexes self-heal without a reindex.

## Tests

- Indexer captures true totals independent of `commit_limit`; the public capture used by the update path returns the same record.
- Stats activity prefers stored whole-history totals over the bounded sample, and folds the sample only when they are absent.
- Migration up/down verified; existing git/stats/resume/incremental suites and the hosted fixture test pass.