### PR TITLE
fix(server): launch persisted polling sync job

### DIFF
--- a/packages/server/src/repowise/server/scheduler.py
+++ b/packages/server/src/repowise/server/scheduler.py
@@ -134,7 +134,7 @@ def setup_scheduler(
                         continue
 
                     # Enqueue a sync job
-                    await crud.upsert_generation_job(
+                    job = await crud.upsert_generation_job(
                         session,
                         repository_id=repo.id,
                         status="pending",

--- a/tests/unit/server/test_scheduler.py
+++ b/tests/unit/server/test_scheduler.py
@@ -1,0 +1,64 @@
+"""Tests for APScheduler background jobs."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from sqlalchemy import select
+
+from repowise.core.persistence import crud
+from repowise.core.persistence.database import get_session
+from repowise.core.persistence.models import GenerationJob
+from repowise.server.scheduler import setup_scheduler
+
+
+async def test_polling_fallback_launches_persisted_job(session_factory, tmp_path) -> None:
+    """A diverged repository should launch the sync job that was persisted."""
+    repo_path = tmp_path / "repo"
+    state_path = repo_path / ".repowise" / "state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(json.dumps({"last_sync_commit": "old-sha"}), encoding="utf-8")
+
+    async with get_session(session_factory) as session:
+        repo = await crud.upsert_repository(
+            session,
+            name="test-repo",
+            local_path=str(repo_path),
+        )
+        repo_id = repo.id
+
+    app_state = SimpleNamespace(background_tasks=set())
+    scheduler = setup_scheduler(session_factory, app_state=app_state)
+    polling_job = next(job for job in scheduler.get_jobs() if job.id == "polling_fallback")
+    head_result = SimpleNamespace(returncode=0, stdout="new-sha\n")
+    execute_job = AsyncMock()
+
+    with (
+        patch("subprocess.run", return_value=head_result),
+        patch("repowise.server.job_executor.execute_job", execute_job),
+    ):
+        await polling_job.func()
+        if app_state.background_tasks:
+            await asyncio.gather(*app_state.background_tasks)
+
+    execute_job.assert_awaited_once()
+    job_id, launched_state = execute_job.await_args.args
+    assert launched_state is app_state
+
+    async with get_session(session_factory) as session:
+        result = await session.execute(
+            select(GenerationJob).where(GenerationJob.repository_id == repo_id)
+        )
+        persisted_job = result.scalar_one()
+
+    assert job_id == persisted_job.id
+    assert persisted_job.status == "pending"
+    assert json.loads(persisted_job.config_json) == {
+        "mode": "sync",
+        "trigger": "polling_fallback",
+        "before": "old-sha",
+        "after": "new-sha",
+    }


### PR DESCRIPTION
fix #830 

## Summary

  - Retain the `GenerationJob` returned by the polling fallback upsert.
  - Launch the background executor using the persisted job ID.
  - Add a regression test covering repository divergence, persisted job metadata,
    and executor invocation.

  ## Problem

  When the polling fallback detected that a repository's HEAD differed from its
  last synchronized commit, it created and committed a pending generation job.

  The returned job object was discarded, but the scheduler subsequently attempted
  to call `execute_job(job.id, app_state)`. This raised a `NameError`, which was
  caught by the scheduler's outer exception handler.

  As a result:

  1. The pending job remained in the database.
  2. No background sync was launched.
  3. Subsequent polling runs skipped the repository because an active pending job
     already existed.

  ## Fix

  Store the result of `upsert_generation_job()` in `job` and use its persisted ID
  when launching the background task.

  ## Testing

  - Added `test_polling_fallback_launches_persisted_job`.
  - Verified the persisted job status and polling configuration.
  - Verified that the executor receives the persisted job ID.
  - Changed files pass Ruff formatting/linting and mypy.
  - All JavaScript lint, type-check, unit, and VS Code smoke tests pass.

  Verification note: the full Python run reached 7,484 passed, 14 skipped. Two unrelated code-rationale tests fail independently on the existing
  branch. Thirteen initially sandbox-sensitive failures passed when rerun outside the sandbox. Repository-wide Ruff/format/mypy also report 
substantial pre-existing issues, while both changed files pass their focused checks.