### PR TITLE
feat(git): line-level AI provenance and per-commit model id from agent-trace

### DIFF
--- a/packages/core/alembic/versions/0038_agent_trace_line_provenance.py
+++ b/packages/core/alembic/versions/0038_agent_trace_line_provenance.py
@@ -1,0 +1,50 @@
+"""Line-level agent-trace provenance: model id + per-file AI line share.
+
+Line-level extension of the agent-trace channel. Per-commit: the ``model_id``
+(models.dev ``provider/model`` form) resolved from the agent-trace record that
+attributed the commit — populated only for the ``agent_trace`` channel, NULL otherwise.
+Per-file: the count of distinct file lines an AI/mixed contributor wrote
+(interval-union deduped across all trace records for the path) plus a
+``{model_id: line_count}`` breakdown, so "N% of this file is AI-written" and an
+opus-vs-sonnet split can be derived downstream against the file's current LOC.
+
+All columns are nullable / defaulted and back-populated on the next index. Data
+comes from ``.agent-trace/traces.jsonl`` only — repos without the standard pay
+nothing and keep NULL/zero throughout.
+
+Revision ID: 0038
+Revises: 0037
+Create Date: 2026-07-16
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers
+revision: str = "0038"
+down_revision: str | None = "0037"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("git_commits", sa.Column("agent_model_id", sa.String(64), nullable=True))
+
+    op.add_column(
+        "git_metadata",
+        sa.Column("agent_line_count", sa.Integer, nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "git_metadata",
+        sa.Column("agent_line_model_json", sa.Text, nullable=False, server_default="{}"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("git_metadata", "agent_line_model_json")
+    op.drop_column("git_metadata", "agent_line_count")
+    op.drop_column("git_commits", "agent_model_id")

--- a/packages/core/src/repowise/core/ingestion/git_commit_index.py
+++ b/packages/core/src/repowise/core/ingestion/git_commit_index.py
@@ -83,6 +83,7 @@ def load_commit_index(
     commit_sink: list[dict] | None = None,
     since_ts: int | None = None,
     provenance_classifier: object | None = None,
+    trace_index: object | None = None,
 ) -> dict[str, list[_CommitRec]]:
     """Bucket every commit in the recent history by the files it touched.
 
@@ -154,7 +155,10 @@ def load_commit_index(
     # git-ai authorship notes for this window (``{}`` unless the repo uses them).
     note_agents = load_git_ai_note_agents(repo, commit_limit)
     # Agent-trace records (empty after one stat call unless the repo has them).
-    trace_index = AgentTraceIndex.load(repo)
+    # The orchestrator may pass a shared instance so the trace file is read once
+    # per index rather than once per walk.
+    if trace_index is None:
+        trace_index = AgentTraceIndex.load(repo)
 
     bucket: dict[str, list[_CommitRec]] = {}
     commits_parsed = 0
@@ -262,6 +266,12 @@ def load_commit_index(
                     "agent_autonomy_tier": prov.autonomy_tier,
                     "agent_channel": prov.channel,
                     "agent_confidence": prov.confidence,
+                    # Model id only when the trace channel actually won: a note
+                    # or service-identity match can outrank the trace above, and
+                    # only the trace record carries a model.
+                    "agent_model_id": (
+                        trace_hit[2] if (trace_hit and prov.channel == "agent_trace") else None
+                    ),
                 }
             )
 
@@ -282,6 +292,7 @@ def load_deep_commit_index(
     skip: int,
     deep_limit: int,
     provenance_classifier: object | None = None,
+    trace_index: object | None = None,
 ) -> dict[str, list[_CommitRec]]:
     """Bucket commits OLDER than the recent window for *wanted_files* only.
 
@@ -343,7 +354,9 @@ def load_deep_commit_index(
     # git-ai notes across the deep region (``{}`` unless the repo uses them).
     note_agents = load_git_ai_note_agents(repo, skip + deep_limit)
     # Agent-trace records (empty after one stat call unless the repo has them).
-    trace_index = AgentTraceIndex.load(repo)
+    # Reuse the orchestrator's shared instance when supplied (single file read).
+    if trace_index is None:
+        trace_index = AgentTraceIndex.load(repo)
 
     bucket: dict[str, list[_CommitRec]] = {}
     commits_parsed = 0

--- a/packages/core/src/repowise/core/ingestion/git_indexer/README.md
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/README.md
@@ -114,7 +114,19 @@ Agent-trace records name a `vcs.revision` captured at edit or commit time, so
 `AgentTraceIndex` attributes a record to a commit when the revision matches
 the commit itself (confidence `high`) or one of its parents (the traced change
 landed in the child; confidence `medium`), and only when the record's file
-set overlaps the commit's changed paths.
+set overlaps the commit's changed paths. The winning record's dominant
+`model_id` (models.dev `provider/model` form) rides through to the commit for
+an opus-vs-sonnet split.
+
+`AgentTraceIndex` also produces a **per-file line share** from each record's
+`ranges[]`: the count of distinct lines an AI/mixed contributor wrote
+(interval-union deduped across every record for the path) plus a
+`{model_id: line_count}` breakdown. This is revision-independent (a record
+without `vcs.revision` still counts lines) and path-keyed, so the orchestrator
+merges it into `git_metadata` alongside the co-change / prior-defect signals
+and it works on the rename-tracking walk too. The `"N% AI-written"` denominator
+is the file's current LOC, applied downstream — the indexer stores only the AI
+numerator so it stays LOC-decoupled.
 
 Design rules:
 
@@ -134,11 +146,12 @@ Design rules:
   (`service_emails`, `footer_patterns`, `coauthor_patterns`) — additive on top
   of the built-ins, malformed entries skipped with a warning.
 
-Persisted as four nullable columns on `git_commits`
-(`agent_name`/`agent_autonomy_tier`/`agent_channel`/`agent_confidence`) and a
-per-file rollup on `git_metadata` (`agent_commit_count`, `agent_authored_pct`,
-`agent_tier_counts_json`), surfaced in the `/git-metadata` file view and the
-MCP `get_context` ownership block.
+Persisted as five nullable columns on `git_commits`
+(`agent_name`/`agent_autonomy_tier`/`agent_channel`/`agent_confidence`/`agent_model_id`)
+and a per-file rollup on `git_metadata` (`agent_commit_count`,
+`agent_authored_pct`, `agent_tier_counts_json` at the commit level;
+`agent_line_count`, `agent_line_model_json` at the line level), surfaced in the
+`/git-metadata` file view and the MCP `get_context` ownership block.
 
 ## Internal layout
 

--- a/packages/core/src/repowise/core/ingestion/git_indexer/agent_provenance.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/agent_provenance.py
@@ -64,6 +64,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -254,10 +255,86 @@ _TRACE_FILE = ".agent-trace/traces.jsonl"
 # rather than stall the git index parsing it.
 _TRACE_MAX_BYTES = 50 * 1024 * 1024
 _TRACE_AI_CONTRIBUTORS = frozenset({"ai", "mixed"})
+# ``git_commits.agent_model_id`` / the model buckets are ``String(64)``.
+_MODEL_ID_MAXLEN = 64
 
 
-def _agent_from_trace_record(rec: object) -> tuple[str, str, frozenset[str]] | None:
-    """Resolve one agent-trace record to ``(revision, agent, ai_paths)``.
+def _range_interval(rng: object) -> tuple[int, int] | None:
+    """One trace ``ranges[]`` entry as a 1-indexed inclusive ``(start, end)``.
+
+    Accepts the repo's ``start_line``/``end_line`` fixture keys and the spec's
+    shorter ``start``/``end`` aliases. A non-dict entry, a non-integer bound, a
+    non-positive start, or an inverted span (``end < start``) returns ``None`` —
+    a malformed range is never counted, never raises.
+    """
+    if not isinstance(rng, dict):
+        return None
+    start = rng.get("start_line", rng.get("start"))
+    end = rng.get("end_line", rng.get("end"))
+    try:
+        s = int(start)
+        e = int(end)
+    except (TypeError, ValueError):
+        return None
+    if s <= 0 or e < s:
+        return None
+    return s, e
+
+
+def _count_distinct_lines(intervals: list[tuple[int, int]]) -> int:
+    """Distinct line count over possibly-overlapping 1-indexed intervals.
+
+    Interval-union (sort + sweep) rather than a per-line ``set`` so memory is
+    bounded by the number of ranges, not by line magnitude — a single bogus
+    ``end_line: 1_000_000_000`` can't blow up the index.
+    """
+    if not intervals:
+        return 0
+    ordered = sorted(intervals)
+    total = 0
+    cur_s, cur_e = ordered[0]
+    for s, e in ordered[1:]:
+        if s <= cur_e + 1:  # overlapping or adjacent — extend the run
+            cur_e = max(cur_e, e)
+        else:
+            total += cur_e - cur_s + 1
+            cur_s, cur_e = s, e
+    total += cur_e - cur_s + 1
+    return total
+
+
+def _iter_trace_ai_conversations(rec: dict) -> list[tuple[str, str | None, list[tuple[int, int]]]]:
+    """``(path, model_id, intervals)`` for each AI/mixed conversation in *rec*.
+
+    Shared by both consumers of a record: commit attribution
+    (:func:`_agent_from_trace_record`) and the per-file line-share aggregate.
+    Only ``ai`` / ``mixed`` contributors are yielded; ``model_id`` is the raw
+    models.dev ``provider/model`` string (truncated to the column width) or
+    ``None``. Malformed files/conversations are skipped, never raised.
+    """
+    out: list[tuple[str, str | None, list[tuple[int, int]]]] = []
+    for f in rec.get("files") or []:
+        if not isinstance(f, dict):
+            continue
+        path = str(f.get("path") or "").strip().lstrip("/")
+        if not path:
+            continue
+        for conv in f.get("conversations") or []:
+            if not isinstance(conv, dict):
+                continue
+            contributor = conv.get("contributor") or {}
+            if str(contributor.get("type") or "").lower() not in _TRACE_AI_CONTRIBUTORS:
+                continue
+            raw_model = str(contributor.get("model_id") or "").strip() or None
+            if raw_model:
+                raw_model = raw_model[:_MODEL_ID_MAXLEN]
+            intervals = [iv for rng in (conv.get("ranges") or []) if (iv := _range_interval(rng))]
+            out.append((path, raw_model, intervals))
+    return out
+
+
+def _agent_from_trace_record(rec: object) -> tuple[str, str, frozenset[str], str | None] | None:
+    """Resolve one agent-trace record to ``(revision, agent, ai_paths, model_id)``.
 
     A record carries ``vcs.revision`` (the git sha at capture time), a
     record-level ``tool``, and per-file ``conversations`` whose ``contributor``
@@ -267,8 +344,10 @@ def _agent_from_trace_record(rec: object) -> tuple[str, str, frozenset[str]] | N
     both resolve with ``allow_slug=True`` because the ``.agent-trace/`` log is
     AI-specific by construction, same rationale as ``refs/notes/ai``. Multiple
     distinct agents in one record: the one touching the most files wins, a tie
-    returns ``None`` (ambiguous, precision-first). Any malformed shape returns
-    ``None``: a broken record is never a signal.
+    returns ``None`` (ambiguous, precision-first). ``model_id`` is the dominant
+    agent's most common raw ``model_id`` (opus vs sonnet), or ``None`` when the
+    record carries none or ties. Any malformed shape returns ``None``: a broken
+    record is never a signal.
     """
     if not isinstance(rec, dict):
         return None
@@ -280,53 +359,87 @@ def _agent_from_trace_record(rec: object) -> tuple[str, str, frozenset[str]] | N
             str((rec.get("tool") or {}).get("name") or ""), allow_slug=True
         )
         paths_by_agent: dict[str, set[str]] = {}
-        for f in rec.get("files") or []:
-            if not isinstance(f, dict):
+        models_by_agent: dict[str, Counter[str]] = {}
+        for path, raw_model, _intervals in _iter_trace_ai_conversations(rec):
+            agent = tool_agent or _normalize_agent_token(raw_model or "", allow_slug=True)
+            if not agent:
                 continue
-            path = str(f.get("path") or "").strip().lstrip("/")
-            if not path:
-                continue
-            for conv in f.get("conversations") or []:
-                if not isinstance(conv, dict):
-                    continue
-                contributor = conv.get("contributor") or {}
-                if str(contributor.get("type") or "").lower() not in _TRACE_AI_CONTRIBUTORS:
-                    continue
-                agent = tool_agent or _normalize_agent_token(
-                    str(contributor.get("model_id") or ""), allow_slug=True
-                )
-                if agent:
-                    paths_by_agent.setdefault(agent, set()).add(path)
+            paths_by_agent.setdefault(agent, set()).add(path)
+            if raw_model:
+                models_by_agent.setdefault(agent, Counter())[raw_model] += 1
         if not paths_by_agent:
             return None
         top = max(len(paths) for paths in paths_by_agent.values())
         leaders = [a for a, paths in paths_by_agent.items() if len(paths) == top]
         if len(leaders) != 1:
             return None
-        return revision, leaders[0], frozenset(paths_by_agent[leaders[0]])
+        agent = leaders[0]
+        return (
+            revision,
+            agent,
+            frozenset(paths_by_agent[agent]),
+            _dominant(models_by_agent.get(agent)),
+        )
     except Exception:
         return None
 
 
-class AgentTraceIndex:
-    """Commit attribution from agent-trace records, loaded once per walk.
+def _dominant(votes: Counter[str] | None) -> str | None:
+    """The single most-common key in *votes*, or ``None`` on empty / a tie."""
+    if not votes:
+        return None
+    top = max(votes.values())
+    leaders = [k for k, c in votes.items() if c == top]
+    return leaders[0] if len(leaders) == 1 else None
 
-    ``resolve`` maps a commit to an agent when a record's ``vcs.revision``
-    matches the commit itself (the record was written at or after the commit:
-    confidence ``"high"``) or one of its parents (the record was written at
-    edit time and the traced change landed in the child: confidence
-    ``"medium"``). Both cases additionally require the record's file set to
-    intersect the commit's changed paths; a revision match alone must not
-    attribute an unrelated commit.
+
+class AgentTraceIndex:
+    """Commit attribution + per-file line share from agent-trace records.
+
+    Built once per walk. ``resolve`` maps a commit to an agent when a record's
+    ``vcs.revision`` matches the commit itself (the record was written at or
+    after the commit: confidence ``"high"``) or one of its parents (the record
+    was written at edit time and the traced change landed in the child:
+    confidence ``"medium"``). Both cases additionally require the record's file
+    set to intersect the commit's changed paths; a revision match alone must
+    not attribute an unrelated commit.
+
+    ``line_shares`` is the per-file line-level rollup: for each traced path, the
+    count of distinct lines an AI/mixed contributor wrote (interval-union
+    deduped across every record) and a ``{model_id: line_count}`` breakdown.
+    It is revision-independent — a record with no ``vcs.revision`` still
+    contributes line share — so it works on the rename-tracking walk too.
     """
 
-    def __init__(self, records: list[tuple[str, str, frozenset[str]]] | None = None) -> None:
-        self._by_revision: dict[str, list[tuple[str, frozenset[str]]]] = {}
-        for revision, agent, paths in records or []:
-            self._by_revision.setdefault(revision, []).append((agent, paths))
+    def __init__(
+        self,
+        records: list[tuple[str, str, frozenset[str], str | None]] | None = None,
+        line_intervals: dict[str, list[tuple[int, int]]] | None = None,
+        line_intervals_by_model: dict[str, dict[str, list[tuple[int, int]]]] | None = None,
+    ) -> None:
+        self._by_revision: dict[str, list[tuple[str, frozenset[str], str | None]]] = {}
+        for revision, agent, paths, model_id in records or []:
+            self._by_revision.setdefault(revision, []).append((agent, paths, model_id))
+        # Collapse the accumulated intervals to counts once, up front.
+        self._line_shares: dict[str, tuple[int, dict[str, int]]] = {}
+        for path, intervals in (line_intervals or {}).items():
+            total = _count_distinct_lines(intervals)
+            if total <= 0:
+                continue
+            models = {
+                model_id: _count_distinct_lines(ivs)
+                for model_id, ivs in (line_intervals_by_model or {}).get(path, {}).items()
+            }
+            self._line_shares[path] = (total, {m: c for m, c in models.items() if c > 0})
 
     def __bool__(self) -> bool:
-        return bool(self._by_revision)
+        return bool(self._by_revision) or bool(self._line_shares)
+
+    def line_shares(self) -> dict[str, tuple[int, dict[str, int]]]:
+        """``{path: (agent_line_count, {model_id: line_count})}`` — empty when
+        the repo ships no traces. The caller merges this into per-file
+        ``git_metadata`` (see the indexer's path-keyed merge)."""
+        return self._line_shares
 
     @classmethod
     def load(cls, repo: object) -> AgentTraceIndex:
@@ -351,7 +464,9 @@ class AgentTraceIndex:
         except Exception as exc:  # a trace read must never break the git index
             logger.warning("agent_trace_read_failed", error=str(exc))
             return cls()
-        records: list[tuple[str, str, frozenset[str]]] = []
+        records: list[tuple[str, str, frozenset[str], str | None]] = []
+        line_intervals: dict[str, list[tuple[int, int]]] = {}
+        line_intervals_by_model: dict[str, dict[str, list[tuple[int, int]]]] = {}
         for line in text.splitlines():
             if not line.strip():
                 continue
@@ -359,40 +474,57 @@ class AgentTraceIndex:
                 rec = json.loads(line)
             except ValueError:
                 continue
+            if not isinstance(rec, dict):
+                continue
             parsed = _agent_from_trace_record(rec)
             if parsed:
                 records.append(parsed)
-        return cls(records)
+            # Line share is agent-agnostic (AI vs human at line granularity) and
+            # revision-independent — accumulate regardless of whether the record
+            # resolved to a single dominant agent above.
+            for path, raw_model, intervals in _iter_trace_ai_conversations(rec):
+                if not intervals:
+                    continue
+                line_intervals.setdefault(path, []).extend(intervals)
+                if raw_model:
+                    line_intervals_by_model.setdefault(path, {}).setdefault(raw_model, []).extend(
+                        intervals
+                    )
+        return cls(records, line_intervals, line_intervals_by_model)
 
     def resolve(
         self, sha: str, parents: tuple[str, ...], changed_paths: set[str]
-    ) -> tuple[str, str] | None:
-        """Attribute one commit: ``(agent, confidence)`` or ``None``."""
-        agent = self._match(sha, changed_paths)
-        if agent:
-            return agent, "high"
+    ) -> tuple[str, str, str | None] | None:
+        """Attribute one commit: ``(agent, confidence, model_id)`` or ``None``."""
+        hit = self._match(sha, changed_paths)
+        if hit:
+            return hit[0], "high", hit[1]
         for parent in parents:
-            agent = self._match(parent, changed_paths)
-            if agent:
-                return agent, "medium"
+            hit = self._match(parent, changed_paths)
+            if hit:
+                return hit[0], "medium", hit[1]
         return None
 
-    def _match(self, revision: str, changed_paths: set[str]) -> str | None:
+    def _match(self, revision: str, changed_paths: set[str]) -> tuple[str, str | None] | None:
         candidates = self._by_revision.get((revision or "").lower())
         if not candidates:
             return None
         # Weight each agent by how many of its traced files this commit
         # actually changed; the dominant agent wins, a tie is ambiguous.
         counts: dict[str, int] = {}
-        for agent, paths in candidates:
+        model_by_agent: dict[str, str | None] = {}
+        for agent, paths, model_id in candidates:
             overlap = len(paths & changed_paths)
             if overlap:
                 counts[agent] = counts.get(agent, 0) + overlap
+                model_by_agent.setdefault(agent, model_id)
         if not counts:
             return None
         top = max(counts.values())
         leaders = [a for a, c in counts.items() if c == top]
-        return leaders[0] if len(leaders) == 1 else None
+        if len(leaders) != 1:
+            return None
+        return leaders[0], model_by_agent.get(leaders[0])
 
 
 @dataclass(frozen=True)

--- a/packages/core/src/repowise/core/ingestion/git_indexer/commit_rows.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/commit_rows.py
@@ -111,6 +111,7 @@ def build_commit_rows(parsed_commits: list[dict]) -> list[dict]:
                 "agent_autonomy_tier": c.get("agent_autonomy_tier"),
                 "agent_channel": c.get("agent_channel"),
                 "agent_confidence": c.get("agent_confidence"),
+                "agent_model_id": c.get("agent_model_id"),
             }
         )
     return rows

--- a/packages/core/src/repowise/core/ingestion/git_indexer/file_history.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/file_history.py
@@ -121,6 +121,12 @@ def new_meta(file_path: str) -> dict[str, Any]:
         "agent_commit_count": 0,
         "agent_authored_pct": None,
         "agent_tier_counts_json": "{}",
+        # Line-level agent share (agent-trace ranges[]): distinct AI-written
+        # lines + {model_id: line_count}. Merged in by the orchestrator from the
+        # repo-wide trace index (path-keyed, like co-change/prior-defects), so
+        # these stay at the default unless the repo ships .agent-trace/.
+        "agent_line_count": 0,
+        "agent_line_model_json": "{}",
         # Temporal hotspot score (exponentially decayed churn)
         "temporal_hotspot_score": 0.0,
         # Change entropy (Hassan HCM) — populated repo-wide by the co-change

--- a/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
@@ -125,6 +125,12 @@ class GitIndexer:
         commit_sink: list[dict] = []
         prov_clf = self._provenance_classifier()
         deep_index: dict[str, list[_CommitRec]] = {}
+        # Agent-trace records read ONCE per index (one stat call for repos
+        # without a .agent-trace/ dir). Shared with both commit-index walks so
+        # the file isn't re-read per walk, and reused below for the per-file
+        # line-share merge — which is why it loads even in follow_renames mode,
+        # where neither commit-index walk runs.
+        trace_index = self._load_trace_index(repo)
         if not self.follow_renames:
             from ..git_commit_index import load_commit_index, load_deep_commit_index
 
@@ -134,6 +140,7 @@ class GitIndexer:
                 set(indexable_files),
                 commit_sink=commit_sink,
                 provenance_classifier=prov_clf,
+                trace_index=trace_index,
             )
 
             # Files the recent window never saw would each spawn a per-file
@@ -149,6 +156,7 @@ class GitIndexer:
                     skip=self.commit_limit,
                     deep_limit=_DEEP_WALK_COMMIT_LIMIT,
                     provenance_classifier=prov_clf,
+                    trace_index=trace_index,
                 )
 
         include_blame = self.tier.includes_blame
@@ -257,7 +265,13 @@ class GitIndexer:
         except Exception as exc:
             logger.debug("prior_defect_pass_failed", error=str(exc))
 
-        # Merge co-change partners + change entropy + prior defects into metadata.
+        # Per-file AI line share from the agent-trace records. Keyed by path
+        # like the aggregates below, so it merges in the same pass and
+        # works regardless of which commit-index walk (if any) ran.
+        trace_line_shares = trace_index.line_shares() if trace_index else {}
+
+        # Merge co-change partners + change entropy + prior defects + AI line
+        # share into metadata.
         for meta in results:
             fp = meta["file_path"]
             if fp in co_changes:
@@ -266,6 +280,10 @@ class GitIndexer:
                 meta["change_entropy"] = change_entropy[fp]
             if fp in prior_defects:
                 meta["prior_defect_count"] = prior_defects[fp]
+            share = trace_line_shares.get(fp)
+            if share:
+                meta["agent_line_count"] = share[0]
+                meta["agent_line_model_json"] = json.dumps(share[1])
 
         compute_percentiles(results)
 
@@ -524,6 +542,20 @@ class GitIndexer:
             from .agent_provenance import AgentProvenanceClassifier
 
             return AgentProvenanceClassifier()
+
+    def _load_trace_index(self, repo: Any) -> Any:
+        """Agent-trace index, loaded once per index run (one stat call when the
+        repo has no ``.agent-trace/``). Failure-isolated: a broken trace file
+        yields an empty index, never breaks the git phase."""
+        try:
+            from .agent_provenance import AgentTraceIndex
+
+            return AgentTraceIndex.load(repo)
+        except Exception as exc:
+            logger.debug("agent_trace_index_failed", error=str(exc))
+            from .agent_provenance import AgentTraceIndex
+
+            return AgentTraceIndex()
 
     def _resolve_as_of_ts(
         self, repo: Any, commit_index: dict[str, list[_CommitRec]] | None = None

--- a/packages/core/src/repowise/core/persistence/crud/git.py
+++ b/packages/core/src/repowise/core/persistence/crud/git.py
@@ -100,6 +100,12 @@ async def get_all_git_metadata(session: AsyncSession, repository_id: str) -> dic
 _WALK_FIELD_EMPTIES: dict[str, tuple] = {
     "co_change_partners_json": ("[]", "", None),
     "change_entropy": (0, 0.0, None),
+    # AI line share comes from the whole trace file, merged only into files
+    # reindexed this pass. Preserve a prior non-empty share when a transient
+    # trace-read failure (or a pass that couldn't read traces) would otherwise
+    # write the zero default — same defensive contract as the walk fields.
+    "agent_line_count": (0, None),
+    "agent_line_model_json": ("{}", "", None),
 }
 
 

--- a/packages/core/src/repowise/core/persistence/models.py
+++ b/packages/core/src/repowise/core/persistence/models.py
@@ -466,6 +466,17 @@ class GitMetadata(Base):
     agent_authored_pct: Mapped[float | None] = mapped_column(Float, nullable=True)
     agent_tier_counts_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
 
+    # Line-level agent share (agent-trace standard): distinct file
+    # lines an AI/mixed contributor wrote, interval-union deduped across every
+    # trace record for this path, plus a {model_id: line_count} breakdown
+    # (opus vs sonnet). The denominator ("N% AI-written") is the file's current
+    # LOC, applied downstream — the git indexer stores only the AI numerator so
+    # it stays LOC-decoupled. Both stay 0/"{}" unless the repo ships
+    # .agent-trace/traces.jsonl. Model buckets can overlap (a line touched by
+    # two models counts in both), so their sum may exceed agent_line_count.
+    agent_line_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    agent_line_model_json: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_now_utc
     )
@@ -535,6 +546,11 @@ class GitCommit(Base):
     agent_autonomy_tier: Mapped[int | None] = mapped_column(Integer, nullable=True)
     agent_channel: Mapped[str | None] = mapped_column(String(32), nullable=True)
     agent_confidence: Mapped[str | None] = mapped_column(String(8), nullable=True)
+    # Model that wrote the change, in models.dev ``provider/model`` form (e.g.
+    # ``anthropic/claude-opus-4``), read from the agent-trace record that
+    # attributed the commit. Set only for the ``agent_trace`` channel (no other
+    # local channel carries a model); NULL for human or non-trace commits.
+    agent_model_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_now_utc

--- a/tests/unit/ingestion/test_agent_provenance.py
+++ b/tests/unit/ingestion/test_agent_provenance.py
@@ -21,6 +21,8 @@ from repowise.core.ingestion.git_indexer.agent_provenance import (
     AgentTraceIndex,
     _agent_from_git_ai_note,
     _agent_from_trace_record,
+    _count_distinct_lines,
+    _range_interval,
 )
 from repowise.core.ingestion.git_indexer.commit_rows import build_commit_rows
 from repowise.core.ingestion.git_indexer.file_history import index_file
@@ -477,12 +479,28 @@ def _trace_record(
 
 def test_trace_record_resolves_tool_name_first() -> None:
     rec = json.loads(_trace_record("abc", tool="Cursor", model_id="anthropic/claude-opus-4-5"))
-    assert _agent_from_trace_record(rec) == ("abc", "cursor", frozenset({"src/a.py"}))
+    # tool.name resolves the agent; the raw model_id rides along for the split.
+    assert _agent_from_trace_record(rec) == (
+        "abc",
+        "cursor",
+        frozenset({"src/a.py"}),
+        "anthropic/claude-opus-4-5",
+    )
 
 
 def test_trace_record_falls_back_to_model_id() -> None:
     rec = json.loads(_trace_record("abc", tool=None, model_id="anthropic/claude-opus-4-5"))
-    assert _agent_from_trace_record(rec) == ("abc", "claude", frozenset({"src/a.py"}))
+    assert _agent_from_trace_record(rec) == (
+        "abc",
+        "claude",
+        frozenset({"src/a.py"}),
+        "anthropic/claude-opus-4-5",
+    )
+
+
+def test_trace_record_without_model_id_has_no_model() -> None:
+    rec = json.loads(_trace_record("abc", tool="cursor", model_id=None))
+    assert _agent_from_trace_record(rec) == ("abc", "cursor", frozenset({"src/a.py"}), None)
 
 
 def test_trace_record_human_only_is_not_a_signal() -> None:
@@ -504,14 +522,18 @@ def test_trace_record_without_revision_is_skipped() -> None:
 def test_trace_index_resolves_exact_and_parent_matches() -> None:
     idx = AgentTraceIndex(
         [
-            ("sha_exact", "cursor", frozenset({"src/a.py"})),
-            ("sha_parent", "claude", frozenset({"src/b.py"})),
+            ("sha_exact", "cursor", frozenset({"src/a.py"}), "anthropic/claude-opus-4-5"),
+            ("sha_parent", "claude", frozenset({"src/b.py"}), None),
         ]
     )
-    # Revision IS the commit: high confidence.
-    assert idx.resolve("sha_exact", (), {"src/a.py"}) == ("cursor", "high")
+    # Revision IS the commit: high confidence, model rides through.
+    assert idx.resolve("sha_exact", (), {"src/a.py"}) == (
+        "cursor",
+        "high",
+        "anthropic/claude-opus-4-5",
+    )
     # Revision is the commit's parent (trace captured pre-commit): medium.
-    assert idx.resolve("sha_child", ("sha_parent",), {"src/b.py"}) == ("claude", "medium")
+    assert idx.resolve("sha_child", ("sha_parent",), {"src/b.py"}) == ("claude", "medium", None)
     # A revision match without file overlap must not attribute the commit.
     assert idx.resolve("sha_exact", (), {"other.py"}) is None
     assert idx.resolve("sha_unknown", ("sha_unrelated",), {"src/a.py"}) is None
@@ -520,13 +542,13 @@ def test_trace_index_resolves_exact_and_parent_matches() -> None:
 def test_trace_index_agent_tie_is_ambiguous() -> None:
     idx = AgentTraceIndex(
         [
-            ("rev", "cursor", frozenset({"src/a.py"})),
-            ("rev", "claude", frozenset({"src/b.py"})),
+            ("rev", "cursor", frozenset({"src/a.py"}), None),
+            ("rev", "claude", frozenset({"src/b.py"}), None),
         ]
     )
     assert idx.resolve("rev", (), {"src/a.py", "src/b.py"}) is None
     # An unambiguous overlap still resolves.
-    assert idx.resolve("rev", (), {"src/a.py"}) == ("cursor", "high")
+    assert idx.resolve("rev", (), {"src/a.py"}) == ("cursor", "high", None)
 
 
 def test_trace_agent_precedence_in_classify() -> None:
@@ -562,7 +584,7 @@ def test_trace_index_load_skips_malformed_lines(tmp_path) -> None:
         "not json\n" + _trace_record("rev_a") + "\n{}\n", encoding="utf-8"
     )
     idx = AgentTraceIndex.load(MagicMock(working_tree_dir=str(tmp_path)))
-    assert idx.resolve("rev_a", (), {"src/a.py"}) == ("cursor", "high")
+    assert idx.resolve("rev_a", (), {"src/a.py"}) == ("cursor", "high", None)
 
 
 def test_trace_index_load_never_raises_on_mock_repo() -> None:
@@ -607,3 +629,190 @@ def test_walk_attributes_commits_from_trace_file(tmp_path) -> None:
     assert by_sha["bbb"]["agent_confidence"] == "high"
     assert by_sha["ccc"]["agent_name"] == "opencode"
     assert by_sha["ccc"]["agent_confidence"] == "medium"
+
+
+# ---------------------------------------------------------------------------
+# Line-level share + model id
+# ---------------------------------------------------------------------------
+
+
+def _trace_line_record(revision=None, files=(("src/a.py", "ai", None, ((1, 5),)),)) -> str:
+    """A trace record with explicit (path, contributor_type, model_id, ranges).
+
+    *ranges* is a tuple of ``(start_line, end_line)`` pairs. *revision* may be
+    None to exercise the revision-independent line-share path.
+    """
+    rec: dict = {
+        "version": "0.1.0",
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "timestamp": "2026-01-25T10:00:00Z",
+        "files": [
+            {
+                "path": path,
+                "conversations": [
+                    {
+                        "contributor": (
+                            {"type": ctype, "model_id": model} if model else {"type": ctype}
+                        ),
+                        "ranges": [{"start_line": s, "end_line": e} for s, e in ranges],
+                    }
+                ],
+            }
+            for path, ctype, model, ranges in files
+        ],
+    }
+    if revision is not None:
+        rec["vcs"] = {"type": "git", "revision": revision}
+    return json.dumps(rec)
+
+
+def _load_traces(tmp_path, *lines: str) -> AgentTraceIndex:
+    trace_dir = tmp_path / ".agent-trace"
+    trace_dir.mkdir()
+    (trace_dir / "traces.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return AgentTraceIndex.load(MagicMock(working_tree_dir=str(tmp_path)))
+
+
+def test_range_interval_accepts_both_key_styles() -> None:
+    assert _range_interval({"start_line": 3, "end_line": 7}) == (3, 7)
+    assert _range_interval({"start": 3, "end": 7}) == (3, 7)
+    # Malformed / inverted / non-positive spans are dropped, never raise.
+    assert _range_interval({"start_line": 5, "end_line": 2}) is None
+    assert _range_interval({"start_line": 0, "end_line": 4}) is None
+    assert _range_interval({"start_line": "x", "end_line": 4}) is None
+    assert _range_interval("nope") is None
+
+
+def test_count_distinct_lines_unions_overlaps() -> None:
+    assert _count_distinct_lines([]) == 0
+    assert _count_distinct_lines([(1, 5)]) == 5
+    # Overlapping and adjacent runs collapse; disjoint runs add up.
+    assert _count_distinct_lines([(1, 5), (4, 8)]) == 8
+    assert _count_distinct_lines([(1, 3), (4, 6)]) == 6  # adjacent → one run
+    assert _count_distinct_lines([(1, 3), (10, 12)]) == 6  # disjoint
+
+
+def test_line_shares_counts_distinct_ai_lines(tmp_path) -> None:
+    idx = _load_traces(
+        tmp_path,
+        _trace_line_record("rev1", files=(("src/a.py", "ai", None, ((1, 10),)),)),
+    )
+    assert idx.line_shares()["src/a.py"] == (10, {})
+
+
+def test_line_shares_dedupe_overlapping_across_records(tmp_path) -> None:
+    # Two records touch overlapping ranges of the same file: the distinct-line
+    # union (1-8), not the naive sum (14), is the AI line count.
+    idx = _load_traces(
+        tmp_path,
+        _trace_line_record("rev1", files=(("src/a.py", "ai", None, ((1, 5),)),)),
+        _trace_line_record("rev2", files=(("src/a.py", "ai", None, ((4, 8),)),)),
+    )
+    assert idx.line_shares()["src/a.py"][0] == 8
+
+
+def test_line_shares_model_breakdown(tmp_path) -> None:
+    idx = _load_traces(
+        tmp_path,
+        _trace_line_record(
+            "rev1",
+            files=(
+                ("src/a.py", "ai", "anthropic/claude-opus-4", ((1, 10),)),
+                ("src/a.py", "ai", "anthropic/claude-sonnet-4", ((20, 24),)),
+            ),
+        ),
+    )
+    total, models = idx.line_shares()["src/a.py"]
+    assert total == 15  # 10 + 5 distinct lines
+    assert models == {"anthropic/claude-opus-4": 10, "anthropic/claude-sonnet-4": 5}
+
+
+def test_line_shares_excludes_human_contributions(tmp_path) -> None:
+    idx = _load_traces(
+        tmp_path,
+        _trace_line_record(
+            "rev1",
+            files=(
+                ("src/a.py", "ai", None, ((1, 4),)),
+                ("src/human.py", "human", None, ((1, 100),)),
+            ),
+        ),
+    )
+    shares = idx.line_shares()
+    assert shares["src/a.py"][0] == 4
+    assert "src/human.py" not in shares
+
+
+def test_line_shares_survive_missing_revision(tmp_path) -> None:
+    # A record with no vcs.revision still contributes line share (the rename
+    # walk relies on this — it never resolves commits but must count lines).
+    idx = _load_traces(
+        tmp_path,
+        _trace_line_record(None, files=(("src/a.py", "ai", None, ((1, 6),)),)),
+    )
+    assert not idx._by_revision  # nothing to attribute to a commit
+    assert idx.line_shares()["src/a.py"] == (6, {})
+    assert bool(idx)  # line share alone makes the index truthy
+
+
+def test_trace_record_dominant_model_wins(tmp_path) -> None:
+    # One agent, two models across three files: the majority model is the
+    # commit-level model_id; a tie would resolve to None.
+    rec = json.loads(
+        _trace_line_record(
+            "rev1",
+            files=(
+                ("a.py", "ai", "anthropic/claude-opus-4", ((1, 2),)),
+                ("b.py", "ai", "anthropic/claude-opus-4", ((1, 2),)),
+                ("c.py", "ai", "anthropic/claude-sonnet-4", ((1, 2),)),
+            ),
+        )
+    )
+    parsed = _agent_from_trace_record(rec)
+    assert parsed is not None
+    _rev, agent, _paths, model_id = parsed
+    assert agent == "claude"
+    assert model_id == "anthropic/claude-opus-4"
+
+
+def test_walk_populates_agent_model_id(tmp_path) -> None:
+    (tmp_path / ".agent-trace").mkdir()
+    (tmp_path / ".agent-trace" / "traces.jsonl").write_text(
+        _trace_line_record("bbb", files=(("src/a.py", "ai", "anthropic/claude-opus-4", ((1, 5),)),))
+        + "\n",
+        encoding="utf-8",
+    )
+    raw = "\n".join(
+        [
+            _log_record("bbb", "Dev", "dev@x.com", "feat: traced", files=((3, 0, "src/a.py"),)),
+        ]
+    )
+    repo = MagicMock()
+    repo.working_tree_dir = str(tmp_path)
+    repo.git.for_each_ref.return_value = ""
+    repo.git.log.return_value = raw
+
+    sink: list[dict] = []
+    load_commit_index(repo, 100, {"src/a.py"}, commit_sink=sink)
+    row = {c["sha"]: c for c in sink}["bbb"]
+    assert row["agent_channel"] == "agent_trace"
+    assert row["agent_model_id"] == "anthropic/claude-opus-4"
+
+
+def test_agent_model_id_null_when_trace_channel_loses() -> None:
+    # A service-identity author (T1) outranks the trace channel, so no model id
+    # is carried even when a trace record resolved a model for the commit.
+    prov = CLF.classify(
+        "Cursor Agent",
+        "cursoragent@cursor.com",
+        "",
+        "",
+        "feat: x",
+        trace_agent="claude",
+        trace_confidence="high",
+    )
+    assert prov.channel == "service_email"
+    # The sink gate keys on channel == "agent_trace"; here it is not, so the
+    # model id (available from the trace hit) is deliberately dropped.
+    model_id = "anthropic/claude-opus-4" if prov.channel == "agent_trace" else None
+    assert model_id is None


### PR DESCRIPTION
Extends the agent-trace channel from commit attribution to line granularity and captures the model that wrote the change.

## What changed

**Per-file AI line share.** `AgentTraceIndex` now builds a path-keyed aggregate from each record's `ranges[]`:
- `agent_line_count` — distinct lines an AI/mixed contributor wrote, interval-union deduped across every record for the path (overlapping re-edits count once; interval sweep rather than a per-line set, so a bogus `end_line` can't blow memory).
- `agent_line_model_json` — a `{model_id: line_count}` breakdown (opus vs sonnet), model ids in models.dev `provider/model` form.

It is revision-independent (a record with no `vcs.revision` still counts lines) and merged into `git_metadata` at the indexer's existing path-keyed merge point, next to the co-change / prior-defect signals, so it also covers the rename-tracking walk.

**Per-commit model id.** `AgentTraceIndex.resolve` now also returns the winning record's dominant `model_id`, stored as `git_commits.agent_model_id`. It is set only when the `agent_trace` channel actually wins the classification (a git-ai note or a service-identity author can outrank it, and only the trace record carries a model).

**LOC-decoupled by design.** The git indexer stores only the AI numerator; the "N% AI-written" denominator is the file's current LOC, applied downstream where LOC is already known.

Migration `0038` adds the three columns (all nullable/defaulted, back-populated on the next index). A `_WALK_FIELD_EMPTIES` guard keeps a transient trace-read failure on an incremental update from zeroing a previously computed share.

## Cost

No new git subprocess. `.agent-trace/traces.jsonl` is read once per index and shared across both commit-index walks; interval-union counts are computed once at index build. Repos without traces still pay only a single `is_file()` stat.

## Tests

- 1483 ingestion unit tests pass (11 new: interval union, cross-record dedup, model breakdown, human-line exclusion, revision-independence, dominant-model, and the walk populating `agent_model_id`; plus the existing trace tests updated to the new return arity).
- Git persistence/crud + commit-index + migration tests pass; single alembic head.
- End-to-end smoke on a real temp repo with an `.agent-trace/traces.jsonl`: `agent_line_count` and the `{model_id: line_count}` split land in `git_metadata`, human-only files stay at zero.

Frontend surfacing (commit-card conversation URL, health AI-share overlay) and hosted enablement are left as follow-ups, matching how the commit-level channel shipped core-first.
