### PR TITLE
Add -v/--verbose flag to `repowise export`

### DIFF
--- a/packages/cli/src/repowise/cli/commands/export_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/export_cmd.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 from rich.progress import Progress
 
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.helpers import (
     console,
     ensure_repowise_dir,
@@ -40,13 +41,23 @@ from repowise.cli.helpers import (
     default=False,
     help="Include decisions, dead code, git metadata, and provenance in JSON export.",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show debug logs from the pipeline.",
+)
 def export_command(
     path: str | None,
     fmt: str,
     output_dir: str | None,
     full_export: bool = False,
+    verbose: bool = False,
 ) -> None:
     """Export wiki pages to files."""
+    configure_cli_logging(verbose=verbose)
+
     repo_path = resolve_repo_path(path)
     ensure_repowise_dir(repo_path)
 

--- a/tests/unit/cli/test_export_cmd.py
+++ b/tests/unit/cli/test_export_cmd.py
@@ -1,0 +1,49 @@
+"""Tests for the `--verbose/-v` flag on `repowise export`.
+
+The export flow itself (markdown/html/json output) isn't covered here; this
+only asserts the flag reaches `configure_cli_logging`, matching #930.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from click.testing import CliRunner
+
+from repowise.cli.commands import export_cmd
+from repowise.cli.helpers import ensure_repowise_dir, get_db_url_for_repo
+from repowise.cli.main import cli
+from repowise.core.persistence import create_engine, init_db
+
+
+def _init_empty_db(repo_path):
+    """Create the wiki DB schema, mirroring what `repowise init` would do."""
+    ensure_repowise_dir(repo_path)
+    engine = create_engine(get_db_url_for_repo(repo_path))
+    asyncio.run(init_db(engine))
+
+
+def test_export_verbose_flag_reaches_configure_cli_logging(tmp_path, monkeypatch):
+    _init_empty_db(tmp_path)
+    calls = []
+    monkeypatch.setattr(
+        export_cmd, "configure_cli_logging", lambda *, verbose: calls.append(verbose)
+    )
+
+    result = CliRunner().invoke(cli, ["export", str(tmp_path), "-v"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [True]
+
+
+def test_export_defaults_to_quiet(tmp_path, monkeypatch):
+    _init_empty_db(tmp_path)
+    calls = []
+    monkeypatch.setattr(
+        export_cmd, "configure_cli_logging", lambda *, verbose: calls.append(verbose)
+    )
+
+    result = CliRunner().invoke(cli, ["export", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [False]


### PR DESCRIPTION
## Summary
#929 made `init`/`update` quiet by default via `configure_cli_logging()`, scoped to just those two commands. This wires the same `-v` flag into `export`, one command off the remaining-commands list in #930.

`reindex` was already claimed by another contributor when I picked this up — the issue explicitly calls out that picking a single command is a reasonable scope for one PR ("This is splittable... Picking a single command off this list is a reasonable first contribution").

## Changes
- `export_cmd.py`: adds `--verbose/-v`, calls `configure_cli_logging(verbose=verbose)` as the first statement in the command body (matching the `update_cmd` reference call site), following the exact pattern from the issue.
- `tests/unit/cli/test_export_cmd.py`: asserts the flag reaches `configure_cli_logging` with the right value, both with and without `-v`.

## How I tested this
- `pytest tests/unit/cli/test_export_cmd.py -v` — 2 passed
- Full `pytest tests/unit/cli/` — 804 passed (no regressions)
- `ruff check` / `ruff format --diff` on changed files — clean

## Related issue
Part of #930 (export command only; other commands on that list are left for follow-up PRs, per the issue's own suggestion).