### PR TITLE
feat(ui): make Attention Needed a triage panel again

### DIFF
--- a/packages/ui/__tests__/dashboard/attention-panel.test.tsx
+++ b/packages/ui/__tests__/dashboard/attention-panel.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  AttentionPanel,
+  type AttentionItem,
+  type AttentionItemType,
+} from "../../src/dashboard/attention-panel";
+
+function item(
+  id: string,
+  type: AttentionItemType,
+  severity: AttentionItem["severity"] = "medium",
+): AttentionItem {
+  return { id, type, title: `title-${id}`, description: `desc-${id}`, severity };
+}
+
+/** Server order: strictly severity-sorted, which is what the panel re-mixes. */
+function severitySorted(items: AttentionItem[]): AttentionItem[] {
+  const rank = { high: 0, medium: 1, low: 2 } as const;
+  return [...items].sort((a, b) => rank[a.severity] - rank[b.severity]);
+}
+
+describe("AttentionPanel", () => {
+  it("collapses auto-proposed decisions into one row instead of listing them", () => {
+    const items = [
+      item("stale-1", "stale_decision", "high"),
+      ...Array.from({ length: 40 }, (_, i) => item(`prop-${i}`, "proposed_decision")),
+    ];
+
+    render(<AttentionPanel items={items} repoId="r1" previewCount={5} />);
+
+    expect(screen.getByText(/40/)).toBeInTheDocument();
+    expect(screen.getByText(/auto-proposed decisions awaiting review/)).toBeInTheDocument();
+    // None of the 40 proposals are rendered as their own rows.
+    expect(screen.queryByText("title-prop-0")).not.toBeInTheDocument();
+    expect(screen.getByText("title-stale-1")).toBeInTheDocument();
+  });
+
+  it("counts only the triage queue in the badge, not the proposal inbox", () => {
+    const items = [
+      item("silo-1", "knowledge_silo"),
+      ...Array.from({ length: 99 }, (_, i) => item(`prop-${i}`, "proposed_decision")),
+    ];
+
+    render(<AttentionPanel items={items} repoId="r1" previewCount={5} />);
+
+    // The badge is the triage count (1) — not 100, which would read as a
+    // problem count when 99 of those are our own unreviewed suggestions.
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.queryByText("100")).not.toBeInTheDocument();
+  });
+
+  it("surfaces every type in the preview instead of letting the biggest win", () => {
+    // Strict severity order would fill a 4-row preview with stale decisions
+    // alone and never show the silo, hotspot, or dead-code categories.
+    const items = severitySorted([
+      ...Array.from({ length: 10 }, (_, i) => item(`stale-${i}`, "stale_decision", "high")),
+      ...Array.from({ length: 10 }, (_, i) => item(`silo-${i}`, "knowledge_silo")),
+      ...Array.from({ length: 10 }, (_, i) => item(`hot-${i}`, "ungoverned_hotspot")),
+      ...Array.from({ length: 10 }, (_, i) => item(`dead-${i}`, "dead_code", "low")),
+    ]);
+
+    render(<AttentionPanel items={items} repoId="r1" previewCount={4} />);
+
+    expect(screen.getByText("title-stale-0")).toBeInTheDocument();
+    expect(screen.getByText("title-silo-0")).toBeInTheDocument();
+    expect(screen.getByText("title-hot-0")).toBeInTheDocument();
+    expect(screen.getByText("title-dead-0")).toBeInTheDocument();
+    // Round-robin: no type takes a second slot before every type has one.
+    expect(screen.queryByText("title-stale-1")).not.toBeInTheDocument();
+  });
+
+  it("keeps the most severe type leading the preview", () => {
+    const items = severitySorted([
+      item("dead-0", "dead_code", "low"),
+      item("stale-0", "stale_decision", "high"),
+      item("silo-0", "knowledge_silo"),
+    ]);
+
+    render(<AttentionPanel items={items} repoId="r1" previewCount={3} />);
+
+    const rows = screen.getAllByText(/^title-/);
+    expect(rows[0]).toHaveTextContent("title-stale-0");
+  });
+
+  it("still shows the proposal row when nothing else needs triage", () => {
+    const items = Array.from({ length: 3 }, (_, i) => item(`prop-${i}`, "proposed_decision"));
+
+    render(<AttentionPanel items={items} repoId="r1" previewCount={5} />);
+
+    expect(screen.getByText(/auto-proposed decisions awaiting review/)).toBeInTheDocument();
+    expect(screen.queryByText("Nothing needs attention")).not.toBeInTheDocument();
+  });
+
+  it("reports all clear only when both queues are empty", () => {
+    render(<AttentionPanel items={[]} repoId="r1" />);
+
+    expect(screen.getByText("Nothing needs attention")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/dashboard/attention-panel.tsx
+++ b/packages/ui/src/dashboard/attention-panel.tsx
@@ -76,6 +76,39 @@ interface AttentionPanelProps {
   repoName?: string;
 }
 
+/**
+ * Round-robin one item from each type before taking a second from any, so the
+ * preview window shows a spread instead of whatever category happens to be
+ * biggest.
+ *
+ * The server sorts strictly by severity, which sounds right and isn't: the
+ * categories are wildly different sizes (hotspots / silos / dead code are each
+ * capped at 10, decisions are not), so a strict sort lets one type monopolise
+ * the window and the other four never surface at all. Buckets are walked in
+ * first-appearance order, and the incoming list is severity-sorted, so the
+ * most severe type still leads — each type just gets a voice before any type
+ * gets a second row.
+ */
+function diversifyByType(items: AttentionItem[], count: number): AttentionItem[] {
+  const buckets = new Map<AttentionItemType, AttentionItem[]>();
+  for (const item of items) {
+    const bucket = buckets.get(item.type);
+    if (bucket) bucket.push(item);
+    else buckets.set(item.type, [item]);
+  }
+
+  const queues = [...buckets.values()];
+  const out: AttentionItem[] = [];
+  let cursor = 0;
+  while (out.length < count && queues.some((q) => q.length > 0)) {
+    const queue = queues[cursor % queues.length]!;
+    const next = queue.shift();
+    if (next) out.push(next);
+    cursor++;
+  }
+  return out;
+}
+
 function getDefaultHref(item: AttentionItem, prefix: string): string {
   const target = item.target_id;
   switch (item.type) {
@@ -111,8 +144,21 @@ export function AttentionPanel({
   const prefix = linkPrefix ?? `/repos/${repoId}`;
   const [expanded, setExpanded] = useState(false);
   const [promptOpen, setPromptOpen] = useState(false);
-  const visible = expanded ? items : items.slice(0, previewCount);
-  if (items.length === 0) {
+
+  // Auto-proposed decisions are a review inbox, not a health signal: they are
+  // suggestions *we* generated, and they routinely outnumber everything else by
+  // two orders of magnitude (1,066 of 1,107 on this repo). Mixing them in made
+  // the panel a backlog dump and the count read as "your repo has 1,107
+  // problems". They collapse to a single row pointing at the Decisions page,
+  // where reviewing them in bulk actually belongs.
+  const proposed = items.filter((i) => i.type === "proposed_decision");
+  const triage = items.filter((i) => i.type !== "proposed_decision");
+
+  // Preview samples across types; expanding falls back to the server's
+  // severity order, which is the right read once you are actually triaging.
+  const visible = expanded ? triage : diversifyByType(triage, previewCount);
+
+  if (triage.length === 0 && proposed.length === 0) {
     return (
       <Card>
         <CardContent className="p-2">
@@ -140,8 +186,11 @@ export function AttentionPanel({
               label="Hand queue to AI"
               onClick={() => setPromptOpen(true)}
             />
+            {/* Counts the triage queue only. Including the proposed-decision
+                inbox here made the badge read as a problem count when it was
+                mostly our own un-reviewed suggestions. */}
             <Badge variant="outline" className="text-[10px] h-5 tabular-nums">
-              {items.length}
+              {triage.length}
             </Badge>
           </span>
         </CardTitle>
@@ -176,7 +225,7 @@ export function AttentionPanel({
               </a>
             );
           })}
-          {items.length > previewCount && (
+          {triage.length > previewCount && (
             <button
               type="button"
               onClick={() => setExpanded((v) => !v)}
@@ -184,8 +233,28 @@ export function AttentionPanel({
             >
               {expanded
                 ? "Show fewer"
-                : `+${items.length - previewCount} more items — show all`}
+                : `+${triage.length - previewCount} more items — show all`}
             </button>
+          )}
+
+          {proposed.length > 0 && (
+            <a
+              // Plain /decisions: the page lists proposals inline and has no
+              // URL-driven status filter to deep-link into yet.
+              href={`${prefix}/decisions`}
+              className="group mt-1 flex items-center gap-2.5 rounded-md border-t border-[var(--color-border-default)] p-2 -mx-2 pt-2.5 transition-colors hover:bg-[var(--color-bg-elevated)]"
+            >
+              <Lightbulb className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-tertiary)]" />
+              <span className="min-w-0 flex-1 text-xs text-[var(--color-text-secondary)]">
+                <span className="font-medium tabular-nums text-[var(--color-text-primary)]">
+                  {proposed.length.toLocaleString()}
+                </span>{" "}
+                auto-proposed decision{proposed.length === 1 ? "" : "s"} awaiting review
+              </span>
+              <span className="shrink-0 text-xs text-[var(--color-accent-primary)] group-hover:underline">
+                Review →
+              </span>
+            </a>
           )}
         </div>
       </CardContent>
@@ -195,7 +264,10 @@ export function AttentionPanel({
       onOpenChange={setPromptOpen}
       getPrompt={(flavor) =>
         buildWorkQueueAiPrompt({
-          items: items.map((it) => ({
+          // Triage only, matching the panel: handing an agent 1,000+ decisions
+          // we auto-proposed as a "prioritized worklist" buries the handful of
+          // real items and asks it to do review work it cannot judge.
+          items: triage.map((it) => ({
             type: it.type,
             title: it.title,
             description: it.description,


### PR DESCRIPTION
"Attention Needed" had stopped being a triage surface and become a backlog dump. On this repo it listed **1,107 items**:

| Type | Count | Severity |
|---|---:|---|
| `proposed_decision` | **1,066** | medium |
| `stale_decision` | 11 | high |
| `dead_code` | 10 | low |
| `knowledge_silo` | 10 | medium |
| `ungoverned_hotspot` | 10 | medium |

Two problems compounded each other:

1. **Uneven caps.** `ungoverned_hotspots`, `knowledge_silos`, and `dead_code` are each capped at `[:10]` in `_build_attention_items`; decisions are uncapped. So one category outnumbered everything else by two orders of magnitude.
2. **Strict severity sort.** The 11 high-severity stale decisions took the entire 5-row preview, so silos, hotspots, and dead code could *never* appear in it. Not just in the preview either — "show all" buried them below ~1,077 rows.

The net effect: the panel showed five near-identical rows, four of its five categories were unreachable, and the badge read as if the repo had 1,107 problems.

## Changes

**Auto-proposed decisions collapse to one row** linking to Decisions. They are a review inbox, not a health signal — suggestions the tool generated itself, meant to be processed in bulk where that belongs, rather than interleaved with "this hotspot has no owner". This is the root fix: it is what made the panel a dump.

**The preview round-robins across types**, so each category surfaces its top item before any category takes a second row. The incoming list is severity-sorted and buckets are walked in first-appearance order, so the most severe type still leads — each type just gets a voice first. Expanding falls back to the full severity order, which is the right read once you are actually triaging.

**The badge counts the triage queue only** — 41 instead of 1,107.

**The AI work queue is fed the same triage list.** It previously reported "Items in this queue: 1,107" and ranked the proposals in. Handing an agent 1,000+ auto-proposed decisions as a "prioritized worklist" buries the handful of real items and asks it to do review work it cannot judge.

## Before / after

The preview went from five stale-decision rows to an actual spread — stale decision, ungoverned hotspot, knowledge silo, dead code — with `1,066 auto-proposed decisions awaiting review →` as a single quiet row beneath.

## Notes

- The proposal row links to plain `/decisions`: that page lists proposals inline and has no URL-driven status filter to deep-link into yet.
- The `[:10]` caps are left as-is. They are arbitrary and uncommented, but changing them is a separate call from fixing the surface.
- The full payload still crosses the wire; only the presentation changed here.

## Verification

- Adds the first tests for this component (it had none): the partition, the badge count, type diversity, severity ordering, and both empty states.
- `npm run type-check` clean; ui suite 612 passed.
- Verified in the browser: badge reads 41, all four triage categories appear in the preview, proposal row renders and links correctly.
