### PR TITLE
docs: lead with the numbers, restore the five-layer table, fix serve ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@
 
 <p align="center"><sub>
   <a href="#your-agent-stops-guessing">For your agent</a> ·
+  <a href="#what-one-index-actually-builds">The five layers</a> ·
   <a href="#stop-paying-for-output-nobody-reads">Distill</a> ·
   <a href="#know-whats-dangerous-before-you-merge">Change risk</a> ·
   <a href="#-know-exactly-what-to-fix">Code health</a> ·
   <a href="#see-all-of-it">Dashboard</a> ·
   <a href="#past-one-repo">Workspaces</a> ·
-  <a href="#quickstart">Quickstart</a> ·
+  <a href="#quickstart-under-5-minutes-no-api-key">Quickstart</a> ·
   <a href="#the-ten-mcp-tools">MCP tools</a> ·
   <a href="#how-it-compares">Comparison</a> ·
   <a href="#for-teams--enterprises">Teams</a>
@@ -41,7 +42,10 @@
 
 ### Your AI agent burns most of its budget rediscovering your codebase. Index it once, and it never has to again.
 
-<sub>Free and self-hosted, runs on your machine, and the first index needs no API key.</sub>
+### up to −96% tokens to load context&nbsp;&nbsp;·&nbsp;&nbsp;−89% file reads&nbsp;&nbsp;·&nbsp;&nbsp;−70% tool calls
+
+<sub>Paired runs, same model, same harness, with and without repowise ([the numbers, and what they do not show →](docs/BENCHMARKS.md)).<br />
+Free and self-hosted, runs on your machine, and the first index needs no API key.</sub>
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset=".github/assets/one-index-dark.svg" />
@@ -73,18 +77,10 @@ built around **tasks**: pass several targets in one call, get complete context b
 
 <img src=".github/assets/demo.gif" alt="Claude Code querying the codebase through repowise's MCP tools" width="100%" />
 
-Because the exploration work is already done, that phase mostly disappears:
-
-<div align="center">
-
-**up to −96% tokens to load context&nbsp;&nbsp;·&nbsp;&nbsp;−89% file reads&nbsp;&nbsp;·&nbsp;&nbsp;−70% tool calls**
-
-</div>
-
-Loading one commit's context through `get_context` costs **2,391 tokens instead of
-64,039** raw. On a long multi-step investigation that compounds to **−41% of the
-context re-read across the whole session**. Paired runs, same model, same harness,
-with and without repowise ([the numbers, and what they do not show →](docs/BENCHMARKS.md)).
+Because the exploration work is already done, that phase mostly disappears. Loading
+one commit's context through `get_context` costs **2,391 tokens instead of 64,039**
+raw. On a long multi-step investigation that compounds to **−41% of the context
+re-read across the whole session**.
 
 **And it arrives without being asked.** Optional [hooks](docs/agent/HOOKS.md) push
 context into the session at the moment it matters: the governing architectural
@@ -98,6 +94,28 @@ for the corrections you keep making ("use the shared HTTP client, not raw reques
 and turns the durable ones into tracked decisions it delivers back later. The wiki
 generation budget tilts toward the modules you and your agent ask about most. All
 local, all deterministic, no extra LLM calls.
+
+---
+
+## What one index actually builds
+
+Five layers, built in a single pass and kept in sync on every commit. Each one is
+queryable from the CLI, the MCP tools, and the local dashboard.
+
+| Layer | What it gives you | Edge |
+|---|---|---|
+| **◈ Graph** | Dependency graph across 16 languages · file + symbol nodes · 3-tier call resolution · Leiden communities · PageRank and execution flows · framework-aware route→handler edges | A real graph most tools never build |
+| **◈ Git** | Hotspots (churn × complexity) · ownership % · co-change pairs (hidden coupling) · bus factor · which files actually get bug-fixed, and how recently | Behavioural signals static analysis cannot see |
+| **◈ Docs** | A generated wiki page per module and file · rebuilt incrementally every commit · freshness and confidence scoring · hybrid search (full-text + vector) · selectable style and output language | Stays current instead of rotting |
+| **◈ Decisions** | Architectural decisions mined from eight sources, evidence-backed, linked to the graph nodes they govern, connected by supersedes / refines / conflicts_with, tracked for staleness | **★ Captured nowhere else** |
+| **★ Code health** | **25 deterministic markers**, 1 to 10 per file · three signals: defect risk · maintainability · performance · coverage ingestion · concrete refactoring plans (Extract Class / Helper, Move Method, Break Cycle, Split File) · **zero LLM, under 30s** | **★ Defect-validated, with the fix attached** |
+
+Only the Docs layer needs an LLM. `repowise init --index-only` builds the graph,
+git, decision, and health layers with no API key and no spend (seven of the eight
+decision sources are deterministic; only the one harvested during doc generation
+needs a provider).
+
+Full detail on every layer: **[docs/layers/INTELLIGENCE_LAYERS.md →](docs/layers/INTELLIGENCE_LAYERS.md)**
 
 ---
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -163,8 +163,9 @@ correlated with strictly no leakage: nothing after T0 feeds the score.
 
 ### Cross-project validation
 
-Across **21 open-source repositories spanning all 9 Full-tier languages** and
-2,826 files:
+Across **21 open-source repositories spanning 9 languages** and 2,826 files
+(the study predates the promotion of Scala and Ruby to the Full tier, so it
+covers 9 of today's 11):
 
 - **Mean ROC AUC 0.74** (95% CI 0.68 to 0.79) at identifying the files that go
   on to receive bug fixes, reaching **0.90** on individual repos. ROC AUC is the

--- a/docs/start/DASHBOARD.md
+++ b/docs/start/DASHBOARD.md
@@ -1,14 +1,19 @@
 # The dashboard
 
-`repowise serve` starts a local web app on `http://localhost:7777` that reads
-the same `.repowise/wiki.db` the CLI and MCP server read. Nothing leaves your
-machine, and no view calls an LLM unless you click something that says it will
-(Chat, refactoring code generation, doc regeneration).
+`repowise serve` starts the API on `http://localhost:7337` and the local web
+dashboard on `http://localhost:3000`. Both read the same `.repowise/wiki.db`
+the CLI and MCP server read. Nothing leaves your machine, and no view calls an
+LLM unless you click something that says it will (Chat, refactoring code
+generation, doc regeneration).
 
 ```bash
-repowise serve                 # http://localhost:7777
-repowise serve --port 8080
+repowise serve                       # API on :7337, dashboard on :3000
+repowise serve --port 8080           # move the API
+repowise serve --ui-port 3001        # move the dashboard
+repowise serve --no-ui               # API only
 ```
+
+The dashboard needs Node >= 20. Without it, `serve` falls back to API-only.
 
 The URL shape is `/repos/<repo-id>/<view>`. Every view is directly linkable,
 including tab state, so a link you paste in a PR lands on exactly what you were


### PR DESCRIPTION
## Lead with the numbers

The efficiency numbers were buried a screen and a half down, inside the "your agent stops guessing" section. They are the value proposition, so they now sit directly under the headline at heading size:

> ### Your AI agent burns most of its budget rediscovering your codebase. Index it once, and it never has to again.
> ### up to −96% tokens to load context · −89% file reads · −70% tool calls

Methodology and the link to the caveats sit right beneath, so the claim never appears without its qualifier. The supporting detail (2,391 vs 64,039 tokens, −41% session re-read) stays where it was.

Both lines are `###` so the punchline does not visually outrank the headline.

## Restore the five-layer table

This went missing in the README overhaul, and what repowise actually builds was no longer stated anywhere near the top. A reader had to infer the layers from the feature sections. It is back between "Your agent stops guessing" and the distill section, tighter than the original, with:

- 16 languages, not 15
- bug-fix history added to the Git row
- the unverifiable "15 output languages" claim dropped (no doc backs a specific count)
- a closing line that only the Docs layer needs an LLM, so `--index-only` builds the other four with no key

Seven of the eight decision sources are deterministic per `docs/layers/DECISIONS.md:49-51`; only the one harvested during doc generation needs a provider. The table says so rather than implying decisions are LLM-derived.

## Two errors from the docs overhaul

**Ports.** `docs/start/DASHBOARD.md` documented `repowise serve` on `localhost:7777`. That port appears nowhere in the CLI. It is **7337** for the API and **3000** for the dashboard, per `serve_cmd.py:534,537`. Added `--ui-port`, `--no-ui`, and the Node >= 20 fallback while there. This one mattered because the hosted docs site was written against the correct ports, so the two sources disagreed.

**Stale tier claim.** `docs/BENCHMARKS.md:166` said the health study spanned "all 9 Full-tier languages". The study scope of 9 is correct, but the Full tier is now 11, so the claim had quietly become false. Now reads "9 languages" with a note that the study predates the Scala and Ruby promotions. The other "9 languages" figures are study scope and are untouched.

## Also

The nav linked to `#quickstart`, but the heading slug is `#quickstart-under-5-minutes-no-api-key`, so that link did nothing. Fixed. All 11 nav anchors and every `docs/` link in the README now resolve.