### PR TITLE
feat(cli): add verbose logging to claude-md

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -877,6 +877,7 @@ Generate or update `CLAUDE.md` with codebase intelligence. Custom instructions a
 | `--stdout` | Print generated content to stdout instead of writing a file |
 | `--workspace` / `-w` | Force workspace mode: generates a workspace-level `CLAUDE.md` at the workspace root with cross-repo contracts, co-changes, and per-repo summaries |
 | `--no-workspace` | Force single-repo mode even when invoked from a workspace |
+| `--verbose` / `-v` | Show debug logs from the pipeline |
 
 Auto-detects workspace mode when invoked from a workspace root.
 
@@ -885,6 +886,7 @@ repowise generate-claude-md
 repowise generate-claude-md -o custom-path.md
 repowise generate-claude-md --stdout
 repowise generate-claude-md --workspace    # workspace-level CLAUDE.md
+repowise generate-claude-md --verbose      # show pipeline debug logs
 ```
 
 `repowise init` and `repowise update` keep it current automatically; you rarely need to run this directly.

--- a/packages/cli/src/repowise/cli/commands/claude_md_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/claude_md_cmd.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import click
 
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.helpers import (
     console,
     ensure_repowise_dir,
@@ -51,12 +52,20 @@ from repowise.cli.helpers import (
     default=False,
     help="Force single-repo mode even when invoked from a workspace.",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show debug logs from the pipeline.",
+)
 def claude_md_command(
     path: str | None,
     output_path: str | None,
     to_stdout: bool,
     workspace_mode: bool,
     no_workspace: bool,
+    verbose: bool,
 ) -> None:
     """Generate or update CLAUDE.md with codebase intelligence context.
 
@@ -71,6 +80,8 @@ def claude_md_command(
     Auto-detects workspace mode when invoked from a workspace root. Use
     --workspace to force on, --no-workspace to force off.
     """
+    configure_cli_logging(verbose=verbose)
+
     target = resolve_command_target(
         path=path,
         workspace_flag=workspace_mode,

--- a/tests/unit/cli/test_claude_md_cmd.py
+++ b/tests/unit/cli/test_claude_md_cmd.py
@@ -1,0 +1,38 @@
+"""Tests for the ``generate-claude-md`` command boundary."""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from repowise.cli.commands import claude_md_cmd
+from repowise.cli.main import cli
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_verbose"),
+    [([], False), (["--verbose"], True)],
+)
+def test_generate_claude_md_configures_logging_before_target_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    extra_args: list[str],
+    expected_verbose: bool,
+) -> None:
+    events: list[tuple[str, bool | None]] = []
+
+    def fake_configure_cli_logging(*, verbose: bool = False) -> None:
+        events.append(("logging", verbose))
+
+    def fake_resolve_command_target(**_kwargs: object) -> None:
+        events.append(("target", None))
+        raise click.ClickException("stop after target resolution")
+
+    monkeypatch.setattr(claude_md_cmd, "configure_cli_logging", fake_configure_cli_logging)
+    monkeypatch.setattr(claude_md_cmd, "resolve_command_target", fake_resolve_command_target)
+
+    result = CliRunner().invoke(cli, ["generate-claude-md", *extra_args])
+
+    assert result.exit_code == 1
+    assert "stop after target resolution" in result.output
+    assert events == [("logging", expected_verbose), ("target", None)]


### PR DESCRIPTION
## Summary

- add `--verbose` / `-v` to `repowise generate-claude-md`
- configure CLI logging before target resolution, covering both single-repo and workspace execution
- document the flag and test default/verbose forwarding order

## Related Issues

Part of #930 (`generate-claude-md` slice).

## Test Plan

- [x] `uv run pytest tests/unit/cli/test_claude_md_cmd.py tests/unit/cli/test_claude_md_contract_curation.py -q` (7 passed)
- [x] `uv run pytest tests/unit/cli/ -q` (803 passed, 1 unrelated baseline failure)
- [x] `uv run ruff check packages/cli/src/repowise/cli/commands/claude_md_cmd.py tests/unit/cli/test_claude_md_cmd.py`
- [x] `uv run ruff format --check packages/cli/src/repowise/cli/commands/claude_md_cmd.py tests/unit/cli/test_claude_md_cmd.py`
- [x] `uv run repowise generate-claude-md --help`
- [x] Web build not required (no frontend changes)

The CLI suite failure is the unrelated existing mascot assertion `test_banner_at_wide_width_stays_compact_with_long_tagline`; this change does not touch mascot rendering.

## Checklist

- [x] My code follows the project style
- [x] I added tests for the new functionality
- [x] I updated the CLI reference
- [ ] All existing tests pass (see unrelated baseline failure above)