### PR TITLE
feat(docs): graph-derived related pages with self-healing backfill

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -394,6 +394,27 @@ async def _persist_full_update_async(
             except Exception as exc:
                 _skip("Tombstone marking", exc)
 
+            # Refresh related-pages metadata repo-wide. The generation pass
+            # only touched this run's regenerated pages; this LLM-free
+            # backfill heals every other page (pre-feature pages, import
+            # drift) in the same transaction.
+            try:
+                from repowise.core.generation.related_pages import file_import_edges
+                from repowise.core.persistence.crud import backfill_related_pages
+
+                await backfill_related_pages(
+                    session,
+                    repo_id,
+                    import_edges=file_import_edges(graph_builder),
+                    git_meta_map=git_meta_map,
+                    pagerank=graph_builder.pagerank(),
+                    # This run's pages carry fresher metadata (including
+                    # module siblings) than the recompute could produce.
+                    skip_page_ids={p.page_id for p in generated_pages},
+                )
+            except Exception as exc:
+                _skip("Related-pages backfill", exc)
+
             # Weakly-affected pages (cascade overflow beyond the budget,
             # co-change partners, 2-hop rename fallout) decay to 'stale' so
             # the coverage view and get_stale_pages reflect them — the

--- a/packages/core/src/repowise/core/generation/__init__.py
+++ b/packages/core/src/repowise/core/generation/__init__.py
@@ -56,6 +56,7 @@ _EXPORTS = {
     "WikiLink": ".interlinking",
     "attach_wiki_links_and_backlinks": ".interlinking",
     "resolve_wiki_links": ".interlinking",
+    "attach_related_pages": ".related_pages",
     "SUPPORTED_LANGUAGES": ".languages",
     "SYSTEM_PROMPTS": ".page_generator",
     "PageGenerator": ".page_generator",

--- a/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
+++ b/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
@@ -546,6 +546,25 @@ class _GenerationRun:
         except Exception as exc:
             log.debug("interlinking.failed", error=str(exc))
 
+        # Post-generation: graph-derived related pages. Runs AFTER
+        # interlinking so prose-derived wiki_links win dedup and related
+        # entries only fill the gaps.
+        try:
+            from ..related_pages import attach_related_pages
+
+            attach_related_pages(
+                all_pages,
+                import_edges=self._file_import_edges(),
+                git_meta_map=self.git_meta_map,
+                module_groups=self.sel_module_groups,
+                pagerank=self.pagerank,
+                # On incremental updates only the affected pages are in
+                # all_pages; the persisted ids keep resolution repo-wide.
+                prior_page_ids=list(self.gen._prior_pages or {}),
+            )
+        except Exception as exc:
+            log.debug("related_pages.failed", error=str(exc))
+
         # Post-generation: link KG tour steps to wiki page IDs.
         if self.kg_ctx.available and self.repo_path:
             try:

--- a/packages/core/src/repowise/core/generation/related_pages.py
+++ b/packages/core/src/repowise/core/generation/related_pages.py
@@ -1,0 +1,175 @@
+"""Post-generation related pages — connect pages by graph evidence.
+
+Runs after ``interlinking`` in the post-generation pass chain. Where
+``wiki_links`` depend on the LLM mentioning a file in prose, this pass
+derives neighbors deterministically from signals the pipeline already
+computed: import edges, co-change partners, and module membership.
+Resolved hits land in ``page.metadata["related_pages"]``; the reader's
+Related rail merges them with the prose-derived links.
+
+No LLM call — pure dict lookups over the run's page set, so a page whose
+prose never names its collaborators is still connected to them.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import structlog
+
+from .interlinking import LinkIndex
+from .models import GeneratedPage
+
+log = structlog.get_logger(__name__)
+
+# Reasons in priority order — a target reachable via several signals is
+# reported once, under the strongest one.
+_REASON_PRIORITY = ("imports", "imported-by", "co-changes-with", "same-module")
+
+_PER_REASON_CAP = 5
+_TOTAL_CAP = 12
+
+# Page types whose target_path is a real file path.
+_FILE_BACKED = frozenset({"file_page", "api_contract", "infra_page"})
+
+
+def _co_change_partners(git_meta: dict | None) -> list[tuple[str, float]]:
+    """``(partner_path, co_change_count)`` pairs, strongest first."""
+    if not git_meta:
+        return []
+    raw = git_meta.get("co_change_partners_json") or "[]"
+    try:
+        partners = json.loads(raw)
+    except (TypeError, ValueError):
+        return []
+    out: list[tuple[str, float]] = []
+    for p in partners:
+        if not isinstance(p, dict):
+            continue
+        path = p.get("file_path")
+        if not path:
+            continue
+        out.append((path, float(p.get("co_change_count") or 0.0)))
+    out.sort(key=lambda t: -t[1])
+    return out
+
+
+def _module_siblings(
+    module_groups: list[Any] | None,
+) -> dict[str, list[str]]:
+    """``path -> ordered sibling paths`` from the selected module groups."""
+    siblings: dict[str, list[str]] = {}
+    for group in module_groups or []:
+        paths = list(getattr(group, "file_paths", ()) or ())
+        for path in paths:
+            # First group wins — curated groups precede fallbacks upstream.
+            siblings.setdefault(path, [p for p in paths if p != path])
+    return siblings
+
+
+def attach_related_pages(
+    pages: list[GeneratedPage],
+    *,
+    import_edges: list[tuple[str, str]] | None = None,
+    git_meta_map: dict[str, dict] | None = None,
+    module_groups: list[Any] | None = None,
+    pagerank: dict[str, float] | None = None,
+    prior_page_ids: Any = None,
+) -> None:
+    """Populate ``metadata['related_pages']`` on file-backed pages.
+
+    Mutates each :class:`GeneratedPage` in place. Idempotent — recomputed
+    from scratch on every run.
+
+    ``prior_page_ids`` widens resolution beyond this run's page set: on an
+    incremental update only the affected pages are regenerated, so without
+    the persisted ids every neighbor outside the diff would fail to resolve
+    and the update would overwrite good metadata with near-empty lists.
+    Current-run pages always win over a prior id; the reader drops entries
+    whose target no longer exists, so stale prior ids are harmless.
+    """
+    if not pages:
+        return
+
+    index = LinkIndex.build(pages)
+    titles = {p.page_id: p.title for p in pages}
+    for pid in prior_page_ids or ():
+        ptype, _, tpath = str(pid).partition(":")
+        if ptype in _FILE_BACKED and tpath:
+            index.by_path.setdefault(tpath, pid)
+            titles.setdefault(pid, tpath)
+    pr = pagerank or {}
+
+    # Adjacency from the import graph: src imports dst.
+    imports_of: dict[str, list[str]] = {}
+    imported_by: dict[str, list[str]] = {}
+    for src, dst in import_edges or []:
+        imports_of.setdefault(src, []).append(dst)
+        imported_by.setdefault(dst, []).append(src)
+
+    siblings = _module_siblings(module_groups)
+
+    attached_pages = 0
+    total_entries = 0
+    for page in pages:
+        if page.page_type not in _FILE_BACKED or not page.target_path:
+            continue
+        path = page.target_path
+
+        # Prose links win — related fills the gaps, never duplicates.
+        prose_targets = {
+            link.get("target_page_id") for link in page.metadata.get("wiki_links") or []
+        }
+
+        candidates: dict[str, list[tuple[str, float]]] = {
+            # Order within a reason: strongest evidence first. Import edges
+            # carry no weight of their own, so central targets go first.
+            "imports": sorted(
+                ((p, pr.get(p, 0.0)) for p in imports_of.get(path, ())),
+                key=lambda t: -t[1],
+            ),
+            "imported-by": sorted(
+                ((p, pr.get(p, 0.0)) for p in imported_by.get(path, ())),
+                key=lambda t: -t[1],
+            ),
+            "co-changes-with": _co_change_partners((git_meta_map or {}).get(path)),
+            "same-module": [(p, 0.0) for p in siblings.get(path, ())],
+        }
+
+        seen: set[str] = {page.page_id} | prose_targets
+        related: list[dict] = []
+        for reason in _REASON_PRIORITY:
+            kept = 0
+            for target_path, weight in candidates[reason]:
+                if kept >= _PER_REASON_CAP or len(related) >= _TOTAL_CAP:
+                    break
+                target_id = index.resolve(target_path)
+                if target_id is None or target_id in seen:
+                    continue
+                seen.add(target_id)
+                kept += 1
+                related.append(
+                    {
+                        "target_page_id": target_id,
+                        "title": titles.get(target_id, target_path),
+                        "reason": reason,
+                        "weight": round(weight, 4),
+                    }
+                )
+            if len(related) >= _TOTAL_CAP:
+                break
+
+        page.metadata["related_pages"] = related
+        if related:
+            attached_pages += 1
+            total_entries += len(related)
+
+    log.info(
+        "related_pages.attached",
+        pages_with_related=attached_pages,
+        total_entries=total_entries,
+    )
+
+
+__all__ = ["attach_related_pages"]

--- a/packages/core/src/repowise/core/generation/related_pages.py
+++ b/packages/core/src/repowise/core/generation/related_pages.py
@@ -172,4 +172,20 @@ def attach_related_pages(
     )
 
 
-__all__ = ["attach_related_pages"]
+def file_import_edges(graph_builder: Any) -> list[tuple[str, str]]:
+    """``(src, dst)`` import edges between file nodes (src imports dst).
+
+    Shared by the persistence-layer backfill call sites; mirrors the
+    orchestrator's ``_GenerationRun._file_import_edges``.
+    """
+    edges: list[tuple[str, str]] = []
+    try:
+        for src, dst in graph_builder.graph().edges():
+            if isinstance(src, str) and isinstance(dst, str):
+                edges.append((src, dst))
+    except Exception:
+        pass
+    return edges
+
+
+__all__ = ["attach_related_pages", "file_import_edges"]

--- a/packages/core/src/repowise/core/persistence/crud/pages.py
+++ b/packages/core/src/repowise/core/persistence/crud/pages.py
@@ -214,6 +214,94 @@ async def upsert_page_from_generated(
     )
 
 
+async def backfill_related_pages(
+    session: AsyncSession,
+    repository_id: str,
+    *,
+    import_edges: list[tuple[str, str]] | None = None,
+    git_meta_map: dict[str, dict] | None = None,
+    pagerank: dict[str, float] | None = None,
+    skip_page_ids: set[str] | None = None,
+) -> int:
+    """Recompute ``metadata['related_pages']`` across every persisted page.
+
+    LLM-free, so every update flavor (docs, index-only, workspace) can heal
+    pages generated before related-pages shipped — or drifted by new
+    imports — without a regeneration run.
+
+    Selection module groups exist only during full generation, so this
+    recompute covers the other three reasons and *preserves* any existing
+    same-module entries instead of stripping them. ``skip_page_ids`` exempts
+    pages the current run already attached (their metadata is fresher than
+    anything this recompute could produce).
+
+    Returns the number of rows whose metadata changed.
+    """
+    # Import lazily — keeps persistence independent of generation models at
+    # module-load time (same pattern as load_prior_pages above).
+    from types import SimpleNamespace
+
+    from repowise.core.generation.related_pages import attach_related_pages
+
+    result = await session.execute(
+        select(Page).where(
+            Page.repository_id == repository_id,
+            Page.freshness_status != "tombstone",
+        )
+    )
+    rows = [r for r in result.scalars() if r.id not in (skip_page_ids or set())]
+    if not rows:
+        return 0
+
+    shims = []
+    prior_related: list[Any] = []
+    for row in rows:
+        try:
+            meta = json.loads(row.metadata_json or "{}")
+        except ValueError:
+            meta = {}
+        prior_related.append(meta.get("related_pages"))
+        shims.append(
+            SimpleNamespace(
+                page_id=row.id,
+                page_type=row.page_type,
+                title=row.title,
+                target_path=row.target_path,
+                metadata=meta,
+            )
+        )
+
+    attach_related_pages(
+        shims,  # type: ignore[arg-type]  # duck-typed GeneratedPage view
+        import_edges=import_edges,
+        git_meta_map=git_meta_map,
+        pagerank=pagerank,
+    )
+
+    changed = 0
+    for row, shim, before in zip(rows, shims, prior_related, strict=True):
+        after = shim.metadata.get("related_pages")
+        if after is None:
+            continue
+        # Preserve prior same-module entries — recomputing without module
+        # groups must not strip what a full generation attached.
+        if before:
+            seen_targets = {r.get("target_page_id") for r in after}
+            after.extend(
+                entry
+                for entry in before
+                if entry.get("reason") == "same-module"
+                and entry.get("target_page_id") not in seen_targets
+            )
+        if after == before:
+            continue
+        row.metadata_json = json.dumps(shim.metadata)
+        changed += 1
+    if changed:
+        await session.flush()
+    return changed
+
+
 async def get_page(session: AsyncSession, page_id: str) -> Page | None:
     """Return a Page by its page_id, or None."""
     return await session.get(Page, page_id)

--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -688,6 +688,25 @@ async def persist_incremental_index(
             except Exception as exc:
                 _skip("Graph edges persist", exc)
 
+            # Refresh related-pages metadata across the whole wiki. LLM-free,
+            # so even index-only updates heal pages generated before the
+            # feature shipped (or drifted by new imports) in one run.
+            try:
+                from repowise.core.generation.related_pages import file_import_edges
+                from repowise.core.persistence.crud import backfill_related_pages
+
+                changed_rel = await backfill_related_pages(
+                    session,
+                    repo_id,
+                    import_edges=file_import_edges(graph_builder),
+                    git_meta_map=git_meta_map,
+                    pagerank=graph_builder.pagerank(),
+                )
+                if changed_rel:
+                    log(f"Related pages refreshed on {changed_rel} pages")
+            except Exception as exc:
+                _skip("Related-pages backfill", exc)
+
             if knowledge_graph_result is not None:
                 try:
                     from repowise.core.pipeline.persist import persist_kg

--- a/packages/ui/src/docs/docs-reader.tsx
+++ b/packages/ui/src/docs/docs-reader.tsx
@@ -27,9 +27,18 @@ import { TableOfContents } from "../wiki/table-of-contents";
 import { BacklinksPanel } from "../wiki/backlinks-panel";
 import {
   getBacklinks,
+  getRelatedPages,
   getWikiLinks,
+  type RelatedReason,
 } from "../wiki/wiki-links-types";
 import { Breadcrumb } from "../shared/breadcrumb";
+
+const RELATED_REASON_LABELS: Record<RelatedReason, string> = {
+  imports: "imports",
+  "imported-by": "imported by",
+  "co-changes-with": "changes together",
+  "same-module": "same module",
+};
 
 /** Router-aware anchor — host injects Next.js Link / in-app interception. */
 export type ReaderLinkComponent = React.ElementType<{
@@ -181,7 +190,18 @@ function DocsReaderBody({
   const relatedLinks = useMemo(() => {
     const byId = new Map(pages.map((p) => [p.id, p]));
     const seen = new Set<string>();
-    const out: { id: string; title: string }[] = [];
+    const out: { id: string; title: string; reason?: RelatedReason }[] = [];
+    // Graph-derived neighbors first — they carry a reason and exist even
+    // when the prose never mentions the target. The backend dedups them
+    // against wiki_links, but stay defensive here.
+    for (const rel of getRelatedPages(page.metadata)) {
+      const target = rel.target_page_id;
+      if (target === page.id || seen.has(target)) continue;
+      const hit = byId.get(target);
+      if (!hit) continue;
+      seen.add(target);
+      out.push({ id: hit.id, title: hit.title, reason: rel.reason });
+    }
     for (const link of wikiLinks) {
       const target = link.target_page_id;
       if (target === page.id || seen.has(target)) continue;
@@ -191,7 +211,7 @@ function DocsReaderBody({
       out.push({ id: hit.id, title: hit.title });
     }
     return out;
-  }, [wikiLinks, pages, page.id]);
+  }, [wikiLinks, page.metadata, pages, page.id]);
 
   const layerName =
     typeof page.metadata?.layer_name === "string" ? page.metadata.layer_name : "";
@@ -488,7 +508,7 @@ function DocsReaderBody({
                   Related
                 </p>
                 <ul className="space-y-1.5">
-                  {relatedLinks.slice(0, 5).map((r) => (
+                  {relatedLinks.slice(0, 8).map((r) => (
                     <li key={r.id} className="text-xs">
                       <button
                         onClick={() => goToPageId(r.id)}
@@ -497,12 +517,17 @@ function DocsReaderBody({
                       >
                         {r.title}
                       </button>
+                      {r.reason && (
+                        <span className="block text-[10px] text-[var(--color-text-tertiary)]">
+                          {RELATED_REASON_LABELS[r.reason]}
+                        </span>
+                      )}
                     </li>
                   ))}
                 </ul>
-                {relatedLinks.length > 5 && (
+                {relatedLinks.length > 8 && (
                   <p className="mt-1 text-[10px] text-[var(--color-text-tertiary)]">
-                    + {relatedLinks.length - 5} more
+                    + {relatedLinks.length - 8} more
                   </p>
                 )}
               </div>

--- a/packages/ui/src/docs/docs-reader.tsx
+++ b/packages/ui/src/docs/docs-reader.tsx
@@ -455,6 +455,29 @@ function DocsReaderBody({
                   </ul>
                 </div>
               )}
+
+            {/* Related pages, bottom strip. The right rail is hidden below
+                lg (vscode webview panels rarely reach lg either), so narrow
+                viewports get the related links here instead. */}
+            {relatedLinks.length > 0 && (
+              <div className="mt-8 lg:hidden">
+                <p className="text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider mb-2">
+                  Related
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {relatedLinks.slice(0, 8).map((r) => (
+                    <button
+                      key={r.id}
+                      onClick={() => goToPageId(r.id)}
+                      className="rounded-full border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-2.5 py-1 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-accent-primary)] hover:border-[var(--color-accent-primary)] transition-colors"
+                      title={r.reason ? RELATED_REASON_LABELS[r.reason] : r.title}
+                    >
+                      {r.title}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/packages/ui/src/wiki/wiki-links-types.ts
+++ b/packages/ui/src/wiki/wiki-links-types.ts
@@ -33,6 +33,25 @@ export interface Backlink {
   anchor: string;
 }
 
+/**
+ * Graph-derived neighbor persisted in ``page.metadata.related_pages`` by
+ * the backend's related-pages post-processor
+ * (`packages/core/.../generation/related_pages.py`). Unlike wiki_links,
+ * these do not depend on the page prose mentioning the target.
+ */
+export type RelatedReason =
+  | "imports"
+  | "imported-by"
+  | "co-changes-with"
+  | "same-module";
+
+export interface RelatedPageRef {
+  target_page_id: string;
+  title: string;
+  reason: RelatedReason;
+  weight: number;
+}
+
 function isWikiLinkRef(v: unknown): v is WikiLinkRef {
   if (typeof v !== "object" || v === null) return false;
   const r = v as Record<string, unknown>;
@@ -60,6 +79,33 @@ export function getWikiLinks(
   const raw = metadata["wiki_links"];
   if (!Array.isArray(raw)) return [];
   return raw.filter(isWikiLinkRef);
+}
+
+const RELATED_REASONS = new Set([
+  "imports",
+  "imported-by",
+  "co-changes-with",
+  "same-module",
+]);
+
+function isRelatedPageRef(v: unknown): v is RelatedPageRef {
+  if (typeof v !== "object" || v === null) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r["target_page_id"] === "string" &&
+    typeof r["title"] === "string" &&
+    typeof r["reason"] === "string" &&
+    RELATED_REASONS.has(r["reason"])
+  );
+}
+
+export function getRelatedPages(
+  metadata: Record<string, unknown> | undefined | null,
+): RelatedPageRef[] {
+  if (!metadata) return [];
+  const raw = metadata["related_pages"];
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(isRelatedPageRef);
 }
 
 export function getBacklinks(

--- a/tests/unit/generation/test_related_pages.py
+++ b/tests/unit/generation/test_related_pages.py
@@ -1,0 +1,197 @@
+"""Unit tests for the related-pages post-processor."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from repowise.core.generation.models import GeneratedPage
+from repowise.core.generation.related_pages import attach_related_pages
+
+
+def _make_page(
+    page_type: str,
+    target_path: str,
+    content: str = "",
+    *,
+    title: str = "",
+) -> GeneratedPage:
+    return GeneratedPage(
+        page_id=f"{page_type}:{target_path}",
+        page_type=page_type,
+        title=title or f"{page_type} {target_path}",
+        content=content,
+        source_hash="x",
+        model_name="mock",
+        provider_name="mock",
+        input_tokens=0,
+        output_tokens=0,
+        cached_tokens=0,
+        generation_level=0,
+        target_path=target_path,
+        created_at="2026-01-01T00:00:00+00:00",
+        updated_at="2026-01-01T00:00:00+00:00",
+    )
+
+
+@dataclass(frozen=True)
+class _Group:
+    key: str
+    file_paths: tuple[str, ...]
+
+
+def _related(page: GeneratedPage) -> list[dict]:
+    return page.metadata["related_pages"]
+
+
+def test_import_edges_connect_pages_without_prose_mentions():
+    """A page whose prose never names its imports still gets related entries."""
+    pages = [
+        _make_page("file_page", "a.py", content="No mentions here."),
+        _make_page("file_page", "b.py"),
+        _make_page("file_page", "c.py"),
+    ]
+
+    attach_related_pages(pages, import_edges=[("a.py", "b.py"), ("c.py", "a.py")])
+
+    rel = _related(pages[0])
+    by_reason = {(r["reason"], r["target_page_id"]) for r in rel}
+    assert ("imports", "file_page:b.py") in by_reason
+    assert ("imported-by", "file_page:c.py") in by_reason
+
+
+def test_prose_wiki_links_win_dedup():
+    """A target already linked from prose is not repeated as related."""
+    pages = [
+        _make_page("file_page", "a.py"),
+        _make_page("file_page", "b.py"),
+    ]
+    pages[0].metadata["wiki_links"] = [
+        {"anchor": "b.py", "target_page_id": "file_page:b.py", "kind": "file"}
+    ]
+
+    attach_related_pages(pages, import_edges=[("a.py", "b.py")])
+
+    assert _related(pages[0]) == []
+
+
+def test_reason_priority_reports_target_once():
+    """A target reachable via imports AND co-change appears once, as imports."""
+    pages = [
+        _make_page("file_page", "a.py"),
+        _make_page("file_page", "b.py"),
+    ]
+    git_meta = {
+        "a.py": {
+            "co_change_partners_json": json.dumps([{"file_path": "b.py", "co_change_count": 9}])
+        }
+    }
+
+    attach_related_pages(pages, import_edges=[("a.py", "b.py")], git_meta_map=git_meta)
+
+    rel = _related(pages[0])
+    assert len(rel) == 1
+    assert rel[0]["reason"] == "imports"
+
+
+def test_co_change_partners_ordered_by_count():
+    pages = [
+        _make_page("file_page", "a.py"),
+        _make_page("file_page", "b.py"),
+        _make_page("file_page", "c.py"),
+    ]
+    git_meta = {
+        "a.py": {
+            "co_change_partners_json": json.dumps(
+                [
+                    {"file_path": "b.py", "co_change_count": 2},
+                    {"file_path": "c.py", "co_change_count": 7},
+                ]
+            )
+        }
+    }
+
+    attach_related_pages(pages, git_meta_map=git_meta)
+
+    rel = _related(pages[0])
+    assert [r["target_page_id"] for r in rel] == [
+        "file_page:c.py",
+        "file_page:b.py",
+    ]
+    assert rel[0]["weight"] == 7.0
+
+
+def test_module_siblings_and_caps():
+    """Same-module fills in last and per-reason/total caps hold."""
+    member_paths = tuple(f"m/f{i}.py" for i in range(10))
+    pages = [_make_page("file_page", p) for p in member_paths]
+    groups = [_Group(key="m", file_paths=member_paths)]
+
+    attach_related_pages(pages, module_groups=groups)
+
+    rel = _related(pages[0])
+    # Per-reason cap: at most 5 same-module entries despite 9 siblings.
+    assert len(rel) == 5
+    assert all(r["reason"] == "same-module" for r in rel)
+
+
+def test_deleted_targets_drop_out():
+    """Candidates without a page in this run's set resolve to nothing."""
+    pages = [_make_page("file_page", "a.py")]
+
+    attach_related_pages(pages, import_edges=[("a.py", "gone.py")])
+
+    assert _related(pages[0]) == []
+
+
+def test_non_file_pages_untouched():
+    pages = [_make_page("module_page", "community-1")]
+
+    attach_related_pages(pages, import_edges=[])
+
+    assert "related_pages" not in pages[0].metadata
+
+
+def test_prior_page_ids_widen_resolution_on_incremental_update():
+    """Neighbors outside the regenerated subset resolve via persisted ids."""
+    pages = [_make_page("file_page", "a.py")]
+
+    attach_related_pages(
+        pages,
+        import_edges=[("a.py", "b.py")],
+        prior_page_ids=["file_page:b.py", "module_page:community-1"],
+    )
+
+    rel = _related(pages[0])
+    assert [r["target_page_id"] for r in rel] == ["file_page:b.py"]
+    # Title falls back to the target path for prior-only pages.
+    assert rel[0]["title"] == "b.py"
+
+
+def test_current_run_page_wins_over_prior_id():
+    """A page regenerated this run resolves to itself, not a stale prior id."""
+    pages = [
+        _make_page("file_page", "a.py"),
+        _make_page("file_page", "b.py", title="Fresh B"),
+    ]
+
+    attach_related_pages(
+        pages,
+        import_edges=[("a.py", "b.py")],
+        prior_page_ids=["file_page:b.py"],
+    )
+
+    rel = _related(pages[0])
+    assert rel[0]["title"] == "Fresh B"
+
+
+def test_bad_co_change_json_tolerated():
+    pages = [
+        _make_page("file_page", "a.py"),
+        _make_page("file_page", "b.py"),
+    ]
+    git_meta = {"a.py": {"co_change_partners_json": "{not json"}}
+
+    attach_related_pages(pages, import_edges=[("a.py", "b.py")], git_meta_map=git_meta)
+
+    assert [r["reason"] for r in _related(pages[0])] == ["imports"]

--- a/tests/unit/persistence/test_related_backfill.py
+++ b/tests/unit/persistence/test_related_backfill.py
@@ -1,0 +1,118 @@
+"""Unit tests for the related-pages metadata backfill."""
+
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import select
+
+from repowise.core.persistence.crud import backfill_related_pages, upsert_page
+from repowise.core.persistence.models import Page
+from tests.unit.persistence.helpers import insert_repo, make_page_kwargs
+
+
+async def _insert_page(session, repo_id: str, path: str, **overrides):
+    return await upsert_page(
+        session,
+        **make_page_kwargs(
+            repo_id,
+            page_id=f"file_page:{path}",
+            target_path=path,
+            title=path,
+            **overrides,
+        ),
+    )
+
+
+async def _related_of(session, page_id: str) -> list[dict] | None:
+    row = (await session.execute(select(Page).where(Page.id == page_id))).scalars().one()
+    return json.loads(row.metadata_json or "{}").get("related_pages")
+
+
+async def test_backfill_heals_pages_without_related_metadata(async_session):
+    """Pre-feature pages get related_pages from one backfill run."""
+    repo = await insert_repo(async_session)
+    await _insert_page(async_session, repo.id, "a.py")
+    await _insert_page(async_session, repo.id, "b.py")
+
+    changed = await backfill_related_pages(async_session, repo.id, import_edges=[("a.py", "b.py")])
+
+    assert changed == 2  # a gets imports, b gets imported-by
+    rel = await _related_of(async_session, "file_page:a.py")
+    assert [(r["reason"], r["target_page_id"]) for r in rel] == [("imports", "file_page:b.py")]
+
+
+async def test_backfill_preserves_same_module_entries(async_session):
+    """Recomputing without module groups keeps prior same-module entries."""
+    repo = await insert_repo(async_session)
+    await _insert_page(
+        async_session,
+        repo.id,
+        "a.py",
+        metadata={
+            "related_pages": [
+                {
+                    "target_page_id": "file_page:m.py",
+                    "title": "m.py",
+                    "reason": "same-module",
+                    "weight": 0.0,
+                }
+            ]
+        },
+    )
+    await _insert_page(async_session, repo.id, "b.py")
+    await _insert_page(async_session, repo.id, "m.py")
+
+    await backfill_related_pages(async_session, repo.id, import_edges=[("a.py", "b.py")])
+
+    rel = await _related_of(async_session, "file_page:a.py")
+    reasons = {(r["reason"], r["target_page_id"]) for r in rel}
+    assert ("imports", "file_page:b.py") in reasons
+    assert ("same-module", "file_page:m.py") in reasons
+
+
+async def test_backfill_skips_current_run_pages(async_session):
+    """Pages in skip_page_ids keep their metadata untouched."""
+    repo = await insert_repo(async_session)
+    await _insert_page(async_session, repo.id, "a.py")
+    await _insert_page(async_session, repo.id, "b.py")
+
+    changed = await backfill_related_pages(
+        async_session,
+        repo.id,
+        import_edges=[("a.py", "b.py")],
+        skip_page_ids={"file_page:a.py"},
+    )
+
+    assert changed == 1  # only b.py (imported-by)
+    assert await _related_of(async_session, "file_page:a.py") is None
+
+
+async def test_backfill_idempotent(async_session):
+    """A second identical run reports zero changed rows."""
+    repo = await insert_repo(async_session)
+    await _insert_page(async_session, repo.id, "a.py")
+    await _insert_page(async_session, repo.id, "b.py")
+    edges = [("a.py", "b.py")]
+
+    first = await backfill_related_pages(async_session, repo.id, import_edges=edges)
+    second = await backfill_related_pages(async_session, repo.id, import_edges=edges)
+
+    assert first == 2
+    assert second == 0
+
+
+async def test_backfill_skips_tombstoned_pages(async_session):
+    repo = await insert_repo(async_session)
+    await _insert_page(async_session, repo.id, "a.py")
+    await _insert_page(async_session, repo.id, "gone.py", freshness_status="tombstone")
+
+    changed = await backfill_related_pages(
+        async_session, repo.id, import_edges=[("a.py", "gone.py")]
+    )
+
+    # gone.py is excluded both as a source row and from the resolution
+    # index, so a.py ends up with an empty list and gone.py stays untouched.
+    assert changed == 1
+    assert await _related_of(async_session, "file_page:a.py") == []
+    assert await _related_of(async_session, "file_page:gone.py") is None


### PR DESCRIPTION
## What

Every file-backed wiki page now carries a deterministic `related_pages` metadata block derived from signals the pipeline already computes:

- **imports** / **imported by**: the file's import-graph neighbors
- **changes together**: co-change partners from git history
- **same module**: siblings from the selected module grouping

Until now, cross-page links only existed when the generated prose happened to mention another file in backticks. A page whose text never named its collaborators was an island even though the index knew its dependencies. The new pass runs after interlinking (prose links win dedup), costs zero LLM tokens, and is capped at 5 entries per reason / 12 total.

## Self-healing on update

A metadata-only backfill recomputes `related_pages` across every persisted page and is wired into all three update flavors: docs mode, `--index-only`, and workspace updates. Existing wikis heal in one ordinary `repowise update` with no re-init and no LLM cost. Verified on this repo: 1348 of 1526 pages gained the metadata from a single index-only update.

Details that keep the recompute honest:

- Incremental updates pass only affected files to generation, so resolution is widened with the persisted page ids; without that, an update would overwrite good metadata with near-empty lists.
- Module groupings only exist during full generation, so the backfill preserves prior same-module entries instead of stripping them.
- Pages the current run just generated are skipped; their metadata is fresher than the recompute.
- Tombstoned pages are excluded as both sources and targets.

## UI

- The reader's Related rail now merges graph-derived entries (with reason labels) ahead of prose-derived ones.
- New bottom-of-page chip strip below the `lg` breakpoint: the right rail is hidden on narrow viewports, so mobile and VS Code webview readers previously saw no related links at all.

## Retrieval / MCP

No impact. The pass never touches page content, embeddings, or ranking; `get_answer` and `search_codebase` behave identically. The metadata is additive and available for future surfaces.

## Tests

- `tests/unit/generation/test_related_pages.py`: reason priority, caps, prose-link dedup, prior-id resolution, malformed co-change JSON.
- `tests/unit/persistence/test_related_backfill.py`: heal-from-nothing, same-module preservation, skip set, idempotence, tombstone exclusion.
- Full generation + persistence suites pass (962 tests); typecheck and lint clean.