### PR TITLE
feat(answer): lean high-confidence payload behind REPOWISE_ANSWER_LEAN_HIGH

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/answer.py
@@ -178,6 +178,47 @@ def _cache_disabled() -> bool:
     return os.environ.get(_DISABLE_CACHE_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+# Opt-in: strip re-read evidence from high-confidence answers. A high answer's
+# contract is "cite this, do not re-read the source" — so the symbol bodies,
+# quotes, flow_path, and candidate evidence are payload the consumer was told it
+# does not need, re-dragged through the agent's context every turn. Dropping them
+# at high (and ONLY at high, and ONLY for mainline synthesis) shrinks that
+# payload. Off by default; only safe once high-confidence answers are reliable
+# enough that the prose + citation suffices, so the agent rarely needs a dropped
+# body (else it calls get_symbol and adds a round-trip).
+#
+# Two carve-outs keep the evidence where it IS the answer: grounded fast paths
+# (their inlined body is the whole answer) and why-questions — a "because X" is
+# justified by exactly the code_rationale / quotes this strips, so a lean
+# why-answer loses the grounding its rationale stands on.
+_LEAN_HIGH_ENV = "REPOWISE_ANSWER_LEAN_HIGH"
+
+# Re-read evidence stripped from a lean high answer. NOT stripped: answer,
+# citations, confidence, retrieval_quality, fallback_targets, note, _meta.
+_LEAN_HIGH_DROP_KEYS = ("symbol_bodies", "quotes", "flow_path", "best_guesses", "code_rationale")
+
+
+def _lean_high() -> bool:
+    return os.environ.get(_LEAN_HIGH_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _apply_lean_high(payload: dict, question: str) -> dict:
+    """Strip re-read evidence from a mainline high-confidence answer, in place.
+
+    No-op unless the flag is on and confidence is high. Two carve-outs keep the
+    body where it IS the answer: grounded fast paths (extracted / exact_symbol /
+    symbol_body / data_shape, which carry a ``grounding`` key) and why-questions
+    (whose rationale is grounded in the stripped evidence — see module note).
+    """
+    if not _lean_high() or payload.get("confidence") != "high" or payload.get("grounding"):
+        return payload
+    if _is_why_question(question):
+        return payload
+    for k in _LEAN_HIGH_DROP_KEYS:
+        payload.pop(k, None)
+    return payload
+
+
 def _always_synthesize() -> bool:
     """Whether to always synthesize (default) or keep the legacy abstain gate."""
     return os.environ.get(_ALWAYS_SYNTHESIZE_ENV, "").strip().lower() not in {
@@ -670,6 +711,7 @@ async def get_answer(
                     repository=repository,
                     targets=[p for p in cached_paths if isinstance(p, str) and p],
                 )
+                _apply_lean_high(payload, question)
                 return payload
 
     # --- Retrieval pipeline ------------------------------------------------
@@ -1593,4 +1635,5 @@ async def get_answer(
         repository=repository,
         targets=[*citations, *fallback_targets],
     )
+    _apply_lean_high(payload, question)
     return payload

--- a/tests/unit/server/mcp/test_answer_calibration.py
+++ b/tests/unit/server/mcp/test_answer_calibration.py
@@ -190,6 +190,77 @@ class TestFrameTermGrounding:
         assert ungrounded == []
 
 
+class TestLeanHigh:
+    """REPOWISE_ANSWER_LEAN_HIGH strips re-read evidence from mainline
+    high-confidence answers only — never grounded fast paths, never <high,
+    and only when the flag is on."""
+
+    from repowise.server.mcp_server.tool_answer.answer import _LEAN_HIGH_DROP_KEYS
+
+    def _payload(self, **over) -> dict:
+        base = {
+            "answer": "Retries are gated by MIN_COUNT.",
+            "citations": ["pkg/alpha/one.py"],
+            "confidence": "high",
+            "fallback_targets": ["pkg/alpha/two.py"],
+            "note": "High confidence.",
+            "symbol_bodies": [{"path": "pkg/alpha/one.py", "source": "..."}],
+            "quotes": [{"path": "pkg/alpha/one.py", "quote": "MIN_COUNT = 2"}],
+            "flow_path": ["a", "b"],
+            "best_guesses": [{"file": "pkg/alpha/one.py"}],
+            "code_rationale": [{"path": "pkg/alpha/one.py", "comment": "why"}],
+        }
+        base.update(over)
+        return base
+
+    _HOW_Q = "How does retry gating work?"
+    _WHY_Q = "Why are retries gated by MIN_COUNT?"
+
+    def test_flag_on_high_strips_evidence_keeps_core(self, monkeypatch) -> None:
+        from repowise.server.mcp_server.tool_answer.answer import _apply_lean_high
+
+        monkeypatch.setenv("REPOWISE_ANSWER_LEAN_HIGH", "1")
+        out = _apply_lean_high(self._payload(), self._HOW_Q)
+        for k in self._LEAN_HIGH_DROP_KEYS:
+            assert k not in out
+        for k in ("answer", "citations", "confidence", "fallback_targets", "note"):
+            assert k in out
+
+    def test_grounded_fast_path_untouched(self, monkeypatch) -> None:
+        from repowise.server.mcp_server.tool_answer.answer import _apply_lean_high
+
+        monkeypatch.setenv("REPOWISE_ANSWER_LEAN_HIGH", "1")
+        out = _apply_lean_high(self._payload(grounding="exact_symbol"), self._HOW_Q)
+        for k in self._LEAN_HIGH_DROP_KEYS:
+            assert k in out
+
+    def test_why_question_untouched(self, monkeypatch) -> None:
+        # A why-answer's rationale is grounded in the very evidence lean-high
+        # would strip, so why-questions are exempt even at high confidence.
+        from repowise.server.mcp_server.tool_answer.answer import _apply_lean_high
+
+        monkeypatch.setenv("REPOWISE_ANSWER_LEAN_HIGH", "1")
+        out = _apply_lean_high(self._payload(), self._WHY_Q)
+        for k in self._LEAN_HIGH_DROP_KEYS:
+            assert k in out
+
+    def test_medium_untouched(self, monkeypatch) -> None:
+        from repowise.server.mcp_server.tool_answer.answer import _apply_lean_high
+
+        monkeypatch.setenv("REPOWISE_ANSWER_LEAN_HIGH", "1")
+        out = _apply_lean_high(self._payload(confidence="medium"), self._HOW_Q)
+        for k in self._LEAN_HIGH_DROP_KEYS:
+            assert k in out
+
+    def test_flag_off_untouched(self, monkeypatch) -> None:
+        from repowise.server.mcp_server.tool_answer.answer import _apply_lean_high
+
+        monkeypatch.delenv("REPOWISE_ANSWER_LEAN_HIGH", raising=False)
+        out = _apply_lean_high(self._payload(), self._HOW_Q)
+        for k in self._LEAN_HIGH_DROP_KEYS:
+            assert k in out
+
+
 # ---------------------------------------------------------------------------
 # End-to-end gate behaviour through get_answer
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds `REPOWISE_ANSWER_LEAN_HIGH` (opt-in, default off): at **high** confidence,
strip the re-read evidence — `symbol_bodies`, `quotes`, `flow_path`,
`best_guesses`, `code_rationale` — from a `get_answer` response, keeping
`answer`, `citations`, `confidence`, `retrieval_quality`, `fallback_targets`,
`note`.

## Why

A high answer's contract is *"cite this, do not re-read the source."* The stripped
fields are then payload the consumer was told it does not need — yet the agent
carries it through context on every subsequent turn. Dropping it at high shrinks
the per-turn footprint. This is only safe once high-confidence answers are
reliable enough that the prose + citation usually suffices, so the agent rarely
needs a dropped body (otherwise it calls `get_symbol` and adds a round-trip).

## Carve-outs

Two cases keep the evidence, because there the body *is* the answer:

- **Grounded fast paths** (`grounding` set: extracted / exact_symbol /
  symbol_body / data_shape) — the inlined body is the whole answer.
- **Why-questions** — a "because X" is justified by exactly the `code_rationale`
  / `quotes` this would strip, so a lean why-answer loses the grounding its
  rationale stands on.

## Notes

- Serve-time trim only: the cached payload stays full-shaped, so **no schema bump**.
- Default off — enable per-deployment once validated.

## Tests

`tests/unit/server/mcp/test_answer_calibration.py::TestLeanHigh`: flag-on high
strips evidence and keeps the core fields; grounded fast path untouched;
why-question untouched; medium untouched; flag-off untouched.
