### PR TITLE
feat(cli): make init/update quiet by default, show debug logs under --verbose

### DIFF
--- a/packages/cli/src/repowise/cli/_setup.py
+++ b/packages/cli/src/repowise/cli/_setup.py
@@ -3,32 +3,48 @@
 from __future__ import annotations
 
 
-def setup_logging_silence() -> None:
-    """Quiet library + structlog output so progress bars are the only output.
+def configure_cli_logging(*, verbose: bool = False) -> None:
+    """Set library + structlog verbosity for a progress-bar command.
 
-    ``init`` / ``update`` render their own Rich progress bars; the underlying
-    library loggers (httpx/httpcore) and the ``repowise.core`` / ``repowise.server``
-    structlog loggers would otherwise interleave debug/info lines with the bars.
+    ``init`` / ``update`` render their own Rich progress bars. By default the
+    underlying library loggers (httpx/httpcore) and the ``repowise.core`` /
+    ``repowise.server`` structlog loggers are quieted to ERROR so they don't
+    interleave debug/info lines with the bars. ``verbose=True`` lets the
+    repowise loggers through at DEBUG so a user can see provider/pipeline
+    activity (``repowise update -v``); httpx/httpcore stay quiet either way,
+    since their debug stream is HTTP-level noise that buries the useful lines.
 
     ``cache_logger_on_first_use=False`` is load-bearing: modules that called
     ``structlog.get_logger(__name__)`` at import time hold a bound logger
-    snapshotted before this ``configure`` runs — so without disabling the cache,
-    debug lines from ``core/ingestion/*`` (graph, traverser, parser, …) leak past
-    the ERROR filter on the first run of a session.
+    snapshotted before this ``configure`` runs, so without disabling the cache,
+    debug lines from ``core/ingestion/*`` (graph, traverser, parser, ...) leak
+    past the filter on the first run of a session.
     """
     import logging
+
+    level = logging.DEBUG if verbose else logging.ERROR
 
     logging.getLogger("httpx").setLevel(logging.ERROR)
     logging.getLogger("httpcore").setLevel(logging.ERROR)
     for _logger_name in ("repowise.core", "repowise.server"):
-        logging.getLogger(_logger_name).setLevel(logging.ERROR)
+        logging.getLogger(_logger_name).setLevel(level)
 
     try:
         import structlog
 
         structlog.configure(
-            wrapper_class=structlog.make_filtering_bound_logger(logging.ERROR),
+            wrapper_class=structlog.make_filtering_bound_logger(level),
             cache_logger_on_first_use=False,
         )
     except ImportError:
         pass
+
+
+def setup_logging_silence() -> None:
+    """Quiet library + structlog output so progress bars are the only output.
+
+    Thin wrapper over :func:`configure_cli_logging` for the quiet (default)
+    path, kept for the call sites that never want logs regardless of a verbose
+    flag (e.g. the multi-repo workspace flow).
+    """
+    configure_cli_logging(verbose=False)

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -18,7 +18,7 @@ import click
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from rich.table import Table
 
-from repowise.cli._setup import setup_logging_silence
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.editor_integrations.defaults import (
     get_default_disabled_project_files,
     get_default_integration_overrides,
@@ -500,7 +500,10 @@ def _run_generation_phase(
     "-v",
     is_flag=True,
     default=False,
-    help="Show the full changed-file list and per-phase internals.",
+    help=(
+        "Show per-phase internals plus debug logs. Without it, debug/info "
+        "logging is suppressed so the progress bar is the only output."
+    ),
 )
 @click.option(
     "--progress",
@@ -678,8 +681,9 @@ def init_command(
     ensure_repowise_dir(repo_path)
     load_dotenv(repo_path)
 
-    # Suppress library/structlog output — progress bars are the only output needed.
-    setup_logging_silence()
+    # Quiet library/structlog output so the progress bars are the only output;
+    # `-v` lets repowise's debug lines through for troubleshooting.
+    configure_cli_logging(verbose=verbose)
 
     # On --resume, continue the prior run's git tier so a resumed fast index
     # doesn't silently fall back to the expensive FULL tier (issue #341). Done

--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -16,6 +16,7 @@ from typing import Any
 import click
 import structlog
 
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.helpers import (
     clear_update_pending,
     clear_update_queued,
@@ -263,7 +264,9 @@ def _surface_release_news(*, written_by: str | None) -> None:
     help=(
         "Show the full changed-file list and per-phase internals (adaptive "
         "cascade budget, decision-marker/evolution counts, best-effort skip "
-        "warnings, and the detailed generation report)."
+        "warnings, and the detailed generation report), plus debug logs. "
+        "Without it, debug/info logging is suppressed so the progress bar is "
+        "the only output."
     ),
 )
 @click.option(
@@ -377,6 +380,11 @@ def run_update(
         click.get_current_context().call_on_close(lambda: setattr(console, "file", None))
         emitter = JsonProgressEmitter()
         emitter.start(repo=str(path or "."), since=since)
+    else:
+        # Human console mode: quiet library/structlog output so it doesn't
+        # interleave with the live progress bar (issue #922); `-v` lets
+        # repowise's debug lines through for troubleshooting.
+        configure_cli_logging(verbose=verbose)
 
     # --- Resolve target up front (single repo or workspace) ---
     target = resolve_command_target(

--- a/tests/unit/cli/test_shared_helpers.py
+++ b/tests/unit/cli/test_shared_helpers.py
@@ -161,5 +161,38 @@ def test_setup_logging_silence_runs() -> None:
     assert logging.getLogger("httpcore").level == logging.ERROR
 
 
+def test_configure_cli_logging_quiet_by_default() -> None:
+    import logging
+
+    prior = {n: logging.getLogger(n).level for n in ("repowise.core", "repowise.server")}
+    try:
+        _setup.configure_cli_logging(verbose=False)
+        assert logging.getLogger("repowise.core").level == logging.ERROR
+        assert logging.getLogger("repowise.server").level == logging.ERROR
+        # HTTP libs stay quiet regardless of verbosity.
+        assert logging.getLogger("httpx").level == logging.ERROR
+    finally:
+        for name, level in prior.items():
+            logging.getLogger(name).setLevel(level)
+
+
+def test_configure_cli_logging_verbose_shows_repowise_debug() -> None:
+    import logging
+
+    prior = {n: logging.getLogger(n).level for n in ("repowise.core", "repowise.server")}
+    try:
+        _setup.configure_cli_logging(verbose=True)
+        assert logging.getLogger("repowise.core").level == logging.DEBUG
+        assert logging.getLogger("repowise.server").level == logging.DEBUG
+        # HTTP libs are HTTP-level noise; kept at ERROR even in verbose mode.
+        assert logging.getLogger("httpx").level == logging.ERROR
+        assert logging.getLogger("httpcore").level == logging.ERROR
+    finally:
+        for name, level in prior.items():
+            logging.getLogger(name).setLevel(level)
+        # Restore the quiet default so verbose state doesn't leak to other tests.
+        _setup.configure_cli_logging(verbose=False)
+
+
 def test_repo_session_exposes_open_repo_db() -> None:
     assert callable(_repo_session.open_repo_db)


### PR DESCRIPTION
Follow-up to #928, closing the rest of #922.

## Problem

`repowise update` printed provider and pipeline debug lines (`ollama.generate.done`, etc.) straight into the live progress bar. The repeated "Generating pages..." rows in the #922 screenshot are that debug output interleaving with the Rich bar.

The two commands handled logging inconsistently: `init` silenced logs unconditionally, `update` never silenced them at all, and neither gave the user a way to turn logs back on when they actually want to debug a run.

## Fix

One knob, `configure_cli_logging(verbose=...)`:

- Default (no `-v`): repowise and library loggers are quieted to ERROR, so the progress bars are the only output. This is what stops the debug spew and the duplicated progress rows.
- `-v`: repowise's own loggers (`repowise.core` / `repowise.server`) are let through at DEBUG so a user can watch provider/pipeline activity. httpx/httpcore stay quiet either way, since their debug stream is HTTP-level noise that would bury the useful lines.

Both commands already had a `-v` flag meaning "more output" (fuller changed-file list, per-phase internals); it now also governs logging, which is what users expect from verbose. `setup_logging_silence` remains as a thin wrapper over the quiet path for the multi-repo workspace flow, which stays quiet by design.

## Scope

This covers the single-repo `init` path and `update`. The multi-repo workspace init flow stays always-quiet (its display is deliberately terse even in verbose mode, so it does not thread the flag). Extending quiet-by-default plus `-v` to the other CLI commands is a good first issue for contributors and is intentionally left out here.

## Tests

- `configure_cli_logging` sets the repowise loggers to ERROR by default and DEBUG under verbose, with httpx/httpcore pinned to ERROR in both.
- Verified behaviorally: a `repowise.core.*` debug event is suppressed in the default path and emitted under verbose.
- Existing shared-helper, update-reporting, and update-progress-json suites pass.