### PR TITLE
feat(cli): add verbose logging to restyle

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -210,12 +210,14 @@ working. See [WIKI_STYLES.md](WIKI_STYLES.md).
 | `--model` | Override model |
 | `--concurrency` | Max concurrent LLM calls (default: 12) |
 | `--reasoning` | Reasoning mode for supported providers |
+| `--verbose` / `-v` | Show debug logs from the pipeline |
 | `--yes` / `-y` | Skip the confirmation prompt |
 
 ```bash
 repowise restyle                       # show current style + options
 repowise restyle caveman               # condensed, AI-first
 repowise restyle reference --yes       # API-manual, skip the confirm
+repowise restyle tutorial --verbose    # show pipeline debug logs
 ```
 
 > Editing `wiki_style` in `config.yaml` by hand and running `update` does **not**

--- a/packages/cli/src/repowise/cli/commands/restyle_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/restyle_cmd.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import click
 
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.helpers import (
     config_fingerprint,
     console,
@@ -145,6 +146,13 @@ async def _run_restyle(
 @click.option("--model", default=None, help="Model identifier override.")
 @click.option("--concurrency", type=int, default=12, help="Max concurrent LLM calls.")
 @click.option("--reasoning", default=None, help="Reasoning mode override.")
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show debug logs from the pipeline.",
+)
 @click.option("--yes", "-y", is_flag=True, default=False, help="Skip the confirmation prompt.")
 def restyle_command(
     style: str | None,
@@ -153,6 +161,7 @@ def restyle_command(
     model: str | None,
     concurrency: int,
     reasoning: str | None,
+    verbose: bool,
     yes: bool,
 ) -> None:
     """Switch a repo's wiki STYLE and regenerate every page in the new voice.
@@ -163,6 +172,8 @@ def restyle_command(
     This regenerates the whole wiki with LLM calls (a cost), reusing the existing
     index/graph/git so no re-resolution or re-blame is needed.
     """
+    configure_cli_logging(verbose=verbose)
+
     repo_path = resolve_repo_path(path)
     load_dotenv(repo_path)
     state = load_state(repo_path)

--- a/tests/unit/cli/test_restyle_cmd.py
+++ b/tests/unit/cli/test_restyle_cmd.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
+from repowise.cli.commands import restyle_cmd
 from repowise.cli.main import cli
 
 
@@ -56,6 +57,24 @@ def test_restyle_no_style_shows_current_and_options():
     assert "Current wiki style" in result.output
     assert "reference" in result.output
     assert "caveman" in result.output  # catalogue shown
+
+
+def test_restyle_verbose_configures_cli_logging(monkeypatch, tmp_path):
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        restyle_cmd,
+        "configure_cli_logging",
+        lambda *, verbose=False: calls.append(verbose),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["restyle", "caveman", str(tmp_path), "--yes", "--verbose"],
+    )
+
+    assert result.exit_code == 1
+    assert "No index found" in result.output
+    assert calls == [True]
 
 
 def test_restyle_unknown_style_errors(tmp_path):


### PR DESCRIPTION
## Summary

- add `--verbose` / `-v` to `repowise restyle`
- configure CLI logging before resolving the repository or starting provider/pipeline work
- document the new flag and add focused forwarding coverage

## Related Issues

Part of #930 (`restyle` slice).

## Test Plan

- [x] `uv run pytest tests/unit/cli/test_restyle_cmd.py -q` (8 passed)
- [x] `uv run pytest tests/unit/ -q` (7,593 passed, 1 unrelated baseline failure)
- [x] `uv run ruff check packages/cli/src/repowise/cli/commands/restyle_cmd.py tests/unit/cli/test_restyle_cmd.py`
- [x] `uv run ruff format --check packages/cli/src/repowise/cli/commands/restyle_cmd.py tests/unit/cli/test_restyle_cmd.py`
- [x] `uv run repowise restyle --help`
- [x] Web build not required (no frontend changes)

The exhaustive unit-suite failure is the unrelated existing mascot assertion `test_banner_at_wide_width_stays_compact_with_long_tagline`; this change does not touch mascot rendering.

## Checklist

- [x] My code follows the project style
- [x] I added tests for the new functionality
- [x] I updated the CLI reference
- [ ] All existing tests pass (see unrelated baseline failure above)