### PR TITLE
feat(cli): add verbose logging to workspace

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -697,6 +697,7 @@ This defaults to `--index --docs` when a provider is configured, the added repo 
 | `--provider` / `--model` | Override the inherited provider/model |
 | `--concurrency` | Max concurrent LLM calls for this repo's generation |
 | `--primary` | Mark this repo as the workspace default |
+| `--verbose`, `-v` | Show debug logs from indexing and doc generation |
 
 ```bash
 repowise workspace add ../new-service --alias api-gateway
@@ -715,6 +716,7 @@ Re-scan the workspace directory for new repos not yet added.
 | Flag | Description |
 |------|-------------|
 | `--yes` / `-y` | Auto-add all discovered repos without prompting |
+| `--verbose`, `-v` | Show debug logs while scanning for repositories |
 
 ```bash
 repowise workspace scan

--- a/packages/cli/src/repowise/cli/commands/workspace_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/workspace_cmd.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import click
 from rich.table import Table
 
+from repowise.cli._setup import configure_cli_logging
 from repowise.cli.helpers import (
     console,
     find_workspace_root,
@@ -242,6 +243,13 @@ def _format_relative_time(iso_timestamp: str | None) -> str:
 @click.option(
     "--concurrency", type=int, default=10, help="Max concurrent LLM calls during doc generation."
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show debug logs from the pipeline.",
+)
 def workspace_add(
     path: str,
     alias: str | None,
@@ -250,6 +258,7 @@ def workspace_add(
     provider_name: str | None,
     model: str | None,
     concurrency: int,
+    verbose: bool,
 ) -> None:
     """Add a repo to the workspace and (by default) index + generate docs for it.
 
@@ -263,6 +272,8 @@ def workspace_add(
     Use ``--no-index`` to only register the entry without indexing, or
     ``--no-docs`` to index without LLM generation.
     """
+    configure_cli_logging(verbose=verbose)
+
     from repowise.core.workspace.config import RepoEntry
 
     repo_path = Path(path).resolve()
@@ -766,8 +777,17 @@ def workspace_remove(alias: str) -> None:
     default=False,
     help="Auto-add all discovered repos without prompting.",
 )
-def workspace_scan(path: str | None, yes: bool) -> None:
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Show debug logs from the pipeline.",
+)
+def workspace_scan(path: str | None, yes: bool, verbose: bool) -> None:
     """Scan the workspace root for new repos not yet in the config."""
+    configure_cli_logging(verbose=verbose)
+
     from repowise.core.workspace.config import RepoEntry
     from repowise.core.workspace.scanner import scan_for_repos
 

--- a/tests/unit/cli/test_workspace_logging.py
+++ b/tests/unit/cli/test_workspace_logging.py
@@ -1,0 +1,66 @@
+"""Tests for logging setup at workspace command boundaries."""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from repowise.cli.commands import workspace_cmd
+from repowise.cli.main import cli
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_verbose"),
+    [([], False), (["--verbose"], True)],
+)
+def test_workspace_add_configures_logging_before_workspace_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    extra_args: list[str],
+    expected_verbose: bool,
+) -> None:
+    events: list[tuple[str, bool | None]] = []
+
+    def fake_configure_cli_logging(*, verbose: bool = False) -> None:
+        events.append(("logging", verbose))
+
+    def fake_require_workspace(*_args: object, **_kwargs: object) -> None:
+        events.append(("workspace", None))
+        raise click.ClickException("stop after workspace resolution")
+
+    monkeypatch.setattr(workspace_cmd, "configure_cli_logging", fake_configure_cli_logging)
+    monkeypatch.setattr(workspace_cmd, "_require_workspace", fake_require_workspace)
+
+    result = CliRunner().invoke(cli, ["workspace", "add", ".", *extra_args])
+
+    assert result.exit_code == 1
+    assert "stop after workspace resolution" in result.output
+    assert events == [("logging", expected_verbose), ("workspace", None)]
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "expected_verbose"),
+    [([], False), (["--verbose"], True)],
+)
+def test_workspace_scan_configures_logging_before_path_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    extra_args: list[str],
+    expected_verbose: bool,
+) -> None:
+    events: list[tuple[str, bool | None]] = []
+
+    def fake_configure_cli_logging(*, verbose: bool = False) -> None:
+        events.append(("logging", verbose))
+
+    def fake_resolve_repo_path(_path: str | None) -> None:
+        events.append(("path", None))
+        raise click.ClickException("stop after path resolution")
+
+    monkeypatch.setattr(workspace_cmd, "configure_cli_logging", fake_configure_cli_logging)
+    monkeypatch.setattr(workspace_cmd, "resolve_repo_path", fake_resolve_repo_path)
+
+    result = CliRunner().invoke(cli, ["workspace", "scan", *extra_args])
+
+    assert result.exit_code == 1
+    assert "stop after path resolution" in result.output
+    assert events == [("logging", expected_verbose), ("path", None)]


### PR DESCRIPTION
Part of #930

## Summary

- add `--verbose/-v` to `workspace add` and `workspace scan`
- configure CLI logging before workspace/path resolution, indexing, docs generation, or scanning
- retain quiet-by-default behavior while exposing pipeline diagnostics on demand
- document both flags and add command-boundary ordering tests

The nested indexing and docs helpers do not reconfigure logging, so boundary configuration carries through without an extra propagation parameter.

## Tests

- `uv run pytest -q tests/unit/cli/test_workspace_logging.py tests/unit/cli/test_workspace_cmd.py tests/unit/cli/test_workspace_add_defaults.py` (56 passed)
- `uv run pytest -q tests/unit/cli` (805 passed, 1 pre-existing mascot assertion failure already reproduced on clean `origin/main`)
- targeted Ruff lint and formatting checks
- targeted mypy (`--follow-imports=skip`)