### PR TITLE
fix(web): contain overflowing modal inputs in Add Repository dialog (#843)

### DIFF
--- a/packages/ui/src/onboarding/add-repo-wizard.tsx
+++ b/packages/ui/src/onboarding/add-repo-wizard.tsx
@@ -263,7 +263,7 @@ export function AddRepoWizard({ adapter, open, onOpenChange }: AddRepoWizardProp
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-md w-[calc(100vw-2rem)]">
+      <DialogContent className="sm:max-w-md w-[calc(100vw-2rem)] flex flex-col">
         {step === "details" && (
           <>
             <DialogHeader>

--- a/packages/ui/src/onboarding/add-repo-wizard.tsx
+++ b/packages/ui/src/onboarding/add-repo-wizard.tsx
@@ -263,7 +263,7 @@ export function AddRepoWizard({ adapter, open, onOpenChange }: AddRepoWizardProp
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-md w-[calc(100vw-2rem)] flex flex-col">
+      <DialogContent className="sm:max-w-md w-[calc(100vw-2rem)] flex flex-col overflow-hidden">
         {step === "details" && (
           <>
             <DialogHeader>

--- a/packages/ui/src/onboarding/add-repo-wizard.tsx
+++ b/packages/ui/src/onboarding/add-repo-wizard.tsx
@@ -270,7 +270,7 @@ export function AddRepoWizard({ adapter, open, onOpenChange }: AddRepoWizardProp
               <DialogTitle>Add Repository</DialogTitle>
             </DialogHeader>
 
-            <form onSubmit={handleDetailsSubmit} className="space-y-4 py-2">
+            <form onSubmit={handleDetailsSubmit} className="space-y-4 py-2 min-w-0">
               <div className="space-y-1.5">
                 <Label htmlFor="repo-name">Name</Label>
                 <Input

--- a/packages/ui/src/ui/input.tsx
+++ b/packages/ui/src/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1 text-sm text-[var(--color-text-primary)] transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-[var(--color-text-tertiary)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent-primary)] disabled:cursor-not-allowed disabled:opacity-50",
+          "box-border flex h-9 w-full rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1 text-sm text-[var(--color-text-primary)] transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-[var(--color-text-tertiary)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent-primary)] disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/packages/ui/src/ui/input.tsx
+++ b/packages/ui/src/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "box-border flex h-9 w-full rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1 text-sm text-[var(--color-text-primary)] transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-[var(--color-text-tertiary)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent-primary)] disabled:cursor-not-allowed disabled:opacity-50",
+          "box-border min-w-0 flex h-9 w-full rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-1 text-sm text-[var(--color-text-primary)] transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-[var(--color-text-tertiary)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent-primary)] disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         ref={ref}

--- a/packages/ui/src/ui/select.tsx
+++ b/packages/ui/src/ui/select.tsx
@@ -16,7 +16,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-sm text-[var(--color-text-primary)] ring-offset-[var(--color-bg-root)] placeholder:text-[var(--color-text-tertiary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent-primary)] disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "box-border flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-sm text-[var(--color-text-primary)] ring-offset-[var(--color-bg-root)] placeholder:text-[var(--color-text-tertiary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent-primary)] disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className,
     )}
     {...props}

--- a/packages/ui/src/ui/select.tsx
+++ b/packages/ui/src/ui/select.tsx
@@ -16,7 +16,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "box-border flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-sm text-[var(--color-text-primary)] ring-offset-[var(--color-bg-root)] placeholder:text-[var(--color-text-tertiary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent-primary)] disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "box-border min-w-0 flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-sm text-[var(--color-text-primary)] ring-offset-[var(--color-bg-root)] placeholder:text-[var(--color-text-tertiary)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent-primary)] disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className,
     )}
     {...props}


### PR DESCRIPTION
Fixes the layout overflow reported in #843, where input fields inside the "Add Repository" modal extended past the modal's container bounds.

## Root Cause
The modal's inputs were missing two properties needed for correct sizing inside a flex/grid layout:
- No `box-sizing: border-box` equivalent, so horizontal padding was added on top of the declared 100% width instead of being included in it.
- No `min-width: 0`, so inputs couldn't shrink below their browser-default intrinsic width once the flex/grid container ran out of space.

## Changes
- **Added `box-border` to `Input` and `SelectTrigger`** — ensures padding is included in the 100% width calculation instead of expanding past it.
- **Added `min-w-0` to the inputs** — allows them to shrink correctly inside flex/grid layouts instead of overflowing at their intrinsic minimum width.
- **Added `overflow-hidden` to the modal container as a failsafe** — the two fixes above resolve the root cause, but this guards against similar overflow if new fields are added to the modal in the future without the same width handling.

## Screenshots
**Before:**
<img width="966" height="828" alt="image" src="https://github.com/user-attachments/assets/a970ee59-78c5-4bb0-ae4e-a59d3459ba88" />


**After:**
<img width="1300" height="733" alt="image" src="https://github.com/user-attachments/assets/06751410-5d83-48e8-a5f5-ddab548cd89b" />


Fixes #843