### PR TITLE
fix(answer): never silently drop synthesis when a usable API key exists

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -896,15 +896,23 @@ async def get_answer(
     provider = _resolve_provider_for_answer(getattr(ctx, "path", None))
     if provider is None:
         # Retrieval-only mode (no provider). Return the hits so the agent can
-        # at least skip the search_codebase step.
-        return {
+        # at least skip the search_codebase step — but mark the degradation
+        # loudly: an arm/user should never need to diff payload shapes to
+        # notice synthesis is unplugged.
+        _log.warning(
+            "get_answer running WITHOUT synthesis: no LLM provider resolvable "
+            "(set REPOWISE_PROVIDER + its API key, or any supported API key)."
+        )
+        payload = {
             "answer": "",
             "citations": [],
             "confidence": "low",
+            "degraded": "no-llm-provider",
             "fallback_targets": fallback_targets,
             "retrieval": _serialize_hits(hits),
             "note": (
-                "No LLM provider configured (set REPOWISE_PROVIDER + API key). "
+                "DEGRADED: no LLM provider configured (set REPOWISE_PROVIDER "
+                "+ API key). "
                 "Returning retrieval hits only — Read the listed files to answer."
             ),
             "_meta": _build_meta(
@@ -914,6 +922,8 @@ async def get_answer(
                 targets=fallback_targets,
             ),
         }
+        payload["_meta"]["degraded"] = "no-llm-provider"
+        return payload
 
     # Decision fusion (why-shaped questions only) + structured prelude. Both
     # layers are gated on signal: no ADRs for the top hits → no decisions
@@ -952,9 +962,10 @@ async def get_answer(
             "answer": "",
             "citations": [],
             "confidence": "low",
+            "degraded": "synthesis-failed",
             "fallback_targets": fallback_targets,
             "retrieval": _serialize_hits(hits),
-            "note": f"LLM synthesis failed ({type(exc).__name__}). Read the listed files to answer.",
+            "note": f"DEGRADED: LLM synthesis failed ({type(exc).__name__}). Read the listed files to answer.",
             "_meta": _build_meta(
                 timing_ms=(time.perf_counter() - t0) * 1000,
                 hint=_answer_hint("low", len(hits)),

--- a/packages/server/src/repowise/server/mcp_server/tool_answer/synthesis.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/synthesis.py
@@ -42,6 +42,7 @@ def _load_repo_provider_config(
     if repo_path is None:
         return None, None, {}
 
+    config_path = repo_path / ".repowise" / "config.yaml"
     state_path = repo_path / ".repowise" / "state.json"
     env_path = repo_path / ".repowise" / ".env"
 
@@ -49,11 +50,27 @@ def _load_repo_provider_config(
     model: str | None = None
     overlay: dict[str, str] = {}
 
+    # config.yaml first: it is the user-editable intent. state.json only
+    # records what the LAST index run used, which goes stale the moment the
+    # user switches providers (observed: a config saying openai while
+    # state.json still said gemini from a months-old index build — resolution
+    # followed state.json into a keyless provider and synthesis went dark).
+    try:
+        if config_path.is_file():
+            import yaml
+
+            data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            if isinstance(data, dict):
+                name = data.get("provider") or None
+                model = data.get("model") or None
+    except Exception:
+        _log.debug("Failed to read %s", config_path, exc_info=True)
+
     try:
         if state_path.is_file():
             data = _json.loads(state_path.read_text(encoding="utf-8"))
-            name = data.get("provider") or None
-            model = data.get("model") or None
+            name = name or data.get("provider") or None
+            model = model or data.get("model") or None
     except Exception:
         _log.debug("Failed to read %s", state_path, exc_info=True)
 
@@ -126,25 +143,42 @@ def _resolve_provider_for_answer(repo_path: Path | None = None):
                 return val
         return None
 
-    # Explicit selection wins.
+    # Explicit selection wins — when its key is actually available. A
+    # configured/persisted provider whose key is absent must NOT end
+    # resolution: returning None here made get_answer silently drop to
+    # retrieval-only mode even though another provider's key sat in the env
+    # (the auto-detect below was unreachable). Fall through instead, and
+    # drop the persisted model on the way down — it belongs to the named
+    # provider and would break a cross-provider fallback call.
+    _KEY_ENVS = {
+        "anthropic": ("ANTHROPIC_API_KEY",),
+        "openai": ("OPENAI_API_KEY",),
+        "deepseek": ("DEEPSEEK_API_KEY",),
+        "kimi": ("KIMI_API_KEY",),
+        "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    }
     if name:
-        kw: dict[str, Any] = {}
-        if model:
-            kw["model"] = model
-        if name == "anthropic" and _env("ANTHROPIC_API_KEY"):
-            kw["api_key"] = _env("ANTHROPIC_API_KEY")
-        elif name == "openai" and _env("OPENAI_API_KEY"):
-            kw["api_key"] = _env("OPENAI_API_KEY")
-        elif name == "deepseek" and _env("DEEPSEEK_API_KEY"):
-            kw["api_key"] = _env("DEEPSEEK_API_KEY")
-        elif name == "kimi" and _env("KIMI_API_KEY"):
-            kw["api_key"] = _env("KIMI_API_KEY")
-        elif name == "gemini" and (_env("GEMINI_API_KEY") or _env("GOOGLE_API_KEY")):
-            kw["api_key"] = _env("GEMINI_API_KEY") or _env("GOOGLE_API_KEY")
-        base_url = _resolve_base_url(name)
-        if base_url:
-            kw["base_url"] = base_url
-        return _try(name, **kw)
+        key_envs = _KEY_ENVS.get(name)
+        key = next((v for v in map(_env, key_envs or ()) if v), None)
+        if key_envs is None or key:
+            kw: dict[str, Any] = {}
+            if model:
+                kw["model"] = model
+            if key:
+                kw["api_key"] = key
+            base_url = _resolve_base_url(name)
+            if base_url:
+                kw["base_url"] = base_url
+            provider = _try(name, **kw)
+            if provider is not None:
+                return provider
+        _log.warning(
+            "Configured provider %r has no usable key/setup; falling back to "
+            "auto-detection from available API keys.",
+            name,
+        )
+        if not (os.environ.get("REPOWISE_DOC_MODEL") or os.environ.get("REPOWISE_MODEL")):
+            model = None  # persisted model was provider-specific
 
     # Auto-detect from API keys.
     if _env("ANTHROPIC_API_KEY"):

--- a/tests/unit/server/mcp/test_provider_resolution.py
+++ b/tests/unit/server/mcp/test_provider_resolution.py
@@ -1,0 +1,85 @@
+"""get_answer provider resolution: intent precedence and keyless fall-through.
+
+Regression coverage for the silent retrieval-only degradation: an index
+whose state.json recorded a provider from a months-old build, in an env
+that only carried a different provider's key, resolved to None and ran
+get_answer without synthesis — no error, no fallback, even though a usable
+key was sitting in the environment.
+"""
+
+from __future__ import annotations
+
+import json as _json
+
+import pytest
+
+from repowise.server.mcp_server.tool_answer.synthesis import (
+    _load_repo_provider_config,
+    _resolve_provider_for_answer,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in ("REPOWISE_PROVIDER", "REPOWISE_DOC_MODEL", "REPOWISE_MODEL",
+                "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY",
+                "GOOGLE_API_KEY", "DEEPSEEK_API_KEY", "KIMI_API_KEY",
+                "OLLAMA_BASE_URL", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _write_repo(tmp_path, *, config=None, state=None):
+    d = tmp_path / ".repowise"
+    d.mkdir(parents=True, exist_ok=True)
+    if config is not None:
+        (d / "config.yaml").write_text(
+            "\n".join(f"{k}: {v}" for k, v in config.items()), encoding="utf-8")
+    if state is not None:
+        (d / "state.json").write_text(_json.dumps(state), encoding="utf-8")
+    return tmp_path
+
+
+def test_config_yaml_outranks_state_json(tmp_path):
+    """config.yaml is user intent; state.json only records the last run."""
+    repo = _write_repo(
+        tmp_path,
+        config={"provider": "openai", "model": "gpt-5.4-nano"},
+        state={"provider": "gemini", "model": "gemini-3.1-flash-lite-preview"},
+    )
+    name, model, _ = _load_repo_provider_config(repo)
+    assert name == "openai"
+    assert model == "gpt-5.4-nano"
+
+
+def test_state_json_still_used_when_config_lacks_provider(tmp_path):
+    repo = _write_repo(tmp_path, config={"commit_limit": 200},
+                       state={"provider": "openai", "model": "gpt-5.4-nano"})
+    name, model, _ = _load_repo_provider_config(repo)
+    assert name == "openai"
+    assert model == "gpt-5.4-nano"
+
+
+def test_keyless_persisted_provider_falls_back_to_available_key(tmp_path, monkeypatch):
+    """gemini persisted, only OPENAI_API_KEY present -> openai provider, not None."""
+    repo = _write_repo(tmp_path,
+                       state={"provider": "gemini", "model": "gemini-3.1-flash"})
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    provider = _resolve_provider_for_answer(repo)
+    assert provider is not None
+    assert getattr(provider, "provider_name", "") == "openai"
+    # The persisted gemini model must not leak into the openai call.
+    assert "gemini" not in (getattr(provider, "model_name", "") or "")
+
+
+def test_no_keys_at_all_resolves_to_none(tmp_path):
+    repo = _write_repo(tmp_path, state={"provider": "gemini"})
+    assert _resolve_provider_for_answer(repo) is None
+
+
+def test_explicit_env_provider_still_wins(tmp_path, monkeypatch):
+    repo = _write_repo(tmp_path, state={"provider": "gemini"})
+    monkeypatch.setenv("REPOWISE_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    provider = _resolve_provider_for_answer(repo)
+    assert provider is not None
+    assert getattr(provider, "provider_name", "") == "openai"


### PR DESCRIPTION
## Problem

Provider resolution treated the provider persisted in `.repowise/state.json` as final: if that provider's key was absent from the environment, resolution returned `None` before the auto-detect-from-available-keys path could run, and `get_answer` silently served retrieval-only payloads. Observed live: an index built months ago under gemini, queried in an environment holding only an OpenAI key, ran every `get_answer` call without synthesis — no error anywhere, just quietly thinner answers.

## Change

- `config.yaml` (user-editable intent) now outranks `state.json` (a record of the last index run) when naming the provider.
- A named provider whose key is missing falls through to key auto-detection with a warning instead of ending resolution; the persisted model is dropped on the way down (it belongs to the named provider and would break a cross-provider call).
- When nothing resolves at all, the degradation is loud: `degraded: "no-llm-provider"` in the payload and `_meta`, a DEGRADED-prefixed note, and a server-side warning — same marker on the synthesis-failure path.

## Testing

New `tests/unit/server/mcp/test_provider_resolution.py`: config-over-state precedence, keyless fall-through to an available key (without model leakage), explicit env override, and the no-keys-at-all case. 38 tests green across the touched suites.