### PR TITLE
fix(workspace): scope file count and top-language queries to node_type='file'

### DIFF
--- a/packages/server/src/repowise/server/routers/workspace.py
+++ b/packages/server/src/repowise/server/routers/workspace.py
@@ -65,7 +65,7 @@ def _query_top_language(db_path: Path) -> str:
         with sqlite3.connect(str(db_path)) as conn:
             row = conn.execute(
                 "SELECT language, COUNT(*) AS cnt FROM graph_nodes "
-                "WHERE language IS NOT NULL AND language != '' "
+                "WHERE node_type = 'file' AND language IS NOT NULL AND language != '' "
                 "GROUP BY language ORDER BY cnt DESC LIMIT 1"
             ).fetchone()
             return row[0] if row else "unknown"
@@ -143,8 +143,8 @@ def _query_repo_stats(db_path: Path) -> dict:
         if row:
             result["repo_id"] = row[0]
 
-        # file count (graph_nodes)
-        row = c.execute("SELECT COUNT(*) FROM graph_nodes").fetchone()
+        # file count (graph_nodes) 
+        row = c.execute("SELECT COUNT(*) FROM graph_nodes WHERE node_type = 'file'").fetchone()
         result["file_count"] = row[0] if row else 0
 
         # symbol count

--- a/tests/unit/server/test_graph.py
+++ b/tests/unit/server/test_graph.py
@@ -76,6 +76,9 @@ async def test_export_graph_with_data(client: AsyncClient, app) -> None:
     assert data["links"][0]["source"] == "src/main.py"
     assert data["links"][0]["target"] == "src/utils.py"
     assert data["links"][0]["imported_names"] == ["helper_func"]
+    # End-to-end test: verify nodes are fully populated from database through API
+    assert data["nodes"][0]["symbol_count"] == 3
+    assert data["nodes"][1]["symbol_count"] == 5
 
 
 @pytest.mark.asyncio

--- a/tests/unit/server/test_workspace_router.py
+++ b/tests/unit/server/test_workspace_router.py
@@ -176,6 +176,7 @@ def _create_workspace_repo_db(
             CREATE TABLE repositories (id TEXT PRIMARY KEY);
             CREATE TABLE graph_nodes (
                 id TEXT PRIMARY KEY,
+                node_type TEXT NOT NULL DEFAULT 'file',
                 language TEXT,
                 symbol_count INTEGER DEFAULT 0
             );
@@ -191,9 +192,12 @@ def _create_workspace_repo_db(
                 nloc INTEGER NOT NULL
             );
             INSERT INTO repositories (id) VALUES ('repo-backend');
-            INSERT INTO graph_nodes (id, language, symbol_count) VALUES
-                ('src/a.py', 'python', 2),
-                ('src/b.py', 'python', 3);
+            INSERT INTO graph_nodes (id, node_type, language, symbol_count) VALUES
+                ('src/a.py', 'file', 'python', 2),
+                ('src/b.py', 'file', 'python', 3),
+                ('src/a.py::Foo', 'symbol', 'python', 0),
+                ('src/a.py::Foo.bar', 'symbol', 'python', 0),
+                ('src/b.py::baz', 'symbol', 'python', 0);
             INSERT INTO wiki_pages (id, confidence) VALUES
                 ('page-a', 0.8),
                 ('page-b', 0.6);
@@ -512,11 +516,21 @@ class TestGetWorkspaceGraph:
 
 
 class TestQueryRepoStats:
-    def _make_wiki_db(self, db_path: Path, rows: list[tuple[int, float]]) -> None:
+    def _make_wiki_db(
+        self,
+        db_path: Path,
+        rows: list[tuple[int, float]],
+        *,
+        graph_nodes: list[tuple[str, str, str]] | None = None,
+    ) -> None:
         """Create a minimal wiki.db with a git_metadata table.
 
         ``rows`` is a list of ``(is_hotspot, churn_percentile)`` tuples.
         churn_percentile is stored on the real 0.0-1.0 scale.
+
+        ``graph_nodes`` is an optional list of ``(node_id, node_type, language)``
+        tuples inserted into ``graph_nodes``, letting a test model the mix of
+        file and symbol rows the real table contains.
         """
         db_path.parent.mkdir(parents=True, exist_ok=True)
         with sqlite3.connect(str(db_path)) as conn:
@@ -527,6 +541,8 @@ class TestQueryRepoStats:
                 CREATE TABLE repositories (id TEXT PRIMARY KEY);
                 CREATE TABLE graph_nodes (
                     id TEXT PRIMARY KEY,
+                    node_type TEXT NOT NULL DEFAULT 'file',
+                    language TEXT,
                     symbol_count INTEGER DEFAULT 0
                 );
                 CREATE TABLE wiki_pages (id TEXT PRIMARY KEY, confidence REAL);
@@ -542,6 +558,11 @@ class TestQueryRepoStats:
                 conn.execute(
                     "INSERT INTO git_metadata (id, is_hotspot, churn_percentile) VALUES (?, ?, ?)",
                     (f"src/f{idx}.py", is_hotspot, churn),
+                )
+            for node_id, node_type, language in graph_nodes or []:
+                conn.execute(
+                    "INSERT INTO graph_nodes (id, node_type, language) VALUES (?, ?, ?)",
+                    (node_id, node_type, language),
                 )
 
     def test_hotspot_count_uses_is_hotspot_flag(self, tmp_path: Path) -> None:
@@ -569,6 +590,66 @@ class TestQueryRepoStats:
         stats = workspace._query_repo_stats(db_path)
 
         assert stats["hotspot_count"] == 0
+
+    
+    def test_file_count_excludes_symbol_nodes(self, tmp_path: Path) -> None:
+        """Regression: graph_nodes stores file *and* symbol rows.
+
+        file_count must only count node_type='file' rows. Previously an
+        unfiltered COUNT(*) inflated the number by every symbol (function,
+        class, etc.) indexed alongside each file — roughly 10x on real repos.
+        """
+        db_path = tmp_path / ".repowise" / "wiki.db"
+        self._make_wiki_db(
+            db_path,
+            rows=[],
+            graph_nodes=[
+                ("src/a.py", "file", "python"),
+                ("src/b.py", "file", "python"),
+                ("src/c.py", "file", "python"),
+                # Every file contributes several symbol rows to the same table.
+                ("src/a.py::Foo", "symbol", "python"),
+                ("src/a.py::Foo.bar", "symbol", "python"),
+                ("src/a.py::Foo.baz", "symbol", "python"),
+                ("src/b.py::qux", "symbol", "python"),
+                ("src/b.py::quux", "symbol", "python"),
+                ("src/c.py::corge", "symbol", "python"),
+            ],
+        )
+
+        stats = workspace._query_repo_stats(db_path)
+
+        assert stats["file_count"] == 3
+
+    def test_top_language_excludes_symbol_nodes(self, tmp_path: Path) -> None:
+        """Regression: top-language must be derived from file rows only.
+
+        A language with fewer files can still "win" on an unfiltered count
+        if its files happen to contain lots of symbol rows. Here Python has
+        more files (3) than JavaScript (1), but JavaScript's single file has
+        many more symbol rows — an unfiltered query would incorrectly pick
+        JavaScript as the top language.
+        """
+        db_path = tmp_path / ".repowise" / "wiki.db"
+        self._make_wiki_db(
+            db_path,
+            rows=[],
+            graph_nodes=[
+                ("src/a.py", "file", "python"),
+                ("src/b.py", "file", "python"),
+                ("src/c.py", "file", "python"),
+                ("src/dense.js", "file", "javascript"),
+                ("src/dense.js::f1", "symbol", "javascript"),
+                ("src/dense.js::f2", "symbol", "javascript"),
+                ("src/dense.js::f3", "symbol", "javascript"),
+                ("src/dense.js::f4", "symbol", "javascript"),
+                ("src/dense.js::f5", "symbol", "javascript"),
+            ],
+        )
+
+        top_language = workspace._query_top_language(db_path)
+
+        assert top_language == "python"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #945

## What's wrong

`graph_nodes` stores both `file` and `symbol` rows, but `_query_repo_stats()` and `_query_top_language()` in `packages/server/src/repowise/server/routers/workspace.py` counted/grouped over the whole table. That inflated the per-repo file count (~10x on real repos), the "Total Files" header total (a sum of those numbers), and could skew the top-language pick toward a language with fewer files but denser symbol counts.

## The fix

Added `WHERE node_type = 'file'` to both queries. Minimal, scoped change — no schema or API shape changes.

The unfiltered `COUNT(*)` diagnostic in `packages/core/src/repowise/core/persistence/coordinator.py` is intentionally left untouched, per the issue.

## Testing

- Extended fixtures in `tests/unit/server/test_workspace_router.py` to model file + symbol rows together
- Added two regression tests: `test_file_count_excludes_symbol_nodes`, `test_top_language_excludes_symbol_nodes`
- Full suite: `tests/unit/server/test_workspace_router.py` → 41/41 passing
- Manually