### PR TITLE
fix(answer): gated-path excerpts died to a silently-swallowed AttributeError

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/retrieval.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/retrieval.py
@@ -165,7 +165,7 @@ async def _enrich_gated_excerpts(hits: list[dict], ctx: Any = None) -> None:
     try:
         async with get_session(ctx.session_factory) as session:
             res = await session.execute(
-                select(Page.id, Page.content_md).where(Page.id.in_(page_ids))
+                select(Page.id, Page.content).where(Page.id.in_(page_ids))
             )
             content_by_id = {row[0]: (row[1] or "") for row in res.all()}
     except Exception:

--- a/tests/unit/server/mcp/test_answer_calibration.py
+++ b/tests/unit/server/mcp/test_answer_calibration.py
@@ -1021,3 +1021,25 @@ async def test_frame_gated_answer_surfaces_code_rationale(setup_mcp, monkeypatch
     assert result["confidence"] == "medium"
     assert "code_rationale" in result
     assert any("floods the synthesis context" in r["comment"] for r in result["code_rationale"])
+
+
+# ---------------------------------------------------------------------------
+# Gated-path excerpt enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestGatedExcerptEnrichment:
+    """_enrich_gated_excerpts must run its real query against the real Page
+    model — a silently-swallowed AttributeError here shipped pointers-only
+    gated payloads and re-opened the 8-15 call fallback spree the excerpts
+    exist to prevent."""
+
+    async def test_excerpts_attached_from_real_page_rows(self, factory, populated_db):
+        from repowise.server.mcp_server.tool_answer.retrieval import (
+            _enrich_gated_excerpts,
+        )
+
+        hits = [{"page_id": "repo_overview:test-repo", "score": 1.0}]
+        ctx = SimpleNamespace(session_factory=factory)
+        await _enrich_gated_excerpts(hits, ctx)
+        assert hits[0].get("excerpt", "").startswith("# Test Repo")


### PR DESCRIPTION
## Why

The gated low-confidence path in `get_answer` queries `Page.content_md` — an attribute that does not exist on the `Page` model (the column is `content`). The `AttributeError` raises inside the enrichment's `try`, the bare `except` returns silently, and every gated payload since #887 merged has shipped **pointers-only** (no `excerpt` fields), silently re-opening the 8–15-call native fallback spree the excerpts exist to prevent.

Measured impact (context-tool bench, flask, n=1): the worst-case question went back from 6 agent calls (pre-merge validation of #887) to 17 on merged main; flask C1 median est. cost rose ~40% (/bin/zsh.161 → /bin/zsh.235/question).

## What

- One-line fix: `Page.content_md` → `Page.content` in `_enrich_gated_excerpts`.
- Regression test that runs the real query against the real model on a seeded in-memory DB — the enrichment was previously untested against the model, so the attribute rename degraded payloads without failing anything. Verified red without the fix, green with it.
- Live-verified against a real index: the regressed question now returns 3/3 `best_guesses` with 1500-char excerpts.

Full `tests/unit/server/mcp` suite passes.