### PR TITLE
release: v0.32.0 — full-codebase retrieval coverage, answer-quality fixes, new stats signals

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.32.0] — 2026-07-15
+
+### Added
+- **Every file is now retrievable.** After the LLM budget picks its file pages, every remaining parsed code file gets a zero-LLM deterministic page, so concept search reaches the whole codebase instead of only the ~20% the budget covers. These tail pages are down-weighted in `search_codebase` and `get_answer` so a thin template page never displaces a rich page on a tie, and they carry `is_deterministic` / `doc_tier` in the API responses. (#817, #819)
+- **More signals on the stats page.** "By the Numbers" gained a coding-rhythm punch card (weekday × hour commit heatmap, UTC), 90-day momentum against the prior window, the wiki's own build cost stats, a change-risk mix, and a truck factor — all derived from data the index already holds, with no new indexing. (#828)
+- **Kimi is a first-class provider.** (#824)
+- **Decisions follow you into Codex.** The Codex SessionStart hook now delivers relevance-ranked standing decisions, matching what Claude Code already did. (#788)
+- **Test breakage is called out separately in risk.** `get_risk` PR mode splits test files into a new `will_break_tests` field, so a burst of broken tests can't crowd real structural impact out of the capped `will_break` list. (#739)
+- **Richer anonymous telemetry.** One event per MCP tool call, an interrupted status, and index-shape outcomes, so the collected numbers answer real questions. Consent and env vars are unchanged. (#820)
+
+### Fixed
+- **Search scores the identifier, not the whole question.** (#853)
+- **A generic method mention no longer hijacks the answer.** A prose `get_answer` question that merely mentioned a common method (`to_dict`, `provider_name`) was routed into the exact-name union path and returned the whole definition set instead of answering. Large unions on prose questions now defer to synthesis; small unions and bare symbol lookups are untouched. (#823)
+- **Key Concepts picks real concepts.** Ranking was by file PageRank, so every public symbol in a high-ranked file inherited that rank — surfacing five methods of one registry class as the codebase's core concepts, and leaking pytest fixtures into the prose. Symbols are now ranked directly and spread across clusters. (#813)
+- **Custom `serve` ports work again.** Next.js standalone compiled rewrites with build-time env vars, breaking custom port arguments; `/api/*`, `/health`, and `/metrics` now proxy through runtime middleware. (#838, #839)
+- **Persisted vector indexes load on startup.** (#835)
+- **Go dead-code false positives.** Function references in Go are now detected, rescuing live functions that were reported as dead. (#815)
+- **Dataflow recurses into `with`-statement bodies.** (#836)
+- **Stats report true project age, commit, and contributor counts**, with compact k/m formatting and years/months age in the hero. (#730, #827, #798)
+- **Source citations show normalized confidence**, not the raw score. (#846)
+- **Anthropic thinking blocks are handled.** (#787)
+- **Add Repository dialog no longer overflows its inputs.** (#843, #844)
+- **Friendlier empty state for documents.** (#822)
+
 ## [0.31.0] — 2026-07-12
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.31.0"
+__version__ = "0.32.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.31.0"
+__version__ = "0.32.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.32.0] — 2026-07-15
+
+### Added
+- **Every file is now retrievable.** After the LLM budget picks its file pages, every remaining parsed code file gets a zero-LLM deterministic page, so concept search reaches the whole codebase instead of only the ~20% the budget covers. These tail pages are down-weighted in `search_codebase` and `get_answer` so a thin template page never displaces a rich page on a tie, and they carry `is_deterministic` / `doc_tier` in the API responses. (#817, #819)
+- **More signals on the stats page.** "By the Numbers" gained a coding-rhythm punch card (weekday × hour commit heatmap, UTC), 90-day momentum against the prior window, the wiki's own build cost stats, a change-risk mix, and a truck factor — all derived from data the index already holds, with no new indexing. (#828)
+- **Kimi is a first-class provider.** (#824)
+- **Decisions follow you into Codex.** The Codex SessionStart hook now delivers relevance-ranked standing decisions, matching what Claude Code already did. (#788)
+- **Test breakage is called out separately in risk.** `get_risk` PR mode splits test files into a new `will_break_tests` field, so a burst of broken tests can't crowd real structural impact out of the capped `will_break` list. (#739)
+- **Richer anonymous telemetry.** One event per MCP tool call, an interrupted status, and index-shape outcomes, so the collected numbers answer real questions. Consent and env vars are unchanged. (#820)
+
+### Fixed
+- **Search scores the identifier, not the whole question.** (#853)
+- **A generic method mention no longer hijacks the answer.** A prose `get_answer` question that merely mentioned a common method (`to_dict`, `provider_name`) was routed into the exact-name union path and returned the whole definition set instead of answering. Large unions on prose questions now defer to synthesis; small unions and bare symbol lookups are untouched. (#823)
+- **Key Concepts picks real concepts.** Ranking was by file PageRank, so every public symbol in a high-ranked file inherited that rank — surfacing five methods of one registry class as the codebase's core concepts, and leaking pytest fixtures into the prose. Symbols are now ranked directly and spread across clusters. (#813)
+- **Custom `serve` ports work again.** Next.js standalone compiled rewrites with build-time env vars, breaking custom port arguments; `/api/*`, `/health`, and `/metrics` now proxy through runtime middleware. (#838, #839)
+- **Persisted vector indexes load on startup.** (#835)
+- **Go dead-code false positives.** Function references in Go are now detected, rescuing live functions that were reported as dead. (#815)
+- **Dataflow recurses into `with`-statement bodies.** (#836)
+- **Stats report true project age, commit, and contributor counts**, with compact k/m formatting and years/months age in the hero. (#730, #827, #798)
+- **Source citations show normalized confidence**, not the raw score. (#846)
+- **Anthropic thinking blocks are handled.** (#787)
+- **Add Repository dialog no longer overflows its inputs.** (#843, #844)
+- **Friendlier empty state for documents.** (#822)
+
 ## [0.31.0] — 2026-07-12
 
 ### Added

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.31.0"
+__version__ = "0.32.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.32.0
+
+### Changed
+- Version bump to track the repowise 0.32.0 release. No command, skill, or MCP
+  tool-surface changes this cycle.
+
 ## 0.31.0
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.31.0"
+version = "0.32.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3056,7 +3056,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.31.0"
+version = "0.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Cuts v0.32.0 from `main` (20 commits since v0.31.0). Bump + changelog only — no functional changes in this branch.

## What's in the release

The theme this cycle is **retrieval coverage**: every parsed file now gets a page (deterministic tail, #817/#819), so concept search reaches the whole codebase rather than the ~20% the LLM budget covers. Alongside that, a batch of `get_answer` / search-quality fixes, new stats signals, a Kimi provider, and decisions delivered into Codex.

Full breakdown in `docs/CHANGELOG.md`.

## Version bump

Six synchronized files + lockfile:
- `pyproject.toml`, `packages/{cli,core,server}/src/**/__init__.py` → `0.32.0`
- `.claude-plugin/marketplace.json`, `plugins/claude-code/.claude-plugin/plugin.json` → `0.32.0`
- `uv.lock` self-entry `0.31.0 → 0.32.0` (via explicit `uv lock`)

**Not bumped, deliberately:**
- `STORE_FORMAT_VERSION` / `PARSER_SCHEMA_VERSION` stay at `1`. The Go change (#815) is a `.scm` query — its bytes are already hashed into the parse-cache fingerprint. The with-statement fix (#836) is in `analysis/health/dataflow`, not the ingestion parser that produces `ParsedFile`. No store reacts, no cache churn.
- `plugins/codex/.codex-plugin/plugin.json` stays at `0.1.1` — `plugins/codex/` has no diff since v0.31.0. (#788 landed in the CLI hook code, not the plugin dir.)
- `packages/vscode/package.json` — rides its own version line; no extension release in this window.

## Test plan

- [x] `uv lock` — self-entry moved; drift grep clean (remaining `0.31.0` hits are the coincidental `asyncpg` dep)
- [x] `uv build --wheel` → `dist/repowise-0.32.0-py3-none-any.whl`, 69 command modules incl. `serve_cmd.py`, 38 `.scm`/`.j2` data files, bundled changelog present
- [x] `npm ci && npm run build --workspace packages/web` — **green**, all routes built, standalone `server.js` emitted, workspace-package code transpiled into chunks. Middleware entry (34.3 kB) present, confirming #839 compiled
- [x] Bundled changelog resynced; `tests/unit/upgrade/test_bundled_changelog_sync.py` passes
- [x] Plugin MCP tool-surface parity — every tool the plugin references is in the live `list_tools()` set. `get_architecture_diagram` appears only in the plugin CHANGELOG documenting its removal, which is expected
- [ ] Squash-merge, tag `v0.32.0` on the squash commit, push tag → `publish.yml`
- [ ] Post-release: PyPI version, GitHub release assets, web tarball structure
- [ ] End-user smoke test from a fresh dir (needs a machine without the local monorepo)
