### PR TITLE
fix(ui): render the bug-fix history these surfaces already receive

### DIFF
--- a/packages/api-client/src/types/git.ts
+++ b/packages/api-client/src/types/git.ts
@@ -74,6 +74,10 @@ export interface HotspotResponse {
   change_entropy?: number;
   change_entropy_pct?: number;
   prior_defect_count?: number;
+  /** Decayed fix mass past its trigger. A recency claim, so any copy showing
+   *  it must show `last_fix_at` too. */
+  bug_magnet?: boolean;
+  last_fix_at?: string | null;
   original_path?: string | null;
 }
 

--- a/packages/server/src/repowise/server/routers/git.py
+++ b/packages/server/src/repowise/server/routers/git.py
@@ -100,6 +100,8 @@ def _hotspot_from_row(r: GitMetadata) -> HotspotResponse:
         # Normalize 0-1 -> 0-100 to match churn_percentile.
         change_entropy_pct=(r.change_entropy_pct or 0.0) * 100.0,
         prior_defect_count=r.prior_defect_count or 0,
+        bug_magnet=bool(r.bug_magnet),
+        last_fix_at=r.last_fix_at,
         original_path=r.original_path,
     )
 

--- a/packages/server/src/repowise/server/schemas/git.py
+++ b/packages/server/src/repowise/server/schemas/git.py
@@ -134,6 +134,11 @@ class HotspotResponse(BaseModel):
     change_entropy: float = 0.0
     change_entropy_pct: float = 0.0
     prior_defect_count: int = 0
+    # ``last_fix_at`` travels with ``bug_magnet`` because a magnet flag with no
+    # age describes "fixed 4x last month" and "fixed 4x two years ago"
+    # identically. Consumers drop the flag when the timestamp is missing.
+    bug_magnet: bool = False
+    last_fix_at: datetime | None = None
     original_path: str | None = None
 
 

--- a/packages/types/src/git.ts
+++ b/packages/types/src/git.ts
@@ -107,6 +107,10 @@ export interface Hotspot {
   change_entropy_pct?: number;
   /** Bug-fix commits touching this file in the trailing defect window. */
   prior_defect_count?: number;
+  /** Decayed fix mass past its trigger. A recency claim, so any copy showing
+   *  it must show `last_fix_at` too. */
+  bug_magnet?: boolean;
+  last_fix_at?: string | null;
   /** The file's path before its most recent rename, if any. */
   original_path?: string | null;
 }

--- a/packages/ui/__tests__/git/fix-history-badge.test.tsx
+++ b/packages/ui/__tests__/git/fix-history-badge.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FixHistoryBadge } from "../../src/git/fix-history-badge.js";
+
+const daysAgo = (n: number) =>
+  new Date(Date.now() - n * 86_400_000).toISOString();
+
+describe("FixHistoryBadge", () => {
+  it("renders nothing for a file with no counted fixes", () => {
+    const { container } = render(
+      <FixHistoryBadge count={0} lastFixAt={daysAgo(2)} bugMagnet />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the count is absent entirely", () => {
+    const { container } = render(<FixHistoryBadge count={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the count alongside the age of the last fix", () => {
+    render(<FixHistoryBadge count={3} lastFixAt={daysAgo(2)} />);
+    expect(screen.getByText("3 fixes · last 2d ago")).toBeTruthy();
+  });
+
+  it("calls out a bug magnet once an age anchors it", () => {
+    render(<FixHistoryBadge count={4} lastFixAt={daysAgo(6)} bugMagnet />);
+    expect(screen.getByText(/^Bug magnet ·/)).toBeTruthy();
+  });
+
+  it("hides the magnet wording when the timestamp is missing", () => {
+    render(<FixHistoryBadge count={4} lastFixAt={null} bugMagnet />);
+    expect(screen.getByText("4 fixes")).toBeTruthy();
+    expect(screen.queryByText(/Bug magnet/)).toBeNull();
+  });
+});

--- a/packages/ui/__tests__/git/hotspot-table.test.tsx
+++ b/packages/ui/__tests__/git/hotspot-table.test.tsx
@@ -74,3 +74,59 @@ describe("HotspotTable virtualization", () => {
     expect(screen.getByText("No hotspots found")).toBeInTheDocument();
   });
 });
+
+const daysAgo = (n: number) =>
+  new Date(Date.now() - n * 86_400_000).toISOString();
+
+describe("HotspotTable fix history", () => {
+  it("hides the Fixes column entirely when no row has counted fixes", () => {
+    render(<HotspotTable hotspots={rows} />);
+    expect(screen.queryByRole("button", { name: /^Fixes/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Bug magnet/ })).not.toBeInTheDocument();
+  });
+
+  it("shows the Fixes column once the index carries fix data", () => {
+    const withFixes = [
+      hotspot({ file_path: "src/a.ts", prior_defect_count: 7, last_fix_at: daysAgo(3) }),
+      hotspot({ file_path: "src/b.ts", prior_defect_count: 0 }),
+    ];
+    render(<HotspotTable hotspots={withFixes} />);
+    expect(screen.getByRole("button", { name: /^Fixes/ })).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+    // The file with no fixes shows a dash, not a misleading zero.
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("sorts on fix count, independently of churn", () => {
+    const withFixes = [
+      hotspot({ file_path: "src/low-fix.ts", commit_count_90d: 99, prior_defect_count: 1, last_fix_at: daysAgo(2) }),
+      hotspot({ file_path: "src/high-fix.ts", commit_count_90d: 1, prior_defect_count: 9, last_fix_at: daysAgo(2) }),
+    ];
+    render(<HotspotTable hotspots={withFixes} />);
+    fireEvent.click(screen.getByRole("button", { name: /^Fixes/ }));
+    const paths = screen
+      .getAllByTitle(/^src\//)
+      .map((el) => el.textContent);
+    expect(paths[0]).toBe("src/high-fix.ts");
+  });
+
+  it("offers a Bug magnet chip only for magnets that carry a timestamp", () => {
+    const anchored = hotspot({
+      file_path: "src/magnet.ts",
+      prior_defect_count: 5,
+      bug_magnet: true,
+      last_fix_at: daysAgo(4),
+    });
+    const unanchored = hotspot({
+      file_path: "src/unanchored.ts",
+      prior_defect_count: 5,
+      bug_magnet: true,
+      last_fix_at: null,
+    });
+    render(<HotspotTable hotspots={[anchored, unanchored]} />);
+    // One of the two claims a magnet; the timestamp-less one is not counted.
+    fireEvent.click(screen.getByRole("button", { name: /^Bug magnet \(1\)$/ }));
+    expect(screen.getByText("src/magnet.ts")).toBeInTheDocument();
+    expect(screen.queryByText("src/unanchored.ts")).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/__tests__/lib/fix-history.test.ts
+++ b/packages/ui/__tests__/lib/fix-history.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { summarizeFixHistory } from "../../src/lib/fix-history.js";
+
+const daysAgo = (n: number) =>
+  new Date(Date.now() - n * 86_400_000).toISOString();
+
+describe("summarizeFixHistory", () => {
+  it("is silent for a file with no counted fixes", () => {
+    expect(summarizeFixHistory(0, daysAgo(3), true)).toBeNull();
+    expect(summarizeFixHistory(null)).toBeNull();
+    expect(summarizeFixHistory(undefined)).toBeNull();
+  });
+
+  it("pairs the count with the age of the last fix", () => {
+    const fix = summarizeFixHistory(3, daysAgo(2));
+    expect(fix?.countLabel).toBe("3 fixes");
+    expect(fix?.age).toBe("2d ago");
+    expect(fix?.label).toBe("3 fixes · last 2d ago");
+  });
+
+  it("singularizes a lone fix", () => {
+    expect(summarizeFixHistory(1, daysAgo(1))?.countLabel).toBe("1 fix");
+  });
+
+  it("keeps the count when the timestamp is unknown", () => {
+    const fix = summarizeFixHistory(4, null);
+    expect(fix?.age).toBeNull();
+    expect(fix?.label).toBe("4 fixes");
+  });
+
+  it("drops the magnet flag when there is no age to anchor it", () => {
+    expect(summarizeFixHistory(4, null, true)?.magnet).toBe(false);
+    expect(summarizeFixHistory(4, "not-a-date", true)?.magnet).toBe(false);
+  });
+
+  it("drops the magnet flag on a future timestamp rather than reading 'in 3d'", () => {
+    const fix = summarizeFixHistory(4, daysAgo(-3), true);
+    expect(fix?.age).toBeNull();
+    expect(fix?.magnet).toBe(false);
+  });
+
+  it("keeps the magnet flag when an age is available", () => {
+    expect(summarizeFixHistory(4, daysAgo(5), true)?.magnet).toBe(true);
+  });
+
+  it("never invents a magnet the data did not claim", () => {
+    expect(summarizeFixHistory(9, daysAgo(1))?.magnet).toBe(false);
+    expect(summarizeFixHistory(9, daysAgo(1), false)?.magnet).toBe(false);
+  });
+});

--- a/packages/ui/__tests__/symbols/symbol-headers.test.tsx
+++ b/packages/ui/__tests__/symbols/symbol-headers.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SymbolPage } from "../../src/symbols/symbol-page.js";
+import { SymbolDrawer } from "../../src/symbols/symbol-drawer.js";
+import type {
+  SymbolDetailData,
+  SymbolDetailResponse,
+} from "@repowise-dev/types/symbols";
+
+const daysAgo = (n: number) =>
+  new Date(Date.now() - n * 86_400_000).toISOString();
+
+const routeData = (
+  overrides: Partial<SymbolDetailResponse> = {},
+): SymbolDetailResponse => ({
+  symbol: {
+    id: "s1",
+    repository_id: "r",
+    file_path: "src/foo.ts",
+    symbol_id: "src/foo.ts::bar",
+    name: "bar",
+    qualified_name: "foo.bar",
+    kind: "function",
+    signature: "function bar()",
+    start_line: 10,
+    end_line: 15,
+    docstring: null,
+    visibility: "public",
+    is_async: false,
+    complexity_estimate: 3,
+    language: "typescript",
+    parent_name: null,
+    file_is_hotspot: true,
+  },
+  graph: { pagerank: 0, in_degree: 0, out_degree: 0, callers: [], callees: [] },
+  governing_decisions: [],
+  file_context: {
+    file_path: "src/foo.ts",
+    health_score: 70,
+    is_hotspot: true,
+    primary_owner: "Ada",
+    language: "typescript",
+  },
+  ...overrides,
+});
+
+const drawerData = (
+  overrides: Partial<SymbolDetailData> = {},
+): SymbolDetailData => ({
+  identity: {
+    name: "bar",
+    qualified_name: "foo.bar",
+    kind: "function",
+    visibility: "public",
+    language: "typescript",
+    is_async: false,
+    file_path: "src/foo.ts",
+    start_line: 10,
+    parent_name: null,
+    file_is_hotspot: true,
+  },
+  ...overrides,
+});
+
+describe("symbol headers", () => {
+  it("shows the fix count beside the hot-file flame on the route", () => {
+    render(
+      <SymbolPage
+        data={routeData({ fix_count: 2, fix_last_at: daysAgo(5) })}
+        repoId="r"
+      />,
+    );
+    expect(screen.getByText("hot file")).toBeTruthy();
+    expect(screen.getByText("2 fixes · last 5d ago")).toBeTruthy();
+  });
+
+  it("leaves the route header unchanged for a symbol with no fixes", () => {
+    render(<SymbolPage data={routeData({ fix_count: 0 })} repoId="r" />);
+    expect(screen.getByText("hot file")).toBeTruthy();
+    expect(screen.queryByText(/fix/)).toBeNull();
+  });
+
+  it("shows the same fix count in the drawer header", () => {
+    render(
+      <SymbolDrawer
+        data={drawerData({ fix_count: 2, fix_last_at: daysAgo(5) })}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText("2 fixes · last 5d ago")).toBeTruthy();
+  });
+
+  it("leaves the drawer header unchanged for a symbol with no fixes", () => {
+    render(<SymbolDrawer data={drawerData({ fix_count: null })} onClose={() => {}} />);
+    expect(screen.queryByText(/fix/)).toBeNull();
+  });
+});

--- a/packages/ui/__tests__/wiki/git-history-panel.test.tsx
+++ b/packages/ui/__tests__/wiki/git-history-panel.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GitHistoryPanel } from "../../src/wiki/git-history-panel.js";
+import type { GitMetadata } from "@repowise-dev/types/git";
+
+const daysAgo = (n: number) =>
+  new Date(Date.now() - n * 86_400_000).toISOString();
+
+const meta = (overrides: Partial<GitMetadata> = {}): GitMetadata => ({
+  file_path: "src/foo.ts",
+  commit_count_total: 40,
+  commit_count_90d: 8,
+  commit_count_30d: 2,
+  first_commit_at: daysAgo(400),
+  last_commit_at: daysAgo(3),
+  primary_owner_name: "Ada",
+  primary_owner_email: "ada@example.com",
+  primary_owner_commit_pct: 0.6,
+  recent_owner_name: "Ada",
+  recent_owner_commit_pct: 0.5,
+  top_authors: [],
+  significant_commits: [],
+  co_change_partners: [],
+  is_hotspot: true,
+  is_stable: false,
+  churn_percentile: 92,
+  age_days: 400,
+  bus_factor: 2,
+  contributor_count: 4,
+  lines_added_90d: 100,
+  lines_deleted_90d: 40,
+  avg_commit_size: 30,
+  commit_categories: {},
+  merge_commit_count_90d: 0,
+  ...overrides,
+});
+
+describe("GitHistoryPanel fix history", () => {
+  it("puts the fix count beside the churn badges, and agrees with the card below", () => {
+    render(<GitHistoryPanel git={meta({ prior_defect_count: 3, last_fix_at: daysAgo(4) })} />);
+    // The headline badge and the change-history card's fix row, telling the
+    // same story rather than one counting and the other not.
+    expect(screen.getAllByText(/3 fixes · last 4d ago/)).toHaveLength(2);
+  });
+
+  it("adds nothing to a file with no counted fixes", () => {
+    render(<GitHistoryPanel git={meta({ prior_defect_count: 0 })} />);
+    expect(screen.queryByText(/fixes/)).toBeNull();
+    expect(screen.queryByText(/Bug magnet/)).toBeNull();
+  });
+
+  it("flags a bug magnet only with the age beside it", () => {
+    const { unmount } = render(
+      <GitHistoryPanel
+        git={meta({ prior_defect_count: 5, last_fix_at: daysAgo(6), bug_magnet: true })}
+      />,
+    );
+    expect(screen.getByText(/^Bug magnet ·/)).toBeTruthy();
+    unmount();
+
+    render(
+      <GitHistoryPanel
+        git={meta({ prior_defect_count: 5, last_fix_at: null, bug_magnet: true })}
+      />,
+    );
+    expect(screen.queryByText(/Bug magnet/)).toBeNull();
+  });
+
+  it("leaves the card's fix row as a bare count when the timestamp is missing", () => {
+    render(<GitHistoryPanel git={meta({ prior_defect_count: 2, last_fix_at: null })} />);
+    expect(screen.getAllByText(/2 fixes/)).toHaveLength(2);
+    expect(screen.queryByText(/· last/)).toBeNull();
+  });
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -104,6 +104,7 @@
     "./lib/cn": "./src/lib/cn.ts",
     "./lib/confidence": "./src/lib/confidence.ts",
     "./lib/errors": "./src/lib/errors.ts",
+    "./lib/fix-history": "./src/lib/fix-history.ts",
     "./lib/format": "./src/lib/format.ts",
     "./lib/page-types": "./src/lib/page-types.ts"
   },

--- a/packages/ui/src/git/change-history-card.tsx
+++ b/packages/ui/src/git/change-history-card.tsx
@@ -1,11 +1,15 @@
 import { Activity, Bug, FileSymlink, History } from "lucide-react";
 import { ChurnBar } from "./churn-bar";
+import { formatRelativeTimeOrNull } from "../lib/format";
 
 export interface ChangeHistoryCardProps {
   /** Repo-wide percentile rank of change entropy, 0–100. */
   changeEntropyPct?: number | null;
   /** Bug-fix commits touching this file in the trailing defect window. */
   priorDefectCount?: number | null;
+  /** When the most recent counted fix landed. A count without an age reads the
+   *  same at two weeks and two years, so it is shown wherever it is known. */
+  lastFixAt?: string | null;
   /** The file's path before its most recent rename, if any. */
   originalPath?: string | null;
   /** True when the per-file commit-history cap was hit during indexing. */
@@ -22,6 +26,7 @@ export interface ChangeHistoryCardProps {
 export function ChangeHistoryCard({
   changeEntropyPct,
   priorDefectCount,
+  lastFixAt,
   originalPath,
   commitCountCapped,
   className,
@@ -29,6 +34,8 @@ export function ChangeHistoryCard({
   const hasEntropy = changeEntropyPct != null && changeEntropyPct > 0;
   const hasDefects = priorDefectCount != null && priorDefectCount > 0;
   const hasRename = !!originalPath;
+  // Empty when unknown, so the count degrades to standing on its own.
+  const fixAge = hasDefects ? formatRelativeTimeOrNull(lastFixAt ?? null, "") : "";
 
   // Nothing meaningful to show — let the caller omit the section entirely.
   if (!hasEntropy && !hasDefects && !hasRename && !commitCountCapped) return null;
@@ -70,6 +77,7 @@ export function ChangeHistoryCard({
               title="Bug-fix commits that touched this file in the trailing defect window."
             >
               {priorDefectCount} {priorDefectCount === 1 ? "fix" : "fixes"}
+              {fixAge ? ` · last ${fixAge}` : ""}
             </span>
           </div>
         )}

--- a/packages/ui/src/git/fix-history-badge.tsx
+++ b/packages/ui/src/git/fix-history-badge.tsx
@@ -1,0 +1,50 @@
+import { Bug } from "lucide-react";
+import { Badge } from "../ui/badge";
+import { summarizeFixHistory } from "../lib/fix-history";
+
+export interface FixHistoryBadgeProps {
+  /** Counted bug fixes in the trailing defect window. */
+  count?: number | null;
+  /** Timestamp of the most recent counted fix, if known. */
+  lastFixAt?: string | null;
+  /** Decayed fix mass past its trigger. Ignored unless an age is available. */
+  bugMagnet?: boolean | null;
+  /** Override the tooltip — symbol-level counts hedge, file-level ones don't. */
+  title?: string;
+  className?: string;
+}
+
+const DEFAULT_TITLE =
+  "Bug-fix commits that touched this file in the trailing defect window.";
+
+/** Symbol-level counts are matched by line range, so their copy hedges. */
+export const SYMBOL_FIX_TITLE =
+  "Bug fixes that landed in this symbol in the trailing defect window (approximate: matched by line range).";
+
+/**
+ * The headline "N fixes, last X ago" pill. Renders nothing when the file has
+ * no counted fixes, and drops the magnet wording when there is no timestamp to
+ * anchor it — both rules live in {@link summarizeFixHistory}. Aggregate counts
+ * only: no inducing commit is ever named.
+ */
+export function FixHistoryBadge({
+  count,
+  lastFixAt,
+  bugMagnet,
+  title,
+  className,
+}: FixHistoryBadgeProps) {
+  const fix = summarizeFixHistory(count, lastFixAt, bugMagnet);
+  if (!fix) return null;
+
+  return (
+    <Badge
+      variant={fix.magnet ? "outdated" : "outline"}
+      className={className}
+      title={title ?? DEFAULT_TITLE}
+    >
+      <Bug className="h-2.5 w-2.5" />
+      {fix.magnet ? `Bug magnet · ${fix.label}` : fix.label}
+    </Badge>
+  );
+}

--- a/packages/ui/src/git/hotspot-table.tsx
+++ b/packages/ui/src/git/hotspot-table.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useState, useMemo } from "react";
-import { TrendingUp, TrendingDown, Search, Flame, ArrowUpDown, ArrowUp, ArrowDown, GitBranch, BookOpen, Radius, ChevronRight, ChevronDown } from "lucide-react";
+import { TrendingUp, TrendingDown, Search, Flame, Bug, ArrowUpDown, ArrowUp, ArrowDown, GitBranch, BookOpen, Radius, ChevronRight, ChevronDown } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Input } from "../ui/input";
 import { EmptyState } from "../shared/empty-state";
@@ -11,6 +11,7 @@ import { RowActions } from "../shared/row-actions";
 import { AiPromptButton } from "../health/ai-prompt-button";
 import { ChurnBar } from "./churn-bar";
 import { formatLOC } from "../lib/format";
+import { summarizeFixHistory } from "../lib/fix-history";
 import { cn } from "../lib/cn";
 import { useVirtualRows } from "../shared/virtualized-table";
 import { clickableRowProps, CLICKABLE_ROW_CLS } from "../shared/responsive-table";
@@ -54,9 +55,13 @@ interface HotspotTableProps {
   onGeneratePrompt?: (hotspot: Hotspot) => void;
 }
 
-type Filter = "all" | "hot" | "risk" | "accelerating";
-type SortKey = "trend" | "churn" | "commits";
+type Filter = "all" | "hot" | "risk" | "accelerating" | "magnet";
+type SortKey = "trend" | "churn" | "commits" | "fixes";
 type SortDir = "asc" | "desc";
+
+/** A row's fix history, or null when it has none. */
+const fixOf = (h: Hotspot) =>
+  summarizeFixHistory(h.prior_defect_count, h.last_fix_at, h.bug_magnet);
 
 function SortIcon({ column, sortKey, sortDir }: { column: SortKey; sortKey: SortKey; sortDir: SortDir }) {
   if (column !== sortKey) return <ArrowUpDown className="inline h-3 w-3 ml-1 opacity-60" />;
@@ -129,6 +134,9 @@ export function HotspotTable({
       case "accelerating":
         items = items.filter((h) => h.commit_count_30d * 3 > h.commit_count_90d);
         break;
+      case "magnet":
+        items = items.filter((h) => fixOf(h)?.magnet);
+        break;
     }
 
     const sign = sortDir === "desc" ? -1 : 1;
@@ -140,6 +148,8 @@ export function HotspotTable({
       }
       if (sortKey === "churn") return sign * (a.churn_percentile - b.churn_percentile);
       if (sortKey === "commits") return sign * (a.commit_count_90d - b.commit_count_90d);
+      if (sortKey === "fixes")
+        return sign * ((a.prior_defect_count ?? 0) - (b.prior_defect_count ?? 0));
       return 0;
     });
 
@@ -148,13 +158,23 @@ export function HotspotTable({
 
   // Memoize the filter chips' counts so the three full `hotspots` scans only
   // run when the dataset changes, not on every keystroke / sort / expand.
-  const filters: { key: Filter; label: string; count: number }[] = useMemo(
-    () => [
+  const filters: { key: Filter; label: string; count: number }[] = useMemo(() => {
+    const base: { key: Filter; label: string; count: number }[] = [
       { key: "all", label: "All", count: hotspots.length },
       { key: "hot", label: "Hot", count: hotspots.filter((h) => h.is_hotspot).length },
       { key: "risk", label: "Bus factor risk", count: hotspots.filter((h) => h.bus_factor <= 1).length },
       { key: "accelerating", label: "Accelerating", count: hotspots.filter((h) => h.commit_count_30d * 3 > h.commit_count_90d).length },
-    ],
+    ];
+    // A repo with no counted magnets gets no chip at all rather than a zero.
+    const magnets = hotspots.filter((h) => fixOf(h)?.magnet).length;
+    if (magnets > 0) base.push({ key: "magnet", label: "Bug magnet", count: magnets });
+    return base;
+  }, [hotspots]);
+
+  // Churn and bug-fix history are different claims, so the Fixes column only
+  // appears once the index actually carries fix data for this set of files.
+  const hasFixData = useMemo(
+    () => hotspots.some((h) => (h.prior_defect_count ?? 0) > 0),
     [hotspots],
   );
 
@@ -247,6 +267,22 @@ export function HotspotTable({
                     Commits 90d<SortIcon column="commits" sortKey={sortKey} sortDir={sortDir} />
                   </button>
                 </th>
+                {hasFixData && (
+                  <th
+                    scope="col"
+                    aria-sort={ariaSortFor("fixes", sortKey, sortDir)}
+                    className="px-3 py-2.5 text-right text-[11px] font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider w-24"
+                  >
+                    <button
+                      type="button"
+                      className="cursor-pointer select-none uppercase tracking-wider font-medium hover:text-[var(--color-text-secondary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent-primary)] rounded"
+                      onClick={() => handleSort("fixes")}
+                      title="Bug-fix commits that touched this file in the trailing defect window. Churn counts every change; this counts only the ones that fixed something."
+                    >
+                      Fixes<SortIcon column="fixes" sortKey={sortKey} sortDir={sortDir} />
+                    </button>
+                  </th>
+                )}
                 <th
                   scope="col"
                   aria-sort={ariaSortFor("churn", sortKey, sortDir)}
@@ -298,6 +334,7 @@ export function HotspotTable({
               if (h === undefined) return null;
               const i = vr.index;
               const accelerating = h.commit_count_30d * 3 > h.commit_count_90d;
+              const fix = fixOf(h);
               const trendScore = h.temporal_hotspot_score;
               const isExpanded = expanded.has(h.file_path);
               return (
@@ -350,6 +387,34 @@ export function HotspotTable({
                         )}
                       </span>
                     </td>
+                    {hasFixData && (
+                      <td className="px-3 py-2.5 tabular-nums text-xs text-right">
+                        {fix ? (
+                          <span
+                            className={cn(
+                              "inline-flex items-center justify-end gap-1",
+                              fix.magnet
+                                ? "text-[var(--color-error)]"
+                                : "text-[var(--color-text-secondary)]",
+                            )}
+                            title={
+                              fix.magnet
+                                ? `Bug magnet: ${fix.label}`
+                                : `Bug fixes: ${fix.label}`
+                            }
+                          >
+                            <Bug className="h-3 w-3 shrink-0" />
+                            {fix.count}
+                            {/* The magnet emphasis never travels without its age. */}
+                            {fix.magnet && (
+                              <span className="text-[10px] font-normal">{fix.age}</span>
+                            )}
+                          </span>
+                        ) : (
+                          <span className="text-[var(--color-text-tertiary)]">—</span>
+                        )}
+                      </td>
+                    )}
                     <td className="px-3 py-2.5 hidden lg:table-cell">
                       <div className="flex items-center gap-2">
                         <ChurnBar percentile={h.churn_percentile} className="w-16" />
@@ -419,7 +484,7 @@ export function HotspotTable({
                   {expandable && isExpanded && (
                     <tr className="border-b border-[var(--color-table-divider)] bg-[var(--color-bg-subtle)] last:border-0">
                       <td className="px-1" />
-                      <td colSpan={9} className="px-3 py-3">
+                      <td colSpan={hasFixData ? 10 : 9} className="px-3 py-3">
                         {renderExpandedRow!(h)}
                       </td>
                     </tr>

--- a/packages/ui/src/git/index.ts
+++ b/packages/ui/src/git/index.ts
@@ -9,6 +9,7 @@ export * from "./commit-category-sparkline";
 export * from "./contributor-bar";
 export * from "./contributors-strip";
 export * from "./contributor-network";
+export * from "./fix-history-badge";
 export * from "./hotspot-table";
 export * from "./ownership-donut";
 export * from "./ownership-table";

--- a/packages/ui/src/lib/fix-history.ts
+++ b/packages/ui/src/lib/fix-history.ts
@@ -1,0 +1,48 @@
+import { formatRelativeTimeOrNull } from "./format";
+
+export interface FixHistorySummary {
+  /** Counted bug fixes in the trailing defect window. Always > 0. */
+  count: number;
+  /** "3 fixes" / "1 fix" — safe to show on its own. */
+  countLabel: string;
+  /** "2mo ago", or null when the timestamp is missing, invalid, or in the future. */
+  age: string | null;
+  /** Only ever true when `age` is non-null — see the recency contract below. */
+  magnet: boolean;
+  /** "3 fixes · last 2mo ago", or just the count when the age is unknown. */
+  label: string;
+}
+
+/**
+ * The one place that turns raw fix columns into copy, so every surface tells
+ * the same story about the same file.
+ *
+ * Two rules are baked in rather than left to each caller:
+ *
+ * - Silence when absent. No counted fixes means null, and callers render
+ *   nothing at all — not a zero, not an empty row. A clean file's UI is
+ *   unchanged by this feature.
+ * - Recency. `bug_magnet` is a claim about *recent* fix pressure, so `magnet`
+ *   is suppressed unless an age can sit beside it. "Fixed 4x last month" and
+ *   "fixed 4x two years ago" must not render identically, and an unanchored
+ *   flag says exactly that. The count itself is windowed and stands alone.
+ *
+ * `formatRelativeTimeOrNull` supplies the future-guard, so a clock-skewed
+ * timestamp degrades to count-only rather than "in 3 days".
+ */
+export function summarizeFixHistory(
+  count: number | null | undefined,
+  lastFixAt?: string | null,
+  bugMagnet?: boolean | null,
+): FixHistorySummary | null {
+  if (count == null || count <= 0) return null;
+  const age = formatRelativeTimeOrNull(lastFixAt ?? null, "") || null;
+  const countLabel = `${count} ${count === 1 ? "fix" : "fixes"}`;
+  return {
+    count,
+    countLabel,
+    age,
+    magnet: Boolean(bugMagnet) && age !== null,
+    label: age ? `${countLabel} · last ${age}` : countLabel,
+  };
+}

--- a/packages/ui/src/shared/file-card/file-card.tsx
+++ b/packages/ui/src/shared/file-card/file-card.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { Badge } from "../../ui/badge";
 import { formatLOC } from "../../lib/format";
+import { summarizeFixHistory } from "../../lib/fix-history";
 import { cn } from "../../lib/cn";
 import type { FileCardData, FileCardLinks } from "./types";
 
@@ -64,6 +65,12 @@ export function FileCard({ data, links, hideHeader = false, className }: FileCar
   const { git, docs, symbols, deadCode, decisions, security } = data;
   const busFactor = git?.bus_factor;
   const isHotspot = git?.is_hotspot;
+  // Null for a file with no counted fixes, so the card gains no empty row.
+  const fix = summarizeFixHistory(
+    git?.prior_defect_count,
+    git?.last_fix_at,
+    git?.bug_magnet,
+  );
 
   return (
     <div className={cn("space-y-4", className)}>
@@ -130,6 +137,13 @@ export function FileCard({ data, links, hideHeader = false, className }: FileCar
                       ? "text-[var(--color-warning)]"
                       : "text-[var(--color-text-secondary)]"
                 }
+              />
+            )}
+            {fix && (
+              <Stat
+                label="Bug fixes"
+                value={fix.age ? `${fix.count} · last ${fix.age}` : String(fix.count)}
+                {...(fix.magnet ? { accent: "text-[var(--color-error)]" } : {})}
               />
             )}
           </Section>

--- a/packages/ui/src/shared/file-card/types.ts
+++ b/packages/ui/src/shared/file-card/types.ts
@@ -19,6 +19,11 @@ export interface FileCardData {
     primary_owner?: string | null;
     is_hotspot?: boolean;
     temporal_hotspot_score?: number | null;
+    /** Counted bug fixes in the trailing defect window. */
+    prior_defect_count?: number;
+    /** A recency claim, so consumers only show it with `last_fix_at` beside it. */
+    bug_magnet?: boolean;
+    last_fix_at?: string | null;
   };
 
   /** Documentation status. When `has_doc` is false the section becomes a CTA. */
@@ -65,6 +70,9 @@ export interface HotspotLike {
   primary_owner?: string | null;
   is_hotspot?: boolean;
   temporal_hotspot_score?: number | null;
+  prior_defect_count?: number;
+  bug_magnet?: boolean;
+  last_fix_at?: string | null;
 }
 
 /**
@@ -83,6 +91,9 @@ export function hotspotToFileCard(h: HotspotLike): FileCardData {
   if (h.is_hotspot !== undefined) git.is_hotspot = h.is_hotspot;
   if (h.temporal_hotspot_score !== undefined)
     git.temporal_hotspot_score = h.temporal_hotspot_score;
+  if (h.prior_defect_count !== undefined) git.prior_defect_count = h.prior_defect_count;
+  if (h.bug_magnet !== undefined) git.bug_magnet = h.bug_magnet;
+  if (h.last_fix_at !== undefined) git.last_fix_at = h.last_fix_at;
   return { file_path: h.file_path, git };
 }
 

--- a/packages/ui/src/symbols/symbol-drawer.tsx
+++ b/packages/ui/src/symbols/symbol-drawer.tsx
@@ -12,6 +12,7 @@ import { Badge } from "../ui/badge";
 import { ScrollArea } from "../ui/scroll-area";
 import { Separator } from "../ui/separator";
 import type { SymbolDetailData } from "@repowise-dev/types/symbols";
+import { FixHistoryBadge, SYMBOL_FIX_TITLE } from "../git/fix-history-badge";
 import { SymbolDetailBody } from "./symbol-detail-body";
 
 interface SymbolDrawerProps {
@@ -72,6 +73,11 @@ export function SymbolDrawer({
                     <Flame className="h-2.5 w-2.5" /> hot file
                   </Badge>
                 )}
+                <FixHistoryBadge
+                  count={data.fix_count ?? null}
+                  lastFixAt={data.fix_last_at ?? null}
+                  title={SYMBOL_FIX_TITLE}
+                />
               </div>
             </div>
 

--- a/packages/ui/src/symbols/symbol-page.tsx
+++ b/packages/ui/src/symbols/symbol-page.tsx
@@ -7,6 +7,7 @@ import type {
   SymbolDetailData,
   SymbolDetailResponse,
 } from "@repowise-dev/types/symbols";
+import { FixHistoryBadge, SYMBOL_FIX_TITLE } from "../git/fix-history-badge";
 import { SymbolDetailBody } from "./symbol-detail-body";
 
 export interface SymbolPageProps {
@@ -139,6 +140,12 @@ export function SymbolPage({
                 <Flame className="h-2.5 w-2.5" /> hot file
               </Badge>
             )}
+            <FixHistoryBadge
+              count={data.fix_count ?? null}
+              lastFixAt={data.fix_last_at ?? null}
+              title={SYMBOL_FIX_TITLE}
+              className="h-5 text-[10px]"
+            />
             <a
               href={fileEntityPath(prefix, s.file_path)}
               title={`${s.file_path}:${s.start_line}`}

--- a/packages/ui/src/wiki/git-history-panel.tsx
+++ b/packages/ui/src/wiki/git-history-panel.tsx
@@ -3,6 +3,7 @@ import { Badge } from "../ui/badge";
 import { CommitCategorySparkline } from "../git/commit-category-sparkline";
 import { CoChangeList } from "../git/co-change-list";
 import { ChangeHistoryCard } from "../git/change-history-card";
+import { FixHistoryBadge } from "../git/fix-history-badge";
 import { formatRelativeTime, formatDate, formatAgeDays } from "../lib/format";
 import type { GitMetadata } from "@repowise-dev/types/git";
 
@@ -74,6 +75,11 @@ export function GitHistoryPanel({ git }: GitHistoryPanelProps) {
             {git.is_stable && <Badge variant="fresh">Stable</Badge>}
             {!git.is_hotspot && !git.is_stable && <Badge variant="default">Active</Badge>}
             {git.test_gap === true && <Badge variant="outdated">No tests</Badge>}
+            <FixHistoryBadge
+              count={git.prior_defect_count ?? null}
+              lastFixAt={git.last_fix_at ?? null}
+              bugMagnet={git.bug_magnet ?? false}
+            />
             <span className={`text-xs ${velocity.color}`}>{velocity.label}</span>
           </div>
           <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
@@ -171,6 +177,7 @@ export function GitHistoryPanel({ git }: GitHistoryPanelProps) {
       <ChangeHistoryCard
         changeEntropyPct={git.change_entropy_pct ?? null}
         priorDefectCount={git.prior_defect_count ?? null}
+        lastFixAt={git.last_fix_at ?? null}
         originalPath={git.original_path ?? null}
         commitCountCapped={git.commit_count_capped ?? false}
       />

--- a/packages/vscode/src/features/trees/hotspots.ts
+++ b/packages/vscode/src/features/trees/hotspots.ts
@@ -4,6 +4,7 @@ import type {
   HotspotResponse,
   OwnershipEntry,
 } from "@repowise-dev/api-client/types";
+import { summarizeFixHistory } from "@repowise-dev/ui/lib/fix-history";
 import {
   baseName,
   openFileCommand,
@@ -41,17 +42,34 @@ export class HotspotsTreeProvider extends RepowiseTreeProvider {
     return page.items.map((row) => this.hotspotNode(row));
   }
 
+  /**
+   * One hotspot row. Commit counts alone contradicted the file hover sitting
+   * beside this tree, which has shown counted bug fixes since the fix rollup
+   * landed, so the fix history rides along here too. Silent on files with no
+   * counted fixes, and aggregate only — no inducing commit is named.
+   */
   private hotspotNode(row: HotspotResponse): RepoTreeNode {
     const owner = row.primary_owner ?? "unknown";
+    const fix = summarizeFixHistory(
+      row.prior_defect_count,
+      row.last_fix_at,
+      row.bug_magnet,
+    );
     const tooltip = new vscode.MarkdownString();
     tooltip.appendMarkdown(`\`${row.file_path}\`\n\n`);
     tooltip.appendMarkdown(`- Churn percentile: ${Math.round(row.churn_percentile)}\n`);
+    if (fix) {
+      const magnet = fix.magnet ? " **bug magnet**" : "";
+      tooltip.appendMarkdown(`- Bug fixes: ${fix.label}${magnet}\n`);
+    }
     tooltip.appendMarkdown(`- Bus factor: ${row.bus_factor}\n`);
     tooltip.appendMarkdown(`- Contributors: ${row.contributor_count}\n`);
     return {
       key: `hotspot:${row.file_path}`,
       label: baseName(row.file_path),
-      description: `${row.commit_count_90d} commits · ${owner}`,
+      description: fix
+        ? `${row.commit_count_90d} commits · ${fix.countLabel} · ${owner}`
+        : `${row.commit_count_90d} commits · ${owner}`,
       tooltip,
       icon: new vscode.ThemeIcon("flame"),
       collapsibleState: vscode.TreeItemCollapsibleState.None,

--- a/packages/web/src/components/docs/docs-viewer.tsx
+++ b/packages/web/src/components/docs/docs-viewer.tsx
@@ -9,9 +9,11 @@ import {
   GitBranch,
   ArrowRight,
   Flame,
+  Bug,
 } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 import { getGitMetadata } from "@/lib/api/git";
+import { summarizeFixHistory } from "@repowise-dev/ui/lib/fix-history";
 import { DocsReader } from "@repowise-dev/ui/docs/docs-reader";
 import { Badge } from "@repowise-dev/ui/ui/badge";
 import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
@@ -167,6 +169,12 @@ function AtAGlance({ repoId, targetPath }: { repoId: string; targetPath: string 
   if (!data || data.commit_count_total === 0) return null;
 
   const churnTop = Math.max(1, 100 - Math.round(data.churn_percentile));
+  // Null for a file with no counted fixes, so the panel says nothing new.
+  const fix = summarizeFixHistory(
+    data.prior_defect_count,
+    data.last_fix_at,
+    data.bug_magnet,
+  );
   return (
     <div>
       <div className="flex items-center gap-1.5 mb-2">
@@ -190,6 +198,16 @@ function AtAGlance({ repoId, targetPath }: { repoId: string; targetPath: string 
             Bus factor 1
           </Badge>
         )}
+        {fix?.magnet && (
+          <Badge
+            variant="outline"
+            className="text-[10px] border-[var(--color-error)]/40 text-[var(--color-error)]"
+            title={`Repeatedly bug-fixed, most recently ${fix.age}.`}
+          >
+            <Bug className="h-2.5 w-2.5 mr-1" />
+            Bug magnet
+          </Badge>
+        )}
       </div>
       <div className="mt-2 space-y-1 text-xs text-[var(--color-text-secondary)]">
         {data.primary_owner_name && (
@@ -206,6 +224,15 @@ function AtAGlance({ repoId, targetPath }: { repoId: string; targetPath: string 
           <span className="text-[var(--color-text-tertiary)]">Commits (90d)</span>
           <span className="font-mono">{data.commit_count_90d}</span>
         </div>
+        {fix && (
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-[var(--color-text-tertiary)]">Bug fixes</span>
+            <span className="font-mono" title="Bug-fix commits that touched this file in the trailing defect window.">
+              {fix.count}
+              {fix.age && ` · last ${fix.age}`}
+            </span>
+          </div>
+        )}
         <div className="flex items-center justify-between gap-2">
           <span className="text-[var(--color-text-tertiary)]">Contributors</span>
           <span className="font-mono">{data.contributor_count}</span>

--- a/tests/unit/server/test_git.py
+++ b/tests/unit/server/test_git.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 
 import pytest
 from httpx import AsyncClient
@@ -10,6 +11,8 @@ from httpx import AsyncClient
 from repowise.core.persistence import crud
 from repowise.core.persistence.database import get_session
 from tests.unit.server.conftest import create_test_repo
+
+_LAST_FIX_AT = datetime(2026, 3, 1, 12, 0, tzinfo=UTC)
 
 
 async def _insert_git_metadata(session_factory, repo_id: str) -> None:
@@ -37,6 +40,8 @@ async def _insert_git_metadata(session_factory, repo_id: str) -> None:
             change_entropy=1.5,
             change_entropy_pct=0.9,
             prior_defect_count=4,
+            bug_magnet=True,
+            last_fix_at=_LAST_FIX_AT,
             temporal_hotspot_score=12.3,
             commit_count_capped=True,
             original_path="src/old_main.py",
@@ -109,6 +114,36 @@ async def test_get_hotspots(client: AsyncClient, app) -> None:
     assert data[0]["change_entropy_pct"] == 90.0
     assert data[0]["prior_defect_count"] == 4
     assert data[0]["original_path"] == "src/old_main.py"
+    # The magnet flag rides with its timestamp: consumers must be able to put
+    # an age beside it, or they drop the flag rather than show it unanchored.
+    assert data[0]["bug_magnet"] is True
+    assert data[0]["last_fix_at"].startswith("2026-03-01T12:00:00")
+
+
+@pytest.mark.asyncio
+async def test_hotspots_omit_fix_flag_when_never_fixed(client: AsyncClient, app) -> None:
+    """A file with no counted fixes reports the flag off and no timestamp."""
+    repo = await create_test_repo(client)
+    async with get_session(app.state.session_factory) as session:
+        await crud.upsert_git_metadata(
+            session,
+            repository_id=repo["id"],
+            file_path="src/clean.py",
+            commit_count_total=30,
+            commit_count_90d=9,
+            commit_count_30d=2,
+            is_hotspot=True,
+            is_stable=False,
+            churn_percentile=0.8,
+            age_days=100,
+        )
+
+    resp = await client.get(f"/api/repos/{repo['id']}/hotspots")
+    assert resp.status_code == 200
+    row = resp.json()["items"][0]
+    assert row["prior_defect_count"] == 0
+    assert row["bug_magnet"] is False
+    assert row["last_fix_at"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Churn and bug-fix history disagreed across the product. Five surfaces were handed the fix columns on `GitMetadataResponse` and drew only commit counts, so the same file could read "quiet" in one panel and "repeatedly fixed" in the next. The clearest case was inside a single extension: the VS Code file hover has shown counted bug fixes since the fix rollup landed, while the Hotspots tree beside it showed commit counts only.

This is surfacing, not a new signal. Nothing is recomputed and no new query is added.

## The copy rules, in one place

`packages/ui/src/lib/fix-history.ts` turns the raw fix columns into copy, so every surface tells the same story:

- **Silence when absent.** No counted fixes returns null and callers render nothing. Not a zero, not an empty section. A clean file's UI is unchanged.
- **Recency.** `bug_magnet` is a claim about recent fix pressure, so the flag is suppressed unless an age can sit beside it. "Fixed 4x last month" and "fixed 4x two years ago" must not render identically, and an unanchored flag says exactly that. The count itself is windowed and stands alone. `formatRelativeTimeOrNull` supplies the future-guard, so a skewed timestamp degrades to count-only rather than "in 3 days".

Counts and recency only. No inducing commit is named on any surface.

## Surfaces

| Surface | Change |
| --- | --- |
| File wiki "At a glance" | Bug fixes row, plus a Bug magnet badge that only appears with its age |
| Wiki git-history panel | Fix badge in the headline row; `ChangeHistoryCard`'s existing count now carries its recency |
| VS Code Hotspots tree | Fix count in the row description and tooltip, matching the hover beside it |
| Symbol page + drawer headers | Fix count beside the hot-file flame, hedged because symbol attribution is line-range matched |
| Hotspot table | Sortable Fixes column and Bug magnet filter chip, both hidden when the index carries no fix data; fix stats carried through `hotspotToFileCard` into the file card |

`HotspotResponse` gains `bug_magnet` and `last_fix_at`. The ORM already stored both, so this is a schema bump rather than a new query, and the flag never ships without its timestamp.

Deliberately untouched: the churn-complexity quadrant (Tornhill model, X axis stays commit count), the hotspot-health KPI (NLOC-weighted health of the busiest files, a weighting not a risk badge), the bus-factor scatter and churn histogram (knowledge risk, not defect risk), and health scoring itself.

## Verification

Branch verified in isolation, not stacked on other work.

- `type-check`, `test`, `build`, `lint:shared`, and the UI contrast gates all green. ui 736, types 36, api-client 40, web 8, vscode 4.
- Server suite: 1109 passed, run from this worktree against its own sources.
- New tests confirmed red against the pre-change code: reverting the wiring files failed 5/8 UI integration assertions, 3/4 hotspot-table assertions, and 2 Python assertions with `KeyError: 'bug_magnet'`. The assertions that stayed green are the "renders nothing" guards, which is correct.
- Dogfooded against a copy of a real index: 822 of 3174 files carry counted fixes and 52 are magnets, all timestamped. One high-fix file has a null `last_fix_at`, so the count-only path is exercised by real data and renders the count with no magnet flag.
