### PR TITLE
feat(ui): visual hierarchy pass on the Overview

### DIFF
--- a/packages/ui/src/dashboard/attention-panel.tsx
+++ b/packages/ui/src/dashboard/attention-panel.tsx
@@ -45,9 +45,16 @@ const ICON_MAP = {
   proposed_decision: Lightbulb,
 } as const;
 
+/**
+ * Severity ramp for the row icons. Only `high` earns a hue — a column of
+ * saturated triangles reads as uniform noise and stops meaning "urgent". The
+ * lower two steps encode severity by *emphasis* (primary vs tertiary text)
+ * rather than colour, so all three stay distinguishable while red keeps its
+ * meaning by being rare.
+ */
 const SEVERITY_COLORS = {
   high: "text-[var(--color-error)]",
-  medium: "text-[var(--color-warning)]",
+  medium: "text-[var(--color-text-secondary)]",
   low: "text-[var(--color-text-tertiary)]",
 } as const;
 

--- a/packages/ui/src/dashboard/health-overview-card.tsx
+++ b/packages/ui/src/dashboard/health-overview-card.tsx
@@ -200,7 +200,9 @@ function MetricTile({
                 width={96}
                 height={28}
                 stroke="var(--color-accent-primary)"
-                fill="color-mix(in srgb, var(--color-accent-fill) 20%, transparent)"
+                // A whisper of fill: enough to read as a trend, not enough to
+                // become an amber blob competing with the score beside it.
+                fill="color-mix(in srgb, var(--color-accent-fill) 8%, transparent)"
               />
             )}
           </div>
@@ -274,7 +276,15 @@ export function HealthOverviewCard({
   const hasData = avg != null || hot != null;
 
   return (
-    <Card className={`overflow-hidden ${className ?? ""}`}>
+    // The hero of the Overview: one step of elevation above its neighbours and
+    // an accent edge, so Code Health reads as the centrepiece instead of one
+    // more equal-weight tile. Everything else on the page stays at --card-shadow.
+    <Card className={`overflow-hidden shadow-[var(--shadow-md)] ${className ?? ""}`}>
+      <div
+        aria-hidden
+        className="h-[3px] w-full"
+        style={{ background: "var(--gradient-ember)" }}
+      />
       <CardHeader className="pb-2">
         <CardTitle className="text-sm flex items-center justify-between">
           <span className="flex items-center gap-2">

--- a/packages/ui/src/dashboard/kpi-strip.tsx
+++ b/packages/ui/src/dashboard/kpi-strip.tsx
@@ -60,9 +60,14 @@ export interface KpiStripProps {
 }
 
 /**
- * Airy KPI bar — gap-separated stat tiles (no divider chrome), each rendered
- * with the canonical `MetricCard`. Percentage metrics carry a mini gauge.
- * Fully presentational: data and the link component arrive via props.
+ * Airy KPI bar — gap-separated stat tiles, each rendered with the canonical
+ * `MetricCard`. Percentage metrics carry a mini gauge. Fully presentational:
+ * data and the link component arrive via props.
+ *
+ * The tiles are deliberately chrome-less: a row of five outlined boxes reads
+ * as five competing objects, so the border/surface/shadow are dropped and
+ * whitespace does the separating. The surface returns on hover to keep the
+ * click target legible.
  */
 export function KpiStrip({ items, LinkComponent, className }: KpiStripProps) {
   return (
@@ -75,6 +80,7 @@ export function KpiStrip({ items, LinkComponent, className }: KpiStripProps) {
           label={kpi.label}
           value={kpi.value}
           href={kpi.href}
+          className="border-transparent bg-transparent shadow-none hover:border-transparent hover:bg-[var(--color-bg-surface)] hover:shadow-[var(--shadow-sm)]"
           {...(kpi.description ? { description: kpi.description } : {})}
           {...(kpi.delta ? { delta: kpi.delta } : {})}
           {...(LinkComponent ? { LinkComponent } : {})}

--- a/packages/ui/styles/globals.css
+++ b/packages/ui/styles/globals.css
@@ -236,8 +236,11 @@
   --shadow-xl: 0 16px 48px rgba(36, 27, 44, 0.14), 0 4px 12px rgba(36, 27, 44, 0.08);
   --shadow-button: 0 1px 2px rgba(214, 127, 16, 0.22);
 
-  /* Card elevation dial: flat by default, flip to a shadow token to float. */
-  --card-shadow: none;
+  /* Card elevation dial: cards float on a hairline + soft shadow rather than
+     reading as flat outlined boxes. Kept at `sm` so the lift is felt, not
+     seen — anything heavier turns a dense dashboard into a pile of panels.
+     `.dark` inherits this via its own --shadow-sm override. */
+  --card-shadow: var(--shadow-sm);
 
   /* ================================================================== */
   /* Non-color tokens (theme-independent)                               */


### PR DESCRIPTION
A visual-hierarchy pass on the Overview. The page was information-dense but flat: every card carried equal weight, so nothing led and Code Health (the moat) wore the same chrome as the index-storage tile. This is about hierarchy, not decoration.

Almost all of it turned out to be *using dials the design system already shipped* rather than adding new styles.

## Elevation: flip the dial the tokens already documented

`globals.css` carried `--card-shadow: none` with the comment *"Card elevation dial: flat by default, flip to a shadow token to float."* Flipped to `var(--shadow-sm)`.

One line, both themes (`.dark` overrides `--shadow-sm` already), and all 63 `Card` consumers get it consistently. Kept at `sm` deliberately: anything heavier turns a dense dashboard into a pile of panels.

## Code Health becomes the hero

An ember accent edge plus `--shadow-md`, one step of elevation above its neighbours. It now reads as the centrepiece instead of a peer of the tiles around it. Everything else stays at `--card-shadow`.

## KPI strip loses its chrome

Five separately-outlined boxes read as five competing objects. The tiles are now borderless and transparent, with whitespace doing the separating and the surface returning on hover to keep the click target legible. `KpiStrip` has only the two overview consumers, so the blast radius is small.

## Colour restraint in the attention rows

Only `high` severity earns a hue now. A column of saturated triangles reads as uniform noise and stops meaning "urgent". The lower two steps encode severity by *emphasis* (secondary vs tertiary text) rather than hue, so all three levels stay distinguishable while red keeps its meaning by being rare.

This mostly affects the expanded list (1,086 of 1,107 items on this repo are `medium`); the 5-row preview is all `high` today for reasons being addressed separately.

## Sparklines

Fill dropped from 20% to 8% of accent-fill. Enough to read as a trend, not enough to become an amber blob competing with the score beside it.

## Verification

- `npm run type-check` clean across all packages; ui suite 606 passed.
- Verified in the browser in **both** light and dark: the ember edge, the elevation ramp, and the borderless tiles all hold up against the graphite surfaces.
