### PR TITLE
fix(chat): show normalized confidence in source citations, not raw score

### DIFF
--- a/packages/ui/__tests__/chat/source-citations.test.tsx
+++ b/packages/ui/__tests__/chat/source-citations.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { extractSources } from "../../src/chat/source-citations.js";
+import type { ChatUIToolCall } from "@repowise-dev/types/chat";
+
+function searchCall(results: Array<Record<string, unknown>>): ChatUIToolCall {
+  return {
+    id: "tc1",
+    name: "search_codebase",
+    arguments: { query: "where is auth handled" },
+    result: { results },
+    status: "done",
+  };
+}
+
+describe("extractSources", () => {
+  it("reads the rank-normalized confidence, not the raw backend score", () => {
+    // BM25 fallback scores are unbounded — reading relevance_score here is what
+    // rendered "1808%" in the sources list.
+    const sources = extractSources(
+      [
+        searchCall([
+          {
+            page_id: "file_page:auth.py",
+            title: "auth.py",
+            relevance_score: 18.08,
+            confidence_score: 1,
+          },
+        ]),
+      ],
+      "repo1",
+    );
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0]?.confidence).toBe(1);
+  });
+
+  it("keeps every confidence renderable as a 0-100% badge", () => {
+    const sources = extractSources(
+      [
+        searchCall([
+          { page_id: "a", title: "a", relevance_score: 18.08, confidence_score: 1 },
+          { page_id: "b", title: "b", relevance_score: 14.75, confidence_score: 0.82 },
+          { page_id: "c", title: "c", relevance_score: 0.43, confidence_score: 0.02 },
+        ]),
+      ],
+      "repo1",
+    );
+
+    expect(sources).toHaveLength(3);
+    for (const s of sources) {
+      expect(s.confidence).toBeGreaterThanOrEqual(0);
+      expect(s.confidence).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("omits confidence when the server sends no confidence_score", () => {
+    const sources = extractSources(
+      [searchCall([{ page_id: "file_page:a.py", title: "a.py", relevance_score: 9.1 }])],
+      "repo1",
+    );
+
+    // Badge hides rather than falling back to the unbounded raw score.
+    expect(sources[0]?.confidence).toBeUndefined();
+  });
+});

--- a/packages/ui/src/chat/source-citations.tsx
+++ b/packages/ui/src/chat/source-citations.tsx
@@ -11,7 +11,12 @@ export interface SourceReference {
   title: string;
   pageType: string;
   targetPath: string;
-  score?: number;
+  /**
+   * Rank-normalized 0–1 confidence, never the raw backend score: embedding
+   * hits are cosine (0–1) but the BM25 fallback is unbounded, so the raw
+   * score has no fixed scale to render as a percentage.
+   */
+  confidence?: number | undefined;
   toolName: string;
 }
 
@@ -39,7 +44,7 @@ export function extractSources(
           title: (r.title as string) ?? pageId,
           pageType: (r.page_type as string) ?? "file_page",
           targetPath: (r.target_path as string) ?? "",
-          score: r.relevance_score as number ?? r.score as number,
+          confidence: r.confidence_score as number | undefined,
           toolName: tc.name,
         });
       }
@@ -176,9 +181,9 @@ export function SourceCitations({
             </span>
             <SourceIcon pageType={source.pageType} className="h-3 w-3 shrink-0 opacity-60" />
             <span className="truncate max-w-[160px] font-medium">{source.title}</span>
-            {source.score != null && (
+            {source.confidence != null && (
               <span className="text-[10px] text-[var(--color-text-tertiary)] tabular-nums">
-                {(source.score * 100).toFixed(0)}%
+                {(source.confidence * 100).toFixed(0)}%
               </span>
             )}
             <ArrowUpRight className="h-2.5 w-2.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />


### PR DESCRIPTION
## The bug

The sources list under a chat answer rendered percentages far above 100%:

```
1 File: packages/server/...  1808%    2 auth.py  1475%    3 File: ...  1374%
4 File: ...  1348%           5 client.py  1279%           6 ...  1187%
```

## Root cause

`source-citations.tsx` multiplied `relevance_score` by 100 as if it were always a 0-1 fraction:

```tsx
{(source.score * 100).toFixed(0)}%
```

It is not. `relevance_score` carries the **raw backend score**, and its scale depends on which retriever answered. `_retrieve_with_method` tries semantic search and falls back to FTS: embedding hits are cosine (0-1), but the BM25 fallback is unbounded. A score of 18.08 rendered as "1808%".

The two chat surfaces already disagreed about this field, which is the tell: `artifacts.tsx:270` renders the same `relevance_score` raw as `score 18.08`, while `source-citations.tsx:181` treated it as a fraction.

## The fix

`search_codebase` already derives `confidence_score` alongside it:

```python
# tool_search.py, _assign_confidence
item[target_key] = round(raw / max_score, 2) if max_score > 0 else 0.0
```

That is bounded 0-1 whichever retriever produced the hits, which is exactly what a percentage badge needs. This reads `confidence_score` instead, and renames the field `score` -> `confidence` so a value that is not a raw score stops being called one.

The `?? r.score` fallback is dropped rather than kept: that field is unbounded too, so it would reintroduce the bug whenever `confidence_score` is absent. The badge now hides in that case.

Only the `search_codebase` branch of `extractSources` ever set this field, so the blast radius is one file. Nothing outside `source-citations.tsx` reads it.

## Verified

Ranking is unaffected: results are sorted server-side and confidence is monotonic in the raw score. Against a live index, the same ten sources now read:

```
100%  82%  76%  75%  71%  66%  65%  63%  55%  53%
```

Each matches `raw / max_score` exactly (1475/1808 = 82%, 949/1808 = 53%), and all ten badges still render, so nothing dropped.

## Tests

Adds `__tests__/chat/source-citations.test.tsx`. The component had no coverage, which is how this shipped; the existing `source-citation.test.tsx` covers the unrelated singular component. The new test pins a BM25-scale payload (`relevance_score: 18.08`) and asserts the badge stays within 0-100%.