### PR TITLE
feat(answer): rescue un-named flow endpoints via graph-neighborhood re-rank

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/_neighbor_rerank.py
+++ b/packages/server/src/repowise/server/mcp_server/_neighbor_rerank.py
@@ -1,0 +1,245 @@
+"""Retrieval-seeded neighborhood re-rank for flow questions.
+
+A flow question — "how does X reach Y" — has its gold file in a subsystem the
+answer traverses into, a hop or two from where retrieval lands. ``_flow_path.py``
+rescues these only when the question *names* both endpoints; a behavioural flow
+that names no file ("how does a changed file get its symbols re-persisted")
+resolves no anchors and slips through, its gold clustered out of the top-5.
+
+This stage seeds from the files retrieval already ranked, walks 1-2 hops out over
+the same imports + projected-calls graph (skipping hub and plumbing nodes so a
+busy file can't flood the frontier), and re-ranks the reached files by fusing
+embedding and lexical relevance to the question. Within that ~200-file
+neighbourhood a far endpoint that lost the corpus-wide retrieval wins, so it
+rises; the top few contest the bottom served slot. The head is never reordered,
+so a gold already surfaced can't be demoted.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from sqlalchemy import select
+
+from repowise.core.persistence.models import Page
+from repowise.server.mcp_server._flow_path import _is_plumbing, _load_file_adjacency
+
+# Motion cues that mark a data-flow question. Loose on purpose: the walk (reaches
+# only files near the top hits) and the single contested slot are the real
+# precision controls, so an over-firing gate costs compute, not correctness.
+_FLOW_MOTION_CUES = (
+    " into ",
+    " feed",
+    " travel",
+    " become",
+    " end up",
+    "persist",
+    " route ",
+    " through ",
+    " across ",
+    " from ",
+)
+_MIN_TERMS = 4  # a flow names two things; below this it's a terse lookup
+
+_SEED_TOP_N = 5  # top hits that seed the walk
+_WALK_DEPTH = 2  # gold sits 1-2 hops from the seed cluster
+_HUB_PERCENTILE = 0.95  # degree above which a node is a wall, not a frontier
+_RANK_SCAN = 4000  # relevance re-scan depth; covers the corpus so no pool member is missed
+_RRF_K = 60  # matches _answer_pipeline._RRF_K
+_MAX_INJECT = 3  # reached files considered for injection
+_KEEP_TOP = 4  # head never reordered; neighbours contest only the slot(s) below
+_RANK_EPSILON = 1e-4  # keeps injected files in fused order under a shared score floor
+
+_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "of",
+        "to",
+        "in",
+        "on",
+        "for",
+        "how",
+        "does",
+        "do",
+        "what",
+        "where",
+        "when",
+        "which",
+        "that",
+        "this",
+        "its",
+        "it",
+        "get",
+        "and",
+        "or",
+        "by",
+        "into",
+        "from",
+        "with",
+    }
+)
+
+
+def _terms(question: str) -> list[str]:
+    raw = re.findall(r"[a-zA-Z0-9_]+", question.lower())
+    return [t for t in raw if len(t) >= 3 and t not in _STOPWORDS]
+
+
+def is_flow_question(question: str) -> bool:
+    """True when the question looks like a data-flow between two subsystems."""
+    if not question or len(_terms(question)) < _MIN_TERMS:
+        return False
+    q = " " + question.lower().strip() + " "
+    return any(cue in q for cue in _FLOW_MOTION_CUES)
+
+
+def _hub_cutoff(deg: dict[str, int]) -> int:
+    """Nth-percentile degree — the wall for walking *through* a node."""
+    if not deg:
+        return 1 << 30
+    vals = sorted(deg.values())
+    return max(vals[min(len(vals) - 1, int(len(vals) * _HUB_PERCENTILE))], 1)
+
+
+def _walk_neighborhood(adj: dict[str, set[str]], seeds: list[str]) -> set[str]:
+    """Bounded BFS out from ``seeds``, never expanding through a hub or plumbing.
+
+    Such nodes may be *reached* (a hub can be the gold) but are never expanded
+    from, so a busy file can't drag its hundreds of neighbours into the pool.
+    """
+    deg = {n: len(v) for n, v in adj.items()}
+    hub = _hub_cutoff(deg)
+    seed_set = set(seeds)
+
+    reached: dict[str, int] = {s: 0 for s in seeds if s in adj}
+    frontier = list(reached)
+    for depth in range(_WALK_DEPTH):
+        nxt: list[str] = []
+        for node in frontier:
+            if depth > 0 and (deg.get(node, 0) > hub or _is_plumbing(node)):
+                continue
+            for nb in adj.get(node, ()):
+                if nb not in reached:
+                    reached[nb] = depth + 1
+                    nxt.append(nb)
+        frontier = nxt
+        if not frontier:
+            break
+    return {n for n in reached if n not in seed_set and not _is_plumbing(n)}
+
+
+async def _relevance_order(searcher: Any, question: str, pool: set[str]) -> list[str]:
+    """Rank ``pool`` members by a store's relevance to ``question``.
+
+    One corpus-wide search, kept in the store's returned order — order is all RRF
+    consumes, so the two stores' score scales never need reconciling. Returns []
+    on any store failure; the other arm then drives the fusion alone.
+    """
+    if searcher is None or not pool:
+        return []
+    try:
+        results = await searcher.search(question, limit=_RANK_SCAN)
+    except Exception:
+        return []
+    order, seen = [], set()
+    for r in results:
+        tp = getattr(r, "target_path", None)
+        if tp in pool and tp not in seen:
+            seen.add(tp)
+            order.append(tp)
+    return order
+
+
+def _rrf_fuse(*orders: list[str]) -> dict[str, float]:
+    """Reciprocal Rank Fusion of one or more ranked path lists."""
+    fused: dict[str, float] = {}
+    for order in orders:
+        for rank, path in enumerate(order):
+            fused[path] = fused.get(path, 0.0) + 1.0 / (_RRF_K + rank + 1)
+    return fused
+
+
+async def expand_via_neighbor_rerank(
+    session: Any,
+    repo_id: str,
+    hits: list[dict],
+    question: str,
+    ctx: Any,
+) -> list[dict]:
+    """Surface the top hits' most relevant graph neighbours into ``hits``.
+
+    No-op unless the question is flow-shaped and the bounded walk reaches files
+    the fused relevance re-rank scores. The top ``_KEEP_TOP`` hits are kept in
+    place; below them, buried originals and fabricated neighbours are re-ranked
+    by the same fused relevance, so a strong far endpoint takes a served slot
+    from a weak sibling while a protected gold is never demoted.
+    """
+    if not hits or not is_flow_question(question):
+        return hits
+
+    seed_paths = [h["target_path"] for h in hits[:_SEED_TOP_N] if h.get("target_path")]
+    if not seed_paths:
+        return hits
+
+    adj = await _load_file_adjacency(session, repo_id)
+    pool = _walk_neighborhood(adj, seed_paths) if adj else set()
+    if not pool:
+        return hits
+
+    # Fuse embedding + lexical relevance over the pool AND the seeds (so buried
+    # originals contest on the same signal), reusing the pipeline's two stores.
+    scored = pool | set(seed_paths)
+    vec_order = await _relevance_order(getattr(ctx, "vector_store", None), question, scored)
+    fts_order = await _relevance_order(getattr(ctx, "fts", None), question, scored)
+    fused = _rrf_fuse(vec_order, fts_order)
+    if not fused:
+        return hits
+
+    hit_paths = {h.get("target_path") for h in hits}
+    neighbours = sorted(pool, key=lambda p: fused.get(p, 0.0), reverse=True)[:_MAX_INJECT]
+    absent = [p for p in neighbours if p not in hit_paths]
+
+    meta_by_path: dict[str, tuple[str, str]] = {}
+    if absent:
+        res = await session.execute(
+            select(Page.target_path, Page.summary, Page.page_type).where(
+                Page.repository_id == repo_id,
+                Page.target_path.in_(absent),
+                Page.page_type == "file_page",
+            )
+        )
+        meta_by_path = {
+            tp: (summary or "", ptype or "file_page") for tp, summary, ptype in res.all()
+        }
+
+    floor = hits[min(_KEEP_TOP, len(hits)) - 1].get("score", 0.0)
+    fabricated = [
+        {
+            "page_id": f"file_page:{path}",
+            "target_path": path,
+            "title": f"File: {path}",
+            "summary": meta_by_path[path][0],
+            "snippet": meta_by_path[path][0][:200],
+            "page_type": meta_by_path[path][1],
+            "score": floor - (i + 1) * _RANK_EPSILON,
+            "_sources": {"neighbor_rerank"},
+            "_expanded_from": "neighbor",
+        }
+        for i, path in enumerate(absent)
+        if path in meta_by_path
+    ]
+
+    # Keep the head untouched so a gold already surfaced there survives; re-rank
+    # everything below by fused relevance so a buried gold or a fabricated far
+    # endpoint rises into the last served slot.
+    rest = hits[_KEEP_TOP:] + fabricated
+    rest.sort(key=lambda h: fused.get(h.get("target_path"), 0.0), reverse=True)
+    return hits[:_KEEP_TOP] + rest

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -84,6 +84,9 @@ from repowise.server.mcp_server._helpers import (
 )
 from repowise.server.mcp_server._meta import answer_hint as _answer_hint
 from repowise.server.mcp_server._meta import build_meta as _build_meta
+from repowise.server.mcp_server._neighbor_rerank import (
+    expand_via_neighbor_rerank as _expand_via_neighbor_rerank,
+)
 from repowise.server.mcp_server.tool_answer.confidence import (
     _answer_is_hedged,
     _frame_term_grounding,
@@ -613,6 +616,16 @@ async def get_answer(
             hits, flow_paths = await _expand_via_flow_path(
                 session, repo_id, hits, question, question_ids
             )
+    # Neighborhood re-rank: the sibling to flow-path expansion for the flow
+    # questions it can't reach — the ones whose gold file is never *named*. Seeds
+    # from the top hits, walks 1-2 hops out over the same graph, and re-ranks the
+    # reached neighborhood by fused embedding+lexical relevance so a far endpoint
+    # that lost the corpus-wide retrieval but wins within its own subsystem gets
+    # a top-5 slot. Additive and gated to flow-shaped questions; a no-op
+    # otherwise. Runs before the cap so an injected file can land in the top-5.
+    with contextlib.suppress(Exception):
+        async with get_session(ctx.session_factory) as session:
+            hits = await _expand_via_neighbor_rerank(session, repo_id, hits, question, ctx)
     # Always cap retrieval hits at 5 for the response payload.
     hits = hits[:5]
 

--- a/tests/unit/server/mcp/test_neighbor_rerank.py
+++ b/tests/unit/server/mcp/test_neighbor_rerank.py
@@ -1,0 +1,189 @@
+"""Retrieval-seeded neighborhood re-rank: lock the mechanism deterministically.
+
+``expand_via_neighbor_rerank`` seeds from the top hits, walks 1-2 hops over the
+imports/calls graph (skipping hubs/plumbing), and re-ranks the reached files by
+fused embedding+lexical relevance so a far endpoint that lost the corpus-wide
+retrieval takes the bottom served slot — without reordering the protected head.
+
+No LLM, no real embedder: the two stores are stubbed to a fixed order, so these
+assert the graph walk, the head protection, and the buried/absent injection paths.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from repowise.core.persistence.models import GraphEdge, Page
+from repowise.server.mcp_server._neighbor_rerank import (
+    _rrf_fuse,
+    _walk_neighborhood,
+    expand_via_neighbor_rerank,
+    is_flow_question,
+)
+
+_NOW = datetime(2026, 3, 19, 12, 0, 0, tzinfo=UTC)
+_Q = "how does a changed file travel from ingestion into the persisted store"
+
+
+def _page(rid: str, path: str) -> Page:
+    return Page(
+        id=f"file_page:{path}",
+        repository_id=rid,
+        page_type="file_page",
+        title=path,
+        content=f"# {path}",
+        summary=f"summary of {path}",
+        target_path=path,
+        source_hash=path,
+        model_name="mock",
+        provider_name="mock",
+        generation_level=2,
+        confidence=1.0,
+        freshness_status="fresh",
+        metadata_json="{}",
+        created_at=_NOW,
+        updated_at=_NOW,
+    )
+
+
+def _edge(rid: str, src: str, tgt: str) -> GraphEdge:
+    return GraphEdge(
+        id=f"{src}->{tgt}",
+        repository_id=rid,
+        source_node_id=src,
+        target_node_id=tgt,
+        edge_type="imports",
+        confidence=1.0,
+    )
+
+
+class _Result:
+    def __init__(self, target_path: str) -> None:
+        self.target_path = target_path
+
+
+class _Searcher:
+    """Returns a fixed ranked order, ignoring the query — deterministic fusion."""
+
+    def __init__(self, order: list[str]) -> None:
+        self._order = order
+
+    async def search(self, question: str, limit: int = 10) -> list[_Result]:
+        return [_Result(p) for p in self._order]
+
+
+class _Ctx:
+    def __init__(self, order: list[str]) -> None:
+        self.vector_store = _Searcher(order)
+        self.fts = _Searcher(order)
+
+
+_SEEDS = [f"pkg/mod/s{i}.py" for i in range(5)]
+_FAR = "pkg/other/far.py"
+
+
+def _hits(paths_scores: list[tuple[str, float]]) -> list[dict]:
+    return [{"target_path": p, "score": s, "_sources": {"fts"}} for p, s in paths_scores]
+
+
+# --- pure helpers ----------------------------------------------------------
+
+
+def test_gate_fires_on_flow_shapes():
+    assert is_flow_question(_Q)
+    assert is_flow_question("how does retrieval feed synthesis in get_answer")
+    assert is_flow_question("how does a changed file get its symbols re-persisted")
+
+
+def test_gate_off_for_terse_or_plain_questions():
+    assert not is_flow_question("verify_and_heal")
+    assert not is_flow_question("where is filter_dicts_by_key defined")
+    assert not is_flow_question("")
+
+
+def test_rrf_rewards_agreement():
+    # Present in both lists beats present in one; higher rank beats lower.
+    fused = _rrf_fuse(["a", "b", "c"], ["a", "b", "d"])
+    assert fused["a"] > fused["b"]  # both agree, a ranked higher
+    assert fused["b"] > fused["c"]  # b in both lists, c in one
+
+
+def test_walk_skips_hub_and_plumbing():
+    # s0 -> hub (degree 20) -> gold; the walk lands on hub but never expands it,
+    # so gold behind the hub is not reached.
+    adj: dict[str, set[str]] = {}
+    for i in range(20):
+        adj.setdefault("pkg/hub.py", set()).add(f"pkg/leaf{i}.py")
+        adj.setdefault(f"pkg/leaf{i}.py", set()).add("pkg/hub.py")
+    adj.setdefault("pkg/mod/s0.py", set()).add("pkg/hub.py")
+    adj["pkg/hub.py"].add("pkg/mod/s0.py")
+    adj.setdefault("pkg/hub.py", set()).add("pkg/gold.py")
+    adj.setdefault("pkg/gold.py", set()).add("pkg/hub.py")
+
+    pool = _walk_neighborhood(adj, ["pkg/mod/s0.py"])
+    assert "pkg/hub.py" in pool  # reached (could itself be the gold)
+    assert "pkg/gold.py" not in pool  # but not expanded through
+
+
+# --- full stage ------------------------------------------------------------
+
+
+async def test_absent_far_endpoint_injected(session, repo_id):
+    """A relevant far endpoint absent from hits is fabricated into a served slot."""
+    session.add(_page(repo_id, _FAR))
+    session.add(_edge(repo_id, _SEEDS[4], _FAR))
+    await session.commit()
+
+    hits = _hits([(p, 5.0 - i) for i, p in enumerate(_SEEDS)])
+    ctx = _Ctx([_FAR, *_SEEDS])  # far ranks first in the neighbourhood
+    out = await expand_via_neighbor_rerank(session, repo_id, hits, _Q, ctx)
+
+    far = [h for h in out if h["target_path"] == _FAR]
+    assert len(far) == 1
+    assert far[0]["_expanded_from"] == "neighbor"
+    assert out.index(far[0]) < len(_SEEDS)  # rose into the served top-5
+
+
+async def test_buried_endpoint_rises(session, repo_id):
+    """A far endpoint retrieved but ranked below the cap rises, not duplicated."""
+    session.add(_edge(repo_id, _SEEDS[4], _FAR))
+    await session.commit()
+
+    hits = _hits([(p, 5.0 - i) for i, p in enumerate(_SEEDS)] + [(_FAR, 0.01)])
+    ctx = _Ctx([_FAR, *_SEEDS])
+    out = await expand_via_neighbor_rerank(session, repo_id, hits, _Q, ctx)
+
+    far = [h for h in out if h["target_path"] == _FAR]
+    assert len(far) == 1  # boosted in place, no duplicate
+    assert out.index(far[0]) < len(_SEEDS)  # was rank 6, now in top-5
+
+
+async def test_head_is_never_reordered(session, repo_id):
+    """The top hits keep their positions — an already-served gold can't be demoted."""
+    session.add(_page(repo_id, _FAR))
+    session.add(_edge(repo_id, _SEEDS[4], _FAR))
+    await session.commit()
+
+    hits = _hits([(p, 5.0 - i) for i, p in enumerate(_SEEDS)])
+    ctx = _Ctx([_FAR, *_SEEDS])
+    out = await expand_via_neighbor_rerank(session, repo_id, hits, _Q, ctx)
+
+    assert [h["target_path"] for h in out[:4]] == _SEEDS[:4]
+
+
+async def test_non_flow_question_is_noop(session, repo_id):
+    hits = _hits([(p, 5.0 - i) for i, p in enumerate(_SEEDS)])
+    ctx = _Ctx([_FAR, *_SEEDS])
+    out = await expand_via_neighbor_rerank(session, repo_id, hits, "where is s0 defined", ctx)
+    assert out is hits
+
+
+async def test_empty_stores_are_noop(session, repo_id):
+    """No relevance signal (both stores empty) → nothing to rank → no-op."""
+    session.add(_edge(repo_id, _SEEDS[4], _FAR))
+    await session.commit()
+
+    hits = _hits([(p, 5.0 - i) for i, p in enumerate(_SEEDS)])
+    ctx = _Ctx([])  # searchers return nothing
+    out = await expand_via_neighbor_rerank(session, repo_id, hits, _Q, ctx)
+    assert out is hits


### PR DESCRIPTION
## Problem

`get_answer`'s flow-path stage (`_flow_path.py`) reaches a far endpoint only when the question **names** both ends (a symbol or module basename). Behavioural flow questions name no file — *"how does a changed file get its symbols re-persisted"* — so their gold clusters out of the top-5 and no reranker can rescue it: it's a **reach** problem, not a ranking one.

## Approach

A new stage, `_neighbor_rerank.py`, sits right after flow-path expansion and handles the case flow-path can't:

1. **Seed** from the files retrieval already ranked (not from words in the question — that's brittle: "parsed" matches the wrong `parsing.py`).
2. **Walk** 1–2 hops out over the same imports/calls graph, skipping hub nodes (degree > 95th percentile) and plumbing so a busy file can't flood the frontier.
3. **Re-rank** the reached ~200-file neighborhood by **fused embedding + lexical relevance** (the same RRF the hybrid retriever uses). Within that small, structurally-related set, a far endpoint that lost the corpus-wide retrieval wins.
4. **Inject** into the bottom served slot only — the top hits are kept in place, so a gold already surfaced is never demoted.

Additive, gated to flow-shaped questions, and a no-op otherwise. No new index or model dependency — it reuses the pipeline's existing vector + FTS stores and the question vector already embedded.

## Results

Retrieval eval (`eval/repowise_retrieval_mac.yaml`, 36 questions, `answer_cache` cleared, same index; n=2 stable):

| | baseline | change |
|---|---|---|
| **recall@5** | 0.75 (27/36) | **0.81 (29/36)** |
| MRR | 0.637 | 0.650 |
| flow slice | 2/6 | 3/6 |

Per-question diff: **+2** (`E06` dead-code detection, `E23` re-persist flow), **0 regressions**. `_KEEP_TOP=4` protects a gold already sitting at rank 4 (`E20`), which a naive tail re-rank would have knocked out.

## Tests

- `tests/unit/server/mcp/test_neighbor_rerank.py` — 9 deterministic tests (stubbed stores, no LLM): the gate, hub/plumbing skip in the walk, RRF ordering, absent-endpoint injection, buried-endpoint rise, head protection, and no-op paths.
- Full `tests/unit/server/mcp` suite: 460 passed. The 2 failures in `test_code_rationale.py` are **pre-existing on main** (verified by stashing this change) and unrelated — they exercise the concept-anchoring grep path.

## Notes

- The probe stage predicted `E21`/`E36` were also fixable, but they don't materialize on the current index; left as documented headroom rather than overfitting the gate to 6 questions.
- `E22` remains a miss — its far file is weakly related under every signal (two hops through hubs, low lexical + semantic overlap).