### PR TITLE
release: v0.33.0 — agent-trace provenance, self-healing docs, change-risk maturity, indexing perf

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.33.0] — 2026-07-18
+
+### Added
+- **Line-level AI authorship from your agent sessions.** repowise reads agent-trace records to attribute commits (and now individual lines) to the agent and model that wrote them, and stamps a per-commit model id, so the contributors and provenance views can tell human-written code from agent-written code down to the line. (#861, #866)
+- **Docs that repair themselves.** Generation now self-repairs hallucinated symbol references, resolves cross-page links across the whole repo on updates, and backfills graph-derived "related pages" with a self-healing pass, so wiki pages link to real symbols and stay cross-linked as the code moves. (#871, #872)
+- **`get_change_risk` grew up.** The change-risk score gained a `-x/--exclude` flag with `.riskignore` support to drop vendored or generated paths from the diff, and now lists the line-level tests a change actually impacts. (#867, #903)
+- **Coverage-backed tests in PR risk.** `get_risk` PR mode now surfaces `tests_to_run` proven by the per-test coverage map, so a reviewer sees exactly which tests exercise the changed files. (#859)
+- **Fewer dead-code false positives.** Whole classes of systematic false positives (re-exports, dynamic references) are eliminated, so `get_dead_code` reports far less that is actually live. (#886)
+- **Better flow answers.** `get_answer` rescues un-named flow endpoints by re-ranking on the graph neighborhood, so "how does X get to Y" answers land on real endpoints more often. (#864)
+- **Leaner MCP entry point.** `get_why` joins the lean MCP profile and `get_answer` is the advertised entry point; `get_conformance` and `generate_refactoring_code` are now opt-in. `AGENTS.md` was brought to parity with the `CLAUDE.md` tool surface. (#889, #875, #900)
+
+### Changed
+- **Faster init and update.** A broad performance pass across indexing: analysis phases run concurrently and incremental re-ingest runs in parallel, init- and update-built graphs converge so the centrality cache hits on updates, self-call resolution and pagerank are cached for cascade ordering, pages reused verbatim skip re-embedding, end-of-run wiki-page upserts are batched, refactoring detectors drop repo-sized per-file work, and coverage discovery plus the repo pre-scan share the pruned file walk. (#894, #895, #891, #892, #904, #893, #898, #897)
+- **Cleaner UI.** The Overview got a visual-hierarchy pass and a denser health card with docs counts split by AI vs auto-generated, and "Attention Needed" is a triage panel again. (#882, #879, #883)
+- **TypeScript path resolution in the CLI.** `TsconfigResolver` is now wired into the CLI commands, so `tsconfig` path aliases resolve during indexing. (#675)
+
+### Fixed
+- **Docs pointer no longer drifts on index-only updates.** The docs commit pointer is preserved during index-only updates and kept separate from the sync pointer, fixing `update --docs` drift. (#849, #878)
+- **Wildcard re-exports are followed in call resolution.** `from x import *` re-exports (and the JS equivalent) are now traced, recovering call edges that were dropped. (#905)
+- **`get_answer` stops dropping substance.** Synthesis is no longer silently skipped when a usable API key exists, the gated low-confidence path serves real substance and unpins cached misses, gated-path excerpts no longer die to a swallowed error, and the live-grep fallback respects gitignore and exclude patterns. (#888, #887, #896, #856)
+- **Sturdier change-risk on the CLI.** A friendly revspec error is restored in `changed_lines`, and subprocess handling is hardened and aligned with the MCP tool conventions. (#902, #899)
+- **Security scan reads real source** and guards repo-root detection, instead of scanning stale or wrong content. (#890)
+- **Smaller fixes.** Unknown `restyle` style arguments raise a usage error; CLI usage errors are classified separately from failures in telemetry; decision staleness timestamps are normalized; webhook jobs run in sync mode; MCP health resolves the repository from the scoped session; and the code-rationale git-grep is hardened for macOS and color configs. (#908, #907, #877, #848, #865, #825)
+
+### Documentation
+- README now counts ten MCP tools, fixes the coverage example, and tightens the Code Health section. (#901)
+- Plugin: both the Claude Code and Codex plugins ship a `change-review` skill; the risk command documents the new `--exclude` flag.
+
 ## [0.32.0] — 2026-07-15
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.33.0] — 2026-07-18
+
+### Added
+- **Line-level AI authorship from your agent sessions.** repowise reads agent-trace records to attribute commits (and now individual lines) to the agent and model that wrote them, and stamps a per-commit model id, so the contributors and provenance views can tell human-written code from agent-written code down to the line. (#861, #866)
+- **Docs that repair themselves.** Generation now self-repairs hallucinated symbol references, resolves cross-page links across the whole repo on updates, and backfills graph-derived "related pages" with a self-healing pass, so wiki pages link to real symbols and stay cross-linked as the code moves. (#871, #872)
+- **`get_change_risk` grew up.** The change-risk score gained a `-x/--exclude` flag with `.riskignore` support to drop vendored or generated paths from the diff, and now lists the line-level tests a change actually impacts. (#867, #903)
+- **Coverage-backed tests in PR risk.** `get_risk` PR mode now surfaces `tests_to_run` proven by the per-test coverage map, so a reviewer sees exactly which tests exercise the changed files. (#859)
+- **Fewer dead-code false positives.** Whole classes of systematic false positives (re-exports, dynamic references) are eliminated, so `get_dead_code` reports far less that is actually live. (#886)
+- **Better flow answers.** `get_answer` rescues un-named flow endpoints by re-ranking on the graph neighborhood, so "how does X get to Y" answers land on real endpoints more often. (#864)
+- **Leaner MCP entry point.** `get_why` joins the lean MCP profile and `get_answer` is the advertised entry point; `get_conformance` and `generate_refactoring_code` are now opt-in. `AGENTS.md` was brought to parity with the `CLAUDE.md` tool surface. (#889, #875, #900)
+
+### Changed
+- **Faster init and update.** A broad performance pass across indexing: analysis phases run concurrently and incremental re-ingest runs in parallel, init- and update-built graphs converge so the centrality cache hits on updates, self-call resolution and pagerank are cached for cascade ordering, pages reused verbatim skip re-embedding, end-of-run wiki-page upserts are batched, refactoring detectors drop repo-sized per-file work, and coverage discovery plus the repo pre-scan share the pruned file walk. (#894, #895, #891, #892, #904, #893, #898, #897)
+- **Cleaner UI.** The Overview got a visual-hierarchy pass and a denser health card with docs counts split by AI vs auto-generated, and "Attention Needed" is a triage panel again. (#882, #879, #883)
+- **TypeScript path resolution in the CLI.** `TsconfigResolver` is now wired into the CLI commands, so `tsconfig` path aliases resolve during indexing. (#675)
+
+### Fixed
+- **Docs pointer no longer drifts on index-only updates.** The docs commit pointer is preserved during index-only updates and kept separate from the sync pointer, fixing `update --docs` drift. (#849, #878)
+- **Wildcard re-exports are followed in call resolution.** `from x import *` re-exports (and the JS equivalent) are now traced, recovering call edges that were dropped. (#905)
+- **`get_answer` stops dropping substance.** Synthesis is no longer silently skipped when a usable API key exists, the gated low-confidence path serves real substance and unpins cached misses, gated-path excerpts no longer die to a swallowed error, and the live-grep fallback respects gitignore and exclude patterns. (#888, #887, #896, #856)
+- **Sturdier change-risk on the CLI.** A friendly revspec error is restored in `changed_lines`, and subprocess handling is hardened and aligned with the MCP tool conventions. (#902, #899)
+- **Security scan reads real source** and guards repo-root detection, instead of scanning stale or wrong content. (#890)
+- **Smaller fixes.** Unknown `restyle` style arguments raise a usage error; CLI usage errors are classified separately from failures in telemetry; decision staleness timestamps are normalized; webhook jobs run in sync mode; MCP health resolves the repository from the scoped session; and the code-rationale git-grep is hardened for macOS and color configs. (#908, #907, #877, #848, #865, #825)
+
+### Documentation
+- README now counts ten MCP tools, fixes the coverage example, and tightens the Code Health section. (#901)
+- Plugin: both the Claude Code and Codex plugins ship a `change-review` skill; the risk command documents the new `--exclude` flag.
+
 ## [0.32.0] — 2026-07-15
 
 ### Added

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.33.0
+
+### Added
+- `change-review` skill for reviewing a change against the risk and blast-radius
+  tools (shipped for both the Claude Code and Codex plugins).
+
+### Changed
+- Version bump to track the repowise 0.33.0 release.
+- `risk` command documents the new `-x/--exclude` flag and `.riskignore` support.
+
 ## 0.32.0
 
 ### Changed

--- a/plugins/claude-code/commands/risk.md
+++ b/plugins/claude-code/commands/risk.md
@@ -25,6 +25,7 @@ Pure git + learned constants: no LLM, no network. A natural pre-merge / PR gate.
 
 Useful flags:
 - `--ext .py,.ts` — only count changes in those file types
+- `-x, --exclude <pattern>` — gitignore-style pattern to drop from the diff (repeatable; also honors a `.riskignore` file)
 - `--format json` — machine-readable score + features + drivers
 - `--path <dir>` — point at a different git repo
 

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Repowise codebase intelligence for Codex.",
   "author": {
     "name": "Repowise",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.32.0"
+version = "0.33.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3056,7 +3056,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.32.0"
+version = "0.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## release: v0.33.0

Version bump + changelog off latest `main`. No store-format or parser-schema bump this cycle.

### Highlights
- **Line-level AI provenance** from agent-trace records (commit + per-line authorship, per-commit model id).
- **Self-healing docs** — hallucinated-symbol repair, repo-wide link resolution on updates, graph-derived related pages with backfill.
- **`get_change_risk` matured** — `-x/--exclude` + `.riskignore`, line-level impacted tests; `get_risk` PR mode now surfaces coverage-backed `tests_to_run`.
- **Big indexing/update performance pass** — concurrent analysis, parallel incremental re-ingest, centrality-cache convergence, verbatim-reuse embedding skip, batched upserts.
- **Fewer dead-code false positives** and a leaner MCP entry point (`get_answer` primary, `get_why` in lean profile; `get_conformance`/`generate_refactoring_code` opt-in).

### Version bump
- `pyproject.toml`, cli/core/server `__init__.py`, `uv.lock` self-entry → `0.33.0`
- Plugin manifests: Claude Code `0.33.0`, Codex `0.2.0` (shipped a `change-review` skill)

### Test plan
- [x] Version drift grep clean (no `0.32.0` hits; `0.33.0` in all 4 Python files + 2 plugin manifests + `uv.lock`)
- [x] `uv build --wheel` — `repowise-0.33.0-py3-none-any.whl` built; `serve_cmd.py` + `.scm`/`.j2` data files present
- [x] Bundled changelog sync guard test passes
- [x] `npm ci && npm run build --workspace packages/web` — all routes built, standalone `server.js` present, workspace-package code compiled into chunks
- [x] MCP tool-surface parity: plugin references only live tools
- [ ] Merge via **regular merge commit (NOT squash)** so the tag points at a real bump-only merge
- [ ] Tag `v0.33.0` on `main` after merge → triggers `publish.yml`

Merge convention: **regular merge commit**, not squash.
