### PR TITLE
perf: skip re-embedding pages reused verbatim from prior runs

### DIFF
--- a/packages/core/src/repowise/core/generation/page_generator/core.py
+++ b/packages/core/src/repowise/core/generation/page_generator/core.py
@@ -677,6 +677,11 @@ class PageGenerator(PerTypeGenerationMixin):
         # styles, so default ("comprehensive") pages keep byte-identical metadata.
         if self._style.is_active:
             page.metadata["style"] = self._style.name
+        # Content came back verbatim from the prior run's persisted page:
+        # downstream (embedding) uses this to skip work whose output already
+        # exists byte-identically.
+        if response.usage.get("reused_from_prior_run"):
+            page.metadata["reused_from_prior_run"] = True
         return page
 
     def _render(self, template_name: str, *, style_prefix: bool = True, **kwargs: Any) -> str:

--- a/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
+++ b/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
@@ -424,7 +424,15 @@ class _GenerationRun:
                             self.on_page_ready(result)
                         except Exception as exc:  # noqa: BLE001
                             log.debug("on_page_ready.failed", error=str(exc))
-                    if self.vector_store is not None:
+                    # A page reused verbatim from the prior run already has an
+                    # identical vector in any store that survives across runs;
+                    # re-embedding it re-bills the embedder for every unchanged
+                    # page on every update. Ephemeral stores start empty each
+                    # run and still need it.
+                    if self.vector_store is not None and not (
+                        result.metadata.get("reused_from_prior_run")
+                        and getattr(self.vector_store, "persists_across_runs", False)
+                    ):
                         embed_items.append(_embed_item(result))
                 return result
             except Exception as exc:

--- a/packages/core/src/repowise/core/persistence/vector_store/_base.py
+++ b/packages/core/src/repowise/core/persistence/vector_store/_base.py
@@ -57,6 +57,12 @@ def cosine_similarity(a: list[float], b: list[float]) -> float:
 class VectorStore(ABC):
     """Abstract vector store.  All methods are async."""
 
+    # Whether vectors written in a previous process survive into this one.
+    # Durable backends set True; generation uses this to skip re-embedding
+    # pages whose content is byte-identical to the prior run. Ephemeral
+    # stores (in-memory) start empty every run and must keep embedding them.
+    persists_across_runs: bool = False
+
     @abstractmethod
     async def embed_and_upsert(self, page_id: str, text: str, metadata: dict) -> None:
         """Embed *text* and upsert the vector under *page_id*."""

--- a/packages/core/src/repowise/core/persistence/vector_store/lancedb_store.py
+++ b/packages/core/src/repowise/core/persistence/vector_store/lancedb_store.py
@@ -42,6 +42,8 @@ class LanceDBVectorStore(VectorStore):
     :meth:`embed_and_upsert`.
     """
 
+    persists_across_runs = True
+
     _TABLE_NAME = "wiki_pages"
 
     def __init__(self, db_path: str, embedder: Embedder, table_name: str | None = None) -> None:

--- a/packages/core/src/repowise/core/persistence/vector_store/pgvector_store.py
+++ b/packages/core/src/repowise/core/persistence/vector_store/pgvector_store.py
@@ -49,6 +49,8 @@ class PgVectorStore(VectorStore):
     level (keeps the base package installable without the extra).
     """
 
+    persists_across_runs = True
+
     def __init__(
         self,
         session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/generation/test_run_level_embed_gating.py
+++ b/tests/unit/generation/test_run_level_embed_gating.py
@@ -1,0 +1,94 @@
+"""Embed gating in ``_GenerationRun.run_level``.
+
+Pages whose content was reused verbatim from the prior run (prompt-hash /
+content-hash cache hit) already have an identical vector in any store that
+persists across runs; re-embedding them re-bills the embedder for every
+unchanged page on every update. run_level therefore skips them, but ONLY when
+the store persists across runs: the in-memory store starts empty each run and
+still needs every page embedded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from repowise.core.generation.models import GeneratedPage
+from repowise.core.generation.page_generator.orchestrate import _GenerationRun
+
+
+def _page(page_id: str, *, reused: bool = False) -> GeneratedPage:
+    now = datetime.now(UTC).isoformat()
+    page = GeneratedPage(
+        page_id=page_id,
+        page_type="file_page",
+        title=page_id,
+        content=f"# {page_id}",
+        source_hash="deadbeef",
+        model_name="mock-model",
+        provider_name="mock",
+        input_tokens=0 if reused else 1,
+        output_tokens=0 if reused else 1,
+        cached_tokens=0,
+        generation_level=2,
+        target_path=page_id,
+        created_at=now,
+        updated_at=now,
+    )
+    if reused:
+        page.metadata["reused_from_prior_run"] = True
+    return page
+
+
+class _RecordingStore:
+    def __init__(self, *, persists: bool) -> None:
+        self.persists_across_runs = persists
+        self.batches: list[list[tuple]] = []
+
+    async def embed_batch(self, items):
+        self.batches.append(list(items))
+
+
+def _fake_run(store) -> SimpleNamespace:
+    return SimpleNamespace(
+        semaphore=asyncio.Semaphore(4),
+        job_system=None,
+        job_id=None,
+        on_page_done=None,
+        on_page_ready=None,
+        vector_store=store,
+        completed_page_summaries={},
+    )
+
+
+def _run_level(store) -> list[str]:
+    async def _go():
+        async def fresh():
+            return _page("fresh.py")
+
+        async def reused():
+            return _page("reused.py", reused=True)
+
+        run = _fake_run(store)
+        await _GenerationRun.run_level(
+            run, [("p1", fresh()), ("p2", reused())], level=2
+        )
+        return [pid for batch in store.batches for (pid, *_rest) in batch]
+
+    return asyncio.run(_go())
+
+
+def test_persistent_store_skips_reused_pages() -> None:
+    store = _RecordingStore(persists=True)
+    embedded = _run_level(store)
+    assert "fresh.py" in embedded
+    assert "reused.py" not in embedded
+
+
+def test_ephemeral_store_still_embeds_reused_pages() -> None:
+    """In-memory stores are rebuilt every run: reuse must not starve them."""
+    store = _RecordingStore(persists=False)
+    embedded = _run_level(store)
+    assert "fresh.py" in embedded
+    assert "reused.py" in embedded


### PR DESCRIPTION
## What

Stop re-embedding wiki pages whose content was reused verbatim from the
prior run.

When the prompt-hash/content-hash cache returns a page's prior content
unchanged, generation skipped the LLM call but still queued the page for
embedding, so every docs-mode update re-billed the embedder for the
unchanged majority of the wiki. Reused pages are now marked and their embed
items skipped.

The skip is gated on a new `VectorStore.persists_across_runs` attribute:
LanceDB and pgvector keep identical vectors from the prior run, so skipping
is a no-op for them, while the in-memory store starts empty every run and
still embeds everything. Fresh or changed pages are unaffected.

## Verification

- New tests: persistent stores skip reused pages, ephemeral stores still
  embed them.
- Full unit suite green.
