### PR TITLE
fix(answer): live-grep fallbacks respect gitignore and exclude_patterns

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/_code_rationale.py
+++ b/packages/server/src/repowise/server/mcp_server/_code_rationale.py
@@ -41,6 +41,7 @@ from repowise.core.analysis.decisions.rationale_comments import (
     RATIONALE_MARKERS,
     extract_comment_blocks,
 )
+from repowise.core.exclusion import build_exclude_spec, is_excluded
 
 _log = logging.getLogger("repowise.mcp.code_rationale")
 
@@ -405,4 +406,9 @@ def grep_comment_candidates(
         path = line.split(":", 1)[0]
         if path:
             counts[path] += 1
-    return [p for p, _ in counts.most_common(max_files)]
+    # ``git grep`` only scans tracked files, but a gitignored copy can still be
+    # tracked (or land here via a future --no-index retry); filter the winners
+    # through the repo's exclusion rules so an ignored path is never anchored on.
+    spec = build_exclude_spec(root)
+    ranked = [p for p, _ in counts.most_common() if not is_excluded(p, spec)]
+    return ranked[:max_files]

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/data_shape.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/data_shape.py
@@ -22,6 +22,7 @@ import re
 import subprocess
 from pathlib import Path
 
+from repowise.core.exclusion import build_exclude_spec, is_excluded
 from repowise.server.mcp_server.tool_answer.config import (
     _DATA_SHAPE_ACCESS_WINDOW,
     _DATA_SHAPE_DOC_WINDOW,
@@ -175,7 +176,7 @@ def _run_grep(
         return None
 
 
-def _grep_identifier_files(repo_root: Path, identifier: str) -> list[str]:
+def _grep_identifier_files(repo_root: Path, identifier: str, spec: object = None) -> list[str]:
     """Source files naming ``identifier`` (whole word), repo-relative.
 
     Tracked ``git grep`` first (fast, skips ignored/vendored). If the tree isn't
@@ -184,6 +185,11 @@ def _grep_identifier_files(repo_root: Path, identifier: str) -> list[str]:
     per-file Python read that wedges on a large tree. Returns the full match set;
     the caller orders (doc files first) then caps, so the documenting file is
     never dropped by an unlucky order.
+
+    ``--no-index`` scans the raw filesystem and ignores ``.gitignore``, so a
+    gitignored stale wheel / vendored copy can surface as a match. The compiled
+    ``spec`` (gitignore + ``exclude_patterns``) filters those out authoritatively,
+    matching every other MCP read path.
     """
     proc = _run_grep(repo_root, [], identifier)
     if proc is not None and proc.returncode == 128:
@@ -191,7 +197,10 @@ def _grep_identifier_files(repo_root: Path, identifier: str) -> list[str]:
         proc = _run_grep(repo_root, ["--no-index"], identifier)
     if proc is None or proc.returncode not in (0, 1):
         return []
-    return [ln.strip().replace("\\", "/") for ln in proc.stdout.splitlines() if ln.strip()]
+    paths = [ln.strip().replace("\\", "/") for ln in proc.stdout.splitlines() if ln.strip()]
+    if spec is not None:
+        paths = [p for p in paths if not is_excluded(p, spec)]
+    return paths
 
 
 def _read_lines(repo_root: Path, rel_path: str) -> list[str] | None:
@@ -384,8 +393,13 @@ def mine_data_shape(repo_root: Path | None, question_ids: set[str]) -> dict | No
     except Exception:
         return None
 
+    # Compile the repo's exclusion rules once per query. The grep fallbacks
+    # (esp. ``git grep --no-index`` on a non-git tree) don't honour .gitignore,
+    # so filter their hits the same way every other MCP read path does.
+    exclude_spec = build_exclude_spec(root)
+
     for identifier in _specific_identifiers(question_ids):
-        files = _grep_identifier_files(root, identifier)
+        files = _grep_identifier_files(root, identifier, exclude_spec)
         if not files:
             continue
         # Scan documenting files first, then cap: the file that documents the

--- a/tests/unit/server/mcp/test_answer_data_shape.py
+++ b/tests/unit/server/mcp/test_answer_data_shape.py
@@ -19,9 +19,11 @@ from pathlib import Path
 import pytest
 
 from repowise.server.mcp_server.tool_answer.data_shape import (
+    _grep_identifier_files,
     _is_data_shape_question,
     mine_data_shape,
 )
+from repowise.core.exclusion import build_exclude_spec
 
 
 def _write(root: Path, rel: str, body: str) -> None:
@@ -337,3 +339,56 @@ def enrich(rows_json, meta, src):
 
 def test_none_repo_root_is_safe():
     assert mine_data_shape(None, {"anything_json"}) is None
+
+
+# --- Gitignore / exclude_patterns are honoured (live-grep fallback) --------
+
+
+def test_grep_skips_gitignored_file(tmp_path):
+    """The ``--no-index`` filesystem grep must not return a gitignored path.
+
+    ``tmp_path`` is not a git checkout, so ``_grep_identifier_files`` retries
+    with ``git grep --no-index`` (which ignores ``.gitignore``). The compiled
+    exclude spec must drop the ignored hit while keeping the tracked one.
+    """
+    _write(tmp_path, ".gitignore", "ignored/\n")
+    _write(tmp_path, "ignored/leak.py", "x = leak_record_json\n")
+    _write(tmp_path, "pkg/real.py", "y = leak_record_json\n")
+    spec = build_exclude_spec(tmp_path)
+    files = _grep_identifier_files(tmp_path, "leak_record_json", spec)
+    assert "pkg/real.py" in files
+    assert "ignored/leak.py" not in files
+
+
+def test_mine_data_shape_ignores_gitignored_leak(tmp_path):
+    """A gitignored stale copy must never be the shape source served."""
+    _write(tmp_path, ".gitignore", "ignored/\n")
+    # The gitignored copy documents a stale/wrong shape.
+    _write(
+        tmp_path,
+        "ignored/leak.py",
+        '''\
+class Stale:
+    """``leak_record_json`` is a JSON list of
+    ``{"stale_one", "stale_two", "stale_three"}`` records."""
+
+    leak_record_json: str
+''',
+    )
+    # The tracked file documents the real shape.
+    _write(
+        tmp_path,
+        "pkg/models.py",
+        '''\
+class Real:
+    """``leak_record_json`` is a JSON list of
+    ``{"author", "commit_sha", "line_count"}`` records."""
+
+    leak_record_json: str
+''',
+    )
+    out = mine_data_shape(tmp_path, {"leak_record_json"})
+    assert out is not None
+    assert out["fields"] == ["author", "commit_sha", "line_count"]
+    # No served source may point at the gitignored copy.
+    assert all("ignored/leak.py" != s["file"] for s in out["sources"])

--- a/tests/unit/server/mcp/test_code_rationale.py
+++ b/tests/unit/server/mcp/test_code_rationale.py
@@ -266,6 +266,36 @@ def test_grep_comment_candidates_ranks_number_bearing_file(tmp_path):
     assert "pager.py" not in cands
 
 
+def test_grep_comment_candidates_skips_gitignored_file(tmp_path):
+    """A gitignored path must not be returned as a rationale candidate.
+
+    ``git grep`` scans tracked files, but a file force-added before it was
+    gitignored stays tracked (this is exactly how a stale vendored copy leaks
+    in). The compiled exclude spec must drop it while keeping the real file.
+    """
+    _RATIONALE = (
+        "# The widget list cap is 77 because the median fan-in is small\n"
+        "# and 77 covers nearly every widget in one call.\n"
+        "LIMIT = 77\n"
+    )
+    (tmp_path / ".gitignore").write_text("stale/\n", encoding="utf-8")
+    (tmp_path / "enrichment.py").write_text(_RATIONALE, encoding="utf-8")
+    (tmp_path / "stale").mkdir()
+    (tmp_path / "stale" / "leak.py").write_text(_RATIONALE, encoding="utf-8")
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "enrichment.py", ".gitignore"], cwd=tmp_path, check=True)
+    # Force-track the ignored copy so git grep can still see it.
+    subprocess.run(["git", "add", "-f", "stale/leak.py"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t.dev", "-c", "user.name=t", "commit", "-qm", "init"],
+        cwd=tmp_path,
+        check=True,
+    )
+    cands = grep_comment_candidates(str(tmp_path), "why is the widget list capped at 77")
+    assert "enrichment.py" in cands
+    assert "stale/leak.py" not in cands
+
+
 def test_grep_comment_candidates_needs_a_noun(tmp_path):
     # Numbers but no content noun (all stopwords) -> nothing to anchor on.
     repo = _git_repo(tmp_path, _CALLER_CAP_FILES)


### PR DESCRIPTION
## What

`get_answer` has two live-grep fallback paths that shell out to `git grep`
without applying the repo's exclusion rules. Both now filter results through
the repo's exclusion spec before returning.

## Why

- `_grep_identifier_files` (data-shape grounding) retries with
  `git grep --no-index` when the tree is not a git checkout. `--no-index`
  scans the raw filesystem and ignores `.gitignore`, so a gitignored stale
  copy (for example an unpacked pip wheel under a scratch dir) could be
  returned as a match and served as the answer's source.
- `grep_comment_candidates` (concept anchoring) ranked candidate files from a
  comment grep with no exclusion filter.

Both now compile the repo's exclusion spec once per query via the existing
`repowise.core.exclusion.build_exclude_spec` (which unions
`.repowise/config.yaml` `exclude_patterns` with the gitignore stack) and drop
excluded paths with `is_excluded` before returning. This is the same
query-time filter every other MCP read path already uses.

## Testing

Added cases that place the target identifier/shape in a gitignored file and
assert it is never returned or served, while a non-ignored file with the same
identifier still is (no over-filtering).

`pytest tests/unit/server/mcp/test_answer_data_shape.py tests/unit/server/mcp/test_code_rationale.py`
passes the new tests. Two failures in `test_code_rationale.py`
(`test_grep_comment_candidates_ranks_number_bearing_file`,
`test_concept_anchor_injects_winner_as_dominant`) are pre-existing and
unrelated: they fail only on Apple Git, whose POSIX-ERE engine does not treat
`\s` as whitespace in the existing comment-grep pattern. They pass on GNU grep.
