### PR TITLE
feat(cli): add verbose logging to coverage add

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -527,6 +527,7 @@ repowise coverage status                # show ingested coverage + the map
 |------|-------------|
 | `--path` | Repo path (defaults to cwd / workspace primary) |
 | `--format` | Force a parser instead of auto-detecting: `lcov`, `cobertura`, `clover`, `repowise-json` |
+| `--verbose` / `-v` | Show debug logs while discovering and ingesting coverage |
 
 `add` ingests per-file line/branch coverage from LCOV, Cobertura, Clover, or a
 coverage.py `.coverage` file. It auto-discovers `coverage/lcov.info`,
@@ -541,6 +542,7 @@ per-file coverage; it just skips the map.
 repowise coverage add                       # discover coverage/lcov.info, .coverage, etc.
 repowise coverage add coverage/lcov.info
 repowise coverage add web.lcov api.lcov     # merged, hit wins
+repowise coverage add --verbose             # show ingestion debug logs
 coverage run --contexts=test -m pytest      # produce .coverage with contexts
 repowise coverage add .coverage             # per-file coverage + per-test map
 repowise coverage status                    # coverage summary + "Test-to-code map" counts

--- a/packages/cli/src/repowise/cli/commands/coverage_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/coverage_cmd.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import click
 
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.helpers import (
     console,
     ensure_repowise_dir,
@@ -65,7 +66,19 @@ def coverage_group() -> None:
     default=None,
     help="Force a parser instead of auto-detecting from content.",
 )
-def coverage_add(paths: tuple[str, ...], repo: str | None, coverage_format: str | None) -> None:
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show debug logs from the pipeline.",
+)
+def coverage_add(
+    paths: tuple[str, ...],
+    repo: str | None,
+    coverage_format: str | None,
+    verbose: bool,
+) -> None:
     """Ingest coverage (auto-discovers reports when none are given).
 
     Stores per-file line/branch coverage, and additionally the per-test
@@ -81,6 +94,8 @@ def coverage_add(paths: tuple[str, ...], repo: str | None, coverage_format: str 
         repowise coverage add .coverage            # per-test map from coverage.py
         repowise coverage add web.lcov api.lcov    # merged hit-wins
     """
+    configure_cli_logging(verbose=verbose)
+
     repo_path = _resolve_coverage_repo(repo)
     ensure_repowise_dir(repo_path)
 

--- a/tests/unit/cli/test_coverage_cmd.py
+++ b/tests/unit/cli/test_coverage_cmd.py
@@ -1,0 +1,45 @@
+"""Tests for the ``coverage add`` command boundary."""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from repowise.cli.commands import coverage_cmd
+from repowise.cli.main import cli
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_verbose"),
+    [([], False), (["--verbose"], True)],
+)
+def test_coverage_add_configures_logging_before_repo_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    extra_args: list[str],
+    expected_verbose: bool,
+) -> None:
+    events: list[tuple[str, bool | None]] = []
+
+    def fake_configure_cli_logging(*, verbose: bool = False) -> None:
+        events.append(("logging", verbose))
+
+    def fake_resolve_coverage_repo(_path: str | None) -> None:
+        events.append(("repo", None))
+        raise click.ClickException("stop after repo resolution")
+
+    monkeypatch.setattr(coverage_cmd, "configure_cli_logging", fake_configure_cli_logging)
+    monkeypatch.setattr(coverage_cmd, "_resolve_coverage_repo", fake_resolve_coverage_repo)
+
+    result = CliRunner().invoke(cli, ["coverage", "add", *extra_args])
+
+    assert result.exit_code == 1
+    assert "stop after repo resolution" in result.output
+    assert events == [("logging", expected_verbose), ("repo", None)]
+
+
+def test_coverage_add_help_lists_verbose() -> None:
+    result = CliRunner().invoke(cli, ["coverage", "add", "--help"])
+
+    assert result.exit_code == 0
+    assert "--verbose" in result.output


### PR DESCRIPTION
## Summary

- add `--verbose` / `-v` to `repowise coverage add`
- configure CLI logging before repository resolution, report discovery, and parser imports
- leave the read-only `coverage status` command unchanged
- document the flag and add focused quiet/verbose ordering coverage

## Related Issues

Part of #930 (`coverage add` slice).

## Test Plan

- [x] focused coverage and command tests (31 passed)
- [x] CLI unit suite (804 passed, 1 unrelated baseline failure)
- [x] Ruff lint and format checks on modified Python files
- [x] strict mypy check for `coverage_cmd.py`
- [x] `git diff --check`

The sole CLI-suite failure is the existing mascot tagline assertion `test_banner_at_wide_width_stays_compact_with_long_tagline`; it reproduces unchanged on clean `origin/main`.

## Checklist

- [x] My code follows the project style
- [x] I added tests for the new functionality
- [x] I updated the CLI reference
- [ ] All existing tests pass (see unrelated baseline failure above)