### PR TITLE
feat(update): onboard a provider when a docs update needs one

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -157,18 +157,18 @@ See [WORKTREES.md](WORKTREES.md).
 | `--reasoning` | Reasoning mode for supported providers: `auto`, `off`/`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max` |
 | `--cascade-budget` | Max pages to regenerate (default: auto) |
 | `--dry-run` | Show what would be updated without regenerating |
-| `--workspace` / `-w` | Update all stale repos in the workspace + cross-repo analysis |
+| `--workspace` / `-w` | Update all stale repos in the workspace + cross-repo analysis. Each repo picks docs vs index-only the same way a single-repo update does, from its own persisted `docs_enabled` plus any `--docs` / `--no-docs` / `--index-only` override on the command. Docs repos regenerate through the full single-repo docs path (pages, diagrams, decisions) so a workspace wiki stays as fresh as one updated repo by repo; the rest take the fast parallel index-only path. |
 | `--no-workspace` | Force single-repo mode (handy when running from a workspace root) |
 | `--repo` | Update a specific workspace repo by alias |
-| `--index-only` | Refresh the index only, skip doc regeneration for this run |
-| `--docs` / `--no-docs` | Regenerate wiki pages for changed files, or skip doc regeneration entirely. Not supported in workspace mode yet: with `--workspace` the flag is ignored (with a warning) and you should run docs per repo, e.g. `repowise update --docs --no-workspace` from inside the repo. |
+| `--index-only` | Refresh the index only, skip doc regeneration for this run. In workspace mode, forces every stale repo to index-only. |
+| `--docs` / `--no-docs` | Regenerate wiki pages for changed files, or skip doc regeneration entirely. Works in workspace mode too: `--docs` fans out to every stale repo's docs update (each needs an LLM provider/key configured, or pass `--provider`), and `--no-docs` forces index-only across the workspace. Without either flag each repo follows its own `docs_enabled`. |
 | `--full` | Upgrade a fast (`--mode fast`) index to a full one, see below. Single-repo only; errors in workspace mode. |
 | `--no-cost-tracking` | Don't record LLM spend for this run |
 | `--agents` / `--no-agents` | Generate or skip managed `AGENTS.md` after update. Persists the preference. |
 | `-v`, `--verbose` | Show the full changed-file list and per-phase internals (cascade budget, decision-marker/evolution counts, best-effort skip warnings, detailed generation report). Off by default for a compact summary. |
 | `--progress` | `rich` (default) for the interactive progress bar, or `json` for newline-delimited JSON events on stdout (for driving update from another process) |
 
-**First-time indexing:** `update --workspace` runs full first-time indexing for workspace entries that have no `.repowise/` dir yet (previously skipped with `"not_indexed"`). The pipeline runs index-only, no LLM cost, and writes a state.json marker so `repowise update --repo <alias> --docs` later picks up doc generation cleanly.
+**First-time indexing:** `update --workspace` runs full first-time indexing for workspace entries that have no `.repowise/` dir yet (previously skipped with `"not_indexed"`). The pipeline runs index-only, no LLM cost, and writes a state.json marker. Doc generation then follows on the next update once the repo has an index: pass `--docs` (or set its `docs_enabled`) and it regenerates pages like any other member.
 
 **Upgrading a fast index to full (`--full`):** a repo first indexed with `repowise init --mode fast` has the full dependency graph + metrics persisted, but only the *essential* git tier (last commits, no per-file blame or co-change) and no LLM docs. `repowise update --full` upgrades it **incrementally**: it backfills the git tier to FULL (per-file blame + repo-wide co-change) using a resumable, checkpointed worker, then generates the docs that fast mode skipped. Crucially, it **reuses the persisted graph**, the dependency graph is rehydrated from SQL rather than re-parsed and re-resolved, so the expensive import/call/heritage resolution and centrality computation the fast index already did are not repeated. This is measurably cheaper than re-running a full `init`. The backfill is resumable: if it is interrupted, re-running `repowise update --full` picks it up. A provider is required (the fast index made no LLM calls), so pass `--provider`/`--model` or have one configured. Single-repo only; it errors if run in workspace mode.
 
@@ -179,7 +179,8 @@ repowise update                        # diff since last sync
 repowise update --dry-run              # preview
 repowise update --since v1.0.0         # diff from a tag
 repowise update --reasoning off        # one-off supported-provider thinking-off run
-repowise update --workspace            # all workspace repos (incl. first-time indexing)
+repowise update --workspace            # all workspace repos (docs where enabled, incl. first-time indexing)
+repowise update --workspace --docs     # force docs regeneration across every stale repo
 repowise update --repo backend         # specific workspace repo
 repowise update --no-workspace         # force single-repo mode in a workspace root
 repowise update -v                     # verbose: full file list + per-phase internals

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -646,8 +646,12 @@ repowise init .
 # Add a repo that lives outside the workspace directory
 repowise workspace add /path/to/external-repo --alias api-gateway
 
-# Update all workspace repos
+# Update all workspace repos. Each repo regenerates docs or refreshes
+# index-only based on its own docs_enabled, just like a single-repo update.
 repowise update --workspace
+
+# Force docs regeneration across every stale repo (needs a provider per repo)
+repowise update --workspace --docs
 
 # Update just one repo
 repowise update --repo backend

--- a/docs/WORKSPACES.md
+++ b/docs/WORKSPACES.md
@@ -554,6 +554,8 @@ repowise update              # Update the primary repo
 repowise update --workspace  # Update all workspace repos
 ```
 
+Each stale repo picks docs vs index-only the same way a single-repo update does, from its own `docs_enabled` (set at init) plus any override on the command. Repos with docs enabled regenerate their wiki (pages, diagrams, decisions) through the full docs path, so a workspace wiki stays as fresh as one you update repo by repo; the rest just refresh the index. Force docs everywhere with `repowise update --workspace --docs` (each repo needs an LLM provider/key, or pass `--provider`), or keep it index-only with `--no-docs`.
+
 Or use watch mode for automatic updates:
 
 ```bash

--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -332,10 +332,15 @@ def run_update(
     no_cost_tracking: bool = False,
     verbose: bool = False,
     progress: str = "rich",
+    skip_cross_repo_hooks: bool = False,
 ) -> None:
     """Incrementally update wiki pages for files changed since last sync.
 
     If `since` is None, the base commit is read from state.json's last_sync_commit.
+
+    ``skip_cross_repo_hooks`` is set only by the workspace docs flow, which
+    calls this per repo and then runs the cross-repo hooks once over every
+    updated repo instead of once per repo.
     """
     start = time.monotonic()
 
@@ -376,13 +381,23 @@ def run_update(
                 "--full is single-repo only. Run it inside a specific repo "
                 "(or pass --no-workspace / --repo <alias>)."
             )
-        if docs_flag:
-            console.print(
-                "[yellow]--docs is not supported in workspace mode yet; run it per repo, "
-                "e.g. repowise update --docs --no-workspace from inside the repo.[/yellow]"
-            )
         try:
-            _workspace_update(target, dry_run=dry_run, agents_md=agents_md, verbose=verbose)
+            _workspace_update(
+                target,
+                dry_run=dry_run,
+                agents_md=agents_md,
+                verbose=verbose,
+                docs_flag=docs_flag,
+                index_only=index_only,
+                since=since,
+                provider_name=provider_name,
+                model=model,
+                reasoning=reasoning,
+                cascade_budget=cascade_budget,
+                concurrency=concurrency,
+                no_cost_tracking=no_cost_tracking,
+                progress=progress,
+            )
         except Exception as exc:
             if emitter is not None:
                 emitter.error(str(exc))
@@ -1230,9 +1245,12 @@ def run_update(
     if pending_head and pending_head == head:
         clear_update_pending(repo_path)
 
-    # Trigger cross-repo hooks if this repo is part of a workspace
+    # Trigger cross-repo hooks if this repo is part of a workspace. The
+    # workspace docs flow suppresses this per-repo and runs the hooks once
+    # over every updated repo, so the cross-repo layer isn't rebuilt from a
+    # half-updated set on every member.
     try:
-        ws_root = find_workspace_root(repo_path)
+        ws_root = find_workspace_root(repo_path) if not skip_cross_repo_hooks else None
         if ws_root is not None:
             from repowise.core.workspace import WorkspaceConfig
             from repowise.core.workspace.update import run_cross_repo_hooks

--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -28,7 +28,7 @@ from repowise.cli.helpers import (
     read_update_pending,
     release_update_lock,
     resolve_command_target,
-    resolve_provider,
+    resolve_provider_or_prompt,
     resolve_reasoning,
     rotate_update_log_if_needed,
     run_async,
@@ -62,6 +62,18 @@ from .reporting import (
 from .workspace import _workspace_update
 
 log = structlog.get_logger(__name__)
+
+
+def _docs_provider_prompt_allowed(emitter: Any) -> bool:
+    """Whether a docs run may block on an interactive provider prompt.
+
+    Requires a real terminal on *both* ends: a terminal stdout (so the table
+    renders) and a tty stdin (so the answer can actually be read). The stdin
+    check is what keeps a background post-commit hook or CI run from hanging
+    even when it inherits a ``FORCE_COLOR`` that makes ``console.is_terminal``
+    report True. ``--progress json`` (emitter set) is always non-interactive.
+    """
+    return console.is_terminal and sys.stdin.isatty() and emitter is None
 
 
 def _record_update_outcome(
@@ -830,7 +842,20 @@ def run_update(
         tier2_tail_dirs=tuple(tail_dirs_cfg) if tail_dirs_cfg else None,
     )
 
-    provider = resolve_provider(provider_name, model, repo_path=repo_path)
+    # Resolve the generation provider. If the repo wants docs but was never
+    # given a provider/key (e.g. it started --index-only and later flipped
+    # docs_enabled on, or `repowise update --docs`), onboard the same way init
+    # does: prompt for provider + key and persist, but only in an interactive
+    # terminal. Hooks / CI / --progress json keep the clean non-blocking error.
+    # In the workspace docs flow each member reaches this per-repo run; the
+    # first prompt sets the key in-process, so later members auto-resolve.
+    provider = resolve_provider_or_prompt(
+        provider_name,
+        model,
+        repo_path,
+        reasoning=reasoning,
+        interactive=_docs_provider_prompt_allowed(emitter),
+    )
 
     # Attach a DB-backed CostTracker so every LLM call made during this update
     # (decision rescan + page regeneration) is persisted to the `llm_costs`

--- a/packages/cli/src/repowise/cli/commands/update_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/workspace.py
@@ -17,17 +17,38 @@ def _workspace_update(
     dry_run: bool = False,
     agents_md: bool | None = None,
     verbose: bool = False,
+    docs_flag: bool | None = None,
+    index_only: bool = False,
+    since: str | None = None,
+    provider_name: str | None = None,
+    model: str | None = None,
+    reasoning: str | None = None,
+    cascade_budget: int | None = None,
+    concurrency: int = 10,
+    no_cost_tracking: bool = False,
+    progress: str = "rich",
 ) -> None:
     """Update stale repos in a workspace.
 
     Takes a resolved :class:`CommandTarget` so the caller has full control
     over how the workspace was located (auto-detected vs explicit flag).
+
+    Each stale repo resolves its own docs-vs-index-only mode the same way a
+    single-repo update does, from its persisted ``docs_enabled`` plus any
+    ``--docs`` / ``--no-docs`` / ``--index-only`` override passed here. Repos
+    that want docs are updated through the full single-repo docs path (so
+    their wiki pages, diagrams, and decisions stay as current as they would
+    under ``repowise update`` run inside the repo); the rest take the fast
+    parallel index-only path. See :func:`_workspace_docs_update`.
     """
+    from repowise.cli.helpers import load_state
     from repowise.core.workspace import (
         check_repo_staleness,
         reconcile_repo_head_commit,
         update_workspace,
     )
+
+    from .mode import _resolve_index_only_mode
 
     start = time.monotonic()
     ws_root = target.ws_root
@@ -45,6 +66,11 @@ def _workspace_update(
     stale_count = 0
     up_to_date_count = 0
     up_to_date_repos: list[tuple[Path, str]] = []
+    # Aliases of stale repos whose effective mode is docs (indexed + docs
+    # wanted). Everything else stale takes the fast index-only path, including
+    # never-indexed repos, which can only be first-time indexed index-only, and
+    # a follow-up ``--docs`` run generates their pages once they have an index.
+    docs_aliases: set[str] = set()
     for entry in ws_config.repos:
         if repo_alias and entry.alias != repo_alias:
             continue
@@ -62,6 +88,10 @@ def _workspace_update(
         # collapse into a single count line unless -v lists everything.
         if is_stale:
             stale_count += 1
+            if indexed and not _resolve_index_only_mode(
+                index_only=index_only, docs_flag=docs_flag, state=load_state(abs_path)
+            ):
+                docs_aliases.add(entry.alias)
         if indexed and not is_stale:
             up_to_date_count += 1
             if head:
@@ -103,6 +133,33 @@ def _workspace_update(
 
     if dry_run:
         console.print(f"[yellow]Dry run \u2014 {stale_count} repo(s) would be updated.[/yellow]")
+        return
+
+    # Repos that want docs go through the full single-repo docs path so their
+    # wiki (pages, diagrams, decisions) stays as fresh as a single-repo update
+    # would keep it; everything else stale takes the fast parallel index-only
+    # path below. Branching here keeps the common all-index-only workspace
+    # update byte-for-byte on its original path with no behavior change.
+    if docs_aliases:
+        _workspace_docs_update(
+            ws_root=ws_root,
+            ws_config=ws_config,
+            repo_filter=repo_alias,
+            docs_aliases=docs_aliases,
+            start=start,
+            agents_md=agents_md,
+            verbose=verbose,
+            docs_flag=docs_flag,
+            index_only=index_only,
+            since=since,
+            provider_name=provider_name,
+            model=model,
+            reasoning=reasoning,
+            cascade_budget=cascade_budget,
+            concurrency=concurrency,
+            no_cost_tracking=no_cost_tracking,
+            progress=progress,
+        )
         return
 
     # Run the updates
@@ -173,6 +230,178 @@ def _workspace_update(
         total_files=total_files,
         total_symbols=total_symbols,
         elapsed=time.monotonic() - start,
+    )
+
+
+def _workspace_docs_update(
+    *,
+    ws_root: Path,
+    ws_config: Any,
+    repo_filter: str | None,
+    docs_aliases: set[str],
+    start: float,
+    agents_md: bool | None,
+    verbose: bool,
+    docs_flag: bool | None,
+    index_only: bool,
+    since: str | None,
+    provider_name: str | None,
+    model: str | None,
+    reasoning: str | None,
+    cascade_budget: int | None,
+    concurrency: int,
+    no_cost_tracking: bool,
+    progress: str,
+) -> None:
+    """Update a workspace where at least one stale repo wants docs.
+
+    Docs repos (``docs_aliases``) run through the full single-repo update
+    (:func:`run_update`) so their pages, diagrams, and decisions regenerate
+    exactly as they would with ``repowise update`` run inside the repo. The
+    remaining stale members (index-only + never-indexed first-timers) take the
+    fast parallel core path. Cross-repo hooks are suppressed on both and run
+    once at the end over every repo that actually changed, so the cross-repo
+    layer is never rebuilt from a half-updated set.
+    """
+    from contextlib import suppress
+
+    from repowise.cli.commands.workspace_cmd import inherit_workspace_distill_verdict
+    from repowise.core.workspace import RepoUpdateResult, update_workspace
+    from repowise.core.workspace.update import (
+        run_cross_repo_hooks,
+        sync_workspace_state_from_disk,
+    )
+
+    from .command import run_update
+
+    changed_aliases: list[str] = []
+    docs_updated = 0
+    docs_failed = 0
+
+    # --- Index-only + first-time members: fast parallel core path ----------
+    # only_aliases bounds the candidate set; update_workspace still re-checks
+    # staleness, so any up-to-date member in the set simply no-ops.
+    core_aliases = {
+        entry.alias
+        for entry in ws_config.repos
+        if (repo_filter is None or entry.alias == repo_filter)
+        and entry.alias not in docs_aliases
+    }
+    core_results: list[RepoUpdateResult] = []
+    if core_aliases:
+
+        def _on_start(alias: str) -> None:
+            console.print(f"  Updating [bold]{alias}[/bold]...")
+
+        def _on_done(result: RepoUpdateResult) -> None:
+            if result.error:
+                console.print(f"    [red]✗ {result.alias}: {result.error}[/red]")
+            elif result.skipped_reason == "in_flight":
+                console.print(
+                    f"    [yellow]↻ {result.alias}: another update is already "
+                    "in flight; this commit was queued for it to pick up.[/yellow]"
+                )
+            elif result.updated:
+                console.print(
+                    f"    [green]✓[/green] {result.alias}: "
+                    f"{result.file_count} files, {result.symbol_count:,} symbols"
+                )
+
+        core_results = run_async(
+            update_workspace(
+                ws_root,
+                ws_config,
+                only_aliases=core_aliases,
+                run_hooks=False,
+                dry_run=False,
+                on_repo_start=_on_start,
+                on_repo_done=_on_done,
+            )
+        )
+        changed_aliases.extend(r.alias for r in core_results if r.updated)
+
+    # --- Docs members: full single-repo docs update, one at a time ---------
+    for entry in ws_config.repos:
+        if entry.alias not in docs_aliases:
+            continue
+        repo_path = (ws_root / entry.path).resolve()
+        console.print(f"  Updating [bold]{entry.alias}[/bold] (docs)...")
+        try:
+            run_update(
+                path=str(repo_path),
+                provider_name=provider_name,
+                model=model,
+                since=since,
+                reasoning=reasoning,
+                cascade_budget=cascade_budget,
+                dry_run=False,
+                workspace=False,
+                no_workspace=True,
+                repo_alias=None,
+                index_only=index_only,
+                docs_flag=docs_flag,
+                full=False,
+                agents_md=agents_md,
+                concurrency=concurrency,
+                no_cost_tracking=no_cost_tracking,
+                verbose=verbose,
+                # rich even when the outer run is --progress json: the parent
+                # already redirected the console to stderr and owns the single
+                # stdout JSON event stream, so a nested json emitter would
+                # corrupt it. The per-repo rich output goes to stderr there.
+                progress="rich",
+                skip_cross_repo_hooks=True,
+            )
+        except Exception as exc:
+            docs_failed += 1
+            console.print(f"    [red]✗ {entry.alias}: {exc}[/red]")
+            continue
+        docs_updated += 1
+        changed_aliases.append(entry.alias)
+
+    # The single-repo path only writes each repo's state.json, not the
+    # workspace config, so re-sync it: the docs repos' advanced last_sync_commit
+    # then lands in last_commit_at_index and the next run sees them up to date.
+    with suppress(Exception):
+        sync_workspace_state_from_disk(ws_root, ws_config)
+
+    # Backfill the distill rewrite-hook verdict for any first-time member the
+    # core path just indexed (matches the index-only workspace path).
+    for entry in ws_config.repos:
+        if repo_filter and entry.alias != repo_filter:
+            continue
+        with suppress(Exception):
+            inherit_workspace_distill_verdict((ws_root / entry.path).resolve())
+
+    # Cross-repo hooks once, over the union of index-only and docs repos.
+    if changed_aliases and len(ws_config.repos) >= 2:
+        console.print("Running cross-repo analysis...")
+        with suppress(Exception):
+            run_async(run_cross_repo_hooks(ws_config, ws_root, changed_aliases))
+        console.print("[green]Cross-repo analysis updated.[/green]")
+
+    # Editor files: re-stamp every member. Docs repos were already stamped by
+    # their single-repo run; the core repos need it here. Idempotent.
+    _refresh_workspace_editor_project_files(
+        ws_root=ws_root,
+        ws_config=ws_config,
+        repo_filter=repo_filter,
+        agents_md=agents_md,
+    )
+
+    core_updated = sum(1 for r in core_results if r.updated)
+    parts: list[str] = []
+    if docs_updated:
+        parts.append(f"{docs_updated} with docs regenerated")
+    if core_updated:
+        parts.append(f"{core_updated} re-indexed")
+    if docs_failed:
+        parts.append(f"[red]{docs_failed} failed[/red]")
+    summary = ", ".join(parts) if parts else "nothing to update"
+    console.print()
+    console.print(
+        f"[green]Workspace update complete[/green]: {summary} "
+        f"[dim]({time.monotonic() - start:.1f}s)[/dim]"
     )
 
 

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -722,6 +722,51 @@ def resolve_provider(
     )
 
 
+def resolve_provider_or_prompt(
+    provider_name: str | None,
+    model: str | None,
+    repo_path: Path,
+    *,
+    reasoning: str | None = None,
+    interactive: bool,
+) -> Any:
+    """Resolve a provider, falling back to init's interactive setup on a miss.
+
+    Ordinary resolution is :func:`resolve_provider`. When that fails because no
+    provider/key is configured and ``interactive`` is set (an interactive
+    terminal, not a hook / CI / ``--progress json`` run), reuse init's exact
+    provider + API-key prompt, persist the choice, and retry — so a docs run
+    that only just gained ``docs_enabled`` onboards the same way ``init`` does
+    instead of dying with "No provider configured".
+
+    When ``interactive`` is False the original error propagates unchanged, so
+    background runs (post-commit hook, CI, machine-driven ``--progress json``)
+    keep their clean, non-blocking failure.
+
+    Persistence reuses init's helpers: the key lands in ``.repowise/.env`` (from
+    the prompt) and provider/model in ``.repowise/config.yaml`` here, so the
+    prompt only ever appears once per repo.
+    """
+    try:
+        return resolve_provider(provider_name, model, repo_path=repo_path)
+    except Exception:
+        if not interactive:
+            raise
+        from repowise.cli.ui import interactive_provider_config_select
+
+        selection = interactive_provider_config_select(
+            console, model, reasoning, repo_path=repo_path
+        )
+        # Persist provider/model so future runs resolve without re-prompting.
+        # The API key was already persisted to .repowise/.env by the prompt.
+        save_config_partial(
+            repo_path,
+            provider=selection.provider_name,
+            model=selection.model,
+        )
+        return resolve_provider(selection.provider_name, selection.model, repo_path=repo_path)
+
+
 # ---------------------------------------------------------------------------
 # Provider validation
 # ---------------------------------------------------------------------------

--- a/packages/core/src/repowise/core/workspace/update.py
+++ b/packages/core/src/repowise/core/workspace/update.py
@@ -520,18 +520,28 @@ async def update_workspace(
     ws_config: WorkspaceConfig,
     *,
     repo_filter: str | None = None,
+    only_aliases: set[str] | None = None,
+    run_hooks: bool = True,
     dry_run: bool = False,
     commit_depth: int = 500,
     exclude_patterns: list[str] | None = None,
     on_repo_start: Callable[[str], None] | None = None,
     on_repo_done: Callable[[RepoUpdateResult], None] | None = None,
 ) -> list[RepoUpdateResult]:
-    """Update stale repos in the workspace.
+    """Update stale repos in the workspace (index-only).
 
     Args:
         workspace_root: Path to the workspace root directory.
         ws_config: Loaded workspace configuration.
         repo_filter: If set, only update this repo alias.
+        only_aliases: If set, restrict the run to this subset of aliases (on
+            top of ``repo_filter``). The CLI uses this to hand the fast
+            index-only path just the repos it isn't updating via the
+            single-repo docs path, so the two orchestrators never touch the
+            same repo in one workspace run.
+        run_hooks: When False, skip the cross-repo analysis hooks at the end.
+            The CLI sets this so it can run them once over the union of
+            index-only and docs repos, instead of on a partial set here.
         dry_run: If True, detect staleness but don't actually update.
         commit_depth: Max commits to analyze per file.
         exclude_patterns: Gitignore-style patterns to exclude.
@@ -553,6 +563,9 @@ async def update_workspace(
             available = ", ".join(ws_config.repo_aliases())
             raise ValueError(f"Unknown repo '{repo_filter}'. Available: {available}")
         entries = [entry]
+
+    if only_aliases is not None:
+        entries = [e for e in entries if e.alias in only_aliases]
 
     # Step 0: Sync ``last_commit_at_index`` from each repo's state.json so
     # the workspace config doesn't drift when a child repo is updated
@@ -746,8 +759,10 @@ async def update_workspace(
     if changed_aliases:
         ws_config.save(workspace_root)
 
-    # Step 4: Run cross-repo hooks (Phase 3/4 placeholder)
-    if changed_aliases:
+    # Step 4: Run cross-repo hooks (Phase 3/4 placeholder). ``run_hooks`` lets
+    # the CLI defer these so they run once over the union of index-only and
+    # docs repos, rather than on this partial set.
+    if changed_aliases and run_hooks:
         await run_cross_repo_hooks(ws_config, workspace_root, changed_aliases)
 
     return results

--- a/tests/unit/cli/test_update_provider_prompt.py
+++ b/tests/unit/cli/test_update_provider_prompt.py
@@ -1,0 +1,183 @@
+"""``repowise update`` onboards a provider when a docs run needs one.
+
+A repo can start life ``--index-only`` and later flip ``docs_enabled`` on (via
+config or ``repowise update --docs``) without a provider/key ever being
+configured. In an interactive terminal the docs run should prompt for the
+provider + key exactly like ``init`` does, persist the choice, and continue,
+rather than dying with "No provider configured". In a non-interactive run
+(hook / CI / ``--progress json``) it must stay a clean, non-blocking failure.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+from repowise.cli.main import cli
+from repowise.cli.ui.provider_selection import ProviderSelection
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(["git", *args], cwd=str(repo), capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def _make_git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "user.name", "Test")
+    # Ignore the index dir so `git add .` never commits repowise's own
+    # artifacts — commit hashes then track only the source changes below.
+    (repo / ".gitignore").write_text(".repowise/\n")
+    (repo / "a.py").write_text("def alpha():\n    return 1\n")
+    (repo / "b.py").write_text("from a import alpha\n\n\ndef beta():\n    return alpha() + 1\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def _index_full(repo: Path) -> None:
+    """Real index-only init: full pipeline + persistence, no provider/key."""
+    from repowise.core.pipeline.full_index import index_repo_full
+
+    asyncio.run(index_repo_full(repo))
+
+
+def _commit_change(repo: Path, name: str, body: str) -> str:
+    (repo / name).write_text(body)
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", f"add {name}")
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _config(repo: Path) -> dict:
+    text = (repo / ".repowise" / "config.yaml").read_text(encoding="utf-8")
+    return yaml.safe_load(text) or {}
+
+
+def _prep_docs_repo_without_provider(tmp_path: Path) -> tuple[Path, str]:
+    """Index-only repo that now wants docs, with no provider/key configured."""
+    repo = _make_git_repo(tmp_path)
+    _index_full(repo)
+    base = _git(repo, "rev-parse", "HEAD")
+
+    from repowise.cli.helpers import save_state
+
+    # docs_enabled flipped on after an index-only start; the docs pointer sits
+    # at the indexed commit so the changed file below is docs work.
+    save_state(repo, {"last_sync_commit": base, "last_docs_commit": base, "docs_enabled": True})
+    new_head = _commit_change(
+        repo, "c.py", "from b import beta\n\n\ndef gamma():\n    return beta() * 2\n"
+    )
+    return repo, new_head
+
+
+class _StubPrompt:
+    """Stand-in for init's interactive provider prompt.
+
+    Records call count and mimics the real prompt's persistence side effect:
+    it sets the key in the environment and writes it to ``.repowise/.env``,
+    exactly as ``interactive_provider_config_select`` does for a real provider,
+    then returns a selection for the (unselectable-in-table) ``mock`` provider.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, console, model, reasoning=None, *, repo_path=None):
+        self.calls += 1
+        import os
+
+        from repowise.cli.ui.env_persistence import _save_key_to_dotenv
+
+        os.environ["MOCK_API_KEY"] = "sk-mock-test-key"
+        if repo_path is not None:
+            _save_key_to_dotenv(repo_path, "MOCK_API_KEY", "sk-mock-test-key")
+        return ProviderSelection("mock", "mock-model-1", "auto")
+
+
+def _force_interactive(monkeypatch) -> None:
+    """Open the docs-prompt gate as if a real interactive terminal were present.
+
+    The gate requires both a terminal stdout and a tty stdin; ``CliRunner``
+    provides neither, so patch the named gate helper directly rather than
+    faking two low-level tty signals.
+    """
+    monkeypatch.setattr(
+        "repowise.cli.commands.update_cmd.command._docs_provider_prompt_allowed",
+        lambda emitter: True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_prompts_and_persists_when_docs_needs_a_provider(tmp_path, monkeypatch) -> None:
+    repo, new_head = _prep_docs_repo_without_provider(tmp_path)
+
+    stub = _StubPrompt()
+    monkeypatch.setattr("repowise.cli.ui.interactive_provider_config_select", stub, raising=False)
+    _force_interactive(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["update", str(repo), "--no-workspace"])
+    assert result.exit_code == 0, result.output
+
+    # The prompt fired exactly once to onboard the provider.
+    assert stub.calls == 1
+
+    # provider/model persisted to config, key persisted to .repowise/.env.
+    cfg = _config(repo)
+    assert cfg.get("provider") == "mock"
+    assert cfg.get("model") == "mock-model-1"
+    env_text = (repo / ".repowise" / ".env").read_text(encoding="utf-8")
+    assert "MOCK_API_KEY=sk-mock-test-key" in env_text
+
+    # Docs were actually generated: the docs pointer advanced to HEAD.
+    state = json.loads((repo / ".repowise" / "state.json").read_text(encoding="utf-8"))
+    assert state["last_docs_commit"] == new_head
+
+    # A second docs run reuses the persisted provider without re-prompting.
+    # run_update releases its single-flight lock via atexit, which fires at
+    # process exit — but back-to-back CliRunner invokes share one process, so
+    # release it here to mimic the real per-process boundary (otherwise run2
+    # would bail as "another update already running").
+    from repowise.cli.helpers import release_update_lock
+
+    release_update_lock(repo)
+    second_head = _commit_change(
+        repo, "d.py", "from c import gamma\n\n\ndef delta():\n    return gamma() + 1\n"
+    )
+    result2 = CliRunner().invoke(cli, ["update", str(repo), "--no-workspace"])
+    assert result2.exit_code == 0, result2.output
+    assert stub.calls == 1, "provider already persisted; must not prompt again"
+    state2 = json.loads((repo / ".repowise" / "state.json").read_text(encoding="utf-8"))
+    assert state2["last_docs_commit"] == second_head
+
+
+def test_update_non_interactive_stays_a_clean_failure(tmp_path, monkeypatch) -> None:
+    repo, _ = _prep_docs_repo_without_provider(tmp_path)
+
+    stub = _StubPrompt()
+    monkeypatch.setattr("repowise.cli.ui.interactive_provider_config_select", stub, raising=False)
+    # No _force_interactive: under CliRunner stdin is not a tty and the console
+    # is not a terminal, so the prompt gate is closed (the hook / CI case).
+
+    result = CliRunner().invoke(cli, ["update", str(repo), "--no-workspace"])
+
+    # Clean, non-blocking failure — never prompted, never hung.
+    assert result.exit_code != 0
+    assert stub.calls == 0
+    assert "No provider configured" in result.output

--- a/tests/unit/cli/test_workspace_autodetect_e2e.py
+++ b/tests/unit/cli/test_workspace_autodetect_e2e.py
@@ -51,7 +51,7 @@ def test_update_from_workspace_root_does_not_create_stray_repowise(
     # spawn a real pipeline, so we intercept _workspace_update.
     called = {}
 
-    def _fake_workspace_update(target, *, dry_run, agents_md=None, verbose=False):
+    def _fake_workspace_update(target, *, dry_run, agents_md=None, verbose=False, **kwargs):
         called["target"] = target
         called["dry_run"] = dry_run
         called["agents_md"] = agents_md

--- a/tests/unit/cli/test_workspace_docs_pointer.py
+++ b/tests/unit/cli/test_workspace_docs_pointer.py
@@ -78,8 +78,10 @@ def test_workspace_update_backfills_docs_pointer(tmp_path: Path) -> None:
     _index_full(repo)
     c0 = _git(repo, "rev-parse", "HEAD")
 
-    # Simulate a state.json written before last_docs_commit existed.
-    save_state(repo, {SYNC_POINTER_KEY: c0, "docs_enabled": True})
+    # Simulate a state.json written before last_docs_commit existed. docs are
+    # disabled so `update --workspace` resolves to the index-only path — the
+    # path this pointer-backfill guard is about.
+    save_state(repo, {SYNC_POINTER_KEY: c0, "docs_enabled": False})
     assert DOCS_POINTER_KEY not in load_state(repo)
 
     c1 = _commit_change(repo, "c.py", "def gamma():\n    return 3\n", "add c.py")
@@ -107,7 +109,9 @@ def test_stale_prose_is_reachable_after_workspace_update(tmp_path: Path) -> None
 
     _index_full(repo)
     c0 = _git(repo, "rev-parse", "HEAD")
-    save_state(repo, {SYNC_POINTER_KEY: c0, "docs_enabled": True})
+    # docs disabled -> `update --workspace` stays index-only and only walks the
+    # sync pointer, which is the scenario that used to strand the docs pointer.
+    save_state(repo, {SYNC_POINTER_KEY: c0, "docs_enabled": False})
 
     c1 = _commit_change(repo, "c.py", "def gamma():\n    return 3\n", "add c.py")
     old_cwd = os.getcwd()
@@ -138,6 +142,35 @@ def test_stale_prose_is_reachable_after_workspace_update(tmp_path: Path) -> None
 
     state = _state(repo)
     assert state.get(DOCS_POINTER_KEY) == c2, "docs pointer should now reach HEAD"
+
+
+def test_workspace_update_regenerates_docs_for_docs_enabled_repo(tmp_path: Path) -> None:
+    """A plain `update --workspace` regenerates docs (not just the index) for a
+    member whose docs are enabled, so its wiki stays as fresh as a single-repo
+    update would keep it. The docs pointer reaching HEAD proves the docs path ran.
+    """
+    repo = _make_workspace(tmp_path)
+
+    _index_full(repo)
+    c0 = _git(repo, "rev-parse", "HEAD")
+    save_state(repo, {SYNC_POINTER_KEY: c0, DOCS_POINTER_KEY: c0, "docs_enabled": True})
+
+    c1 = _commit_change(repo, "c.py", "def gamma():\n    return 3\n", "add c.py")
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(str(repo))
+        result = CliRunner().invoke(cli, ["update", "--workspace", "--provider", "mock"])
+    finally:
+        os.chdir(old_cwd)
+    assert result.exit_code == 0, result.output
+
+    state = _state(repo)
+    assert state[SYNC_POINTER_KEY] == c1
+    assert state.get(DOCS_POINTER_KEY) == c1, (
+        "a docs-enabled member must regenerate docs and advance the docs pointer "
+        "on a plain workspace update"
+    )
 
 
 def test_docs_early_exit_advances_docs_pointer(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

A repo can start life index-only and later flip `docs_enabled` on (via config, or `repowise update --docs`) without a provider or key ever being configured. Until now, that docs run died with `No provider configured`. In the workspace flow it surfaced as a red per-repo error line.

This gives such a run the same smooth onboarding `init` already provides: when generation needs a provider but none is resolvable, an update running in an interactive terminal reuses init's provider + API-key prompt, persists the choice, and continues.

## How

- New `resolve_provider_or_prompt` helper wraps `resolve_provider`: on a miss it launches init's exact prompt (`interactive_provider_config_select`), persists provider/model to `.repowise/config.yaml` and the key to `.repowise/.env` (reusing init's own persistence), then re-resolves. It is a one-time prompt.
- `run_update` calls it at the generation provider-resolution site. Single-repo and workspace docs updates both flow through `run_update`, so both get this from one place; each workspace member persists on its own, and the first prompt sets the key in-process so later members auto-resolve.
- The prompt is gated on a terminal stdout **and** a tty stdin (plus non-JSON progress). Hooks, CI, and `--progress json` keep the existing clean, non-blocking failure; the stdin check keeps a background post-commit hook from blocking even when it inherits a `FORCE_COLOR` that makes the console report a terminal.

## Tests

- New `tests/unit/cli/test_update_provider_prompt.py`: a docs-enabled repo with no key runs a real pipeline through a stubbed interactive prompt, asserts docs generate and provider/model + key persist, and that a second run does not re-prompt. A companion test asserts the non-interactive path stays a clean failure with no hang.
- Existing update suites pass (one pre-existing, unrelated `test_update_e2e` degrade-path failure reproduces without this change).