### PR TITLE
feat(codex): add code-health skill for Codex plugin parity

### DIFF
--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Repowise codebase intelligence for Codex.",
   "author": {
     "name": "Repowise",

--- a/plugins/codex/skills/code-health/SKILL.md
+++ b/plugins/codex/skills/code-health/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: code-health
+description: Use when the user asks about code health, code quality, complexity, technical debt, risky or hard-to-maintain files, what to refactor next, untested hotspots, or coverage gaps in a Repowise-indexed codebase (.repowise/ directory exists). Also use for before/after health reads when planning or finishing a refactor.
+---
+
+# Code Health with Repowise
+
+Repowise scores **every file 1–10** from deterministic markers — McCabe
+complexity, deep nesting, brain methods, class cohesion (LCOM4), god classes,
+clone detection, untested hotspots, function-level churn, ownership dispersion,
+and more. Zero LLM calls; pure local analysis. The weights are calibrated
+against a real defect corpus, so a low score means *more likely to harbour bugs*,
+not just *bigger*.
+
+## Pick the mode by what you pass
+
+- **Dashboard** — `get_health()` (no targets): repo-level KPIs plus the
+  lowest-scoring files. Start here for "how healthy is this codebase?" or "what
+  should we clean up?".
+- **Targeted** — `get_health(targets=["src/x.py", "src/y.py"])`: per-file score
+  and the specific marker findings driving it. Use before/after a refactor,
+  or to explain *why* a file is flagged.
+
+## Useful `include` flags
+
+`get_health(targets=[...], include=[...])`:
+- `"biomarkers"` — always return the findings list (what's wrong, where).
+- `"refactoring"` — deterministic, ranked refactoring suggestions (by impact/effort).
+- `"coverage"` — surface coverage data when it's been ingested.
+- `"trend"` — recent health snapshots + declining / predicted-decline signal.
+
+## How to use the results
+
+1. For "what should I refactor?" → dashboard mode, then
+   `get_health(targets=[worst files], include=["refactoring"])` and present the
+   ranked suggestions, not just the scores.
+2. For a specific file → report the score, the top 2–3 marker findings, and
+   what each one means in plain language. Avoid dumping the raw payload.
+3. Before editing a flagged file → cross-check `get_risk(targets=[...])`; a file
+   that is both low-health *and* a churn hotspot deserves the most care.
+4. Untested-hotspot / coverage questions → tell the user coverage markers
+   light up once they ingest a report: `repowise coverage add cov.lcov`
+   (LCOV / Cobertura / Clover; a coverage.py `.coverage` also builds the
+   per-test map), then re-run `repowise health`.
+
+## CLI equivalents
+
+- `repowise health` — KPIs + lowest-scoring files
+- `repowise health --refactoring-targets` — ranked by impact / effort
+- `repowise health --trend` — snapshots + declining alerts
+- `repowise coverage add <file>` — ingest coverage, light up untested-hotspot
+
+## Error handling
+
+If `get_health` reports no repository, suggest `repowise init`. Code health is
+computed even in index-only mode (no LLM needed), so it should be available
+whenever the repo is indexed.

--- a/tests/unit/cli/test_codex_plugin.py
+++ b/tests/unit/cli/test_codex_plugin.py
@@ -63,6 +63,7 @@ def test_codex_plugin_skills_have_metadata_and_neutral_wording() -> None:
     assert {path.parent.name for path in skill_paths} == {
         "architectural-decisions",
         "change-review",
+        "code-health",
         "codebase-exploration",
         "dead-code-cleanup",
         "pre-modification-check",


### PR DESCRIPTION
## Summary
- Add `plugins/codex/skills/code-health/SKILL.md`, ported from the Claude plugin with Codex-neutral wording (`repowise init` instead of `/repowise:init`, no Claude-specific references).
- Bump Codex plugin version to `0.2.1`.
- Extend `test_codex_plugin.py` to expect six skills including `code-health`.

## Motivation
The Claude Code plugin ships six skills; Codex had five — `code-health` was the only gap. This brings parity so Codex users get the same health/refactoring guidance.

## Test plan
- [x] `pytest tests/unit/cli/test_codex_plugin.py` — all 5 tests pass
- [x] Skill frontmatter validates (single-line description, no Claude/`/repowise:` references)