### PR TITLE
feat(costs): count the agent savings the ledger was dropping

### DIFF
--- a/packages/core/src/repowise/core/generation/cost_tracker.py
+++ b/packages/core/src/repowise/core/generation/cost_tracker.py
@@ -37,7 +37,7 @@ _PRICING: dict[str, dict[str, float]] = {
     "gpt-5-mini": {"input": 0.25, "output": 2.0},
     # Nano tier — $0.05/$0.40 per 1M. Without these keys the model name falls
     # through to ``_FALLBACK_PRICING`` (Sonnet $3/$15) and overstates a nano
-    # indexing run ~40×.
+    # indexing run ~40x.
     "gpt-5-nano": {"input": 0.05, "output": 0.40},
     "gpt-5.4-nano": {"input": 0.05, "output": 0.40},
     "gpt-4o": {"input": 2.5, "output": 10.0},
@@ -90,12 +90,48 @@ def is_local_model(model: str) -> bool:
     )
 
 
+#: Family-tier fallback, tried before the flat ``_FALLBACK_PRICING`` when a
+#: model id isn't an exact ``_PRICING`` key. A dated or point-variant id — a
+#: session transcript reporting ``claude-opus-4-8-20260514`` or a future
+#: ``claude-opus-4-9`` — carries its *tier* unambiguously in the name prefix.
+#: Matching the tier here stops an Opus coding session from being mispriced at
+#: the Sonnet fallback rate, which would undercount the agent savings it earned
+#: by ~5x. Ordered longest/most-specific prefix first.
+_CLAUDE_FAMILY_PRICING: tuple[tuple[str, dict[str, float]], ...] = (
+    ("claude-opus", {"input": 15.0, "output": 75.0}),
+    ("claude-sonnet", {"input": 3.0, "output": 15.0}),
+    ("claude-haiku", {"input": 0.8, "output": 4.0}),
+)
+
+
+def _family_pricing(model: str) -> dict[str, float] | None:
+    """Tier pricing inferred from a model-name family prefix, or ``None``.
+
+    Covers the Anthropic tiers by prefix and the GPT-5 tiers by the ``nano`` /
+    ``mini`` qualifier, so a variant id the exact table misses still resolves to
+    the right tier instead of the flat Sonnet-priced fallback.
+    """
+    for prefix, pricing in _CLAUDE_FAMILY_PRICING:
+        if model.startswith(prefix):
+            return pricing
+    if model.startswith("gpt-5"):
+        if "nano" in model:
+            return {"input": 0.05, "output": 0.40}
+        if "mini" in model:
+            return {"input": 0.25, "output": 2.0}
+        return {"input": 1.25, "output": 10.0}
+    return None
+
+
 def _get_pricing(model: str) -> dict[str, float]:
     """Return pricing for *model*, falling back and warning if unknown."""
     if is_local_model(model):
         return {"input": 0.0, "output": 0.0}
     if model in _PRICING:
         return _PRICING[model]
+    family = _family_pricing(model)
+    if family is not None:
+        return family
     if model not in _warned_models:
         log.warning("cost_tracker.unknown_model", model=model, fallback=_FALLBACK_PRICING)
         _warned_models.add(model)

--- a/packages/server/src/repowise/server/mcp_server/_savings/counterfactual.py
+++ b/packages/server/src/repowise/server/mcp_server/_savings/counterfactual.py
@@ -28,27 +28,61 @@ from typing import Any
 SEARCH_FLOOR_PER_HIT = 400
 
 
-def _estimate_get_context(result: dict[str, Any]) -> int:
-    """Σ full-file tokens the skeleton/doc replaced, over file targets.
+#: A ``get_context`` *module* card lists the module's child files (each with a
+#: one-line summary); the agent would otherwise glob the directory and open
+#: those files to learn what the module does. Credit a low per-listed-file
+#: floor — well under a real Read, since the card only carries the summary.
+#: The child-page query is recursive and uncapped, so a top-level module can
+#: list hundreds of files; ``CONTEXT_MODULE_MAX`` caps the per-target credit
+#: because the agent would never actually have opened all of them. The cap is
+#: set at roughly eight full file reads: orienting in a large unfamiliar module
+#: without this card means globbing the tree (the path listing alone runs to
+#: thousands of tokens at that size) and opening five to fifteen files, so the
+#: real counterfactual sits higher still — the cap keeps the claim an undersell
+#: while leaving the per-file scaling meaningful for mid-sized modules.
+CONTEXT_MODULE_FILE_FLOOR = 250
+CONTEXT_MODULE_MAX = 12_000
 
-    ``get_context`` auto-upgrades file targets to a body-elided *skeleton*; each
-    such target carries ``skeleton.full_tokens`` — the exact size of the file
-    the agent would have Read instead. Summing those is a precise, dict-only
-    counterfactual. Targets without a skeleton (small-file cards, module/symbol
-    targets) contribute nothing.
+#: A ``get_context`` *symbol* card carries the signature, docstring and usage
+#: sites for one symbol — standing in for the agent locating and reading that
+#: definition plus scanning who calls it. A single conservative floor.
+CONTEXT_SYMBOL_FLOOR = 350
+
+
+def _estimate_get_context(result: dict[str, Any]) -> int:
+    """Raw exploration the card replaced, summed over every target.
+
+    File targets: ``get_context`` auto-upgrades them to a body-elided
+    *skeleton* carrying ``skeleton.full_tokens`` — the exact size of the file
+    the agent would have Read instead; summing those is a precise, dict-only
+    counterfactual. Module and symbol targets carry no skeleton, so they used
+    to contribute nothing; they now earn a conservative floor (see the module
+    /symbol constants above) for the directory globbing / symbol lookup they
+    each replace. Small-file file cards (no skeleton) still contribute nothing
+    — a short file is about as cheap to Read directly.
     """
     targets = result.get("targets")
     if not isinstance(targets, dict):
         return 0
     total = 0
     for target in targets.values():
-        if not isinstance(target, dict):
+        if not isinstance(target, dict) or target.get("error"):
             continue
         skeleton = target.get("skeleton")
         if isinstance(skeleton, dict):
             full = skeleton.get("full_tokens")
             if isinstance(full, int) and full > 0:
                 total += full
+                # The skeleton already accounts for this file's full Read cost.
+                continue
+        target_type = target.get("type")
+        if target_type == "module":
+            docs = target.get("docs")
+            files = docs.get("files") if isinstance(docs, dict) else None
+            if isinstance(files, list) and files:
+                total += min(CONTEXT_MODULE_MAX, len(files) * CONTEXT_MODULE_FILE_FLOOR)
+        elif target_type == "symbol":
+            total += CONTEXT_SYMBOL_FLOOR
     return total
 
 
@@ -85,6 +119,38 @@ WHY_FLOOR = 400
 HEALTH_FLOOR = 400
 OVERVIEW_FLOOR = 1200
 
+#: ``get_change_risk`` reasons about a whole diff's defect risk — standing in
+#: for the agent reading the diff and its coverage/co-change context by hand.
+CHANGE_RISK_FLOOR = 500
+#: ``get_architecture`` renders the C4 map — replacing a read of many files and
+#: entry points to infer how the system is layered (workspace-level, so higher).
+ARCHITECTURE_FLOOR = 1200
+#: ``get_dependency_path`` returns the import chain between two files — replacing
+#: the agent tracing imports hop by hop.
+DEPENDENCY_FLOOR = 300
+#: ``get_conformance`` checks contract conformance — replacing cross-file /
+#: cross-repo contract reading.
+CONFORMANCE_FLOOR = 400
+
+#: Signal-scaled floors: where a tool's result *names* the files or graph nodes
+#: its answer replaced, credit grows with that count (still bounded and
+#: undersold) instead of a flat floor.
+#:  * ``get_risk`` — per assessed target (a file whose history the agent would
+#:    reconstruct) plus per PR blast-radius file it surfaces.
+RISK_PER_TARGET = 300
+RISK_PER_RELATED_FILE = 120
+#:  * ``get_blast_radius`` — per downstream file that breaks (one the agent
+#:    would otherwise trace across repos), capped so a huge fan-out still
+#:    undersells.
+BLAST_FLOOR = 400
+BLAST_PER_IMPACTED = 150
+BLAST_MAX = 6000
+#:  * ``get_execution_flows`` — per node on a traced flow (a call-graph hop the
+#:    agent would follow by opening files), capped likewise.
+FLOWS_FLOOR = 400
+FLOWS_PER_NODE = 80
+FLOWS_MAX = 6000
+
 
 def _estimate_get_answer(result: dict[str, Any]) -> int:
     """Search call + cited-file reads the answer obviated.
@@ -114,16 +180,95 @@ def _fixed_floor(tokens: int) -> Callable[[dict[str, Any]], int]:
     return _estimate
 
 
-#: Tool name → estimator. Tools absent here emit no counterfactual (skip).
+def _estimate_get_risk(result: dict[str, Any]) -> int:
+    """Per assessed target + per PR blast-radius file, floored at ``RISK_FLOOR``.
+
+    Each ``targets`` entry is a file whose churn/ownership/co-change history the
+    agent would otherwise reconstruct from ``git log``/``git blame``. PR mode
+    adds a ``directive`` naming the files that break (``will_break``) and the
+    co-change partners the diff missed — each one more file the agent would
+    have had to find by hand.
+    """
+    if result.get("error"):
+        return 0
+    targets = result.get("targets")
+    total = len(targets) * RISK_PER_TARGET if isinstance(targets, dict) else 0
+    directive = result.get("directive")
+    if isinstance(directive, dict):
+        # Union the two lists: a file that both breaks and is a missed
+        # co-change partner is still just one file the agent would open.
+        related_files: set[str] = set()
+        for key in ("will_break", "missing_cochanges"):
+            related = directive.get(key)
+            if isinstance(related, list):
+                related_files.update(f for f in related if isinstance(f, str))
+        total += len(related_files) * RISK_PER_RELATED_FILE
+    return max(RISK_FLOOR, total)
+
+
+def _estimate_get_blast_radius(result: dict[str, Any]) -> int:
+    """Per downstream file the change breaks, floored and capped.
+
+    ``total_impacted`` counts the files the agent would otherwise trace across
+    repos to answer "what breaks if I change this". Undersold to a per-file
+    floor and capped so a large fan-out never overstates.
+    """
+    if result.get("error"):
+        return 0
+    impacted = result.get("total_impacted")
+    n = impacted if isinstance(impacted, int) and impacted > 0 else 0
+    return min(BLAST_MAX, max(BLAST_FLOOR, n * BLAST_PER_IMPACTED))
+
+
+def _estimate_get_execution_flows(result: dict[str, Any]) -> int:
+    """Per node across every traced flow, floored and capped.
+
+    Each node on a flow's ``trace`` is a call-graph hop the agent would follow
+    by opening the next file. Falls back to ``depth + 1`` when a flow omits its
+    node list. Errors / empty results contribute nothing.
+    """
+    if result.get("error"):
+        return 0
+    flows = result.get("flows")
+    if not isinstance(flows, list) or not flows:
+        return 0
+    nodes = 0
+    for flow in flows:
+        if not isinstance(flow, dict):
+            continue
+        trace = flow.get("trace")
+        if isinstance(trace, list):
+            nodes += len(trace)
+        elif isinstance(flow.get("depth"), int):
+            nodes += flow["depth"] + 1
+    if nodes <= 0:
+        return 0
+    return min(FLOWS_MAX, max(FLOWS_FLOOR, nodes * FLOWS_PER_NODE))
+
+
+#: Tool name → estimator. Tools absent here emit no counterfactual (skip). Every
+#: agent-facing tool that replaces real exploration is listed: leaving a tool
+#: out means it can never earn credit yet still takes a dead-end debit on an
+#: error (``recorder.record_mcp_dead_end``), so its ledger contribution could
+#: only ever go negative. Listing a tool here is necessary but not sufficient to
+#: even that out — ``recorder.record_mcp_saving`` still drops any row whose
+#: counterfactual doesn't exceed the delivered response, so a floor set below a
+#: tool's own answer size records nothing (undersell by omission, by design).
 _ESTIMATORS: dict[str, Callable[[dict[str, Any]], int]] = {
     "get_context": _estimate_get_context,
     "search_codebase": _estimate_search_codebase,
     "get_answer": _estimate_get_answer,
-    "get_risk": _fixed_floor(RISK_FLOOR),
+    "get_risk": _estimate_get_risk,
     "get_why": _fixed_floor(WHY_FLOOR),
     "get_health": _fixed_floor(HEALTH_FLOOR),
     "get_overview": _fixed_floor(OVERVIEW_FLOOR),
     "get_dead_code": _fixed_floor(DEAD_CODE_FLOOR),
+    "get_change_risk": _fixed_floor(CHANGE_RISK_FLOOR),
+    "get_blast_radius": _estimate_get_blast_radius,
+    "get_execution_flows": _estimate_get_execution_flows,
+    "get_architecture": _fixed_floor(ARCHITECTURE_FLOOR),
+    "get_dependency_path": _fixed_floor(DEPENDENCY_FLOOR),
+    "get_conformance": _fixed_floor(CONFORMANCE_FLOOR),
 }
 
 

--- a/packages/server/src/repowise/server/routers/costs.py
+++ b/packages/server/src/repowise/server/routers/costs.py
@@ -28,6 +28,15 @@ router = APIRouter(
 )
 
 
+#: Output tokens credited per answered counterfactual MCP query. Each curated
+#: answer stands in for at least one raw exploration tool call the agent never
+#: had to emit (README markets "-70% tool calls"), and that invocation is output
+#: tokens we otherwise ignore. Deliberately one avoided call's worth (~a tool_use
+#: block), not the several reads a single answer often replaces, so the credit
+#: stays an undersell; priced at the agent's output rate below.
+_AVOIDED_CALL_OUTPUT_TOKENS = 60
+
+
 def _parse_since(since: str | None) -> datetime | None:
     """Parse an ISO date string (YYYY-MM-DD) into a datetime, or return None."""
     if since is None:
@@ -167,9 +176,7 @@ async def get_distill_savings(
     finally:
         conn.close()
 
-    per_filter = [
-        {"group": name, **stats} for name, stats in summary["per_filter"].items()
-    ]
+    per_filter = [{"group": name, **stats} for name, stats in summary["per_filter"].items()]
 
     # Missed savings: best-effort scan of local agent transcripts; the module
     # degrades to an empty report on any failure, never raises.
@@ -182,15 +189,28 @@ async def get_distill_savings(
     # Price at the coding agent's actual model — saved tokens are input tokens
     # that agent never had to read. Detection is best-effort (sonnet default).
     resolved = resolve_session_model(Path(repo.local_path))
-    rate = get_model_pricing(resolved.model)["input"]
+    pricing = get_model_pricing(resolved.model)
     total_saved = summary["saved_tokens"] + mcp["tokens"]
+    input_usd = total_saved * pricing["input"] / 1_000_000
+    # Add a small credit for the tool-call output the agent never had to emit:
+    # every answered counterfactual MCP query replaced at least one raw
+    # exploration call. Priced at the output rate; see _AVOIDED_CALL_OUTPUT_TOKENS.
+    # Counted over net-positive counterfactual rows only — a dead-end (error)
+    # call is recorded as a debit and saved the agent nothing, so crediting its
+    # output would flip that debit into a credit.
+    avoided_calls = sum(
+        row["events"]
+        for row in mcp["per_tool"]
+        if row.get("kind") == "counterfactual" and row.get("tokens", 0) > 0
+    )
+    output_usd = avoided_calls * _AVOIDED_CALL_OUTPUT_TOKENS * pricing["output"] / 1_000_000
     return DistillSavingsResponse(
         available=True,
         events=summary["events"],
         raw_tokens=summary["raw_tokens"],
         distilled_tokens=summary["distilled_tokens"],
         saved_tokens=summary["saved_tokens"],
-        estimated_usd_saved=total_saved * rate / 1_000_000,
+        estimated_usd_saved=input_usd + output_usd,
         pricing_model=resolved.model,
         pricing_agent=resolved.agent,
         pricing_source=resolved.source,

--- a/packages/ui/src/costs/distill-savings-card.tsx
+++ b/packages/ui/src/costs/distill-savings-card.tsx
@@ -262,8 +262,9 @@ export function DistillSavingsCard({ data }: DistillSavingsCardProps) {
         <p className="mt-3 text-xs leading-snug text-[var(--color-text-tertiary)]">
           Distill counts <code>repowise distill</code> command/hook savings; MCP counts the raw
           file exploration each tool answer replaced (plus any over-budget content trimmed). Saved
-          tokens are agent input, priced at the agent&apos;s input rate; counts are estimates
-          (~chars/4) and deliberately undersell. Everything stays on this machine.
+          tokens are agent input priced at the agent&apos;s input rate, plus a small credit for the
+          tool calls repowise let the agent skip; counts are estimates (~chars/4) and deliberately
+          undersell. Everything stays on this machine.
         </p>
       </CardContent>
     </Card>

--- a/tests/unit/generation/test_cost_pricing.py
+++ b/tests/unit/generation/test_cost_pricing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from repowise.core.generation.cost_tracker import (
     _FALLBACK_PRICING,
+    _family_pricing,
     get_model_pricing,
 )
 
@@ -21,3 +22,28 @@ def test_nano_models_priced_at_nano_rate_not_fallback() -> None:
 
 def test_unknown_model_still_falls_back() -> None:
     assert get_model_pricing("totally-made-up-model-9000") == _FALLBACK_PRICING
+
+
+def test_dated_opus_variant_prices_at_opus_tier_not_sonnet_fallback() -> None:
+    # An Opus session id the exact table misses (dated / future point release)
+    # must resolve to the Opus tier, not the Sonnet-priced fallback — otherwise
+    # an Opus user's savings are undercounted ~5x.
+    for model in ("claude-opus-4-8-20260514", "claude-opus-4-9", "claude-opus-5"):
+        pricing = get_model_pricing(model)
+        assert pricing == {"input": 15.0, "output": 75.0}
+        assert pricing != _FALLBACK_PRICING
+
+
+def test_family_prefix_covers_sonnet_and_haiku_variants() -> None:
+    # Sonnet's tier is byte-identical to _FALLBACK_PRICING, so assert the family
+    # matcher actually resolved it rather than the value alone.
+    assert _family_pricing("claude-sonnet-4-9") == {"input": 3.0, "output": 15.0}
+    assert _family_pricing("totally-made-up-model-9000") is None
+    assert get_model_pricing("claude-haiku-5") == {"input": 0.8, "output": 4.0}
+
+
+def test_gpt5_variants_resolve_by_tier_qualifier() -> None:
+    assert get_model_pricing("gpt-5.5-nano") == {"input": 0.05, "output": 0.40}
+    assert get_model_pricing("gpt-5.5-mini") == {"input": 0.25, "output": 2.0}
+    # A plain future gpt-5 variant gets the base GPT-5 tier, not the fallback.
+    assert get_model_pricing("gpt-5.5") == {"input": 1.25, "output": 10.0}

--- a/tests/unit/server/mcp/test_counterfactual.py
+++ b/tests/unit/server/mcp/test_counterfactual.py
@@ -86,6 +86,119 @@ def test_fixed_floor_tools_credit_successful_calls_only() -> None:
     assert cf.replaced_tokens_for("get_health", {"summary": {}}) == cf.HEALTH_FLOOR
 
 
+def test_get_context_module_credits_per_child_file() -> None:
+    # A module card lists child files the agent would otherwise open one by one.
+    result = {
+        "targets": {
+            "src/api": {
+                "target": "src/api",
+                "type": "module",
+                "docs": {"files": [{"path": "src/api/a.py"}, {"path": "src/api/b.py"}]},
+            }
+        }
+    }
+    assert cf.replaced_tokens_for("get_context", result) == 2 * cf.CONTEXT_MODULE_FILE_FLOOR
+
+
+def test_get_context_module_credit_is_capped() -> None:
+    # The child-page query is recursive, so a top-level module lists hundreds of
+    # files; the agent would never have opened them all. Credit stays capped.
+    many = [{"path": f"src/f{i}.py"} for i in range(500)]
+    result = {"targets": {"src": {"target": "src", "type": "module", "docs": {"files": many}}}}
+    assert cf.replaced_tokens_for("get_context", result) == cf.CONTEXT_MODULE_MAX
+
+
+def test_get_risk_unions_will_break_and_missing_cochanges() -> None:
+    # A file that both breaks and is a missed co-change partner is one file.
+    # Two targets so the total clears RISK_FLOOR — otherwise the floor masks
+    # whether the overlapping file was counted once or twice.
+    result = {
+        "targets": {"a.py": {}, "b.py": {}},
+        "directive": {"will_break": ["c.py"], "missing_cochanges": ["c.py"]},
+    }
+    expected = 2 * cf.RISK_PER_TARGET + 1 * cf.RISK_PER_RELATED_FILE
+    assert expected > cf.RISK_FLOOR
+    assert cf.replaced_tokens_for("get_risk", result) == expected
+
+
+def test_get_context_symbol_credits_fixed_floor() -> None:
+    result = {"targets": {"Foo": {"target": "Foo", "type": "symbol", "docs": {"name": "Foo"}}}}
+    assert cf.replaced_tokens_for("get_context", result) == cf.CONTEXT_SYMBOL_FLOOR
+
+
+def test_get_context_mixed_targets_sum() -> None:
+    # Skeleton file + module + symbol all contribute; error target is skipped.
+    result = {
+        "targets": {
+            "a.py": {"target": "a.py", "type": "file", "skeleton": {"full_tokens": 1500}},
+            "src/api": {
+                "target": "src/api",
+                "type": "module",
+                "docs": {"files": [{"path": "x.py"}]},
+            },
+            "Foo": {"target": "Foo", "type": "symbol"},
+            "gone.py": {"target": "gone.py", "error": "not found"},
+        }
+    }
+    expected = 1500 + cf.CONTEXT_MODULE_FILE_FLOOR + cf.CONTEXT_SYMBOL_FLOOR
+    assert cf.replaced_tokens_for("get_context", result) == expected
+
+
+def test_get_context_skeleton_file_not_double_counted() -> None:
+    # A file target carrying a skeleton counts once (full_tokens), never also
+    # as a per-type floor.
+    result = {
+        "targets": {"a.py": {"target": "a.py", "type": "file", "skeleton": {"full_tokens": 900}}}
+    }
+    assert cf.replaced_tokens_for("get_context", result) == 900
+
+
+def test_get_risk_scales_with_targets_and_blast() -> None:
+    result = {
+        "targets": {"a.py": {}, "b.py": {}},
+        "directive": {"will_break": ["c.py"], "missing_cochanges": ["d.py", "e.py"]},
+    }
+    expected = 2 * cf.RISK_PER_TARGET + 3 * cf.RISK_PER_RELATED_FILE
+    assert cf.replaced_tokens_for("get_risk", result) == expected
+
+
+def test_get_risk_floors_when_signal_thin() -> None:
+    assert cf.replaced_tokens_for("get_risk", {"targets": {}}) == cf.RISK_FLOOR
+    assert cf.replaced_tokens_for("get_risk", {"error": "nope"}) == 0
+
+
+def test_get_blast_radius_scales_and_caps() -> None:
+    assert cf.replaced_tokens_for("get_blast_radius", {"total_impacted": 3}) == max(
+        cf.BLAST_FLOOR, 3 * cf.BLAST_PER_IMPACTED
+    )
+    # No impact still floors a successful call.
+    assert cf.replaced_tokens_for("get_blast_radius", {"total_impacted": 0}) == cf.BLAST_FLOOR
+    # Huge fan-out is capped.
+    assert cf.replaced_tokens_for("get_blast_radius", {"total_impacted": 10_000}) == cf.BLAST_MAX
+    assert cf.replaced_tokens_for("get_blast_radius", {"error": "workspace only"}) == 0
+
+
+def test_get_execution_flows_scales_with_trace_nodes() -> None:
+    # 5 + 3 = 8 nodes, chosen so the scaled value clears FLOWS_FLOOR — otherwise
+    # max() collapses and the test would pass with the scaling deleted.
+    result = {"flows": [{"trace": [1, 2, 3, 4, 5]}, {"depth": 2}]}
+    scaled = 8 * cf.FLOWS_PER_NODE
+    assert scaled > cf.FLOWS_FLOOR
+    assert cf.replaced_tokens_for("get_execution_flows", result) == scaled
+    assert cf.replaced_tokens_for("get_execution_flows", {"flows": []}) == 0
+    assert cf.replaced_tokens_for("get_execution_flows", {"error": "no entry"}) == 0
+
+
+def test_newly_covered_tools_credit_successful_calls() -> None:
+    # Item 7: tools that previously fell through and could only ever take a
+    # dead-end debit now earn a floor on success.
+    assert cf.replaced_tokens_for("get_change_risk", {"summary": "x"}) == cf.CHANGE_RISK_FLOOR
+    assert cf.replaced_tokens_for("get_architecture", {"layers": []}) == cf.ARCHITECTURE_FLOOR
+    assert cf.replaced_tokens_for("get_dependency_path", {"path": []}) == cf.DEPENDENCY_FLOOR
+    assert cf.replaced_tokens_for("get_conformance", {"contracts": []}) == cf.CONFORMANCE_FLOOR
+    assert cf.replaced_tokens_for("get_change_risk", {"error": "bad revspec"}) == 0
+
+
 def test_dead_end_records_debit_row(tmp_path, monkeypatch) -> None:
     """An error response writes raw=0/distilled=N — a negative net at
     aggregation, so the ledger stops only ever crediting (E11)."""

--- a/tests/unit/server/test_distill_savings.py
+++ b/tests/unit/server/test_distill_savings.py
@@ -76,6 +76,41 @@ async def test_savings_endpoint_surfaces_mcp_drops_and_pricing(
     assert data["estimated_usd_saved"] > 0
 
 
+async def test_savings_endpoint_adds_avoided_tool_call_output_credit(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """Each answered counterfactual MCP query credits a little output token
+    value (the tool call the agent skipped), on top of the input-priced saved
+    tokens. Priced at the resolved agent's output rate."""
+    import pytest
+
+    from repowise.server.routers.costs import _AVOIDED_CALL_OUTPUT_TOKENS
+
+    repo = await create_test_repo(client, tmp_path)
+    repo_dir = Path(repo["local_path"])
+    store = OmissionStore(repo_dir / ".repowise" / "omissions" / "omissions.db")
+    # A counterfactual MCP saving (savings table, mcp:<tool> source) — one query.
+    store.record_saving(
+        filter_name="get_risk",
+        source="mcp:get_risk",
+        command=None,
+        raw_tokens=5_000,
+        distilled_tokens=500,
+    )
+    store.close()
+
+    resp = await client.get(f"/api/repos/{repo['id']}/distill-savings")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["mcp_queries"] == 1
+    # Default agent (no transcripts) → sonnet $3 input / $15 output per 1M.
+    saved = data["saved_tokens"] + data["mcp_tokens"]  # 0 distill + 4_500 mcp
+    input_usd = saved * 3.0 / 1_000_000
+    output_usd = 1 * _AVOIDED_CALL_OUTPUT_TOKENS * 15.0 / 1_000_000
+    assert data["estimated_usd_saved"] == pytest.approx(input_usd + output_usd)
+    assert data["estimated_usd_saved"] > input_usd  # the credit actually applied
+
+
 async def test_savings_endpoint_no_store_is_unavailable(
     client: AsyncClient, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
The savings figure on the Costs page undersold real work in several places. This closes the ones that were losing defensible tokens, without inflating any estimate. Every change either counts something real that was being discarded, or prices something correctly that was being mispriced.

## Pricing precision (largest effect)

Saved tokens are priced at the coding agent's detected model. A session on a model id the pricing table did not list exactly (a dated or point-release Opus, for instance) fell through to the Sonnet-priced fallback, undercounting that session's savings roughly fivefold. Model ids now resolve by family prefix, with exact table entries still taking precedence and local models still valued at zero.

## MCP counterfactuals

- `get_context` module targets earn credit per listed child file, and symbol targets earn a floor. Both contributed nothing before. Module credit is capped: the child-page query is recursive, so a top-level module lists hundreds of files the agent would never actually have opened.
- `get_risk`, `get_blast_radius` and `get_execution_flows` now scale with the files and graph nodes their answers actually name, rather than a flat floor. Fan-outs stay capped so a large blast radius cannot overstate.
- `get_change_risk`, `get_architecture`, `get_dependency_path` and `get_conformance` gained estimators. They earned nothing on success yet still took a dead-end debit on error, so their ledger contribution could only ever go negative.

## Avoided tool calls

An answered counterfactual query also spares the agent the exploration call it would have had to emit. That output token value now earns a small credit at the output rate. It is counted over net-positive counterfactual rows only, because a dead end saved the agent nothing and crediting it would flip its debit into a credit.

## Deliberately not included

Cache-token accounting. Anthropic reports `input_tokens` excluding cache reads, and those reads are currently recorded at zero, so pricing them correctly raises recorded indexing spend rather than lowering it. That direction is worth taking on its own, together with the schema change it needs.

Missed and re-read estimates remain separate opportunity callouts and are still kept out of the metered headline.

## Validation

Lint and format clean on all changed files, UI type-check passes, and 513 tests pass across the MCP and savings suites (1069 across the full MCP plus distill suites before the review pass). New tests cover the module cap, the will-break/co-change union, node scaling, the newly credited tools, family-tier pricing and the output credit.

An adversarial review pass caught an unbounded module credit (one call on a 635-file module would have claimed about 159k tokens) and a dead-end credit that inverted the debit; both are fixed here, along with two tests that would have passed against broken code.