### PR TITLE
fix(restyle): raise a usage error for an unknown style argument

### DIFF
--- a/packages/cli/src/repowise/cli/commands/restyle_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/restyle_cmd.py
@@ -179,7 +179,10 @@ def restyle_command(
     style = style.strip().lower()
     if not is_known_style(style, repo_path):
         valid = ", ".join(s.name for s in list_styles(repo_path))
-        raise click.ClickException(f"Unknown style '{style}'. Choose one of: {valid}.")
+        # An unknown STYLE is a mis-typed argument, not a product failure:
+        # BadArgumentUsage renders the usage hint and (via the telemetry
+        # classifier) records as a usage_error rather than an error.
+        raise click.BadArgumentUsage(f"Unknown style '{style}'. Choose one of: {valid}.")
 
     # Restyle only makes sense for a full index (one that has generated docs).
     if not state:

--- a/tests/unit/cli/test_restyle_cmd.py
+++ b/tests/unit/cli/test_restyle_cmd.py
@@ -60,7 +60,9 @@ def test_restyle_no_style_shows_current_and_options():
 
 def test_restyle_unknown_style_errors(tmp_path):
     result = CliRunner().invoke(cli, ["restyle", "bogus", str(tmp_path)])
-    assert result.exit_code == 1
+    # A mistyped STYLE is a usage error (Click convention: exit code 2), not a
+    # generic failure — see the telemetry usage_error classification.
+    assert result.exit_code == 2
     assert "Unknown style" in result.output
     assert "comprehensive" in result.output  # lists valid choices
 


### PR DESCRIPTION
## What

A mistyped `repowise restyle <style>` now raises `click.BadArgumentUsage` instead of a generic `ClickException`. It renders the usage hint and exits with code 2 (the Click convention for a mis-invocation).

## Why

`restyle` has a very high instant-fail rate, and an unknown style name is a user typo, not a product failure. Paired with the telemetry `usage_error` classification (#907), it no longer counts as a command error. The clearer usage output also helps the user recover.

## Changes

- `restyle_cmd.py`: unknown-style guard raises `BadArgumentUsage`.
- `test_restyle_cmd.py`: unknown-style now asserts exit code 2 (was 1). The index-only and no-index guards are unchanged (they remain real "cannot proceed" errors).

## Note

Exit code for the mistyped-style case moves 1 -> 2. That is the standard usage-error convention; the message content is unchanged.