### PR TITLE
fix(resolver): follow Python/JS wildcard re-exports in call resolution

### DIFF
--- a/packages/core/src/repowise/core/ingestion/call_resolver.py
+++ b/packages/core/src/repowise/core/ingestion/call_resolver.py
@@ -147,18 +147,24 @@ class CallResolver:
                 if name not in file_syms:
                     self._barrel_origins[path][name] = source_file
 
-        # Also track Rust pub-use re-exports that use wildcard (*) bindings.
-        # When a file has `pub use foo::*`, all symbols from foo are
-        # transitively available through this file.
+        # Track wildcard re-exports, which forward every symbol of the imported
+        # module under this file's namespace. Two shapes qualify: Rust
+        # `pub use foo::*` (is_reexport) and Python/JS `from foo import *` (a
+        # "*" imported name). The latter is how package ``__init__.py`` barrels
+        # commonly re-export a subpackage — ``build_import_name_maps`` skips the
+        # "*" name (it is not a binding), so without this pass the barrel chain
+        # dead-ends one hop short of the real definition and a call through the
+        # barrel resolves to nothing.
         for path, parsed in self._parsed_files.items():
+            file_syms = self._file_symbols.get(path, {})
             for imp in parsed.imports:
-                if not imp.is_reexport or not imp.resolved_file:
+                is_wildcard = imp.is_reexport or "*" in imp.imported_names
+                if not is_wildcard or not imp.resolved_file:
                     continue
                 if imp.resolved_file.startswith("external:"):
                     continue
                 resolved = imp.resolved_file
                 source_syms = self._file_symbols.get(resolved, {})
-                file_syms = self._file_symbols.get(path, {})
                 for sym_name in source_syms:
                     if sym_name not in file_syms:
                         self._barrel_origins[path][sym_name] = resolved

--- a/tests/unit/health/test_perf_crossfn.py
+++ b/tests/unit/health/test_perf_crossfn.py
@@ -232,6 +232,47 @@ def test_crossfn_across_files(tmp_path):
     assert h.path[-1].endswith("db.py::fetch_one")
 
 
+def test_crossfn_through_star_import_barrel(tmp_path):
+    """The persist.py:884 shape: a loop calls a DB wrapper that is imported
+    lazily from a package whose ``__init__`` re-exports it via ``from .x import
+    *``, and the wrapper's bare name is shadowed by a same-named method (so the
+    global-unique tier cannot rescue it). The wildcard re-export must be
+    followed for the loop -> wrapper -> sink edge to resolve; without that the
+    cross-function N+1 is silently dropped.
+    """
+    files = {
+        "pkg/crud.py": (
+            "from sqlalchemy import select\n\n\n"
+            "def upsert_one(session, rid):\n"
+            "    return session.execute(select(rid))\n"
+        ),
+        # package barrel re-exports the leaf via a star import
+        "pkg/__init__.py": "from pkg.crud import *\n",
+        # a same-named method elsewhere defeats the Tier-3 global-unique match,
+        # so only the followed barrel edge can resolve the call.
+        "stores.py": (
+            "class Store:\n"
+            "    def upsert_one(self, session, rid):\n"
+            "        return None\n"
+        ),
+        "service.py": (
+            "def persist_all(session, ids):\n"
+            "    from pkg import upsert_one\n"
+            "    for rid in ids:\n"
+            "        upsert_one(session, rid)\n"
+        ),
+    }
+    walked, graph = _build(tmp_path, files)
+    res = collect_crossfn_io_in_loop(walked, graph)
+    hits = [h for hs in res.values() for h in hs]
+    assert len(hits) == 1, f"star-barrel N+1 must be caught; got {hits}"
+    h = hits[0]
+    assert h.function == "persist_all"
+    assert h.detail == "db"
+    assert h.path[0].endswith("service.py::persist_all")
+    assert h.path[-1].endswith("pkg/crud.py::upsert_one")
+
+
 def test_crossfn_pure_helper_is_not_flagged(tmp_path):
     """A loop calling a helper that does NO I/O produces no cross-fn finding."""
     src = "def square(x):\n    return x * x\n\n\ndef run(xs):\n    return [square(x) for x in xs]\n"

--- a/tests/unit/ingestion/test_star_import_barrel.py
+++ b/tests/unit/ingestion/test_star_import_barrel.py
@@ -1,0 +1,75 @@
+"""Call resolution follows Python/JS ``from x import *`` wildcard re-exports.
+
+A package ``__init__.py`` that re-exports a subpackage with ``from .leaf import
+*`` is a barrel: a name defined in ``leaf`` becomes importable straight from the
+package. ``build_import_name_maps`` skips the ``*`` (it is not a binding), so the
+barrel-origin chain used by call resolution has to learn the forwarded names
+from the star import itself. Without that, a call to a barrel-re-exported symbol
+dead-ends at the ``__init__`` (where the name is only re-exported, not defined)
+and no ``calls`` edge is produced -- unless the global-unique tier happens to
+rescue it. These tests pin the followed edge, including the shadowed case where
+the global tier cannot help.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from repowise.core.ingestion import ASTParser, FileTraverser, GraphBuilder
+
+
+def _build_calls(tmp_path: Path, files: dict[str, str]):
+    """Write files, build the graph, return the resolved ``calls`` edge set."""
+    for name, src in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(src, encoding="utf-8")
+    trav = FileTraverser(tmp_path)
+    parser = ASTParser()
+    gb = GraphBuilder(repo_path=tmp_path)
+    for fi in trav.traverse():
+        data = Path(fi.abs_path).read_bytes()
+        gb.add_file(parser.parse_file(fi, data))
+    graph = gb.build()
+    return {
+        (src, dst)
+        for src, dst, d in graph.edges(data=True)
+        if d.get("edge_type") == "calls"
+    }
+
+
+def test_call_through_star_import_barrel_resolves(tmp_path: Path) -> None:
+    """Top-level import of a barrel-re-exported name. A same-named method
+    elsewhere blocks the global-unique tier, so the edge exists only if the
+    ``from .leaf import *`` re-export is followed to the leaf."""
+    files = {
+        "pkg/leaf.py": "def helper(x):\n    return x\n",
+        "pkg/__init__.py": "from pkg.leaf import *\n",
+        # shadow: a second `helper` makes the name globally non-unique
+        "other.py": "class Thing:\n    def helper(self, x):\n        return x\n",
+        "caller.py": "from pkg import helper\n\n\ndef run():\n    return helper(1)\n",
+    }
+    edges = _build_calls(tmp_path, files)
+    assert ("caller.py::run", "pkg/leaf.py::helper") in edges, edges
+    assert ("caller.py::run", "other.py::Thing::helper") not in edges, edges
+
+
+def test_star_barrel_edge_survives_global_name_shadow(tmp_path: Path) -> None:
+    """A same-named method elsewhere makes the name globally non-unique, so the
+    Tier-3 fallback cannot resolve the call: only following the star re-export
+    produces the edge. This is the persist.py:884 condition."""
+    files = {
+        "pkg/leaf.py": "def helper(x):\n    return x\n",
+        "pkg/__init__.py": "from pkg.leaf import *\n",
+        # a second `helper` (a method) defeats the global-unique tier
+        "other.py": "class Thing:\n    def helper(self, x):\n        return x\n",
+        "caller.py": (
+            "def run():\n"
+            "    from pkg import helper\n"  # lazy import, as in persist.py
+            "    return helper(1)\n"
+        ),
+    }
+    edges = _build_calls(tmp_path, files)
+    assert ("caller.py::run", "pkg/leaf.py::helper") in edges, edges
+    # and it did NOT mis-resolve to the shadowing method
+    assert ("caller.py::run", "other.py::Thing::helper") not in edges, edges


### PR DESCRIPTION
## Problem

Call resolution did not follow Python/JS `from x import *` wildcard re-exports. A package `__init__.py` that re-exports a subpackage with `from .leaf import *` is a barrel: a name defined in the leaf becomes importable straight from the package. `build_import_name_maps` skips the `*` (it is not a binding), and the wildcard-reexport pass in `CallResolver._follow_barrel_exports` only fired for Rust `pub use` and Swift `@_exported` (`is_reexport`). Python and JS star imports were not followed, so the barrel-origin chain dead-ended one hop short of the real definition and a call routed through the barrel produced no `calls` edge, unless the global-unique tier happened to rescue it.

This surfaced as a cross-function N+1 the `io_in_loop` performance biomarker silently dropped: a loop calling a DB wrapper re-exported through a `from .x import *` package barrel (the wrapper imported by name from the package, itself re-exported there via a star import). The loop to wrapper `calls` edge was absent, so the cross-function pass had nothing to walk. Duplicate same-named symbols meant the global-unique tier could not mask the gap either.

## Fix

In `_follow_barrel_exports`, treat a `*` imported name as a wildcard re-export alongside `is_reexport`, so the forwarded names populate the barrel origins and the multi-hop chain reaches the defining file.

This is a resolution fix (a real re-export edge, matching Python `import *` semantics), not a heuristic, so it adds no false edges the global tier would not already have found. It runs in the existing barrel pass at graph-build time with no measurable cost, and does not touch the reachability depth bound.

## Verification

- New `tests/unit/ingestion/test_star_import_barrel.py` (2 cases) and `test_crossfn_through_star_import_barrel` in `test_perf_crossfn.py`. Each uses a same-named-method shadow so the global-unique tier cannot mask the fix; all three fail on `main` and pass with the change.
- Suites green: ingestion + dead_code (1685), health + analysis (1423), crossfn + resolver (107).
- Real-tree repro (core, 697 py files): the cross-function N+1 through the barrel now resolves the loop to wrapper to sink chain and is flagged; total `calls` edges +19, build wall unchanged (within noise).