### PR TITLE
fix: normalize decision staleness timestamps

### DIFF
--- a/packages/core/src/repowise/core/analysis/decisions/extractor.py
+++ b/packages/core/src/repowise/core/analysis/decisions/extractor.py
@@ -71,6 +71,18 @@ def _truncate_title(text: str, limit: int) -> str:
     return window[:cut].rstrip() + "…"
 
 
+def _as_aware_utc(value: datetime) -> datetime:
+    """Return ``value`` as a timezone-aware UTC datetime.
+
+    SQLite drops timezone information from ``DateTime(timezone=True)`` columns,
+    but Repowise writes those values as UTC. Treat naive values as UTC so they
+    can be compared with git metadata timestamps, which are already aware UTC.
+    """
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
 # ---------------------------------------------------------------------------
 # Data models
 # ---------------------------------------------------------------------------
@@ -1341,9 +1353,11 @@ class DecisionExtractor:
             if last_commit and decision_created_at:
                 if isinstance(last_commit, str):
                     last_commit = datetime.fromisoformat(last_commit.replace("Z", "+00:00"))
+                last_commit = _as_aware_utc(last_commit)
                 _created = decision_created_at
                 if isinstance(_created, str):
                     _created = datetime.fromisoformat(_created.replace("Z", "+00:00"))
+                _created = _as_aware_utc(_created)
                 if last_commit > _created:
                     age_days = (now - _created).days
                     commit_count = meta.get("commit_count_90d", 0)

--- a/tests/unit/analysis/test_decision_staleness.py
+++ b/tests/unit/analysis/test_decision_staleness.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from repowise.core.analysis.decision_extractor import DecisionExtractor
+
+
+def test_compute_staleness_accepts_sqlite_naive_created_at() -> None:
+    created_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=30)
+    last_commit_at = datetime.now(UTC) - timedelta(days=1)
+
+    score = DecisionExtractor.compute_staleness(
+        decision_created_at=created_at,
+        affected_files=["src/app.py"],
+        git_meta_map={
+            "src/app.py": {
+                "last_commit_at": last_commit_at,
+                "commit_count_90d": 6,
+            }
+        },
+    )
+
+    assert score > 0


### PR DESCRIPTION
Fixes #874.

## Summary

- normalize decision and git timestamps to aware UTC before staleness comparisons
- treat SQLite-returned naive datetimes as UTC, matching how Repowise writes them
- add a regression test for naive decision `created_at` with aware git `last_commit_at`

## Validation

- `uv run pytest tests/unit/analysis/test_decision_staleness.py -v`
- `uv run pytest tests/unit/analysis/test_decision_sources.py tests/unit/analysis/test_decision_provenance.py tests/unit/analysis/test_decision_staleness.py -v`
- `uv run pytest tests/unit/analysis -v`
- `uv run ruff format packages/core/src/repowise/core/analysis/decisions/extractor.py tests/unit/analysis/test_decision_staleness.py`
- `uv run ruff format --check packages/core/src/repowise/core/analysis/decisions/extractor.py tests/unit/analysis/test_decision_staleness.py`
- `uv run ruff check packages/core/src/repowise/core/analysis/decisions/extractor.py tests/unit/analysis/test_decision_staleness.py`
- `git diff --check`
- `rg -n "Karim13014|claude-code@anthropic.com" .`

## Notes

- Full `uv run ruff format --check packages/ tests/` and `uv run ruff check packages/ tests/` still fail on existing unrelated baseline formatting/lint issues outside this PR.
- Targeted `uv run mypy packages/core/src/repowise/core/analysis/decisions/extractor.py` reports existing unrelated errors in the module, but none are from this change.