### PR TITLE
release: v0.34.0 — bug-fix history everywhere, zoomable knowledge graph, present mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.34.0] — 2026-07-20
+
+### Added
+- **Bug-fix history is now a first-class signal.** repowise counts the bug fixes that landed on each file over the trailing six months, traces each fix back to the commit that introduced it, and attributes it down to the symbol. A file that keeps getting fixed is flagged a *bug magnet*, and that flag now leads everywhere risk is shown: `get_risk` and `get_change_risk` return a `defect_profile` (`fix_count`, `last_fix_days_ago`, `bug_magnet`, `top_symbols`), the generated `CLAUDE.md` attention list ranks on fix history instead of raw churn, `get_context`'s triage does the same, and the CLI warns at edit time when you touch a file with a recent run of fixes. Only fixes that change production code are counted, so a test-only touch-up no longer inflates the number. (#931, #939, #940, #946, #947, #954, #956)
+- **Bug-fix history in the UI.** The health drawer, panel and hover show per-file fix history; the symbols view shows and filters by per-symbol fix counts; and the commits view replaces the old file-risk bars with commit-level distribution views. (#948, #949, #950)
+- **A zoomable Knowledge Graph.** The zoom map is now the Knowledge Graph at `/knowledge-graph`, with per-node code health rendered on the map. (#918)
+- **Present mode for docs.** Wiki pages can be presented as a slide deck with a guided walkthrough, and architecture diagrams in wiki pages are now deterministic rather than LLM-drawn. (#914, #915)
+- **Costs page tells the whole story.** Spend is labelled by operation, local runs are recorded at $0 instead of being dropped, ROI framing was added, and the agent savings the ledger was silently discarding are now counted. (#925, #927)
+- **`--verbose/-v` across the CLI.** `init` and `update` are quiet by default and show per-phase internals plus debug logs under `--verbose`; the same flag was added to `health`, `watch`, `restyle`, `generate-claude-md`, `coverage add`, and `workspace add` / `workspace scan`. (#929, #936, #937, #941, #942, #943, #944)
+
+### Changed
+- **`get_answer` always synthesizes.** Confidence is graded after synthesis on how well the answer is grounded in retrieved content, rather than inferred beforehand from the shape of the retrieval. A leaner high-confidence payload is available behind `REPOWISE_ANSWER_LEAN_HIGH`. (#919, #923, #938)
+- **Update keeps more of the index fresh.** A workspace update regenerates docs per repo, onboards a provider when a docs update needs one, and refreshes external systems (C4 L1) when the manifest changes. (#916, #917, #921)
+- **Faster generation.** Knowledge-graph enrichment overlaps page generation, and the inline-marker scan for decisions reuses ingestion's source map instead of re-reading files. (#912, #913)
+- **The SZZ blame pass is gone** from the git indexer; fix attribution is derived without it. (#951)
+- **Feedback CTA sharpened** and the recalibration banner dropped from the web UI. (#920)
+
+### Fixed
+- **Author experience is counted over the whole history**, not just the current update batch, so contributor stats no longer collapse on incremental runs. (#953)
+- **Update progress counts onboarding pages** in the generation total, so the bar no longer overshoots. (#928)
+- **Headline stats stop assuming a Sat/Sun weekend** and are given room to breathe. (#926)
+
+### Documentation
+- README rewritten and the `docs/` tree restructured into `start/`, `reference/`, and `layers/`; the quickstart was rewritten and the user guide collapsed to a guide. Provider extras that don't exist are no longer documented. (#957)
+- Plugin: version bump plus `--verbose` on the `init`, `update`, and `health` commands, and the pre-modification skill now reads `defect_profile`.
+
+### Dependencies
+- `mcp` 1.26.0 → 1.28.1. (#958)
+
 ## [0.33.0] — 2026-07-18
 
 ### Added

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.34.0] — 2026-07-20
+
+### Added
+- **Bug-fix history is now a first-class signal.** repowise counts the bug fixes that landed on each file over the trailing six months, traces each fix back to the commit that introduced it, and attributes it down to the symbol. A file that keeps getting fixed is flagged a *bug magnet*, and that flag now leads everywhere risk is shown: `get_risk` and `get_change_risk` return a `defect_profile` (`fix_count`, `last_fix_days_ago`, `bug_magnet`, `top_symbols`), the generated `CLAUDE.md` attention list ranks on fix history instead of raw churn, `get_context`'s triage does the same, and the CLI warns at edit time when you touch a file with a recent run of fixes. Only fixes that change production code are counted, so a test-only touch-up no longer inflates the number. (#931, #939, #940, #946, #947, #954, #956)
+- **Bug-fix history in the UI.** The health drawer, panel and hover show per-file fix history; the symbols view shows and filters by per-symbol fix counts; and the commits view replaces the old file-risk bars with commit-level distribution views. (#948, #949, #950)
+- **A zoomable Knowledge Graph.** The zoom map is now the Knowledge Graph at `/knowledge-graph`, with per-node code health rendered on the map. (#918)
+- **Present mode for docs.** Wiki pages can be presented as a slide deck with a guided walkthrough, and architecture diagrams in wiki pages are now deterministic rather than LLM-drawn. (#914, #915)
+- **Costs page tells the whole story.** Spend is labelled by operation, local runs are recorded at $0 instead of being dropped, ROI framing was added, and the agent savings the ledger was silently discarding are now counted. (#925, #927)
+- **`--verbose/-v` across the CLI.** `init` and `update` are quiet by default and show per-phase internals plus debug logs under `--verbose`; the same flag was added to `health`, `watch`, `restyle`, `generate-claude-md`, `coverage add`, and `workspace add` / `workspace scan`. (#929, #936, #937, #941, #942, #943, #944)
+
+### Changed
+- **`get_answer` always synthesizes.** Confidence is graded after synthesis on how well the answer is grounded in retrieved content, rather than inferred beforehand from the shape of the retrieval. A leaner high-confidence payload is available behind `REPOWISE_ANSWER_LEAN_HIGH`. (#919, #923, #938)
+- **Update keeps more of the index fresh.** A workspace update regenerates docs per repo, onboards a provider when a docs update needs one, and refreshes external systems (C4 L1) when the manifest changes. (#916, #917, #921)
+- **Faster generation.** Knowledge-graph enrichment overlaps page generation, and the inline-marker scan for decisions reuses ingestion's source map instead of re-reading files. (#912, #913)
+- **The SZZ blame pass is gone** from the git indexer; fix attribution is derived without it. (#951)
+- **Feedback CTA sharpened** and the recalibration banner dropped from the web UI. (#920)
+
+### Fixed
+- **Author experience is counted over the whole history**, not just the current update batch, so contributor stats no longer collapse on incremental runs. (#953)
+- **Update progress counts onboarding pages** in the generation total, so the bar no longer overshoots. (#928)
+- **Headline stats stop assuming a Sat/Sun weekend** and are given room to breathe. (#926)
+
+### Documentation
+- README rewritten and the `docs/` tree restructured into `start/`, `reference/`, and `layers/`; the quickstart was rewritten and the user guide collapsed to a guide. Provider extras that don't exist are no longer documented. (#957)
+- Plugin: version bump plus `--verbose` on the `init`, `update`, and `health` commands, and the pre-modification skill now reads `defect_profile`.
+
+### Dependencies
+- `mcp` 1.26.0 → 1.28.1. (#958)
+
 ## [0.33.0] — 2026-07-18
 
 ### Added

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "repowise",
   "displayName": "Repowise",
   "description": "Know what your change breaks before you push. Health signals, architecture maps, and refactoring plans in your editor, and the same intelligence for your AI agent via MCP. Local and free.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "repowise-dev",
   "license": "AGPL-3.0-or-later",
   "homepage": "https://www.repowise.dev",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.34.0
+
+### Changed
+- Version bump to track the repowise 0.34.0 release.
+- `pre-modification` skill reads the new `defect_profile` block on `get_risk`
+  (fix count, last fix age, `bug_magnet`, `top_symbols`) and leads with it.
+- `init`, `update`, and `health` commands document `-v, --verbose`; `init` and
+  `update` are now quiet by default.
+
 ## 0.33.0
 
 ### Added

--- a/plugins/claude-code/commands/health.md
+++ b/plugins/claude-code/commands/health.md
@@ -31,8 +31,8 @@ Handle `$ARGUMENTS`:
 - "safe" → `repowise health --safe-only`
 - a coverage file (e.g. `cov.lcov`, `coverage.xml`, `.coverage`) → `repowise coverage add <file>` to ingest it (folds into health markers, and builds the per-test map when the report has contexts), then `repowise health`
 
-Other flags: `--format json` for machine-readable output, `--repo <alias>` /
-`--no-workspace` in workspace mode.
+Other flags: `--format json` for machine-readable output, `-v, --verbose` for
+pipeline debug logs, `--repo <alias>` / `--no-workspace` in workspace mode.
 
 ## Notes
 

--- a/plugins/claude-code/commands/init.md
+++ b/plugins/claude-code/commands/init.md
@@ -88,6 +88,7 @@ Git:
 Output:
   --no-claude-md         Don't generate/update CLAUDE.md
   -y, --yes              Skip cost confirmation prompt
+  -v, --verbose          Show per-phase internals plus debug logs (quiet by default)
 
 Recovery:
   --resume               Resume a previously interrupted init

--- a/plugins/claude-code/commands/update.md
+++ b/plugins/claude-code/commands/update.md
@@ -30,6 +30,7 @@ Trigger an incremental update of the Repowise index.
 - `--since REF` — base git ref to diff from (overrides saved last_sync_commit). Accepts a commit SHA, tag, or branch name.
 - `--cascade-budget N` — max pages to regenerate per run (default: 30)
 - `--dry-run` — show affected pages without regenerating
+- `-v, --verbose` — show the full changed-file list, per-phase internals, and debug logs (the run is quiet by default)
 
 ## Handling $ARGUMENTS
 

--- a/plugins/claude-code/skills/pre-modification/SKILL.md
+++ b/plugins/claude-code/skills/pre-modification/SKILL.md
@@ -18,6 +18,12 @@ Call `get_risk(targets=["path/to/file.py"])`. Per file it returns
 `hotspot_score`, `trend`, `risk_type`, `impact_surface` (top 3),
 `dependents_count`, `co_change_partners`, `primary_owner`, `bus_factor`,
 `test_gap`, and `security_signals`. Read it for:
+- **Bug-fix history** (`defect_profile`) — present only on files with counted
+  fixes: `fix_count` over the trailing 6 months, `last_fix_days_ago`, a
+  `bug_magnet` flag for sustained recent fix pressure, and `top_symbols` (the
+  per-symbol counts are approximate — read them as "mostly here"). A file that
+  keeps getting fixed is the strongest single signal that the next edit breaks
+  something; lead with it.
 - **Hotspot status** (`hotspot_score`, `trend`) — high-churn × complex? Extra care needed.
 - **Dependents** (`dependents_count`, `impact_surface`) — how wide is the blast radius?
 - **Co-change partners** — files that change together with this one (often without an import link); you may need to update them too.
@@ -31,6 +37,7 @@ Batch all targets into one call: `get_risk(targets=["file1.py", "file2.py", "mod
 ## When to warn the user
 
 If `get_risk` shows:
+- A `defect_profile` with `bug_magnet` set — say so plainly: this file has been fixed repeatedly and recently
 - Hotspot score above 90th percentile — mention this is a frequently-changed, high-risk file
 - More than 10 dependents — list the top dependents; API changes here will break consumers
 - Bus factor of 1 — note that a single person maintains this code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.33.0"
+version = "0.34.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3056,7 +3056,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.33.0"
+version = "0.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump + changelog for 0.34.0, plus a VS Code extension bump to 0.5.0.

## What ships

The headline of the cycle is bug-fix history as a first-class signal: counted fixes per file over a six-month window, traced back to the commit that introduced them and attributed down to the symbol, surfaced through `get_risk` / `get_change_risk` (`defect_profile`), the generated `CLAUDE.md` attention list, `get_context` triage, an edit-time CLI warning, and the health, symbols and commits views. Alongside that: the zoomable Knowledge Graph with per-node health, Present mode for docs with deterministic architecture diagrams, a rebuilt costs page, post-synthesis confidence grading in `get_answer`, and `--verbose` across the CLI with `init`/`update` quiet by default.

## Version bump

- Four Python files + `uv.lock` at 0.34.0
- Claude Code plugin manifests (marketplace + plugin.json) at 0.34.0; Codex plugin untouched this cycle
- `packages/vscode/package.json` 0.4.0 -> 0.5.0. 12 `packages/ui` commits landed in webview-consumed subpaths (`health/`, `graph/`, `docs/`, `c4/`) since `vscode-v0.4.0`, so the bundled UI is behind. `MIN_SERVER_VERSION` stays at 0.26.0 — the new fix-history fields are optional and absent ones simply render nothing.
- `STORE_FORMAT_VERSION` / `PARSER_SCHEMA_VERSION` unchanged. The new `GitMetadata` columns are additive and back-filled by `_reconcile_schema`; an index that predates the fix-event rollup reports 0/None and falls through to the existing rules until the next update.

## Plugin parity

- `init`, `update`, `health` commands document `-v, --verbose`
- `pre-modification` skill reads `defect_profile` and leads with `bug_magnet`
- MCP tool names in the plugin all appear in the live `list_tools()` output (17 registered)

## Test plan

- [x] `uv lock` — self-entry moved to 0.34.0, no 0.33.0 drift in the grep
- [x] `uv build --wheel` — clean; 71 CLI command entries, 40 `.scm`/`.j2` data files present
- [x] `npm ci && npm run build --workspace packages/web` — 22 routes, standalone `server.js` emitted, workspace-package code present in compiled chunks
- [x] Clean-venv install of the wheel: `repowise --version` -> 0.34.0
- [x] `tests/unit/upgrade/test_bundled_changelog_sync.py` — bundled changelog resynced
- [x] Extension: type-check, host build (120.2 KB of a 300 KB budget), webview build, 43 webview tests, electron smoke, `repowise-0.5.0.vsix` packaged at 2.22 MB
- [ ] Browser click-through of `/repos/[id]/overview`, `/knowledge-graph`, `/hotspots`, `/wiki/[slug]`, `/costs`
- [ ] Tag `v0.34.0` on main after merge, watch `publish.yml`
- [ ] Tag `vscode-v0.5.0` after the PyPI release lands

## Merge convention

Regular **merge commit**, not squash — the tag has to point at a real merge of the bump-only diff.