### PR TITLE
fix: security scan reads real source; guard repo-root detection

### DIFF
--- a/packages/cli/src/repowise/cli/commands/augment_cmd/_shared.py
+++ b/packages/cli/src/repowise/cli/commands/augment_cmd/_shared.py
@@ -7,6 +7,7 @@ depend on ``_shared``, never the other way around.
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 
 
@@ -58,10 +59,20 @@ def _relativize(file_path: str, repo_path: Path) -> str | None:
 
 
 def _find_repo_root(cwd: Path) -> Path | None:
-    """Walk up from cwd to find a directory with .repowise/."""
+    """Walk up from cwd to find a directory with .repowise/.
+
+    ``~/.repowise`` is the user-level config dir and a ``.repowise`` at the
+    system temp ROOT is always a stray artifact (a tool that indexed with
+    cwd=$TMP), so neither counts as a repo opt-in; repos legitimately created
+    UNDER either directory still match.
+    """
     current = Path(cwd).resolve()
+    try:
+        skip = {Path.home().resolve(), Path(tempfile.gettempdir()).resolve()}
+    except (OSError, RuntimeError):
+        skip = set()
     for _ in range(20):
-        if (current / ".repowise").is_dir():
+        if current not in skip and (current / ".repowise").is_dir():
             return current
         parent = current.parent
         if parent == current:

--- a/packages/cli/src/repowise/cli/rewrite_hook.py
+++ b/packages/cli/src/repowise/cli/rewrite_hook.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import os.path
 import re
 import sys
+import tempfile
 
 # Stdlib-only module by design (see hot-path discipline above) — safe to
 # import at module scope. (No pathlib: it costs double-digit milliseconds
@@ -288,13 +289,20 @@ def _find_repo_root(cwd: str) -> str | None:
     try:
         current = os.path.realpath(cwd or ".")
         home = os.path.realpath(os.path.expanduser("~"))
+        temp_root = os.path.realpath(tempfile.gettempdir())
     except OSError:
         return None
     for _ in range(20):
         # ~/.repowise is the *user-level* config dir, not a repo opt-in —
         # without this guard every directory under $HOME would classify as
-        # a repowise repo and get its commands rewritten.
-        if current != home and os.path.isdir(os.path.join(current, ".repowise")):
+        # a repowise repo and get its commands rewritten. The system temp
+        # ROOT gets the same treatment: a .repowise there is always a stray
+        # artifact (a tool that indexed with cwd=$TMP), never an opt-in, and
+        # it would otherwise capture every temp-dir cwd on the machine.
+        # Repos legitimately created UNDER either directory still match.
+        if current not in (home, temp_root) and os.path.isdir(
+            os.path.join(current, ".repowise")
+        ):
             return current
         parent = os.path.dirname(current)
         if parent == current:

--- a/packages/core/src/repowise/core/analysis/security_scan.py
+++ b/packages/core/src/repowise/core/analysis/security_scan.py
@@ -31,6 +31,11 @@ _PATTERNS: list[tuple[re.Pattern, str, str]] = [
     (re.compile(r"\bmd5\b|\bsha1\b"), "weak_hash", "low"),
 ]
 
+# Combined prefilter: one search per line rejects the (overwhelmingly common)
+# clean lines before the per-pattern loop runs. Matches iff some pattern in
+# _PATTERNS matches, so findings are unchanged.
+_ANY_PATTERN = re.compile("|".join(f"(?:{p.pattern})" for p, _, _ in _PATTERNS))
+
 # Symbol names that are informational security hotspots
 _SYMBOL_KEYWORDS = re.compile(
     r"\b(auth|token|password|jwt|session|crypto)\b", re.IGNORECASE
@@ -66,6 +71,8 @@ class SecurityScanner:
 
         # Line-by-line pattern scan
         for lineno, line in enumerate(lines, start=1):
+            if not _ANY_PATTERN.search(line):
+                continue
             for pattern, kind, severity in _PATTERNS:
                 if pattern.search(line):
                     # Trim snippet to keep it concise
@@ -94,35 +101,60 @@ class SecurityScanner:
 
         return findings
 
-    async def persist(self, file_path: str, findings: list[dict]) -> None:
-        """Insert security findings into the security_findings table.
+    async def replace_findings(
+        self,
+        findings_by_file: dict[str, list[dict]],
+        scanned_paths: list[str],
+    ) -> None:
+        """Replace the findings rows for every scanned file in one pass.
 
-        Uses raw INSERT to stay independent of any ORM session state.
-        Silently skips if the table doesn't exist yet (pre-migration).
+        Deleting all *scanned* paths (not just those with findings) keeps the
+        table idempotent: re-indexing never accumulates duplicate rows, and a
+        file whose issues were fixed loses its stale rows. Uses raw SQL to
+        stay independent of any ORM session state; silently skips if the
+        table doesn't exist yet (pre-migration).
         """
         from sqlalchemy import text
 
-        if not findings:
-            return
+        chunk_size = 400  # SQLite parameter-limit headroom, same as the CRUD layer
 
-        now = datetime.now(UTC)
-        for finding in findings:
-            try:
+        try:
+            for i in range(0, len(scanned_paths), chunk_size):
+                chunk = scanned_paths[i : i + chunk_size]
+                placeholders = ", ".join(f":p{j}" for j in range(len(chunk)))
+                params: dict[str, object] = {"repo_id": self._repo_id}
+                params.update({f"p{j}": p for j, p in enumerate(chunk)})
+                await self._session.execute(
+                    text(
+                        "DELETE FROM security_findings "
+                        "WHERE repository_id = :repo_id "
+                        f"AND file_path IN ({placeholders})"
+                    ),
+                    params,
+                )
+
+            now = datetime.now(UTC)
+            rows = [
+                {
+                    "repo_id": self._repo_id,
+                    "file_path": file_path,
+                    "kind": finding["kind"],
+                    "severity": finding["severity"],
+                    "snippet": finding.get("snippet", ""),
+                    "line": finding.get("line", 0),
+                    "detected_at": now,
+                }
+                for file_path, findings in findings_by_file.items()
+                for finding in findings
+            ]
+            if rows:
                 await self._session.execute(
                     text(
                         "INSERT INTO security_findings "
                         "(repository_id, file_path, kind, severity, snippet, line_number, detected_at) "
                         "VALUES (:repo_id, :file_path, :kind, :severity, :snippet, :line, :detected_at)"
                     ),
-                    {
-                        "repo_id": self._repo_id,
-                        "file_path": file_path,
-                        "kind": finding["kind"],
-                        "severity": finding["severity"],
-                        "snippet": finding.get("snippet", ""),
-                        "line": finding.get("line", 0),
-                        "detected_at": now,
-                    },
+                    rows,
                 )
-            except Exception:  # noqa: BLE001 — table may not exist pre-migration
-                break
+        except Exception:  # table may not exist pre-migration
+            return

--- a/packages/core/src/repowise/core/pipeline/orchestrator.py
+++ b/packages/core/src/repowise/core/pipeline/orchestrator.py
@@ -384,6 +384,7 @@ async def run_pipeline(
             git_metadata_list=git_metadata_list,
             git_summary=git_summary,
             external_systems=external_systems,
+            source_map=source_map,
         )
 
     # Emit rich insight summary for the ingestion phase

--- a/packages/core/src/repowise/core/pipeline/persist.py
+++ b/packages/core/src/repowise/core/pipeline/persist.py
@@ -626,22 +626,41 @@ async def persist_ingestion(result: Any, session: Any, repo_id: str) -> int:
         await batch_upsert_symbols(session, repo_id, all_symbols)
 
     # ---- Security scan -------------------------------------------------------
-    # There is already a clear per-file loop over parsed_files here, so the
-    # scan rides alongside symbol persistence. Best-effort — never breaks
-    # the rest of the phase.
+    # Best-effort — never breaks the rest of the phase.
     try:
-        from repowise.core.analysis.security_scan import SecurityScanner
-
-        scanner = SecurityScanner(session, repo_id)
-        for pf in result.parsed_files:
-            source_text = getattr(pf.file_info, "content", "") or ""
-            findings = await scanner.scan_file(pf.file_info.path, source_text, pf.symbols)
-            if findings:
-                await scanner.persist(pf.file_info.path, findings)
+        await persist_security_findings(result, session, repo_id)
     except Exception as _sec_err:
         logger.warning("security_scan_skipped", error=str(_sec_err))
 
     return len(all_symbols)
+
+
+async def persist_security_findings(result: Any, session: Any, repo_id: str) -> None:
+    """Scan every parsed file's source and replace its security findings.
+
+    Source bytes come from ``result.source_map`` (ingestion read them once);
+    ``FileInfo`` itself carries no content, only ``content_hash``, so reading
+    it off ``file_info`` yields empty text and a scan that can never fire.
+    Resume views without a ``source_map`` degrade to the symbol-name scan.
+    """
+    from repowise.core.analysis.security_scan import SecurityScanner
+
+    scanner = SecurityScanner(session, repo_id)
+    source_map = getattr(result, "source_map", None) or {}
+    findings_by_file: dict[str, list[dict]] = {}
+    scanned_paths: list[str] = []
+    for pf in result.parsed_files:
+        path = pf.file_info.path
+        raw = source_map.get(path, b"")
+        if isinstance(raw, (bytes, bytearray)):
+            source_text = raw.decode("utf-8", errors="replace")
+        else:
+            source_text = raw or ""
+        scanned_paths.append(path)
+        findings = await scanner.scan_file(path, source_text, pf.symbols)
+        if findings:
+            findings_by_file[path] = findings
+    await scanner.replace_findings(findings_by_file, scanned_paths)
 
 
 async def persist_git(result: Any, session: Any, repo_id: str) -> None:

--- a/packages/core/src/repowise/core/pipeline/resume/controller.py
+++ b/packages/core/src/repowise/core/pipeline/resume/controller.py
@@ -135,6 +135,7 @@ class ResumeController:
         git_summary: Any | None = None,
         external_systems: list[dict] | None = None,
         execution_flow_report: Any | None = None,
+        source_map: dict[str, bytes] | None = None,
     ) -> None:
         """Persist the INDEX phase (graph + symbols + git) and record it.
 
@@ -152,6 +153,11 @@ class ResumeController:
             git_summary=git_summary,
             external_systems=external_systems or [],
             execution_flow_report=execution_flow_report,
+            # The security scan needs raw bytes; without this the checkpoint
+            # persist degrades to the symbol-name scan and, because the final
+            # persist skips ingestion once the checkpoint marked it done, the
+            # line-pattern scan would silently never run on the init path.
+            source_map=source_map or {},
         )
         await self._ledger.mark_started(ResumePhase.INDEX)
         try:

--- a/tests/unit/analysis/test_security_scan.py
+++ b/tests/unit/analysis/test_security_scan.py
@@ -1,0 +1,181 @@
+"""Security scanner: real-source scanning and idempotent persistence.
+
+Regression anchor: ``persist_ingestion`` used to feed the scanner
+``getattr(pf.file_info, "content", "")``, but ``FileInfo`` has no ``content``
+attribute, so every line-pattern scan ran against an empty string and could
+never produce a finding. The wiring now reads ``result.source_map``. Rows are
+also replaced per scanned file instead of appended, so repeated indexing no
+longer accumulates duplicates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from sqlalchemy import text
+
+from repowise.core.analysis.security_scan import SecurityScanner
+
+SNIPPY = b"""import pickle
+
+password = 'hunter2'
+data = pickle.loads(blob)
+x = eval(user_input)
+"""
+
+CLEAN = b"""def add(a, b):
+    return a + b
+"""
+
+
+def _fake_result(files: dict[str, bytes]):
+    parsed = [
+        SimpleNamespace(file_info=SimpleNamespace(path=p), symbols=[])
+        for p in files
+    ]
+    return SimpleNamespace(parsed_files=parsed, source_map=dict(files))
+
+
+async def _fresh_session_factory(tmp_path: Path):
+    from repowise.cli.helpers import get_db_url_for_repo
+    from repowise.core.persistence import (
+        create_engine,
+        create_session_factory,
+        get_session,
+        init_db,
+    )
+    from repowise.core.persistence.models import Repository
+
+    (tmp_path / ".repowise").mkdir(exist_ok=True)
+    engine = create_engine(get_db_url_for_repo(tmp_path))
+    await init_db(engine)
+    sf = create_session_factory(engine)
+    async with get_session(sf) as session:
+        session.add(Repository(id="repo-1", name="t", local_path=str(tmp_path)))
+    return engine, sf
+
+
+async def _rows(sf) -> list[tuple]:
+    from repowise.core.persistence import get_session
+
+    async with get_session(sf) as session:
+        res = await session.execute(
+            text(
+                "SELECT file_path, kind, line_number FROM security_findings "
+                "ORDER BY file_path, line_number, kind"
+            )
+        )
+        return [tuple(r) for r in res.fetchall()]
+
+
+class TestScanFile:
+    def test_line_patterns_fire_on_real_source(self) -> None:
+        scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
+        findings = asyncio.run(
+            scanner.scan_file("a.py", SNIPPY.decode(), symbols=[])
+        )
+        kinds = {f["kind"] for f in findings}
+        assert "hardcoded_password" in kinds
+        assert "pickle_loads" in kinds
+        assert "eval_call" in kinds
+        by_kind = {f["kind"]: f for f in findings}
+        assert by_kind["hardcoded_password"]["line"] == 3
+
+    def test_clean_source_yields_nothing(self) -> None:
+        scanner = SecurityScanner(session=None, repo_id="r1")  # type: ignore[arg-type]
+        findings = asyncio.run(scanner.scan_file("b.py", CLEAN.decode(), symbols=[]))
+        assert findings == []
+
+
+class TestPersistSecurityFindings:
+    """The persist.py wiring: source_map in, idempotent rows out."""
+
+    def test_findings_fire_from_source_map(self, tmp_path: Path) -> None:
+        from repowise.core.pipeline.persist import persist_security_findings
+
+        async def _run():
+            engine, sf = await _fresh_session_factory(tmp_path)
+            from repowise.core.persistence import get_session
+
+            result = _fake_result({"a.py": SNIPPY, "clean.py": CLEAN})
+            async with get_session(sf) as session:
+                await persist_security_findings(result, session, "repo-1")
+            rows = await _rows(sf)
+            await engine.dispose()
+            return rows
+
+        rows = asyncio.run(_run())
+        assert rows, "line-pattern findings must land from source_map bytes"
+        assert all(r[0] == "a.py" for r in rows)
+
+    def test_rescan_does_not_accumulate_duplicates(self, tmp_path: Path) -> None:
+        from repowise.core.pipeline.persist import persist_security_findings
+
+        async def _run():
+            engine, sf = await _fresh_session_factory(tmp_path)
+            from repowise.core.persistence import get_session
+
+            result = _fake_result({"a.py": SNIPPY})
+            for _ in range(3):
+                async with get_session(sf) as session:
+                    await persist_security_findings(result, session, "repo-1")
+            rows = await _rows(sf)
+            await engine.dispose()
+            return rows
+
+        rows = asyncio.run(_run())
+        counts = {}
+        for r in rows:
+            counts[r] = counts.get(r, 0) + 1
+        assert all(c == 1 for c in counts.values()), f"duplicated rows: {counts}"
+
+    def test_cleaned_file_loses_its_rows(self, tmp_path: Path) -> None:
+        from repowise.core.pipeline.persist import persist_security_findings
+
+        async def _run():
+            engine, sf = await _fresh_session_factory(tmp_path)
+            from repowise.core.persistence import get_session
+
+            async with get_session(sf) as session:
+                await persist_security_findings(
+                    _fake_result({"a.py": SNIPPY}), session, "repo-1"
+                )
+            async with get_session(sf) as session:
+                await persist_security_findings(
+                    _fake_result({"a.py": CLEAN}), session, "repo-1"
+                )
+            rows = await _rows(sf)
+            await engine.dispose()
+            return rows
+
+        assert asyncio.run(_run()) == []
+
+    def test_missing_source_map_degrades_to_symbol_scan(self, tmp_path: Path) -> None:
+        """A result without source_map (resume views) must not crash and must
+        still run the symbol-name scan."""
+        from repowise.core.pipeline.persist import persist_security_findings
+
+        async def _run():
+            engine, sf = await _fresh_session_factory(tmp_path)
+            from repowise.core.persistence import get_session
+
+            # NOTE: _SYMBOL_KEYWORDS uses \b boundaries and underscores are
+            # word chars, so the keyword must stand alone in the name.
+            sym = SimpleNamespace(name="auth", start_line=7)
+            result = SimpleNamespace(
+                parsed_files=[
+                    SimpleNamespace(
+                        file_info=SimpleNamespace(path="auth.py"), symbols=[sym]
+                    )
+                ],
+            )
+            async with get_session(sf) as session:
+                await persist_security_findings(result, session, "repo-1")
+            rows = await _rows(sf)
+            await engine.dispose()
+            return rows
+
+        rows = asyncio.run(_run())
+        assert ("auth.py", "security_sensitive_symbol", 7) in rows

--- a/tests/unit/cli/test_augment_session_start.py
+++ b/tests/unit/cli/test_augment_session_start.py
@@ -129,3 +129,23 @@ def test_changed_file_count_real_git(tmp_path) -> None:
     assert session_start._changed_file_count(tmp_path, sha1, sha2) == 2
     # An unresolvable SHA degrades to None (count omitted), never raises.
     assert session_start._changed_file_count(tmp_path, "f" * 40, sha2) is None
+
+
+def test_temp_root_repowise_is_ignored(tmp_path, monkeypatch) -> None:
+    """A stray .repowise at the system temp ROOT is not a repo opt-in, so a
+    cwd below it stays silent; a repo created UNDER the temp root works."""
+    from repowise.cli.commands.augment_cmd import _shared
+
+    fake_tmp = tmp_path / "faketmp"
+    (fake_tmp / ".repowise").mkdir(parents=True)
+    cwd = fake_tmp / "work"
+    cwd.mkdir()
+    monkeypatch.setattr(_shared.tempfile, "gettempdir", lambda: str(fake_tmp))
+    # Ancestors of tmp_path on the host may legitimately match, so pin only
+    # the guard: the walk must never return the temp root itself.
+    found = _shared._find_repo_root(cwd)
+    assert found != fake_tmp.resolve()
+
+    repo = fake_tmp / "checkout"
+    (repo / ".repowise").mkdir(parents=True)
+    assert _shared._find_repo_root(repo) == repo.resolve()

--- a/tests/unit/distill/test_rewrite_hook.py
+++ b/tests/unit/distill/test_rewrite_hook.py
@@ -477,3 +477,38 @@ class TestMainCodex:
     def test_unknown_agent_falls_back_to_claude_code(self, monkeypatch, repo) -> None:
         out = _run_main(monkeypatch, _payload("pytest -x", str(repo)), argv=["--agent", "weird"])
         assert json.loads(out)["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+class TestNonRepoRoots:
+    """~ and the system temp ROOT never count as repo opt-ins, even when a
+    stray .repowise exists there; repos created UNDER them still match."""
+
+    def test_temp_root_repowise_is_ignored(self, tmp_path, monkeypatch) -> None:
+        fake_tmp = tmp_path / "faketmp"
+        (fake_tmp / ".repowise").mkdir(parents=True)
+        cwd = fake_tmp / "work" / "sub"
+        cwd.mkdir(parents=True)
+        monkeypatch.setattr(
+            rewrite_hook.tempfile, "gettempdir", lambda: str(fake_tmp)
+        )
+        # Ancestors of tmp_path on the host may legitimately match, so pin
+        # only the guard: the walk must never return the temp root itself.
+        import os
+
+        found = rewrite_hook._find_repo_root(str(cwd))
+        assert found is None or os.path.realpath(found) != os.path.realpath(
+            str(fake_tmp)
+        )
+
+    def test_repo_under_temp_root_still_matches(self, tmp_path, monkeypatch) -> None:
+        fake_tmp = tmp_path / "faketmp"
+        repo = fake_tmp / "checkout"
+        (repo / ".repowise").mkdir(parents=True)
+        monkeypatch.setattr(
+            rewrite_hook.tempfile, "gettempdir", lambda: str(fake_tmp)
+        )
+        import os
+
+        found = rewrite_hook._find_repo_root(str(repo))
+        assert found is not None
+        assert os.path.realpath(found) == os.path.realpath(str(repo))


### PR DESCRIPTION
## What

Two correctness fixes in the indexing pipeline's hook and scan layer.

**Security scan never saw source code.** The per-file scan read
`getattr(pf.file_info, "content", "")`, but `FileInfo` only carries
`content_hash`, so every line-pattern scan ran against an empty string and
findings like `hardcoded_password` or `eval_call` could never fire. The scan
now reads from the ingestion `source_map`. Two layers had to be fixed: the
persist-time wiring, and the resume INDEX checkpoint whose view dropped
`source_map` (the final persist skips ingestion once the checkpoint marked it
done, so the checkpoint path is the one that actually runs on a normal init).

While in there, findings persistence became idempotent: each scanned file's
previous rows are replaced instead of appended (re-indexing used to
accumulate duplicates, and a cleaned-up file kept its stale rows forever),
inserts are batched, and a combined prefilter regex keeps the scan at one
search per clean line instead of eleven.

**Repo-root detection trusted directories it shouldn't.** Both repo-root
walks (command rewrite hook and augment hooks) climb up to 20 levels looking
for `.repowise/`. A stray `.repowise` at the system temp root (left by any
tool that indexed with cwd there) captured every temp-directory cwd on the
machine, and the augment walk had no home guard, so a `~/.repowise` config
dir made augment hooks engage for every cwd under home. Both roots are now
excluded; repos legitimately created under them still match.

## Verification

- New tests: scan fires from real source bytes, re-scans don't accumulate
  rows, cleaned files lose rows, missing-source path degrades gracefully,
  and guard tests for both root walks.
- End-to-end: `repowise init --index-only` on a fixture repo now persists
  `hardcoded_password` and `eval_call` rows; before the fix it persisted
  only symbol-name findings.
- Full unit suite green.
