### PR TITLE
perf: concurrent analysis phases and parallel incremental re-ingest

### DIFF
--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -64,7 +64,10 @@ def build_repo_graph(
     Returns ``(parsed_files, source_map, graph_builder, repo_structure,
     file_count)``.
     """
-    from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder, compute_content_hash
+    import os
+    from concurrent.futures import ThreadPoolExecutor
+
+    from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
 
     log = log or _noop_log
 
@@ -74,20 +77,28 @@ def build_repo_graph(
         include_submodules=include_submodules,
         include_nested_repos=include_nested_repos,
     )
-    file_infos = list(traverser.traverse())
-    repo_structure = traverser.get_repo_structure()
+    # Parallel stat + header sniffing, mirroring the init ingestion phase.
+    # A serial traverse() pays per-file I/O latency sequentially; on a cold
+    # OS file cache that was ~50s of every PowerToys-scale update. Passing
+    # the file_infos into get_repo_structure also avoids its re-walk.
+    all_paths = list(traverser._walk())
+    io_workers = min(32, max(4, (os.cpu_count() or 4) * 2))
+    with ThreadPoolExecutor(max_workers=io_workers) as io_pool:
+        maybe_infos = list(io_pool.map(traverser._build_file_info, all_paths))
+    file_infos = [fi for fi in maybe_infos if fi is not None]
+    repo_structure = traverser.get_repo_structure(file_infos)
 
-    # Content-hash parse cache: an incremental update re-ingests the whole
-    # repo, but only the changed files actually need a tree-sitter parse.
-    # Best-effort — any cache failure falls back to a full parse.
-    parse_cache = None
-    try:
-        from repowise.core.ingestion.parse_cache import ParseCache
+    # Thread-pool source reads + content-hash parse cache split, shared with
+    # the init parse phase: only changed files need a tree-sitter parse.
+    # Cache failures degrade to all-miss (full parse), as before.
+    from repowise.core.pipeline.phases.ingestion import (
+        _cache_parsed,
+        _read_sources,
+        _split_cached,
+    )
 
-        parse_cache = ParseCache(Path(repo_path) / ".repowise")
-        parse_cache.load()
-    except Exception:
-        parse_cache = None
+    fi_and_bytes = _read_sources(file_infos, None)
+    parse_cache, cached_hits, to_parse = _split_cached(Path(repo_path), fi_and_bytes, None)
 
     parser: Any = None  # constructed lazily — every-file-cached updates skip query compilation
     parsed_files: list = []
@@ -100,19 +111,26 @@ def build_repo_graph(
         include_nested_repos=include_nested_repos,
     )
 
-    skipped = 0
-    for fi in file_infos:
+    # Parse the misses in process and serially: on the update path they are
+    # change-sized. (Ceiling: a wiped/stale cache re-parses everything on one
+    # core; routing large miss counts through init's process pool would lift
+    # it, at the cost of Windows spawn overhead on every routine update.)
+    merged: dict[int, Any] = dict(cached_hits)
+    for idx, (fi, source), content_hash in to_parse:
         try:
-            source = Path(fi.abs_path).read_bytes()
-            content_hash = compute_content_hash(source)
-            parsed = parse_cache.get(fi, content_hash) if parse_cache is not None else None
-            if parsed is None:
-                if parser is None:
-                    parser = ASTParser()
-                parsed = parser.parse_file(fi, source)
-                if parse_cache is not None:
-                    parse_cache.put(parsed, content_hash)
+            if parser is None:
+                parser = ASTParser()
+            parsed = parser.parse_file(fi, source)
         except Exception:
+            continue
+        merged[idx] = parsed
+        if content_hash:
+            _cache_parsed(parse_cache, parsed, content_hash)
+
+    skipped = len(file_infos) - len(fi_and_bytes)  # unreadable files
+    for idx, (fi, source) in enumerate(fi_and_bytes):
+        parsed = merged.get(idx)
+        if parsed is None:
             skipped += 1
             continue
         parsed_files.append(parsed)

--- a/packages/core/src/repowise/core/pipeline/orchestrator.py
+++ b/packages/core/src/repowise/core/pipeline/orchestrator.py
@@ -460,33 +460,38 @@ async def run_pipeline(
             skip_analysis = False
 
     if not skip_analysis:
-        dead_code_report = await _run_dead_code_analysis(
-            graph_builder, git_meta_map, progress=progress
-        )
-
-        health_report = await _run_health_analysis(
-            graph_builder,
-            git_meta_map,
-            parsed_files,
-            repo_path=repo_path,
-            coverage_report_paths=coverage_report_paths,
-            progress=progress,
+        # The three analyses share read-only inputs (graph, git_meta_map,
+        # parsed_files; the lazy metric caches were warmed during ingestion)
+        # and have no data dependency on each other, so run them concurrently:
+        # decision extraction is I/O/LLM-bound and its wall clock hides
+        # entirely behind the CPU-bound dead-code + health work.
+        dead_code_report, health_report, decision_report = await asyncio.gather(
+            _run_dead_code_analysis(graph_builder, git_meta_map, progress=progress),
+            _run_health_analysis(
+                graph_builder,
+                git_meta_map,
+                parsed_files,
+                repo_path=repo_path,
+                coverage_report_paths=coverage_report_paths,
+                progress=progress,
+            ),
+            _run_decision_extraction(
+                repo_path,
+                llm_client=llm_client,
+                graph_builder=graph_builder,
+                git_meta_map=git_meta_map,
+                parsed_files=parsed_files,
+                progress=progress,
+            ),
         )
 
         # Drop the in-memory-only ``BlameIndex`` now that the health biomarkers
         # have consumed it — before it can leak into ``PipelineResult`` and the
         # downstream JSON artifact writers / DB persistence. ``git_meta_map``
-        # shares these dict objects, so this cleans both views.
+        # shares these dict objects, so this cleans both views. Must stay after
+        # the gather: health reads the blame index while it runs (decision
+        # extraction never does).
         drop_transient_git_signals(git_metadata_list)
-
-        decision_report = await _run_decision_extraction(
-            repo_path,
-            llm_client=llm_client,
-            graph_builder=graph_builder,
-            git_meta_map=git_meta_map,
-            parsed_files=parsed_files,
-            progress=progress,
-        )
         gen_dead_code_report = dead_code_report
         gen_decision_report = decision_report
 

--- a/tests/unit/pipeline/test_drop_transient_git_signals.py
+++ b/tests/unit/pipeline/test_drop_transient_git_signals.py
@@ -46,6 +46,26 @@ def test_drop_is_idempotent_and_safe_without_blame_index() -> None:
     assert meta == {"file_path": "b.py", "commit_count_total": 1}
 
 
+def test_decision_sources_never_read_blame_index() -> None:
+    # The orchestrator runs decision extraction concurrently with health via
+    # asyncio.gather, while the transient BlameIndex is still attached to the
+    # shared git metadata dicts (health consumes it; the drop happens after
+    # the gather). That is only sound while no decision source reads it.
+    from pathlib import Path
+
+    import repowise.core.analysis.decisions as decisions_pkg
+
+    pkg_dir = Path(decisions_pkg.__file__).parent
+    offenders = [
+        py.name for py in pkg_dir.rglob("*.py") if "blame_index" in py.read_text(encoding="utf-8")
+    ]
+    assert not offenders, (
+        f"decision sources reference blame_index ({offenders}); they run "
+        "concurrently with health before drop_transient_git_signals, so this "
+        "needs a re-think of the analysis-phase gather in orchestrator.py"
+    )
+
+
 def test_drop_cleans_shared_git_meta_map_view() -> None:
     # git_meta_map is built from the same dict objects as git_metadata_list, so
     # stripping the list must clean the map view too.


### PR DESCRIPTION
Two structural fixes to where the pipeline spends wall clock, one on init and one on update. No output changes: finding counts, graph shape, and persisted rows are identical, pinned by probes and equivalence tests.

## Init: run the three analysis phases concurrently

Dead-code, health, and decision extraction ran back to back with no data dependency between them. They now run under one asyncio.gather. Decision extraction is I/O and LLM bound and dead code runs in a worker thread, so both hide behind the health phase. An isolated probe on PowerToys puts the analysis window at 95.2s serial vs 84.2s gathered with identical finding counts; the gap widens when an LLM provider is configured because the decision phase then waits on network.

The transient blame-index drop moves after the gather (health consumes it while running). A new guard test pins the invariant that makes the concurrent window sound: no decision source reads blame_index.

## Update: parallelize the incremental re-ingest

The update path re-ingested the repo fully serially: a traverse() that stats and header-sniffs every file one at a time, a second full walk inside get_repo_structure(), and a serial read+hash loop. On a cold OS file cache the serial traverse alone was ~50s of every PowerToys update. build_repo_graph now mirrors the init ingestion phase: thread-pooled file-info builds, repo structure computed from the same traversal, and source reads plus the parse-cache split through the shared _read_sources/_split_cached helpers. Cache misses still parse in process because they are change-sized on this path.

Covered by the parse-cache equivalence suite (ParsedFile-equal and graph-isomorphic across edit, add, delete, rename, and corrupt-cache scenarios); a live PowerToys run reproduces the exact same graph.

## Benchmarks (1 run per config)

| Repo | init | update |
|---|---|---|
| PowerToys | 330.2 -> 260.8s | 184.6 -> 125.6s |
| hugo | 102.7 -> 74.4s | 36.8 -> 27.0s |

Update legs verified on the true incremental path (duplication splice engaged, parse cache 5761/4 and 2011/3 hits/misses). Full suite: 7,465 passed, 1 skipped.
