### PR TITLE
fix(update): count onboarding pages in the generation progress total

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -1123,14 +1123,21 @@ def run_update(
             gen_progress.update(gen_task, total=total)
 
     def _on_page_done(_page_id: str) -> None:
-        nonlocal completed_pages
+        nonlocal completed_pages, total_pages
         completed_pages += 1
+        # The total is an up-front estimate (see _announce_total); some page
+        # categories can't be predicted exactly, so keep it monotonic with the
+        # real count, so it never renders "43 of 41" (issue #922).
+        if total_pages is not None and completed_pages > total_pages:
+            total_pages = completed_pages
         if emitter is not None:
             emitter.page_done(
                 completed=completed_pages, total=total_pages, cost_usd=cost_tracker.session_cost
             )
         else:
-            gen_progress.update(gen_task, advance=1, cost=cost_tracker.session_cost)
+            gen_progress.update(
+                gen_task, advance=1, total=total_pages, cost=cost_tracker.session_cost
+            )
 
     # Checkpoint each page to the DB as it lands: a crash mid-generation used
     # to lose every finished page (persist ran only at the very end), so the
@@ -1171,6 +1178,13 @@ def run_update(
             if emitter is not None:
                 emitter.error(str(exc))
             raise
+
+        # Reconcile the bar to the pages actually produced. The up-front total
+        # is an estimate and onboarding slots may gate-skip, leaving it above
+        # the real count; snap total to completed so the bar reads N of N at
+        # 100% instead of stalling short (issue #922).
+        if gen_task is not None:
+            gen_progress.update(gen_task, total=completed_pages, completed=completed_pages)
 
     # Surface the FAQ-weighted budget tilt when session demand shaped this run
     # (silent when there is no history to weight; human console mode only).

--- a/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
+++ b/packages/core/src/repowise/core/generation/page_generator/orchestrate.py
@@ -307,6 +307,19 @@ class _GenerationRun:
                 for l in self.kg_ctx.get_layers()
                 if len([n for n in l.get("nodeIds", []) if n.startswith("file:")]) >= 3
             )
+        # Level-8 onboarding pages (the non-promoted slots) also emit, and
+        # were previously omitted here, which made the progress total read
+        # lower than the pages actually generated (issue #922: "43 of 41").
+        # Counted in full like every other category above; the completed-id
+        # subtraction below nets out any already-generated slot on resume.
+        # This is still an upper bound: a slot may gate-skip at generation
+        # time (build_context -> None), so the caller reconciles the bar to
+        # the real completed count when generation finishes.
+        onboarding_page_count = 0
+        if getattr(self.config, "enable_onboarding", True):
+            from .. import onboarding as _onboarding
+
+            onboarding_page_count = len(_onboarding.iter_specs())
         estimated_total = (
             counts["api_contract"]
             + counts["symbol_spotlight"]
@@ -317,6 +330,7 @@ class _GenerationRun:
             + int(self.selection.emit_repo_overview)
             + int(self.selection.emit_arch_diagram)
             + counts["infra_page"]
+            + onboarding_page_count
             # Deterministic coverage tail also produces (zero-LLM) pages.
             + len(getattr(self.selection, "deterministic_tail_paths", []))
         )

--- a/tests/unit/generation/test_announce_total.py
+++ b/tests/unit/generation/test_announce_total.py
@@ -1,0 +1,79 @@
+"""The progress total announced by ``_GenerationRun._announce_total``.
+
+Regression for issue #922: the up-front total omitted the level-8 onboarding
+pages (the non-promoted slots), so the bar could report more pages completed
+than its total (e.g. "43 of 41"). The estimate must now include one slot per
+registered onboarding spec that has not already been generated, gated by
+``config.enable_onboarding``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from repowise.core.generation import onboarding as _onboarding
+from repowise.core.generation.models import compute_page_id
+from repowise.core.generation.page_generator.orchestrate import _GenerationRun
+
+
+def _selection() -> SimpleNamespace:
+    """A selection with a single file page and nothing else, so the onboarding
+    contribution is the only moving part of the total."""
+    return SimpleNamespace(
+        counts=lambda: {
+            "api_contract": 0,
+            "symbol_spotlight": 0,
+            "file_page": 1,
+            "scc_page": 0,
+            "module_page": 0,
+            "infra_page": 0,
+        },
+        emit_repo_overview=False,
+        emit_arch_diagram=False,
+        deterministic_tail_paths=[],
+    )
+
+
+def _fake_run(*, enable_onboarding: bool, completed_ids: set[str]) -> SimpleNamespace:
+    announced: list[int] = []
+    return SimpleNamespace(
+        selection=_selection(),
+        kg_ctx=SimpleNamespace(available=False),
+        config=SimpleNamespace(enable_onboarding=enable_onboarding),
+        completed_ids=completed_ids,
+        on_total_known=announced.append,
+        job_system=None,
+        job_id=None,
+        _announced=announced,
+    )
+
+
+def test_total_includes_onboarding_pages() -> None:
+    specs = _onboarding.iter_specs()
+    assert specs, "expected onboarding subkinds to be registered on import"
+
+    run = _fake_run(enable_onboarding=True, completed_ids=set())
+    _GenerationRun._announce_total(run)
+
+    (total,) = run._announced
+    # 1 file page + one page per registered onboarding slot.
+    assert total == 1 + len(specs)
+
+
+def test_onboarding_disabled_excludes_those_pages() -> None:
+    run = _fake_run(enable_onboarding=False, completed_ids=set())
+    _GenerationRun._announce_total(run)
+
+    (total,) = run._announced
+    assert total == 1
+
+
+def test_already_generated_onboarding_pages_are_not_recounted() -> None:
+    specs = _onboarding.iter_specs()
+    done = {compute_page_id("onboarding", _onboarding.target_path(specs[0].slot))}
+    run = _fake_run(enable_onboarding=True, completed_ids=done)
+    _GenerationRun._announce_total(run)
+
+    (total,) = run._announced
+    # The one already-completed slot drops out of the remaining total.
+    assert total == 1 + len(specs) - 1


### PR DESCRIPTION
Fixes part of #922.

## Problem

`repowise update` could show more wiki pages completed than the reported total (the screenshot in #922 shows `43 of 41`, then `45 of 41`).

## Cause

The progress total is estimated once up front in `_announce_total()`. It summed every page category except the level-8 onboarding pages (the non-promoted slots generated by `build_level8_coros`). Those pages still fire `on_page_done` and advance the bar as they land, so completed overshot the total.

## Fix

- Add the onboarding slot count to `estimated_total`, counted in full like the other categories (the existing `- len(completed_ids)` line nets out already-generated slots on resume).
- The estimate still can't be exact: an onboarding slot may gate-skip at generation time (`build_context` returns `None`), and its signals aren't built until after the estimate runs. So the progress callback now keeps the total monotonic (it never falls below completed), and the bar is reconciled to the real count once generation finishes. The bar always ends at N of N at 100%.

## Tests

- New `test_announce_total.py`: the total includes onboarding when enabled, excludes it when `enable_onboarding=False`, and already-completed slots net out.
- Existing progress and generation suites pass.
- Simulated the bar through the reported case (estimate 41, actual 45), the gate-skip overestimate case (47 to 43), and the exact case against a real `Progress` instance: no frame shows completed greater than total, and every run finishes at N of N.

## Not in this PR

The duplicated "Generating pages..." lines and interleaved debug output in #922 are the same underlying issue as running quiet-by-default (provider debug logs colliding with the live bar). That is handled in a follow-up that wires the existing `--verbose` flag to logging.