### PR TITLE
release(vscode): v0.4.0 — ship the accumulated bundled UI

### DIFF
--- a/packages/vscode/RELEASING.md
+++ b/packages/vscode/RELEASING.md
@@ -14,6 +14,24 @@ The extension publishes to the Visual Studio Marketplace (publisher
   pre-release channel. Cut a stable release from a tag once a pre-release has
   been dogfooded.
 
+## When to cut a release (don't let the bundled UI freeze)
+
+The webviews compile `@repowise-dev/ui` (`packages/ui`) into the VSIX at build
+time, so shared-component improvements reach extension users only on a rebuild.
+The extension source can go untouched for cycles while its bundled UI drifts,
+leaving users frozen on whatever `packages/ui` shipped at the last `vscode-v*`
+tag. Cut a release whenever `packages/ui` changed in a webview-consumed subpath
+since the last extension tag, even if `packages/vscode/` itself did not:
+
+```
+LAST_EXT_TAG=$(git tag --list 'vscode-v*' --sort=-v:refname | head -1)
+git log $LAST_EXT_TAG..origin/main --oneline -- packages/ui/src/
+```
+
+Webview-consumed subpaths: `graph/`, `health/`, `docs/`, `c4/`, `refactoring/`,
+`lib/format`, `ui/`, `shared`, `wiki/`. Confirm the live import set with
+`git grep -hoE 'from "@repowise-dev/ui[^"]*"' -- 'packages/vscode/webview/**'`.
+
 ## The one rule that has bitten us before
 
 **CI (and this checklist) must BUILD, not just type-check.** A barrel

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "repowise",
   "displayName": "Repowise",
   "description": "Know what your change breaks before you push. Health signals, architecture maps, and refactoring plans in your editor, and the same intelligence for your AI agent via MCP. Local and free.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "publisher": "repowise-dev",
   "license": "AGPL-3.0-or-later",
   "homepage": "https://www.repowise.dev",


### PR DESCRIPTION
## release(vscode): v0.4.0

The extension has been frozen at `0.3.0` since the v0.27.0 commit, but its webviews bundle `@repowise-dev/ui` at build time. Across v0.28 → v0.33, `packages/ui` took 29 commits in the exact subpaths the webviews render (graph, health, docs, C4, formatters) — all bundled but never shipped to extension users. This release rebuilds and republishes so those improvements land.

### Changes
- `packages/vscode/package.json` version → `0.4.0`
- `MIN_SERVER_VERSION` **unchanged** at `0.26.0` — no new server contract required; the rebundled components render existing API data and degrade gracefully against older servers.
- Documented the bundled-UI freeze trap in `packages/vscode/RELEASING.md` (and the local PyPI runbook) so future releases run a `packages/ui`-since-last-`vscode-v*`-tag check.

### Build validation (local)
- [x] `npm run type-check --workspace packages/vscode`
- [x] `npm run build --workspace packages/vscode` — host bundle 119.5 KB (budget 300 KB)
- [x] `npm run build:webview --workspace packages/vscode` — webview bundle built, rebundles `@repowise-dev/ui`
- [x] `npm run test:webview --workspace packages/vscode` — 43/43 pass
- [ ] Electron smoke + clean-profile VSIX install (runs in `publish-vscode.yml` / dogfood)

### Publishing (after merge)
1. Recommended: run **Publish VS Code extension** via `workflow_dispatch` (pre-release) from `main`, dogfood the rebundled UI in a real editor.
2. Then cut stable: `git tag vscode-v0.4.0 && git push origin vscode-v0.4.0` → triggers `publish-vscode.yml`.

Independent of the PyPI `v0.33.0` release (separate tag namespace, separate workflow).
