### PR TITLE
fix(search): score symbols on the query's identifier, not the whole question

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_search.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_search.py
@@ -620,9 +620,23 @@ async def _structured_search(
     files: list[dict] = []
     concepts: list[dict] = []
 
+    # A hybrid query is prose wrapped around an identifier ("where is X
+    # defined"). The symbol scorer ranks on token overlap, so handing it the
+    # raw prose lets stopword-ish tokens ("is" -> is_ci, "filter" ->
+    # FilterRegistry) outrank the identifier the question is actually about,
+    # which then never reaches _has_exact_symbol and the response claims the
+    # symbol is unindexed. Score symbols on the extracted identifiers instead.
+    symbol_query = query
+    if mode == "hybrid":
+        _idents = _embedded_identifiers(query)
+        if _idents:
+            symbol_query = " ".join(_idents)
+
     for ctx in contexts:
         if mode in ("symbol", "hybrid"):
-            s = await search_symbols_single(ctx, query, limit, symbol_kind=symbol_kind, kind=kind)
+            s = await search_symbols_single(
+                ctx, symbol_query, limit, symbol_kind=symbol_kind, kind=kind
+            )
             _tag_repo(s, ctx, multi)
             symbols.extend(s)
         if mode == "path":

--- a/tests/unit/server/mcp/test_search.py
+++ b/tests/unit/server/mcp/test_search.py
@@ -604,6 +604,38 @@ class TestExactMatchSignal:
         assert _identifier_candidates("rate limiting", "concept") == []
 
     @pytest.mark.asyncio
+    async def test_hybrid_scores_symbols_on_the_identifier_not_the_prose(
+        self, setup_mcp, monkeypatch
+    ):
+        # Regression: the symbol scorer ranks on token overlap, so handing it the
+        # whole question let prose tokens ("is" -> is_ci, "filter" ->
+        # FilterRegistry) outrank the identifier the question asks after. The
+        # identifier then never reached _has_exact_symbol and the response
+        # claimed an indexed symbol was absent.
+        #
+        # Asserted on the query the scorer RECEIVES, not on ranking: a fixture
+        # small enough to unit-test has no decoys to lose to, so an end-to-end
+        # assertion here passes against the bug.
+        from repowise.server.mcp_server import search_codebase, tool_search
+
+        seen: list[str] = []
+        real = tool_search.search_symbols_single
+
+        async def spy(ctx, query, limit, **kwargs):
+            seen.append(query)
+            return await real(ctx, query, limit, **kwargs)
+
+        monkeypatch.setattr(tool_search, "search_symbols_single", spy)
+
+        await search_codebase("where is AuthService defined")
+        assert seen == ["AuthService"], f"symbol scorer got prose, not the identifier: {seen}"
+
+        # A query carrying no identifier still scores on the raw text.
+        seen.clear()
+        await search_codebase("AuthService", mode="symbol")
+        assert seen == ["AuthService"]
+
+    @pytest.mark.asyncio
     async def test_exact_hit_sets_true_and_no_note(self, setup_mcp):
         from repowise.server.mcp_server import search_codebase
 


### PR DESCRIPTION
## The bug

A hybrid query is prose wrapped around an identifier ("where is X defined").
Both symbol and hybrid mode handed the raw query to `search_symbols_single`,
but that scorer ranks on token overlap, so the question's prose tokens compete
as if they were symbol names.

Live, on this repo:

```
search_codebase("filter_dicts_by_key")
  -> mode=symbol, exact_match=true
     _helpers.py::filter_dicts_by_key at rank 1, score 160

search_codebase("where is filter_dicts_by_key defined")
  -> mode=hybrid, exact_match=false, plus the note:
     "No indexed symbol exactly matches 'filter_dicts_by_key'"
```

The claim is false. The symbol is indexed at `_helpers.py:532`. What ranked
instead was `is_ci` (matching the token "is") and `FilterRegistry.get`
(matching "filter"). The real symbol never entered the result window, so
`_has_exact_symbol` saw no match among the returned symbols and the response
asserted the symbol was absent from the index.

That is the worst shape of wrong: the tool is most confident exactly where it
is wrong, and an agent that believes "this symbol is not indexed" stops looking
for something that is right there.

## The fix

`_identifier_candidates` already extracted the identifier at the call site
below, but only to compute the `exact` flag; it never reached the search. This
scores symbols on the extracted identifiers when the query is hybrid, and
leaves symbol mode (already a bare identifier) and identifier-free queries on
the raw text.

## Testing

`tests/unit/server/mcp/test_search.py`: 42 passed.

The new test asserts the query the scorer receives rather than the resulting
ranking. A fixture small enough to unit-test carries no decoys for the
identifier to lose to, so an end-to-end assertion on rank passes against the
bug. Verified to fail without the change (`symbol scorer got prose, not the
identifier: ['where is AuthService defined']`) and pass with it.