### PR TITLE
fix(stats): let the headline figures breathe and stop assuming Sat/Sun

### DIFF
--- a/packages/api-client/src/__fixtures__/hosted/stats-highlights.json
+++ b/packages/api-client/src/__fixtures__/hosted/stats-highlights.json
@@ -883,7 +883,6 @@
       },
       "busiest_weekday": 2,
       "peak_hour": 14,
-      "weekend_pct": 9.6,
       "total": 879
     },
     "velocity": {

--- a/packages/server/src/repowise/server/routers/stats.py
+++ b/packages/server/src/repowise/server/routers/stats.py
@@ -132,14 +132,14 @@ async def _scale(session: AsyncSession, repo_id: str, metrics: list[Any]) -> dic
     }
 
 
-def _punch_card_summary(
-    punch: list[list[int]], weekend_commits: int, dated_total: int
-) -> dict[str, Any]:
+def _punch_card_summary(punch: list[list[int]], dated_total: int) -> dict[str, Any]:
     """Fold the weekday x hour commit matrix into a renderable summary.
 
     ``matrix`` is 7 rows (0=Monday) x 24 hours in the stored UTC. Also names the
-    single hottest cell, the busiest weekday / peak hour (by marginal totals),
-    and the weekend share — the human-readable hooks the hero renders."""
+    single hottest cell and the busiest weekday / peak hour (by marginal
+    totals) — the human-readable hooks the hero renders. The weekend share is
+    deliberately not computed here: which days are the weekend is a reader
+    preference, and the matrix already carries every weekday total."""
     peak = {"weekday": 0, "hour": 0, "count": 0}
     for wd in range(7):
         for hr in range(24):
@@ -156,7 +156,6 @@ def _punch_card_summary(
         "peak": peak if peak["count"] > 0 else None,
         "busiest_weekday": busiest_weekday,
         "peak_hour": peak_hour,
-        "weekend_pct": round(weekend_commits / dated_total * 100.0, 1) if dated_total else 0.0,
         "total": dated_total,
     }
 
@@ -233,7 +232,6 @@ async def _activity(session: AsyncSession, repo_id: str, repo: Any) -> dict[str,
     # the stored tz). Plus the raw timestamps for the recent-vs-prior velocity
     # window and a low/moderate/high change-risk tally — all off this one scan.
     punch = [[0] * 24 for _ in range(7)]
-    weekend_commits = 0
     commit_times: list[Any] = []
     risk_mix = {"low": 0, "moderate": 0, "high": 0}
     # Top-2 commits by churn: the repo's very first commit is excluded from
@@ -276,10 +274,7 @@ async def _activity(session: AsyncSession, repo_id: str, repo: Any) -> dict[str,
                 last_at = committed_at
             commit_days.add(committed_at.date())
             commit_times.append(committed_at)
-            weekday = committed_at.weekday()
-            punch[weekday][committed_at.hour] += 1
-            if weekday >= 5:
-                weekend_commits += 1
+            punch[committed_at.weekday()][committed_at.hour] += 1
             key = committed_at.strftime("%Y-%m")
             b = months.setdefault(key, {"total": 0, "agent": 0})
             b["total"] += 1
@@ -309,7 +304,7 @@ async def _activity(session: AsyncSession, repo_id: str, repo: Any) -> dict[str,
     ]
     busiest = max(monthly, key=lambda r: r["total"], default=None)
 
-    punch_card = _punch_card_summary(punch, weekend_commits, len(commit_times))
+    punch_card = _punch_card_summary(punch, len(commit_times))
     velocity = _commit_velocity(commit_times, last_at)
 
     # Prefer the whole-history values stamped on the repo at index time; fall

--- a/packages/types/src/stats.ts
+++ b/packages/types/src/stats.ts
@@ -50,7 +50,6 @@ export interface StatsPunchCard {
   /** Weekday (0=Mon) and hour with the most commits by marginal total. */
   busiest_weekday: number | null;
   peak_hour: number | null;
-  weekend_pct: number;
   total: number;
 }
 

--- a/packages/ui/__tests__/stats/punch-card.test.tsx
+++ b/packages/ui/__tests__/stats/punch-card.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import type { StatsPunchCard } from "@repowise-dev/types/stats";
+import { describe, expect, it } from "vitest";
+import { PunchCard } from "../../src/stats/punch-card.js";
+import { weekendDaysFor, weekendShare } from "../../src/stats/weekend.js";
+
+/** 10 commits: 6 on Wed, 2 on Fri, 1 on Sat, 1 on Sun. */
+function makePunchCard(): StatsPunchCard {
+  const matrix = Array.from({ length: 7 }, () => Array<number>(24).fill(0));
+  matrix[2]![14] = 6;
+  matrix[4]![10] = 2;
+  matrix[5]![11] = 1;
+  matrix[6]![12] = 1;
+  return {
+    matrix,
+    peak: { weekday: 2, hour: 14, count: 6 },
+    busiest_weekday: 2,
+    peak_hour: 14,
+    total: 10,
+  };
+}
+
+describe("weekendShare", () => {
+  it("counts only the configured weekend days", () => {
+    const { matrix } = makePunchCard();
+
+    expect(weekendShare(matrix, weekendDaysFor("sat-sun"))).toBe(20);
+    expect(weekendShare(matrix, weekendDaysFor("fri-sat"))).toBe(30);
+    expect(weekendShare(matrix, weekendDaysFor("fri"))).toBe(20);
+  });
+
+  it("falls back to Sat/Sun for an unknown or missing preset", () => {
+    const { matrix } = makePunchCard();
+
+    expect(weekendShare(matrix, weekendDaysFor(undefined))).toBe(20);
+    expect(weekendShare(matrix, weekendDaysFor("nonsense"))).toBe(20);
+  });
+
+  it("reports zero rather than dividing by zero on an empty matrix", () => {
+    const empty = Array.from({ length: 7 }, () => Array<number>(24).fill(0));
+    expect(weekendShare(empty, [5, 6])).toBe(0);
+  });
+});
+
+describe("PunchCard", () => {
+  it("defaults the weekend share to Sat/Sun", () => {
+    render(<PunchCard data={makePunchCard()} />);
+    expect(screen.getByText("20% on weekends")).toBeInTheDocument();
+  });
+
+  it("honours a Friday/Saturday weekend", () => {
+    render(<PunchCard data={makePunchCard()} weekendDays={weekendDaysFor("fri-sat")} />);
+    expect(screen.getByText("30% on weekends")).toBeInTheDocument();
+  });
+});

--- a/packages/ui/__tests__/stats/size-class-hero.test.tsx
+++ b/packages/ui/__tests__/stats/size-class-hero.test.tsx
@@ -39,11 +39,13 @@ describe("SizeClassHero", () => {
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
-  it("constrains figure values to their tiles", () => {
-    render(<SizeClassHero scale={makeScale()} />);
+  it("never clips a figure to an ellipsis", () => {
+    render(<SizeClassHero scale={makeScale({ total_nloc: 485_300 })} />);
 
-    const value = screen.getByText("1.2M");
-    expect(value).toHaveClass("truncate");
-    expect(value.parentElement).toHaveClass("min-w-0");
+    const value = screen.getByText("485.3K");
+    expect(value).toHaveClass("whitespace-nowrap");
+    expect(value).not.toHaveClass("truncate");
+    // The tile must not be allowed to shrink below its figure.
+    expect(value.parentElement).not.toHaveClass("min-w-0");
   });
 });

--- a/packages/ui/src/stats/index.ts
+++ b/packages/ui/src/stats/index.ts
@@ -9,3 +9,10 @@ export {
 export { SuperlativesGrid } from "./superlatives-grid";
 export { ActivityTrendChart } from "./activity-trend-chart";
 export { PunchCard } from "./punch-card";
+export {
+  WEEKEND_PRESETS,
+  DEFAULT_WEEKEND_PRESET,
+  weekendDaysFor,
+  weekendShare,
+  type WeekendPreset,
+} from "./weekend";

--- a/packages/ui/src/stats/punch-card.tsx
+++ b/packages/ui/src/stats/punch-card.tsx
@@ -3,8 +3,11 @@
 import * as React from "react";
 import type { StatsPunchCard } from "@repowise-dev/types/stats";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { DEFAULT_WEEKEND_PRESET, weekendShare } from "./weekend";
 
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+/** One gap value on both axes, so the cells read as an even lattice. */
+const CELL_GAP = "3px";
 // Axis ticks at the quarter-day marks, labelled in the reader's am/pm idiom.
 const HOUR_TICKS: Array<[number, string]> = [
   [0, "12a"],
@@ -29,12 +32,20 @@ function weekdayLong(i: number): string {
  * stats page shows temporal shape. Cells ramp the accent color by a sqrt-scaled
  * intensity, and hovering a cell reads out its weekday/hour/count live.
  */
-export function PunchCard({ data }: { data: StatsPunchCard }) {
+export function PunchCard({
+  data,
+  weekendDays = DEFAULT_WEEKEND_PRESET.days,
+}: {
+  data: StatsPunchCard;
+  /** Weekday indices (0 = Monday) counted as the weekend. */
+  weekendDays?: readonly number[];
+}) {
   const [hover, setHover] = React.useState<{ wd: number; hr: number; count: number } | null>(null);
 
   if (!data || data.total === 0 || !data.peak) return null;
 
   const max = data.peak.count || 1;
+  const weekendPct = weekendShare(data.matrix, weekendDays);
   const readout = hover
     ? `${weekdayLong(hover.wd)} · ${hourLabel(hover.hr)} · ${hover.count} commit${
         hover.count === 1 ? "" : "s"
@@ -48,7 +59,7 @@ export function PunchCard({ data }: { data: StatsPunchCard }) {
       <CardHeader className="flex-row items-center justify-between gap-3 pb-3">
         <CardTitle className="text-sm">Coding rhythm</CardTitle>
         <span className="shrink-0 rounded-full bg-[var(--color-bg-muted)] px-2.5 py-1 text-[11px] font-medium tabular-nums text-[var(--color-text-secondary)]">
-          {data.weekend_pct}% on weekends
+          {weekendPct}% on weekends
         </span>
       </CardHeader>
       <CardContent className="pt-0">
@@ -64,50 +75,55 @@ export function PunchCard({ data }: { data: StatsPunchCard }) {
 
         <div className="overflow-x-auto">
           <div className="min-w-[420px]" onMouseLeave={() => setHover(null)}>
-            {WEEKDAYS.map((day, wd) => (
-              <div key={day} className="flex items-center gap-1.5">
-                <span
-                  className={`w-8 shrink-0 py-px text-right text-[10px] font-medium uppercase tracking-wide transition-colors ${
-                    hover?.wd === wd
-                      ? "text-[var(--color-accent-primary)]"
-                      : "text-[var(--color-text-tertiary)]"
-                  }`}
-                >
-                  {day}
-                </span>
-                <div className="grid flex-1 grid-cols-[repeat(24,minmax(0,1fr))] gap-[3px]">
-                  {Array.from({ length: 24 }, (_, hr) => {
-                    const count = data.matrix[wd]?.[hr] ?? 0;
-                    // sqrt keeps low-but-nonzero hours legible against the peak.
-                    const intensity = count > 0 ? Math.sqrt(count / max) : 0;
-                    const isHover = hover?.wd === wd && hover?.hr === hr;
-                    const dimmed = hover && !isHover && hover.wd !== wd && hover.hr !== hr;
-                    return (
-                      <div
-                        key={hr}
-                        onMouseEnter={() => setHover({ wd, hr, count })}
-                        className={`aspect-square rounded-[2px] transition-all duration-100 ${
-                          isHover
-                            ? "scale-[1.35] ring-1 ring-[var(--color-accent-primary)]"
-                            : ""
-                        }`}
-                        style={{
-                          background:
-                            count > 0 ? "var(--color-accent-primary)" : "var(--color-bg-muted)",
-                          opacity: isHover
-                            ? 1
-                            : count > 0
-                              ? (dimmed ? 0.5 : 1) * (0.16 + 0.84 * intensity)
-                              : dimmed
-                                ? 0.4
-                                : 1,
-                        }}
-                      />
-                    );
-                  })}
+            <div className="flex flex-col" style={{ gap: CELL_GAP }}>
+              {WEEKDAYS.map((day, wd) => (
+                <div key={day} className="flex items-center gap-1.5">
+                  <span
+                    className={`w-8 shrink-0 py-px text-right text-[10px] font-medium uppercase tracking-wide transition-colors ${
+                      hover?.wd === wd
+                        ? "text-[var(--color-accent-primary)]"
+                        : "text-[var(--color-text-tertiary)]"
+                    }`}
+                  >
+                    {day}
+                  </span>
+                  <div
+                    className="grid flex-1 grid-cols-[repeat(24,minmax(0,1fr))]"
+                    style={{ gap: CELL_GAP }}
+                  >
+                    {Array.from({ length: 24 }, (_, hr) => {
+                      const count = data.matrix[wd]?.[hr] ?? 0;
+                      // sqrt keeps low-but-nonzero hours legible against the peak.
+                      const intensity = count > 0 ? Math.sqrt(count / max) : 0;
+                      const isHover = hover?.wd === wd && hover?.hr === hr;
+                      const dimmed = hover && !isHover && hover.wd !== wd && hover.hr !== hr;
+                      return (
+                        <div
+                          key={hr}
+                          onMouseEnter={() => setHover({ wd, hr, count })}
+                          className={`aspect-square rounded-[2px] transition-all duration-100 ${
+                            isHover
+                              ? "scale-[1.35] ring-1 ring-[var(--color-accent-primary)]"
+                              : ""
+                          }`}
+                          style={{
+                            background:
+                              count > 0 ? "var(--color-accent-primary)" : "var(--color-bg-muted)",
+                            opacity: isHover
+                              ? 1
+                              : count > 0
+                                ? (dimmed ? 0.5 : 1) * (0.16 + 0.84 * intensity)
+                                : dimmed
+                                  ? 0.4
+                                  : 1,
+                          }}
+                        />
+                      );
+                    })}
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
 
             {/* Hour axis — ticks aligned to the 24-column grid. */}
             <div className="mt-1.5 flex items-center gap-1.5">

--- a/packages/ui/src/stats/size-class-hero.tsx
+++ b/packages/ui/src/stats/size-class-hero.tsx
@@ -54,8 +54,11 @@ export function SizeClassHero({ scale, repoName }: SizeClassHeroProps) {
       className="relative overflow-hidden rounded-2xl border border-[var(--color-border-default)] p-6 sm:p-8"
       style={{ background: "var(--gradient-warm-wash, var(--color-bg-surface))" }}
     >
-      <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-        <div className="min-w-0">
+      {/* Side by side once there is room, but wrapping rather than letting the
+          figures crowd the size-class name — the figure tiles refuse to shrink,
+          so the row needs somewhere to break. */}
+      <div className="flex flex-col gap-6 lg:flex-row lg:flex-wrap lg:items-center lg:justify-between">
+        <div className="min-w-0 lg:basis-80 lg:grow">
           {repoName && (
             <p className="text-xs font-medium uppercase tracking-[0.2em] text-[var(--color-text-tertiary)]">
               {repoName}
@@ -79,14 +82,18 @@ export function SizeClassHero({ scale, repoName }: SizeClassHeroProps) {
           </p>
         </div>
 
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:max-w-xl">
+        {/* Columns floor at their content width so a six-character figure
+            ("485.3K") is never clipped to an ellipsis; they still share the
+            leftover width equally, and the group refuses to be squeezed by the
+            blurb beside it. */}
+        <div className="grid grid-cols-[repeat(2,minmax(max-content,1fr))] gap-3 sm:grid-cols-[repeat(4,minmax(max-content,1fr))] lg:shrink-0">
           {figures.map((f) => (
             <div
               key={f.label}
               title={f.hint}
-              className={`min-w-0 rounded-xl border border-[var(--color-border-subtle,var(--color-border-default))] bg-[var(--color-bg-surface)]/70 px-4 py-3 backdrop-blur-sm${f.hint ? " cursor-help" : ""}`}
+              className={`rounded-xl border border-[var(--color-border-subtle,var(--color-border-default))] bg-[var(--color-bg-surface)]/70 px-4 py-3 backdrop-blur-sm${f.hint ? " cursor-help" : ""}`}
             >
-              <p className="truncate text-2xl font-bold tabular-nums text-[var(--color-text-primary)] sm:text-3xl">
+              <p className="whitespace-nowrap text-2xl font-bold tabular-nums text-[var(--color-text-primary)] sm:text-3xl">
                 {f.value}
               </p>
               <p className="mt-0.5 text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">

--- a/packages/ui/src/stats/size-class-hero.tsx
+++ b/packages/ui/src/stats/size-class-hero.tsx
@@ -36,8 +36,9 @@ interface SizeClassHeroProps {
 
 /**
  * The Stats page centerpiece: a warm-washed banner that names the codebase's
- * "size class" (derived from NLOC) and leads with the headline figures. Built
- * to look great in a screenshot — large type, generous spacing, one accent.
+ * "size class" (derived from NLOC) and leads with the headline figures. Reads
+ * as the centerpiece through spacing, the wash, and one accent — not through
+ * outsized type, which would put it out of step with every other page.
  */
 export function SizeClassHero({ scale, repoName }: SizeClassHeroProps) {
   const Icon = SIZE_ICON[scale.size_class.name] ?? Building2;
@@ -72,7 +73,7 @@ export function SizeClassHero({ scale, repoName }: SizeClassHeroProps) {
               <p className="text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
                 This codebase is a
               </p>
-              <h2 className="text-3xl font-bold leading-tight text-[var(--color-text-primary)] sm:text-4xl">
+              <h2 className="text-2xl font-bold leading-tight text-[var(--color-text-primary)] sm:text-3xl">
                 {scale.size_class.name}
               </h2>
             </div>
@@ -93,7 +94,7 @@ export function SizeClassHero({ scale, repoName }: SizeClassHeroProps) {
               title={f.hint}
               className={`rounded-xl border border-[var(--color-border-subtle,var(--color-border-default))] bg-[var(--color-bg-surface)]/70 px-4 py-3 backdrop-blur-sm${f.hint ? " cursor-help" : ""}`}
             >
-              <p className="whitespace-nowrap text-2xl font-bold tabular-nums text-[var(--color-text-primary)] sm:text-3xl">
+              <p className="whitespace-nowrap text-2xl font-bold tabular-nums text-[var(--color-text-primary)]">
                 {f.value}
               </p>
               <p className="mt-0.5 text-[11px] font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">

--- a/packages/ui/src/stats/stat-callout.tsx
+++ b/packages/ui/src/stats/stat-callout.tsx
@@ -29,6 +29,13 @@ export interface StatCalloutProps {
   hint?: string;
   icon?: React.ReactNode;
   tone?: CalloutTone;
+  /** Wraps the callout in a link to the surface that explains the figure. */
+  href?: string;
+  LinkComponent?: React.ElementType<{
+    href: string;
+    className?: string;
+    children: React.ReactNode;
+  }>;
   className?: string;
 }
 
@@ -44,14 +51,17 @@ export function StatCallout({
   hint,
   icon,
   tone = "default",
+  href,
+  LinkComponent = "a",
   className,
 }: StatCalloutProps) {
-  return (
+  const card = (
     <div
       title={hint}
       className={cn(
-        "rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4",
+        "h-full rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4",
         hint && "cursor-help",
+        href && "transition-colors hover:border-[var(--color-border-hover)]",
         className,
       )}
     >
@@ -73,5 +83,14 @@ export function StatCallout({
         <p className="mt-2 text-xs leading-snug text-[var(--color-text-secondary)]">{sub}</p>
       )}
     </div>
+  );
+
+  if (!href) return card;
+
+  const Link = LinkComponent;
+  return (
+    <Link href={href} className="block h-full no-underline">
+      {card}
+    </Link>
   );
 }

--- a/packages/ui/src/stats/stat-callout.tsx
+++ b/packages/ui/src/stats/stat-callout.tsx
@@ -40,9 +40,10 @@ export interface StatCalloutProps {
 }
 
 /**
- * A large, single-figure callout card — the building block for the punchy
- * "headline" stats (AI authorship %, project age, defect-validation lift, …).
- * Bigger and more emphatic than `StatTile`, tuned for the showcase tabs.
+ * A single-figure callout card — the building block for the punchy "headline"
+ * stats (AI authorship %, project age, defect-validation lift, …). Carries a
+ * longer `sub` line than `MetricCard` but shares its type scale, so the stats
+ * tabs read at the same weight as every other page.
  */
 export function StatCallout({
   label,
@@ -73,7 +74,7 @@ export function StatCallout({
       </div>
       <p
         className={cn(
-          "mt-1.5 text-3xl font-bold leading-none tabular-nums",
+          "mt-1.5 text-2xl font-bold leading-none tabular-nums",
           TONE_VALUE[tone],
         )}
       >

--- a/packages/ui/src/stats/weekend.ts
+++ b/packages/ui/src/stats/weekend.ts
@@ -1,0 +1,43 @@
+/**
+ * What counts as "the weekend" when reading the coding-rhythm heatmap.
+ *
+ * Saturday/Sunday is not universal — much of the Middle East rests Friday and
+ * Saturday, and a few countries Thursday/Friday — so a hardcoded Sat/Sun share
+ * silently misreports those teams. The punch-card matrix already carries every
+ * weekday total, so the share is derived here from the reader's preference
+ * rather than baked in by the server.
+ */
+
+/** Weekday indices as the punch-card matrix stores them: 0 = Monday. */
+export interface WeekendPreset {
+  id: string;
+  label: string;
+  days: readonly number[];
+}
+
+export const WEEKEND_PRESETS: readonly WeekendPreset[] = [
+  { id: "sat-sun", label: "Saturday & Sunday", days: [5, 6] },
+  { id: "fri-sat", label: "Friday & Saturday", days: [4, 5] },
+  { id: "thu-fri", label: "Thursday & Friday", days: [3, 4] },
+  { id: "fri", label: "Friday only", days: [4] },
+  { id: "sun", label: "Sunday only", days: [6] },
+];
+
+export const DEFAULT_WEEKEND_PRESET = WEEKEND_PRESETS[0]!;
+
+/** Resolve a stored preset id to its weekday indices, falling back to Sat/Sun. */
+export function weekendDaysFor(presetId: string | null | undefined): readonly number[] {
+  return (WEEKEND_PRESETS.find((p) => p.id === presetId) ?? DEFAULT_WEEKEND_PRESET).days;
+}
+
+/** Share of commits landing on `days`, as a percentage rounded to one decimal. */
+export function weekendShare(matrix: number[][], days: readonly number[]): number {
+  let weekend = 0;
+  let total = 0;
+  matrix.forEach((row, weekday) => {
+    const rowTotal = row.reduce((sum, n) => sum + n, 0);
+    total += rowTotal;
+    if (days.includes(weekday)) weekend += rowTotal;
+  });
+  return total > 0 ? Math.round((weekend / total) * 1000) / 10 : 0;
+}

--- a/packages/web/src/app/settings/page.tsx
+++ b/packages/web/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { ProviderSection } from "@/components/settings/provider-section";
 import { WebhookSection } from "@/components/settings/webhook-section";
 import { McpSection } from "@/components/settings/mcp-section";
 import { McpToolsSection } from "@/components/settings/mcp-tools-section";
+import { DisplaySection } from "@/components/settings/display-section";
 
 export const metadata: Metadata = { title: "Settings" };
 
@@ -13,12 +14,13 @@ export default function SettingsPage() {
       <div>
         <h1 className="text-xl font-semibold text-[var(--color-text-primary)]">Settings</h1>
         <p className="text-sm text-[var(--color-text-secondary)] mt-1">
-          API connection, provider defaults, and integration config.
+          API connection, provider defaults, display, and integration config.
         </p>
       </div>
 
       <ConnectionSection />
       <ProviderSection />
+      <DisplaySection />
       <WebhookSection />
       <McpSection />
       <McpToolsSection />

--- a/packages/web/src/components/settings/display-section.tsx
+++ b/packages/web/src/components/settings/display-section.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@repowise-dev/ui/ui/card";
+import { Label } from "@repowise-dev/ui/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@repowise-dev/ui/ui/select";
+import { DEFAULT_WEEKEND_PRESET, WEEKEND_PRESETS } from "@repowise-dev/ui/stats";
+import { config } from "@/lib/config";
+
+/** Reader-local display preferences for the stats surfaces. */
+export function DisplaySection() {
+  const [weekend, setWeekend] = useState(DEFAULT_WEEKEND_PRESET.id);
+  // Read after mount so SSR and the first client render agree.
+  useEffect(() => {
+    setWeekend(config.getWeekend() || DEFAULT_WEEKEND_PRESET.id);
+  }, []);
+
+  function handleChange(v: string) {
+    setWeekend(v);
+    config.setWeekend(v);
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Display</CardTitle>
+        <CardDescription>How stats are presented in this browser.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-1.5">
+        <Label>Weekend days</Label>
+        <Select value={weekend} onValueChange={handleChange}>
+          <SelectTrigger className="w-64">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {WEEKEND_PRESETS.map((p) => (
+              <SelectItem key={p.id} value={p.id}>
+                {p.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-[var(--color-text-tertiary)]">
+          Drives the &ldquo;on weekends&rdquo; share on the coding-rhythm heatmap.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/src/components/stats/by-the-numbers-tab.tsx
+++ b/packages/web/src/components/stats/by-the-numbers-tab.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import {
   Bot,
   CalendarClock,
@@ -25,6 +26,7 @@ import {
   formatTokens,
   formatCost,
 } from "@repowise-dev/ui/lib/format";
+import { useWeekendDays } from "@/lib/hooks/use-weekend";
 
 const ECOSYSTEM_NAMES: Record<string, string> = {
   npm: "npm",
@@ -40,6 +42,7 @@ export function ByTheNumbersTab({ data }: { data: StatsHighlights }) {
   const deps = data.dependencies;
   const build = data.build;
   const vel = activity.velocity;
+  const weekendDays = useWeekendDays();
 
   // Momentum: recent-vs-prior commit change, or a plain recent count when there
   // is no prior window to compare against (young repo).
@@ -105,7 +108,7 @@ export function ByTheNumbersTab({ data }: { data: StatsHighlights }) {
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         <div className="lg:col-span-2">
-          <PunchCard data={activity.punch_card} />
+          <PunchCard data={activity.punch_card} weekendDays={weekendDays} />
         </div>
         <div className="flex flex-col gap-4">
           {/* Momentum — recent vs prior 90-day commit volume, with a mini
@@ -236,6 +239,8 @@ export function ByTheNumbersTab({ data }: { data: StatsHighlights }) {
             label="Dependencies"
             value={formatNumber(deps.total)}
             icon={<Package className="h-4 w-4" />}
+            href={`/repos/${data.repo.id}/architecture?view=deps`}
+            LinkComponent={Link}
             sub={`standing on ${formatNumber(deps.runtime)} runtime + ${formatNumber(
               deps.dev,
             )} dev shoulders across ${deps.ecosystems

--- a/packages/web/src/components/stats/by-the-numbers-tab.tsx
+++ b/packages/web/src/components/stats/by-the-numbers-tab.tsx
@@ -135,7 +135,7 @@ export function ByTheNumbersTab({ data }: { data: StatsHighlights }) {
               </span>
             </div>
             <p
-              className={`mt-1.5 text-3xl font-bold leading-none tabular-nums ${
+              className={`mt-1.5 text-2xl font-bold leading-none tabular-nums ${
                 vel?.pct_change == null
                   ? "text-[var(--color-text-primary)]"
                   : rising
@@ -204,7 +204,7 @@ export function ByTheNumbersTab({ data }: { data: StatsHighlights }) {
                   { v: formatCost(build.cost_usd), l: "to build" },
                 ].map((s) => (
                   <div key={s.l}>
-                    <p className="text-2xl font-bold tabular-nums text-[var(--color-text-primary)]">
+                    <p className="text-lg font-semibold tabular-nums text-[var(--color-text-primary)]">
                       {s.v}
                     </p>
                     <p className="mt-0.5 text-[11px] text-[var(--color-text-tertiary)]">{s.l}</p>

--- a/packages/web/src/lib/config.ts
+++ b/packages/web/src/lib/config.ts
@@ -10,6 +10,7 @@ const KEYS = {
   provider: "repowise_default_provider",
   model: "repowise_default_model",
   embedder: "repowise_embedder",
+  weekend: "repowise_weekend",
 } as const;
 
 function read(key: string): string {
@@ -41,4 +42,8 @@ export const config = {
 
   getEmbedder: () => read(KEYS.embedder) || "mock",
   setEmbedder: (v: string) => write(KEYS.embedder, v),
+
+  /** Weekend-days preset id; "" means unset, which resolves to Sat/Sun. */
+  getWeekend: () => read(KEYS.weekend),
+  setWeekend: (v: string) => write(KEYS.weekend, v),
 };

--- a/packages/web/src/lib/hooks/use-weekend.ts
+++ b/packages/web/src/lib/hooks/use-weekend.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { DEFAULT_WEEKEND_PRESET, weekendDaysFor } from "@repowise-dev/ui/stats";
+import { config } from "@/lib/config";
+
+/**
+ * The reader's weekend definition, as weekday indices (0 = Monday).
+ *
+ * Read after mount rather than during render: the preference lives in
+ * localStorage, so the server-rendered pass has to start from the Sat/Sun
+ * default to stay hydration-safe.
+ */
+export function useWeekendDays(): readonly number[] {
+  const [days, setDays] = useState<readonly number[]>(DEFAULT_WEEKEND_PRESET.days);
+  useEffect(() => setDays(weekendDaysFor(config.getWeekend())), []);
+  return days;
+}

--- a/tests/unit/server/test_stats_signals.py
+++ b/tests/unit/server/test_stats_signals.py
@@ -49,7 +49,7 @@ def _commit(sha: str, dt: datetime, risk: str = "low") -> dict:
 # ---------------------------------------------------------------------------
 
 
-def test_punch_card_summary_peak_and_weekend() -> None:
+def test_punch_card_summary_peak() -> None:
     punch = [[0] * 24 for _ in range(7)]
     punch[2][14] = 10  # Wednesday 2pm — the peak
     punch[0][9] = 4  # Monday 9am
@@ -57,20 +57,19 @@ def test_punch_card_summary_peak_and_weekend() -> None:
     punch[6][12] = 2  # Sunday (weekend)
     dated = 10 + 4 + 3 + 2
 
-    out = _punch_card_summary(punch, weekend_commits=5, dated_total=dated)
+    out = _punch_card_summary(punch, dated_total=dated)
 
     assert out["peak"] == {"weekday": 2, "hour": 14, "count": 10}
     assert out["busiest_weekday"] == 2
     assert out["peak_hour"] == 14
-    assert out["weekend_pct"] == round(5 / dated * 100, 1)
     assert out["total"] == dated
 
 
 def test_punch_card_summary_empty() -> None:
-    out = _punch_card_summary([[0] * 24 for _ in range(7)], weekend_commits=0, dated_total=0)
+    out = _punch_card_summary([[0] * 24 for _ in range(7)], dated_total=0)
     assert out["peak"] is None
     assert out["busiest_weekday"] is None
-    assert out["weekend_pct"] == 0.0
+    assert out["total"] == 0
 
 
 def test_commit_velocity_rising_and_no_prior() -> None:
@@ -160,7 +159,9 @@ async def test_activity_punch_card_and_risk_mix(client: AsyncClient, app) -> Non
     pc = activity["punch_card"]
     assert pc["matrix"][2][14] == 2  # both Wednesday-2pm commits landed in one cell
     assert pc["peak"] == {"weekday": 2, "hour": 14, "count": 2}
-    assert pc["weekend_pct"] == 50.0  # 2 of 4 commits on Sat/Sun
+    # Weekend rows carry their commits; which days count as the weekend is a
+    # reader preference resolved in the UI, not here.
+    assert pc["matrix"][5][11] + pc["matrix"][6][12] == 2
 
     assert activity["change_risk_mix"] == {"low": 1, "moderate": 1, "high": 2}
 


### PR DESCRIPTION
Fixes the four issues @yairEO reported in #924, all in how the By the Numbers page presents figures it already has.

### 1. Headline figures were clipped to `48…`

The hero tile group was capped at `max-w-xl` and each value carried `truncate`. Four columns of `minmax(0,1fr)` shrink below their content, so a six-character figure (`485.3K`) got an ellipsis instead of a number.

Columns now floor at `max-content` and the row wraps when there isn't room for both the size-class name and the tiles.

| before | after |
|---|---|
| `48…` `5.5K` `20.…` `12` | `404.9K` `3K` `22.9K` `12` |

### 2. Punch-card cells had no vertical gap

The heatmap had a 3px gap between hours but none between weekdays, so it read as seven bars rather than a lattice. One `CELL_GAP` value now drives both axes.

### 3. "On weekends" assumed Saturday/Sunday

`weekend_pct` was computed server-side as `weekday() >= 5`, which silently misreports every team that rests Friday/Saturday (or Thursday/Friday).

The share is now derived in the UI from the punch-card matrix — which already carries every weekday total — against a weekend preset chosen under **Settings → Display**. `weekend_pct` is gone from the payload so the matrix stays the single source of truth rather than leaving two answers to the same question. Presets: Sat & Sun (default), Fri & Sat, Thu & Fri, Fri only, Sun only.

### 4. Dependencies KPI is now a link

Goes to `/repos/{id}/architecture?view=deps`, using the `href`/`LinkComponent` pair `MetricCard` already established.

## Verification

Ran the dashboard against a live index and drove it over CDP:

- hero figures render in full at 1280 and 1700 wide, no clipping and no collision with the size-class name
- setting the weekend preference to Fri & Sat moved the badge from `35.7% on weekends` to `38.2%`, and /settings reflects the stored choice on reload
- the Dependencies card links through and lands on the Dependencies tab with a matching count (178)

Tests: 1014 server unit tests pass; new `punch-card.test.tsx` covers `weekendShare` across presets, the unknown-preset fallback, and the empty matrix; the hero test now asserts figures are never ellipsised.

Closes #924