### PR TITLE
fix(mcp): make the docstring budget test environment-independent, trim get_change_risk

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_change_risk.py
@@ -47,9 +47,8 @@ async def get_change_risk(
     """Score a live commit or ``base..head`` range from its diff shape.
 
     Use this for a pre-merge score of a commit or PR range. It is distinct from
-    ``get_risk``, which assesses indexed files and PR blast radius. ``extensions``
-    restricts counted suffixes; ``exclude_patterns`` omits gitignore-style paths.
-    Both filters also apply to the baseline used for the repository percentile.
+    ``get_risk``, which assesses indexed files and PR blast radius. Both filters
+    below also apply to the baseline used for the repository percentile.
 
     Prefer ``risk_percentile`` as the indicator of change risk: it ranks this
     change against sampled recent commits in the same repository. Summarize it

--- a/tests/unit/server/mcp/test_tool_docstrings.py
+++ b/tests/unit/server/mcp/test_tool_docstrings.py
@@ -8,6 +8,8 @@ every session. The reference-manual detail belongs in docs/MCP_TOOLS.md.
 
 from __future__ import annotations
 
+import inspect
+
 from repowise.core.registry import mcp_tool_registry
 
 # ~400 tokens at the 4-chars/token estimate used across the codebase.
@@ -25,11 +27,25 @@ def _registered_tools():
     return tools
 
 
+def _schema_doc(fn) -> str:
+    """The docstring as measured, normalized so the verdict is reproducible.
+
+    ``@mcp.tool()`` does not hand back the same string on every version of the
+    ``mcp`` package: 1.27 runs the docstring through ``inspect.cleandoc`` while
+    1.26 (the locked version) leaves each line's source indentation on it. That
+    is a ~90 char swing on a long docstring, which was enough for this budget to
+    pass locally and fail in CI on identical source. Dedent here so the number
+    measures the prose an agent reads rather than the dependency's normalizing
+    behaviour, and so a developer's environment cannot be more lenient than CI.
+    """
+    return inspect.cleandoc(fn.__doc__ or "")
+
+
 def test_every_tool_docstring_fits_the_schema_budget():
     oversized = {
-        fn.__name__: len(fn.__doc__ or "")
+        fn.__name__: len(_schema_doc(fn))
         for fn in _registered_tools()
-        if len(fn.__doc__ or "") > _MAX_DOCSTRING_CHARS
+        if len(_schema_doc(fn)) > _MAX_DOCSTRING_CHARS
     }
     assert not oversized, (
         f"Tool docstrings over {_MAX_DOCSTRING_CHARS} chars (~400 tokens): "
@@ -40,7 +56,7 @@ def test_every_tool_docstring_fits_the_schema_budget():
 
 def test_every_tool_docstring_leads_with_a_task_shaped_line():
     for fn in _registered_tools():
-        doc = (fn.__doc__ or "").strip()
+        doc = _schema_doc(fn).strip()
         assert doc, f"{fn.__name__} has no docstring — its schema would be blank"
         first = doc.splitlines()[0].strip()
         assert len(first) <= _MAX_FIRST_LINE_CHARS, (


### PR DESCRIPTION
`main` is currently red on `test_every_tool_docstring_fits_the_schema_budget`, reporting `get_change_risk` at 1669 chars against a 1600 ceiling.

## The test's verdict depended on a transitive dependency

It measured `fn.__doc__` straight off the registered tool, and `@mcp.tool()` does not return the same string on every version of the `mcp` package:

| | mcp 1.26.0 (pinned in `uv.lock`, so what CI installs) | mcp 1.27.1 |
|---|---|---|
| `fn.__doc__` | raw, each line's source indentation attached: **1669** | run through `inspect.cleandoc`: **1576** |

On a long docstring that is roughly a 90 char swing. The result: the budget passed for anyone whose environment had drifted ahead of the lock, and failed in CI, from byte-identical source. Any local run was systematically more lenient than CI.

The test now dedents before measuring, so it scores the prose an agent actually reads rather than the dependency's normalizing behaviour, and no environment can score more leniently than CI.

## Normalizing alone would have hidden a real overage

Under the locked version the schema genuinely was shipping 1669 chars, about 417 tokens against the ~400 the budget exists to enforce. So `get_change_risk` also loses the sentence describing `extensions` and `exclude_patterns`, which restated what its own `Args` block says two paragraphs later.

Measured from source under both behaviours:

```
BEFORE (main) raw=1669 FAIL | dedented=1576 pass
AFTER  (fix)  raw=1578 pass | dedented=1489 pass
```

Every registered tool now fits under either interpretation; `get_change_risk` is the largest remaining at 1578 raw.

## Scope

The docstring crossed the limit in #946, and this is not a regression from the two changes that landed after it. `docs/MCP_TOOLS.md` does not duplicate the removed sentence, and no other test pins it.

Worth deciding separately: `uv.lock` pins `mcp` 1.26.0 while newer environments install 1.27.x. Closing that drift deliberately would prevent the next version-dependent surprise.

## Testing

26 tests across the docstring, change-risk, tool-selection, tool-table-drift and prior-fixes suites pass.
