### PR TITLE
perf(persist): batch end-of-run wiki-page upserts

### DIFF
--- a/packages/cli/src/repowise/cli/commands/restyle_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/restyle_cmd.py
@@ -76,7 +76,7 @@ async def _run_restyle(
         create_session_factory,
         get_session,
         init_db,
-        upsert_page_from_generated,
+        upsert_pages_from_generated,
         upsert_repository,
     )
     from repowise.core.pipeline import rehydrate_graph_builder, run_generation
@@ -124,8 +124,7 @@ async def _run_restyle(
     await cost_tracker.flush()
 
     async with get_session(sf) as session:
-        for page in generated_pages:
-            await upsert_page_from_generated(session, page, repo_id)
+        await upsert_pages_from_generated(session, generated_pages, repo_id)
 
     try:
         fts = FullTextSearch(engine)

--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -359,7 +359,7 @@ async def _persist_full_update_async(
         create_session_factory,
         get_session,
         init_db,
-        upsert_page_from_generated,
+        upsert_pages_from_generated,
         upsert_repository,
     )
 
@@ -379,8 +379,9 @@ async def _persist_full_update_async(
 
             # Pages first and without a net: everything else is derived
             # metadata, but a docs-mode update that can't write pages failed.
-            for page in generated_pages:
-                await upsert_page_from_generated(session, page, repo_id)
+            # Batched (one SELECT + one flush); the checkpointer sink already
+            # streamed each page per-commit for durability.
+            await upsert_pages_from_generated(session, generated_pages, repo_id)
 
             # Tombstone pages for deleted/renamed files — regeneration only
             # rewrites pages for files that still exist.

--- a/packages/cli/src/repowise/cli/commands/upgrade_flow.py
+++ b/packages/cli/src/repowise/cli/commands/upgrade_flow.py
@@ -156,7 +156,7 @@ async def _run_upgrade(
         create_session_factory,
         get_session,
         init_db,
-        upsert_page_from_generated,
+        upsert_pages_from_generated,
         upsert_repository,
     )
     from repowise.core.pipeline import rehydrate_graph_builder, run_generation
@@ -227,8 +227,7 @@ async def _run_upgrade(
 
     # 6. Persist pages + a GenerationJob marker, then build the FTS index.
     async with get_session(sf) as session:
-        for page in generated_pages:
-            await upsert_page_from_generated(session, page, repo_id)
+        await upsert_pages_from_generated(session, generated_pages, repo_id)
         try:
             from datetime import UTC, datetime
 

--- a/packages/cli/src/repowise/cli/commands/workspace_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/workspace_cmd.py
@@ -638,7 +638,7 @@ def _generate_docs_for_added_repo(
         create_session_factory,
         get_session,
         init_db,
-        upsert_page_from_generated,
+        upsert_pages_from_generated,
         upsert_repository,
     )
 
@@ -700,8 +700,7 @@ def _generate_docs_for_added_repo(
                 name=repo_path.name,
                 local_path=str(repo_path),
             )
-            for p in pages:
-                await upsert_page_from_generated(session, p, repo.id)
+            await upsert_pages_from_generated(session, pages, repo.id)
         fts = FullTextSearch(engine)
         await fts.ensure_index()
         for p in pages:

--- a/packages/core/src/repowise/core/persistence/__init__.py
+++ b/packages/core/src/repowise/core/persistence/__init__.py
@@ -89,6 +89,7 @@ from .crud import (
     upsert_kg_tour_steps,
     upsert_page,
     upsert_page_from_generated,
+    upsert_pages_from_generated,
     upsert_repository,
 )
 from .database import (
@@ -287,5 +288,6 @@ __all__ = [
     "upsert_kg_tour_steps",
     "upsert_page",
     "upsert_page_from_generated",
+    "upsert_pages_from_generated",
     "upsert_repository",
 ]

--- a/packages/core/src/repowise/core/persistence/crud/pages.py
+++ b/packages/core/src/repowise/core/persistence/crud/pages.py
@@ -26,49 +26,43 @@ from ._shared import _parse_dt
 # ---------------------------------------------------------------------------
 
 
-async def upsert_page(
+def _apply_page_upsert(
     session: AsyncSession,
+    existing: Page | None,
     *,
     page_id: str,
     repository_id: str,
     page_type: str,
     title: str,
     content: str,
-    summary: str = "",
+    summary: str,
     target_path: str,
     source_hash: str,
     model_name: str,
     provider_name: str,
-    input_tokens: int = 0,
-    output_tokens: int = 0,
-    cached_tokens: int = 0,
-    generation_level: int = 0,
-    confidence: float = 1.0,
-    freshness_status: str = "fresh",
-    metadata: dict | None = None,
-    created_at: datetime | None = None,
-    updated_at: datetime | None = None,
+    input_tokens: int,
+    output_tokens: int,
+    cached_tokens: int,
+    generation_level: int,
+    confidence: float,
+    freshness_status: str,
+    meta_json: str,
+    created_at: datetime,
+    updated_at: datetime,
+    now: datetime,
 ) -> Page:
-    """Insert or update a wiki page, creating a PageVersion snapshot on update.
+    """Apply the insert / version-snapshot / idempotent-touch branch for one
+    page against a PRE-RESOLVED ``existing`` row.
 
-    First call  → inserts Page at version=1.
-    Subsequent  → archives the current Page as a PageVersion, then updates the
-                  Page in-place (version += 1, created_at preserved).
+    Extracted verbatim from :func:`upsert_page` so the single-page and batch
+    callers share one implementation of the version semantics. Does NOT flush:
+    the caller owns the flush (one per call for ``upsert_page``, one per batch
+    for :func:`upsert_pages_from_generated`).
     """
-    now = _now_utc()
-    page_created_at = created_at or now
-    page_updated_at = updated_at or now
-    meta_json = json.dumps(metadata or {})
-
-    existing_result = await session.execute(select(Page).where(Page.id == page_id))
-    existing = existing_result.scalar_one_or_none()
-
     if existing is not None:
-        # Idempotent no-op: when the content, prompt hash and model are all
-        # unchanged, re-persisting must not bump the version or spawn a
-        # PageVersion snapshot. This makes the write safe to repeat — e.g. an
-        # incremental per-page flush during generation followed by the
-        # end-of-run persist of the same page — without inflating history.
+        # Idempotent no-op: content, prompt hash and model all unchanged, so
+        # do not bump the version or spawn a PageVersion snapshot; only refresh
+        # the cheap derived fields (metadata enrichment lands here).
         if (
             existing.content == content
             and existing.source_hash == source_hash
@@ -78,7 +72,6 @@ async def upsert_page(
             existing.target_path = target_path
             existing.freshness_status = freshness_status
             existing.metadata_json = meta_json
-            await session.flush()
             return existing
 
         # Archive the current state before overwriting
@@ -117,36 +110,96 @@ async def upsert_page(
         existing.confidence = confidence
         existing.freshness_status = freshness_status
         existing.metadata_json = meta_json
-        existing.updated_at = page_updated_at
-
-        await session.flush()
+        existing.updated_at = updated_at
         return existing
-    else:
-        page = Page(
-            id=page_id,
-            repository_id=repository_id,
-            page_type=page_type,
-            title=title,
-            content=content,
-            summary=summary,
-            target_path=target_path,
-            source_hash=source_hash,
-            model_name=model_name,
-            provider_name=provider_name,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cached_tokens=cached_tokens,
-            generation_level=generation_level,
-            version=1,
-            confidence=confidence,
-            freshness_status=freshness_status,
-            metadata_json=meta_json,
-            created_at=page_created_at,
-            updated_at=page_updated_at,
-        )
-        session.add(page)
-        await session.flush()
-        return page
+
+    page = Page(
+        id=page_id,
+        repository_id=repository_id,
+        page_type=page_type,
+        title=title,
+        content=content,
+        summary=summary,
+        target_path=target_path,
+        source_hash=source_hash,
+        model_name=model_name,
+        provider_name=provider_name,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_tokens=cached_tokens,
+        generation_level=generation_level,
+        version=1,
+        confidence=confidence,
+        freshness_status=freshness_status,
+        metadata_json=meta_json,
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+    session.add(page)
+    return page
+
+
+async def upsert_page(
+    session: AsyncSession,
+    *,
+    page_id: str,
+    repository_id: str,
+    page_type: str,
+    title: str,
+    content: str,
+    summary: str = "",
+    target_path: str,
+    source_hash: str,
+    model_name: str,
+    provider_name: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cached_tokens: int = 0,
+    generation_level: int = 0,
+    confidence: float = 1.0,
+    freshness_status: str = "fresh",
+    metadata: dict | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+) -> Page:
+    """Insert or update a wiki page, creating a PageVersion snapshot on update.
+
+    First call  → inserts Page at version=1.
+    Subsequent  → archives the current Page as a PageVersion, then updates the
+                  Page in-place (version += 1, created_at preserved).
+    """
+    now = _now_utc()
+    meta_json = json.dumps(metadata or {})
+
+    existing_result = await session.execute(select(Page).where(Page.id == page_id))
+    existing = existing_result.scalar_one_or_none()
+
+    page = _apply_page_upsert(
+        session,
+        existing,
+        page_id=page_id,
+        repository_id=repository_id,
+        page_type=page_type,
+        title=title,
+        content=content,
+        summary=summary,
+        target_path=target_path,
+        source_hash=source_hash,
+        model_name=model_name,
+        provider_name=provider_name,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_tokens=cached_tokens,
+        generation_level=generation_level,
+        confidence=confidence,
+        freshness_status=freshness_status,
+        meta_json=meta_json,
+        created_at=created_at or now,
+        updated_at=updated_at or now,
+        now=now,
+    )
+    await session.flush()
+    return page
 
 
 async def load_prior_pages(
@@ -212,6 +265,85 @@ async def upsert_page_from_generated(
         created_at=_parse_dt(gp.created_at),  # type: ignore[attr-defined]
         updated_at=_parse_dt(gp.updated_at),  # type: ignore[attr-defined]
     )
+
+
+# Chunk the id SELECT to stay under SQLite's host-parameter limit (same reason
+# as ``persist._PRUNE_CHUNK``).
+_PAGE_SELECT_CHUNK = 500
+
+
+async def upsert_pages_from_generated(
+    session: AsyncSession,
+    generated_pages: list,  # list[GeneratedPage]
+    repository_id: str,
+) -> list[Page]:
+    """Batch equivalent of looping :func:`upsert_page_from_generated`.
+
+    The end-of-run generation persist re-upserts every page. The per-page
+    durability sink already wrote them once during generation; this pass
+    exists to flush the post-generation metadata enrichment (related-pages /
+    interlinking mutate ``page.metadata`` in place after the sink ran), which
+    lands through the idempotent-touch branch. Doing that one page at a time
+    is an N+1: a SELECT + flush each, i.e. one round-trip per page on a remote
+    DB. This resolves every existing row in one (chunked) SELECT and flushes
+    once, preserving :func:`upsert_page`'s exact semantics via the shared
+    :func:`_apply_page_upsert` (version snapshot on content change, no-op touch
+    on metadata-only change, insert on new).
+
+    NOT a drop-in for the per-page durability sinks: this flushes once at the
+    end, so an interrupt mid-batch persists nothing. The ``on_page_ready``
+    streaming sinks must keep calling :func:`upsert_page_from_generated`.
+
+    Assumes ``generated_pages`` carries no duplicate ``page_id`` (true by
+    construction: ids are deterministic, one page per target).
+    """
+    pages = list(generated_pages)
+    if not pages:
+        return []
+
+    # Resolve all existing rows up front. page_id (== Page.id) is unique per
+    # page within the run and each row is resolved independently, so one SELECT
+    # is equivalent to the per-page loop's fresh SELECT-per-page. No repo filter
+    # here, matching ``upsert_page``'s ``WHERE Page.id == page_id``.
+    ids = [gp.page_id for gp in pages]
+    existing_by_id: dict[str, Page] = {}
+    for start in range(0, len(ids), _PAGE_SELECT_CHUNK):
+        chunk = ids[start : start + _PAGE_SELECT_CHUNK]
+        rows = (await session.execute(select(Page).where(Page.id.in_(chunk)))).scalars().all()
+        for row in rows:
+            existing_by_id[row.id] = row
+
+    now = _now_utc()
+    out: list[Page] = []
+    for gp in pages:
+        out.append(
+            _apply_page_upsert(
+                session,
+                existing_by_id.get(gp.page_id),
+                page_id=gp.page_id,
+                repository_id=repository_id,
+                page_type=gp.page_type,
+                title=gp.title,
+                content=gp.content,
+                summary=getattr(gp, "summary", "") or "",
+                target_path=gp.target_path,
+                source_hash=gp.source_hash,
+                model_name=gp.model_name,
+                provider_name=gp.provider_name,
+                input_tokens=gp.input_tokens,
+                output_tokens=gp.output_tokens,
+                cached_tokens=gp.cached_tokens,
+                generation_level=gp.generation_level,
+                confidence=gp.confidence,
+                freshness_status=gp.freshness_status,
+                meta_json=json.dumps(gp.metadata or {}),
+                created_at=_parse_dt(gp.created_at) or now,
+                updated_at=_parse_dt(gp.updated_at) or now,
+                now=now,
+            )
+        )
+    await session.flush()
+    return out
 
 
 async def backfill_related_pages(

--- a/packages/core/src/repowise/core/pipeline/persist.py
+++ b/packages/core/src/repowise/core/pipeline/persist.py
@@ -876,12 +876,15 @@ async def persist_generation(result: Any, session: Any, repo_id: str) -> None:
     Pages upsert per ``page_id`` (archiving prior versions); KG layers/tour
     are full-replace. Both safe to call incrementally / on resume.
     """
-    from repowise.core.persistence import upsert_page_from_generated
+    from repowise.core.persistence import upsert_pages_from_generated
 
     # ---- Pages (if generated) -----------------------------------------------
+    # Batched: one SELECT + one flush instead of a SELECT+flush per page. The
+    # per-page durability sink already streamed these during generation; this
+    # end-of-run pass flushes the post-generation metadata enrichment. See
+    # upsert_pages_from_generated for the equivalence contract.
     if result.generated_pages:
-        for page in result.generated_pages:
-            await upsert_page_from_generated(session, page, repo_id)
+        await upsert_pages_from_generated(session, result.generated_pages, repo_id)
 
     # ---- Knowledge graph layers, tour steps & curated meta ------------------
     kg = getattr(result, "knowledge_graph_result", None)

--- a/packages/server/src/repowise/server/job_executor.py
+++ b/packages/server/src/repowise/server/job_executor.py
@@ -431,12 +431,12 @@ async def execute_job(
         async with get_session(session_factory) as session:
             swept_page_ids = await persist_pipeline_result(result, session, repo_id)
 
-            # Persist incrementally regenerated pages
+            # Persist incrementally regenerated pages (batched: one SELECT +
+            # one flush instead of a round-trip per page on the hosted DB).
             if incremental_pages:
-                from repowise.core.persistence import upsert_page_from_generated
+                from repowise.core.persistence import upsert_pages_from_generated
 
-                for page in incremental_pages:
-                    await upsert_page_from_generated(session, page, repo_id)
+                await upsert_pages_from_generated(session, incremental_pages, repo_id)
 
             # Drop swept pages from the vector store *before* the SQL session
             # commits. The vector store is a separate engine/file (pgvector DB,

--- a/tests/unit/persistence/test_upsert_pages_batch.py
+++ b/tests/unit/persistence/test_upsert_pages_batch.py
@@ -1,0 +1,199 @@
+"""Equivalence tests for ``upsert_pages_from_generated`` (the batched end-of-run
+generation persist that replaces the per-page ``upsert_page_from_generated``
+loop).
+
+The batch must be byte-for-byte equivalent to looping the single-page upsert:
+- new page -> inserted at version 1
+- re-persist identical content -> NO version bump, NO PageVersion snapshot
+- metadata-only change (same content/hash/model) -> metadata written via the
+  idempotent-touch branch, still NO version bump, NO snapshot
+- content change -> PageVersion snapshot + version bump
+
+The final test runs the batch and the per-page loop on two independent DBs over
+the same mixed scenario and asserts row-for-row parity.
+"""
+
+from __future__ import annotations
+
+from repowise.core.persistence import (
+    upsert_page_from_generated,
+    upsert_pages_from_generated,
+)
+from repowise.core.persistence.crud import get_page, get_page_versions
+from tests.unit.persistence.helpers import insert_repo
+
+
+def make_generated_page(page_id: str, **overrides):
+    from repowise.core.generation.models import GeneratedPage
+
+    base = dict(
+        page_id=page_id,
+        page_type="file_page",
+        title="t",
+        content=f"# {page_id}\n\nbody",
+        source_hash="h0",
+        model_name="mock",
+        provider_name="mock",
+        input_tokens=10,
+        output_tokens=20,
+        cached_tokens=0,
+        generation_level=1,
+        target_path=page_id.split(":", 1)[-1],
+        confidence=1.0,
+        freshness_status="fresh",
+        metadata={},
+        created_at="2026-07-18T00:00:00+00:00",
+        updated_at="2026-07-18T00:00:00+00:00",
+    )
+    base.update(overrides)
+    return GeneratedPage(**base)
+
+
+async def test_batch_inserts_new_pages_at_version_1(async_session):
+    repo = await insert_repo(async_session)
+    pages = [make_generated_page(f"file_page:m{i}.py") for i in range(3)]
+
+    result = await upsert_pages_from_generated(async_session, pages, repo.id)
+    await async_session.commit()
+
+    assert len(result) == 3
+    for i in range(3):
+        row = await get_page(async_session, f"file_page:m{i}.py")
+        assert row is not None
+        assert row.version == 1
+        assert await get_page_versions(async_session, f"file_page:m{i}.py") == []
+
+
+async def test_batch_idempotent_no_version_bump(async_session):
+    repo = await insert_repo(async_session)
+    pages = [make_generated_page("file_page:a.py")]
+
+    await upsert_pages_from_generated(async_session, pages, repo.id)
+    await async_session.commit()
+    # identical re-persist (same objects, same content/hash/model)
+    await upsert_pages_from_generated(async_session, pages, repo.id)
+    await async_session.commit()
+
+    row = await get_page(async_session, "file_page:a.py")
+    assert row.version == 1
+    assert await get_page_versions(async_session, "file_page:a.py") == []
+
+
+async def test_batch_metadata_only_change_no_version_bump(async_session):
+    repo = await insert_repo(async_session)
+    p = make_generated_page("file_page:a.py", metadata={})
+
+    await upsert_pages_from_generated(async_session, [p], repo.id)
+    await async_session.commit()
+
+    # metadata enrichment lands after generation; content/hash/model unchanged
+    p2 = make_generated_page(
+        "file_page:a.py", metadata={"wiki_links": ["x"], "backlinks": ["y"]}
+    )
+    await upsert_pages_from_generated(async_session, [p2], repo.id)
+    await async_session.commit()
+
+    row = await get_page(async_session, "file_page:a.py")
+    assert row.version == 1  # no bump
+    assert await get_page_versions(async_session, "file_page:a.py") == []  # no snapshot
+    assert '"wiki_links"' in row.metadata_json  # enrichment persisted
+
+
+async def test_batch_content_change_snapshots_and_bumps(async_session):
+    repo = await insert_repo(async_session)
+    p = make_generated_page("file_page:a.py", content="v1", source_hash="h1")
+
+    await upsert_pages_from_generated(async_session, [p], repo.id)
+    await async_session.commit()
+
+    p2 = make_generated_page("file_page:a.py", content="v2", source_hash="h2")
+    await upsert_pages_from_generated(async_session, [p2], repo.id)
+    await async_session.commit()
+
+    row = await get_page(async_session, "file_page:a.py")
+    assert row.version == 2
+    assert row.content == "v2"
+    versions = await get_page_versions(async_session, "file_page:a.py")
+    assert len(versions) == 1
+    assert versions[0].content == "v1"  # prior state archived
+
+
+async def test_batch_empty_is_noop(async_session):
+    repo = await insert_repo(async_session)
+    assert await upsert_pages_from_generated(async_session, [], repo.id) == []
+
+
+async def _fresh_db():
+    """A standalone in-memory DB + session factory (for the parity test)."""
+    from repowise.core.persistence.database import (
+        create_engine,
+        create_session_factory,
+        init_db,
+    )
+
+    engine = create_engine("sqlite+aiosqlite:///:memory:")
+    await init_db(engine)
+    return engine, create_session_factory(engine)
+
+
+async def test_batch_equivalent_to_per_page_loop():
+    """Batch vs per-page loop on two independent DBs, mixed scenario, must be
+    row-for-row identical (version, content, hash, metadata, snapshot count)."""
+    from repowise.core.persistence import get_session, upsert_repository
+
+    def scenario_round1():
+        return [make_generated_page(f"file_page:m{i}.py") for i in range(5)]
+
+    def scenario_round2():
+        # m0 unchanged, m1 metadata-only, m2 content change, m3 unchanged,
+        # m4 content change; plus a brand-new m5.
+        return [
+            make_generated_page("file_page:m0.py"),
+            make_generated_page("file_page:m1.py", metadata={"wiki_links": ["z"]}),
+            make_generated_page("file_page:m2.py", content="changed", source_hash="hX"),
+            make_generated_page("file_page:m3.py"),
+            make_generated_page("file_page:m4.py", content="changed2", source_hash="hY"),
+            make_generated_page("file_page:m5.py"),
+        ]
+
+    # --- DB A: batched ---
+    eng_a, sf_a = await _fresh_db()
+    async with get_session(sf_a) as s:
+        repo_a = await upsert_repository(s, name="a", local_path="/tmp/a")
+        rid_a = repo_a.id
+    async with get_session(sf_a) as s:
+        await upsert_pages_from_generated(s, scenario_round1(), rid_a)
+    async with get_session(sf_a) as s:
+        await upsert_pages_from_generated(s, scenario_round2(), rid_a)
+
+    # --- DB B: per-page loop ---
+    eng_b, sf_b = await _fresh_db()
+    async with get_session(sf_b) as s:
+        repo_b = await upsert_repository(s, name="b", local_path="/tmp/b")
+        rid_b = repo_b.id
+    async with get_session(sf_b) as s:
+        for p in scenario_round1():
+            await upsert_page_from_generated(s, p, rid_b)
+    async with get_session(sf_b) as s:
+        for p in scenario_round2():
+            await upsert_page_from_generated(s, p, rid_b)
+
+    # --- compare ---
+    ids = [f"file_page:m{i}.py" for i in range(6)]
+    async with get_session(sf_a) as sa, get_session(sf_b) as sb:
+        for pid in ids:
+            ra = await get_page(sa, pid)
+            rb = await get_page(sb, pid)
+            assert (ra is None) == (rb is None), pid
+            if ra is None:
+                continue
+            assert ra.version == rb.version, f"{pid} version"
+            assert ra.content == rb.content, f"{pid} content"
+            assert ra.source_hash == rb.source_hash, f"{pid} hash"
+            assert ra.metadata_json == rb.metadata_json, f"{pid} metadata"
+            va = await get_page_versions(sa, pid)
+            vb = await get_page_versions(sb, pid)
+            assert len(va) == len(vb), f"{pid} snapshot count"
+
+    await eng_a.dispose()
+    await eng_b.dispose()


### PR DESCRIPTION
## What

The end-of-run generation persist re-upserted wiki pages one at a time, doing a `SELECT` + `flush` per page. On a local SQLite index that is a redundant round-trip per page; on the hosted Postgres path it is one network round-trip per page, so persist time scaled linearly with page count and DB latency.

By the time this end-of-run pass runs, the per-page durability sinks (`on_page_ready`) have already streamed every page to the DB during generation. The re-persist exists only to flush the post-generation metadata enrichment (related-pages and interlinking mutate `page.metadata` in place after the sink ran), which lands through `upsert_page`'s idempotent no-op branch.

## Change

- New `upsert_pages_from_generated`: resolves every existing row in one chunked `SELECT` and flushes once, instead of a SELECT+flush per page.
- Factored `upsert_page`'s insert / version-snapshot / idempotent-touch branch into a shared `_apply_page_upsert` helper, so the single-page and batch paths share one implementation of the version semantics by construction.
- Swapped the seven end-of-run full-list persist loops to the batch: init, update, the hosted job executor, restyle, upgrade, and workspace.
- Left the two per-page durability sinks (`_generation_persist` and the update checkpointer) on the single-page upsert. Those flush per page so a Ctrl-C mid-run keeps already-generated pages; the batch flushes once, so it is deliberately not a sink replacement.

## Equivalence

`_apply_page_upsert` is a verbatim extraction of the existing branch logic, so behaviour is preserved: version snapshot + bump on content change, no bump on a metadata-only change, insert on new. New test file pins this, including a two-independent-DB parity test that runs the batch and the old per-page loop over a mixed scenario (new / unchanged / metadata-only / content-changed) and asserts row-for-row equality on version, content, hash, metadata, and snapshot count.

## Numbers

Isolated probe, 1500 pages on SQLite: per-page loop 1314ms to 79ms (16.6x). The bench uses `init --index-only` (no pages generated), so this is invisible to it; the win is doc-mode init and the hosted Postgres path, where it removes N sequential network round-trips.

## Tests

357 passed across the persist-related suites (unit persistence, generation-persist, update-persist, sweep, server pages, integration persistence). Changed files are lint-clean.
