### PR TITLE
feat(cli): add verbose logging to watch

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -282,12 +282,14 @@ Watch for file changes and auto-update wiki pages. Press `Ctrl+C` to stop.
 | `--workspace` / `-w` | Watch all workspace repos |
 | `--no-workspace` | Force single-repo mode |
 | `--repo` | Watch a single workspace repo by alias |
+| `--verbose` / `-v` | Show debug logs from the pipeline and triggered updates |
 
 ```bash
 repowise watch                           # single repo (auto-detects)
 repowise watch --debounce 5000           # 5s debounce
 repowise watch --workspace               # all workspace repos
 repowise watch --repo backend            # just one
+repowise watch --verbose                 # show pipeline debug logs
 ```
 
 ---

--- a/packages/cli/src/repowise/cli/commands/watch_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/watch_cmd.py
@@ -4,19 +4,18 @@ from __future__ import annotations
 
 import threading
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 import click
 
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.helpers import (
     console,
     ensure_repowise_dir,
-    find_workspace_root,
     resolve_command_target,
-    resolve_repo_path,
     run_async,
 )
-
 
 # ---------------------------------------------------------------------------
 # Single-repo watch (existing behavior)
@@ -28,6 +27,7 @@ def _watch_single_repo(
     provider_name: str | None,
     model: str | None,
     debounce_ms: int,
+    verbose: bool,
 ) -> None:
     """Watch a single repo for changes and trigger updates."""
     from watchdog.events import FileSystemEventHandler
@@ -61,6 +61,8 @@ def _watch_single_repo(
                 args.extend(["--provider", provider_name])
             if model:
                 args.extend(["--model", model])
+            if verbose:
+                args.append("--verbose")
             result = runner.invoke(update_command, args, catch_exceptions=False)
             if result.output:
                 console.print(result.output)
@@ -130,7 +132,7 @@ def _watch_workspace(
         repo_changed[entry.alias] = set()
         repo_timers[entry.alias] = None
 
-    def _make_trigger(alias: str) -> callable:
+    def _make_trigger(alias: str) -> Callable[[], None]:
         """Create a trigger function for a specific repo."""
 
         def _on_trigger() -> None:
@@ -142,9 +144,7 @@ def _watch_workspace(
             if not paths:
                 return
 
-            console.print(
-                f"[cyan]{alias}: {len(paths)} changed file(s), updating...[/cyan]"
-            )
+            console.print(f"[cyan]{alias}: {len(paths)} changed file(s), updating...[/cyan]")
             try:
                 # Reload config in case it was updated
                 current_config = WorkspaceConfig.load(ws_root)
@@ -195,7 +195,8 @@ def _watch_workspace(
                 if old_timer is not None:
                     old_timer.cancel()
                 new_timer = threading.Timer(
-                    debounce_ms / 1000.0, _make_trigger(alias),
+                    debounce_ms / 1000.0,
+                    _make_trigger(alias),
                 )
                 new_timer.daemon = True
                 new_timer.start()
@@ -219,7 +220,9 @@ def _watch_workspace(
     observer.start()
 
     repo_list = ", ".join(e.alias for e in ws_config.repos)
-    console.print(f"[bold]Watching workspace ({scheduled} repos: {repo_list})... Ctrl+C to stop[/bold]")
+    console.print(
+        f"[bold]Watching workspace ({scheduled} repos: {repo_list})... Ctrl+C to stop[/bold]"
+    )
 
     try:
         while True:
@@ -253,6 +256,13 @@ def _watch_workspace(
     default=False,
     help="Force single-repo mode even when invoked from a workspace.",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show debug logs from the pipeline.",
+)
 def watch_command(
     path: str | None,
     provider_name: str | None,
@@ -260,11 +270,14 @@ def watch_command(
     debounce_ms: int,
     workspace: bool,
     no_workspace: bool,
+    verbose: bool,
 ) -> None:
     """Watch for file changes and auto-update wiki pages.
 
     Auto-detects workspace mode when invoked from a workspace root.
     """
+    configure_cli_logging(verbose=verbose)
+
     target = resolve_command_target(
         path=path,
         workspace_flag=workspace,
@@ -277,4 +290,10 @@ def watch_command(
         _watch_workspace(target.ws_root, debounce_ms)
     else:
         assert target.repo_path is not None
-        _watch_single_repo(target.repo_path, provider_name, model, debounce_ms)
+        _watch_single_repo(
+            target.repo_path,
+            provider_name,
+            model,
+            debounce_ms,
+            verbose,
+        )

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -78,6 +78,7 @@ class TestCliBasics:
         result = runner.invoke(cli, ["watch", "--help"])
         assert result.exit_code == 0
         assert "--debounce" in result.output
+        assert "--verbose" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_watch_cmd.py
+++ b/tests/unit/cli/test_watch_cmd.py
@@ -1,0 +1,80 @@
+"""Tests for the ``watch`` command boundary."""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from repowise.cli.commands import watch_cmd
+from repowise.cli.helpers import CommandTarget
+from repowise.cli.main import cli
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_verbose"),
+    [([], False), (["--verbose"], True)],
+)
+def test_watch_configures_logging_before_target_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    extra_args: list[str],
+    expected_verbose: bool,
+) -> None:
+    events: list[tuple[str, bool | None]] = []
+
+    def fake_configure_cli_logging(*, verbose: bool = False) -> None:
+        events.append(("logging", verbose))
+
+    def fake_resolve_command_target(**_kwargs: object) -> None:
+        events.append(("target", None))
+        raise click.ClickException("stop after target resolution")
+
+    monkeypatch.setattr(watch_cmd, "configure_cli_logging", fake_configure_cli_logging)
+    monkeypatch.setattr(watch_cmd, "resolve_command_target", fake_resolve_command_target)
+
+    result = CliRunner().invoke(cli, ["watch", *extra_args])
+
+    assert result.exit_code == 1
+    assert "stop after target resolution" in result.output
+    assert events == [("logging", expected_verbose), ("target", None)]
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_verbose"),
+    [([], False), (["--verbose"], True)],
+)
+def test_watch_forwards_logging_mode_to_single_repo_updates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    extra_args: list[str],
+    expected_verbose: bool,
+) -> None:
+    calls: list[tuple[object, ...]] = []
+    monkeypatch.setattr(watch_cmd, "configure_cli_logging", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        watch_cmd,
+        "resolve_command_target",
+        lambda **_kwargs: CommandTarget(mode="single", repo_path=tmp_path),
+    )
+    monkeypatch.setattr(
+        watch_cmd,
+        "_watch_single_repo",
+        lambda *args: calls.append(args),
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "watch",
+            "--provider",
+            "demo-provider",
+            "--model",
+            "demo-model",
+            "--debounce",
+            "750",
+            *extra_args,
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [(tmp_path, "demo-provider", "demo-model", 750, expected_verbose)]


### PR DESCRIPTION
## Summary

- add `--verbose` / `-v` to `repowise watch`
- configure logging before target resolution for both single-repo and workspace modes
- propagate verbose mode into nested single-repo `update` invocations so it is not reset to quiet
- document the flag and add focused quiet/verbose forwarding coverage
- clean up two unused imports and correct the touched file’s invalid `callable` type annotation

## Related Issues

Part of #930 (`watch` slice).

## Test Plan

- [x] focused watch and command tests (32 passed)
- [x] CLI unit suite (804 passed, 1 unrelated baseline failure)
- [x] Ruff lint and format checks on modified Python files
- [x] strict mypy check for `watch_cmd.py`
- [x] `git diff --check`

The sole CLI-suite failure is the existing mascot tagline assertion `test_banner_at_wide_width_stays_compact_with_long_tagline`; it reproduces unchanged on clean `origin/main`.

## Checklist

- [x] My code follows the project style
- [x] I added tests for the new functionality
- [x] I updated the CLI reference
- [ ] All existing tests pass (see unrelated baseline failure above)