### PR TITLE
feat(cli): add verbose logging to health

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -459,6 +459,7 @@ Compute per-file code-health scores from 25 deterministic markers (McCabe comple
 | `--safe-only` | Documented no-op placeholder for a future confidence filter; has no effect today |
 | `--repo` | In workspace mode, target a specific repo (defaults to primary) |
 | `--no-workspace` | Force single-repo mode |
+| `--verbose`, `-v` | Show debug logs from the analysis pipeline |
 
 ```bash
 repowise health                                       # KPIs + lowest-scoring files

--- a/packages/cli/src/repowise/cli/commands/health_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/health_cmd/command.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import click
 from rich.table import Table
 
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.helpers import (
     console,
     err_console,
@@ -105,6 +106,13 @@ from .trends import _render_trend
     default=False,
     help="Print a ready-to-paste health badge (Markdown) for this repo's README.",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show debug logs from the pipeline.",
+)
 def health_command(
     path: str | None,
     file_filter: str | None,
@@ -117,12 +125,15 @@ def health_command(
     module_filter: str | None,
     trend_view: bool,
     badge_view: bool,
+    verbose: bool,
 ) -> None:
     """Compute code-health scores from markers (CCN, nesting, brain-method).
 
     Runs in-process — no LLM, no network. Re-uses the repowise ingestion
     parser, graph builder, and git indexer.
     """
+    configure_cli_logging(verbose=verbose)
+
     from pathlib import Path as PathlibPath
 
     from repowise.core.analysis.health import HealthAnalyzer

--- a/tests/unit/cli/test_health_cmd_logging.py
+++ b/tests/unit/cli/test_health_cmd_logging.py
@@ -1,0 +1,38 @@
+"""Tests for logging setup at the ``health`` command boundary."""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from repowise.cli.commands.health_cmd import command as health_cmd
+from repowise.cli.main import cli
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_verbose"),
+    [([], False), (["--verbose"], True)],
+)
+def test_health_configures_logging_before_target_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    extra_args: list[str],
+    expected_verbose: bool,
+) -> None:
+    events: list[tuple[str, bool | None]] = []
+
+    def fake_configure_cli_logging(*, verbose: bool = False) -> None:
+        events.append(("logging", verbose))
+
+    def fake_resolve_command_target(**_kwargs: object) -> None:
+        events.append(("target", None))
+        raise click.ClickException("stop after target resolution")
+
+    monkeypatch.setattr(health_cmd, "configure_cli_logging", fake_configure_cli_logging)
+    monkeypatch.setattr(health_cmd, "resolve_command_target", fake_resolve_command_target)
+
+    result = CliRunner().invoke(cli, ["health", *extra_args])
+
+    assert result.exit_code == 1
+    assert "stop after target resolution" in result.output
+    assert events == [("logging", expected_verbose), ("target", None)]


### PR DESCRIPTION
Part of #930

## Summary

- add `--verbose/-v` to `repowise health`
- configure CLI logging before target resolution and analysis/provider work
- preserve stricter log silencing for JSON and Markdown output
- document the new flag and cover quiet/verbose forwarding

## Tests

- `uv run pytest -q tests/unit/cli/test_health_cmd_logging.py tests/unit/cli/test_analysis_cmds_include_submodules.py` (6 passed)
- `uv run pytest -q tests/unit/cli` (803 passed, 1 pre-existing mascot assertion failure reproduced on clean `origin/main`)
- targeted Ruff lint and formatting checks
- targeted mypy (`--follow-imports=skip`)

Repository-wide lint/type checking currently reports unrelated baseline issues, including existing Ruff violations and two mypy errors in `health_cmd/refactoring_targets.py`.