### PR TITLE
fix: restore friendly revspec error in changed_lines and register the codex change-review skill

### DIFF
--- a/packages/core/src/repowise/core/analysis/changed_lines.py
+++ b/packages/core/src/repowise/core/analysis/changed_lines.py
@@ -53,7 +53,11 @@ def _parse_unified_diff(diff: str) -> dict[str, set[int]]:
 
 
 def _verify_ref(repo_path: str, ref: str) -> None:
-    if not _git(["rev-parse", "--verify", "--quiet", ref], repo_path).strip():
+    # check=False: `rev-parse --verify --quiet` deliberately exits 1 with empty
+    # stdout for a missing ref, which is the signal we test for here. Without the
+    # opt-out, _git's returncode check (see change_risk.features._git) would raise
+    # CalledProcessError first and mask the friendly ValueError this raises.
+    if not _git(["rev-parse", "--verify", "--quiet", ref], repo_path, check=False).strip():
         raise ValueError(f"unknown revision {ref!r}")
 
 

--- a/tests/unit/cli/test_codex_plugin.py
+++ b/tests/unit/cli/test_codex_plugin.py
@@ -62,6 +62,7 @@ def test_codex_plugin_skills_have_metadata_and_neutral_wording() -> None:
 
     assert {path.parent.name for path in skill_paths} == {
         "architectural-decisions",
+        "change-review",
         "codebase-exploration",
         "dead-code-cleanup",
         "pre-modification-check",


### PR DESCRIPTION
## What

A full `tests/unit` run surfaced two failures, both fallout from the recent change-risk work. Fixes them at the root.

- **`changed_lines` raised the wrong error on an unknown revspec.** `_verify_ref` relies on `git rev-parse --verify --quiet` exiting 1 with empty stdout for a missing ref, then raising a friendly `ValueError`. The shared `_git` helper recently gained a returncode check that raises `CalledProcessError` on any non-zero exit, so it fired first and masked the `ValueError` (the unknown-revision path for `changed_lines` and `repowise impacted-tests`). Fixed by passing `check=False` at that one call site, which is the only caller of the shared `_git` that used the empty-on-failure signal. `git diff`/`git show` calls still fail loud.
- **The codex change-review skill was not registered in its drift test.** The codex plugin gained a `change-review` skill, but the test that pins the codex skill set kept the old four-entry set and failed on the extra directory. Added it; the skill already passes the per-skill metadata and neutral-wording assertions.

## Verification

`tests/unit/cli/test_codex_plugin.py`, `tests/unit/analysis/test_changed_lines.py`, and `tests/unit/server/mcp/test_change_risk.py` all pass (18 tests). These were the two reds in an otherwise green 7,449-test unit run.
