### PR TITLE
feat(agents): bring AGENTS.md to CLAUDE.md tool-surface parity and sync the tool table

### DIFF
--- a/docs/MCP_TOOLS.md
+++ b/docs/MCP_TOOLS.md
@@ -526,7 +526,7 @@ get_health(targets=["module:src.api"], include=["trend", "refactoring"])
 ## Supplementary tools
 
 These are registered and on by default (in the modes noted) but are not part
-of the nine-tool headline set.
+of the ten-tool headline set.
 
 ### `list_repos`
 

--- a/packages/core/src/repowise/core/generation/editor_files/tool_table.py
+++ b/packages/core/src/repowise/core/generation/editor_files/tool_table.py
@@ -58,7 +58,21 @@ TOOL_TABLE_ROWS: dict[str, tuple[str, str]] = {
         "get_risk(targets, changed_files?)",
         "What history says about touching these files: churn, owners, co-change "
         "partners, blast radius. PR mode (`changed_files`) leads with a `directive` "
-        "block — read `will_break` / `missing_cochanges` / `missing_tests` first.",
+        "block — read `will_break` / `missing_cochanges` / `missing_tests` / "
+        "`tests_to_run` first. `tests_to_run` is coverage-backed (the tests the "
+        "per-test map proves exercise the changed files); empty means unknown, "
+        "never no tests. To score a whole commit or diff range instead, use "
+        "`get_change_risk`.",
+    ),
+    "get_change_risk": (
+        "get_change_risk(revspec, extensions?, exclude_patterns?)",
+        "Pre-merge defect score for a whole commit or `base..head` range, computed "
+        "from its diff shape on the live checkout (no index, no LLM). Lead with "
+        "`risk_percentile` (this change ranked against sampled recent commits), "
+        "summarized by `review_priority` and `classification`; `score` / "
+        "`probability` / `level` are the corpus-calibrated fallback. Distinct from "
+        "`get_risk`, which scores indexed files by path. A `warning` field flags an "
+        "empty diff (bad revspec or over-tight extension / exclusion filters).",
     ),
     "get_health": (
         "get_health(targets?, include?)",

--- a/packages/core/src/repowise/core/generation/templates/agents_md.j2
+++ b/packages/core/src/repowise/core/generation/templates/agents_md.j2
@@ -1,45 +1,82 @@
-## Repowise Codebase Context For {{ data.repo_name }}
+## Codebase Intelligence for {{ data.repo_name }} (Repowise)
 
-This repository is indexed by Repowise. Use the Repowise MCP tools for codebase orientation, discovery, implementation context, modification risk, design rationale, and cleanup planning. MCP data reflects the last index run; verify against source files before editing.
+Indexed by [Repowise](https://repowise.dev). Last indexed: {{ data.indexed_at }}{% if data.indexed_commit %} (commit {{ data.indexed_commit }}){% endif %}{% if data.avg_confidence %}. Confidence: {{ (data.avg_confidence * 100) | int }}%.{% endif %}
 
-Last indexed: {{ data.indexed_at }}{% if data.indexed_commit %} (commit {{ data.indexed_commit }}){% endif %}{% if data.avg_confidence %}. Confidence: {{ (data.avg_confidence * 100) | int }}%.{% endif %}
+The MCP tools below serve pre-verified docs, symbols, history, and health from that index. Every response carries `_meta` freshness fields; a `stale_warning` appears only when a file the response actually serves changed after indexing, so silence means current.
 
+### How to work in this repo
+
+- **Pre-edit phase** (locate, understand, assess) is where these tools win: `get_answer` for how/where/why, `search_codebase` to find, `get_context` for a file's map, `get_risk` before touching a hotspot.
+- **Edit phase**: reading a file before you edit it is correct and expected. Use these tools to decide *which* files to read and edit, not to replace that read.
+- **Noisy commands** (tests, builds, `git log`/`diff`, searches, listings): prefer `repowise distill <cmd>`, the same command with its exit code preserved and errors-first compact output. A `[repowise#<ref>: N lines omitted]` marker is fully recoverable via `repowise expand <ref>` (add `-q <regex>` to filter); never re-run the command to see omitted output.
+
+### Trust protocol
+
+- `verified: true` means the served bytes were checked against the live tree. Never follow it with a re-read of the same lines.
+- `get_answer` at `confidence: "high"` or `grounding: "extracted"` is content-grounded: cite it directly. `symbol_bodies`, `quotes`, and `code_rationale` entries are live source, so use them instead of opening the file.
+- The **only** re-read triggers: `bounds: "approximate"`, `_meta.stale_warning`, `search_method: "bm25"`, `confidence: "low"`. `index_behind: true` alone is informational; the served content is unaffected by the drift.
+- Not valid reasons to re-read: "just to be safe", "to see full context" (use the skeleton or a range read), "the file might have changed" (`verified` already checked).
+- For exhaustive literal sweeps (rename every call site) plain text search is unbeatable, so use it. Reach for `get_context(include=["callers"])` when you need the `callers_total`/`callers_truncated` honesty signal instead of a maybe-incomplete grep.
+
+### Tools
+
+{{ data.tool_table_md }}
+
+**Compose them:** low-confidence `get_answer` then read `best_guesses[0].file`; `get_context` shows `hotspot: true` then `get_risk` before editing; `decision_records` titles then `get_why(targets=[...])`; PR review then `get_risk(targets, changed_files)` and read `directive` first. A `tombstone` error means the file moved, so follow `successor_paths`.
 {% if data.architecture_summary %}
+
 ### Architecture
 {{ data.architecture_summary }}
 {% endif %}
 {% if data.key_modules %}
-### Key Modules
-| Module | Purpose | Owner |
-|--------|---------|-------|
+
+### Key modules
 {% for mod in data.key_modules %}
-| `{{ mod.name }}` | {{ mod.purpose or "-" }} | {{ mod.owner or "-" }} |
+- `{{ mod.name }}`{% if mod.purpose %} — {{ mod.purpose }}{% endif %}
+
 {% endfor %}
 {% endif %}
 {% if data.entry_points %}
-### Entry Points
-{% for ep in data.entry_points %}
+
+### Entry points
+{% for ep in data.entry_points[:6] %}
 - `{{ ep }}`
 {% endfor %}
 {% endif %}
 {% if data.hotspots %}
-### Risk Hotspots
-| File | Churn | 90d Commits | Owner |
-|------|-------|-------------|-------|
+
+### Hotspots (high churn — check `get_risk` before editing)
 {% for h in data.hotspots %}
-| `{{ h.path }}` | {{ h.churn_percentile }}th percentile | {{ h.commit_count_90d }} | {{ h.owner or "-" }} |
+- `{{ h.path }}` — {{ h.commit_count_90d }} commits/90d ({{ h.churn_percentile }}th %ile)
 {% endfor %}
 {% endif %}
+{% if data.code_health %}
 
-### Repowise MCP Workflow
+### Code health
+Three co-equal signals: defect risk {{ data.code_health.average_health }}/10 avg, hotspot health {{ data.code_health.hotspot_health }}/10 ({{ data.code_health.hotspot_trend }}), worst `{{ data.code_health.worst_path }}` at {{ data.code_health.worst_score }}/10{% if data.code_health.maintainability_average is not none %} · maintainability {{ data.code_health.maintainability_average }}/10{% endif %}{% if data.code_health.performance_average is not none %} · performance risk {{ data.code_health.performance_findings }} open static I/O-in-loop / N+1 finding{{ 's' if data.code_health.performance_findings != 1 else '' }}{% endif %}. Detail: `get_health()`.
+{% if data.code_health.critical_biomarkers %}
 
-- Overview: call `get_overview()` at the start of an unfamiliar task to orient on architecture, modules, entry points, and tech stack.
-- Search: call `search_codebase(query="...")` when locating where a concept, symbol, feature, or behavior is implemented.
-- Context: call `get_context(targets=["path/or/symbol", "..."])` for enriched docs, ownership, decisions, callers, and related files before relying on raw source alone.
-- Risk: call `get_risk(targets=["path/to/file.py"])` before modifying shared utilities, public APIs, hotspots, high-coupling modules, or files with unknown dependents.
-- Why: call `get_why(query="...")` before architectural changes or when the user asks why code is structured a certain way.
-- Dead code: call `get_dead_code(safe_only=true)` before cleanup or removal work; treat lower-confidence findings as candidates to investigate.
-- Connections: call `get_context(targets=["..."], include=["callers", "callees"])` when tracing how a symbol connects to the rest of the code.
+Critical files:
+{% for b in data.code_health.critical_biomarkers %}
+- `{{ b.path }}` — {{ b.summary }}
+{% endfor %}
+{% endif %}
+{% if data.code_health.untested_hotspots %}
+
+Untested hotspots:
+{% for h in data.code_health.untested_hotspots %}
+- `{{ h.path }}` — {{ h.dependents }} dependents, {{ h.coverage_pct }}% coverage, {{ h.commits_90d }} commits/90d
+{% endfor %}
+{% endif %}
+{% endif %}
+{% if data.decisions %}
+
+### Standing decisions (ask `get_why` before diverging)
+{% for d in data.decisions[:3] %}
+- {{ d.title }}{% if d.rationale %} — {{ d.rationale }}{% endif %}
+
+{% endfor %}
+{% endif %}
 {% if data.build_commands %}
 
 ### Commands

--- a/plugins/claude-code/skills/change-review/SKILL.md
+++ b/plugins/claude-code/skills/change-review/SKILL.md
@@ -15,26 +15,34 @@ this change put at risk" — fusing git history (churn, ownership, co-change) wi
 graph topology (dependents, impact surface), test gaps, security signals, and the
 architectural decisions that govern the touched code.
 
-Two complementary risk signals — use both:
+Two complementary risk signals, use both:
 
-- **`repowise risk` (CLI)** scores the *whole change as one unit* (a commit or a
-  `base..head` range) → a single 0–10 defect-risk score with drivers (lines
-  added/deleted, files, directories, subsystems, change entropy, author
-  familiarity). No LLM, no network. This is the pre-merge gate: "how risky is
-  this change overall?"
+- **`get_change_risk(revspec=…)` (MCP)** scores the *whole change as one unit* (a
+  commit or a `base..head` range) from its diff shape: a single 0-10 defect-risk
+  score with drivers (lines added/deleted, files, directories, subsystems,
+  change entropy, author familiarity). No LLM, no network. Prefer this in-MCP
+  tool; it takes a revspec and diffs server-side, so you never shell out. Lead
+  with `risk_percentile` (this change ranked against sampled recent commits),
+  summarized by `review_priority` and `classification`; `score` / `level` are
+  the corpus-calibrated fallback. This is the pre-merge gate: "how risky is this
+  change overall?" The `repowise risk <revspec>` CLI is the identical scorer for
+  when you are already in a terminal.
 - **`get_risk(changed_files=…)` (MCP)** works *per file* and returns the
-  `directive` block — the specific things to check inside the diff.
+  `directive` block, the specific things to check inside the diff.
 
 ## Score the whole change first
 
 ```
-repowise risk <revspec>     # HEAD, a commit SHA, or base..head (e.g. main..HEAD)
+get_change_risk(revspec="main..HEAD")   # HEAD, a commit SHA, or base..head
 ```
 
-Read the score and its top drivers — a high score from large diffusion (many
-dirs/subsystems) or low author familiarity tells you where to look hardest.
-Add `--ext .py,.ts` to count only certain file types, `--format json` for a
-machine-readable breakdown.
+Read `risk_percentile` and the top drivers: a high score from large diffusion
+(many dirs/subsystems) or low author familiarity tells you where to look
+hardest. `extensions=[".py", ".ts"]` counts only certain file types;
+`exclude_patterns=["tests/"]` omits paths. A `warning` field means the revspec
+or filters matched no files, so an all-zero score there is not a clean bill of
+health. The equivalent from a terminal is `repowise risk <revspec>` (add
+`--ext .py,.ts` or `--format json`).
 
 ## Then drill into the directive block
 
@@ -58,6 +66,12 @@ The response carries a `directive` block — read it first, it's a few short lis
 
 `pr_blast_radius` holds the fuller dossier behind those lists (including the
 per-changed-file `guarding_tests` breakdown behind `tests_to_run`).
+
+For the line-precise version from a terminal, `repowise impacted-tests <revspec>`
+maps each changed line to the tests whose recorded coverage touches it, then
+prints the ids (`--format list | xargs pytest` runs exactly them). It is honest
+about gaps: a changed file with no coverage rows is a labelled filename guess,
+and a brand-new file is "unknown, run the full suite", never "no tests needed".
 
 ## Then go deeper where it matters
 

--- a/plugins/codex/skills/change-review/SKILL.md
+++ b/plugins/codex/skills/change-review/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: change-review
+description: Use when reviewing a set of changes before they merge in a Repowise-indexed repository, a PR, a branch diff, or the working-tree changes you just made. Activates for "review this PR", "is this safe to merge", "what is the blast radius of these changes", or "did I miss anything".
+---
+
+# Change Review With Repowise
+
+When a diff is on the table, Repowise turns "what files changed" into "what does this change put at risk", fusing git history (churn, ownership, co-change) with graph topology (dependents, impact surface), test gaps, and the decisions that govern the touched code. Use two complementary signals.
+
+## Score The Whole Change First
+
+Call `get_change_risk(revspec="main..HEAD")`. It scores the whole change as one unit (a commit or a `base..head` range) from its diff shape, no LLM and no network. Lead with `risk_percentile` (this change ranked against sampled recent commits), summarized by `review_priority` and `classification`; `score` and `level` are the corpus-calibrated fallback. `extensions=[".py"]` counts only certain suffixes and `exclude_patterns=["tests/"]` omits paths. A `warning` field means the revspec or filters matched no files, so an all-zero score there is not a clean bill of health. The identical scorer from a terminal is `repowise risk <revspec>`.
+
+## Then Drill Into The Directive Block
+
+Call `get_risk(targets=<changed files>, changed_files=<same files>)` in PR mode. The `directive` block is a few short lists, read it first:
+
+- `will_break`: files or symbols that depend on what changed but are not in the diff. Likely breakages, check each one.
+- `missing_cochanges`: files that historically change together with the changed files but were left untouched. Often a forgotten update.
+- `missing_tests`: changed code with a test gap. Flag for new or updated tests.
+- `tests_to_run`: the coverage-backed complement of `missing_tests`, the tests the per-test map proves execute the changed files (pytest-runnable ids). Empty means unknown (no coverage map ingested), never "no tests exist".
+
+For the line-precise version from a terminal, `repowise impacted-tests <revspec>` maps each changed line to its covering tests and prints the ids (`--format list | xargs pytest` runs exactly them).
+
+## Then Go Deeper Where It Matters
+
+1. Call `get_why(query="<file>")` for any non-trivial changed file so the change does not silently contradict a recorded decision. Surface `conflicts_with` and `supersedes` hits.
+2. Call `get_health(targets=<changed files>, include=["biomarkers"])` to catch new complexity, deep nesting, or duplication the diff introduced.
+3. Use the `get_risk` ownership and co-change signals to suggest who should review.
+
+## Write The Review Around Evidence
+
+Lead with a risk level and the `directive` findings, each tied to a concrete file. Distinguish "will break" (a dependent outside the diff) from "worth a look" (a co-change or health regression). Do not pad with findings the tools did not support.
+
+## Error Handling
+
+If `get_risk` or `get_change_risk` errors or returns nothing, the MCP server may be down or the repo unindexed. Say so, review from the raw diff, and suggest running `repowise init` if the repo is not indexed.

--- a/tests/unit/generation/test_agents_md.py
+++ b/tests/unit/generation/test_agents_md.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from repowise.core.generation.editor_files.agents_md import AgentsMdGenerator
 from repowise.core.generation.editor_files.data import EditorFileData
+from repowise.core.generation.editor_files.tool_table import (
+    TOOL_TABLE_ROWS,
+    render_tool_table,
+)
 
 
 def _data() -> EditorFileData:
@@ -23,6 +27,22 @@ def test_agents_md_renders_repowise_workflows() -> None:
     assert "get_risk" in rendered
     assert "get_why" in rendered
     assert "get_dead_code" in rendered
+
+
+def test_agents_md_renders_the_full_shared_tool_table() -> None:
+    # AGENTS.md must reach the same tool surface as CLAUDE.md: both render the
+    # single shared table from tool_table.py. Asserting the whole rendered table
+    # is embedded means a future tool added to the registry (and therefore to
+    # TOOL_TABLE_ROWS, which test_tool_table_drift pins to the registry) fails CI
+    # here if AGENTS.md ever stops rendering it. This is the AGENTS.md twin of
+    # the CLAUDE.md guard so the two can never drift apart again.
+    rendered = AgentsMdGenerator().render(_data())
+
+    assert render_tool_table() in rendered
+    for signature, _row in TOOL_TABLE_ROWS.values():
+        assert signature in rendered, f"AGENTS.md omits tool row: {signature}"
+    # get_change_risk is the row that regressed before this guard existed.
+    assert "get_change_risk" in rendered
 
 
 def test_agents_md_writes_repo_root_file(tmp_path) -> None:

--- a/tests/unit/server/mcp/test_tool_table_drift.py
+++ b/tests/unit/server/mcp/test_tool_table_drift.py
@@ -35,6 +35,7 @@ def test_core_default_surface_is_documented():
         "search_codebase",
         "get_overview",
         "get_risk",
+        "get_change_risk",
         "get_why",
         "get_dead_code",
         "get_health",


### PR DESCRIPTION
## What

The generated `AGENTS.md` had become a thin, hand-maintained shadow of the generated `CLAUDE.md`: a 6-tool bullet list (missing `get_answer`, `get_symbol`, `get_health`, `get_change_risk`) that rendered no shared table and had no drift test, so a Codex agent got materially thinner guidance than a Claude agent and the file silently rotted. This drives both docs off the same shared source so they can no longer diverge.

## Changes

- **AGENTS.md parity.** `agents_md.j2` now renders the shared `tool_table_md` plus the same how-to-work, trust-protocol, compose, and data sections `CLAUDE.md` carries, adapted to a harness-neutral audience. A rendered diff against this repo shows the two files differ only in that adapted prose; the tool table and every data section are identical.
- **Shared tool table.** Added a `get_change_risk` row and added `tests_to_run` to the `get_risk` row's directive fields, so both generated docs teach the current surface. `list_repos` stays row-less by design (workspace plumbing).
- **Drift guards.** Added `get_change_risk` to the CLAUDE.md drift test's core set, and added an AGENTS.md drift test that fails CI if the template ever stops rendering the shared table. A future tool addition now fails CI unless both docs pick it up.
- **Skills.** The Claude `change-review` skill now names the `get_change_risk` MCP tool (the in-MCP equivalent an agent should prefer over shelling out) and the `repowise impacted-tests` CLI. Added a matching Codex `change-review` skill for parity.
- **Docs.** `docs/MCP_TOOLS.md` headline count corrected from nine to ten.

## Verification

- Focused suite green: `tests/unit/generation/`, `tests/unit/cli/test_editor_files.py`, `test_tool_table_drift.py`, `test_tool_selection.py`, `test_change_risk.py` (698 passed).
- Rendered a fresh `CLAUDE.md` and `AGENTS.md` against this repo and read both end to end; parity confirmed.
- Exercised `get_change_risk` live on both surfaces (MCP tool and `repowise risk` CLI) plus the bad-revspec, empty-diff-warning, and `repo="all"` paths; both surfaces return identical scores.
