### PR TITLE
fix(ui): render the fix history the file page already receives

### DIFF
--- a/packages/types/src/git.ts
+++ b/packages/types/src/git.ts
@@ -11,7 +11,10 @@ export interface FileAuthor {
   name: string;
   email: string;
   commit_count: number;
-  pct: number;
+  /** Share of the file's commits, 0–1. Optional: the file-detail endpoint
+   *  serves these rows straight off the stored artifact, which records counts
+   *  and no share. Derive from `commit_count` when it is absent. */
+  pct?: number;
 }
 
 export interface SignificantCommit {

--- a/packages/ui/COMPONENT_CONTRACTS.md
+++ b/packages/ui/COMPONENT_CONTRACTS.md
@@ -520,8 +520,15 @@ nothing when the backlink list is empty.
 
 ## `wiki/git-history-panel` — `GitHistoryPanel`
 
-Sidebar panel summarising file lifecycle, commit categories, top
-authors with bars, co-change partners, and recent commits.
+Sidebar panel summarising file lifecycle, fix history, commit categories,
+top authors with bars, co-change partners, and recent commits.
+
+The Age row needs at least one recorded commit before it will render a zero
+age, because `formatAgeDays(0)` reads "< 1 day" and `age_days` is stored NOT
+NULL with a `0` default — so a file whose git indexing never completed is
+otherwise indistinguishable from one created today. Author shares fall back to
+`commit_count / commit_count_total` when a row carries no `pct`, which is what
+the file-detail endpoint serves.
 
 | Prop | Type | Required |
 |------|------|----------|

--- a/packages/ui/__tests__/files/file-history-tab.test.tsx
+++ b/packages/ui/__tests__/files/file-history-tab.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FileHistoryTab } from "../../src/files/file-history-tab.js";
+import type { FileDetailGit } from "@repowise-dev/types/files";
+
+const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000).toISOString();
+
+function makeGit(overrides: Partial<FileDetailGit> = {}): FileDetailGit {
+  return {
+    file_path: "src/foo.ts",
+    commit_count_total: 40,
+    commit_count_90d: 8,
+    commit_count_30d: 2,
+    churn_percentile: 92,
+    primary_owner: "Ada",
+    is_hotspot: true,
+    is_stable: false,
+    bus_factor: 2,
+    contributor_count: 4,
+    lines_added_90d: 100,
+    lines_deleted_90d: 40,
+    avg_commit_size: 30,
+    commit_categories: {},
+    significant_commits: [],
+    top_authors: [],
+    co_change_partners: [],
+    agent: { agent_commit_count: 0, agent_authored_pct: null, tier_counts: {} },
+    first_commit_at: null,
+    ...overrides,
+  };
+}
+
+const partnerHref = (path: string) => `/files/${path}`;
+
+function renderTab(git: FileDetailGit | null) {
+  return render(<FileHistoryTab git={git} linkPrefix="/repos/r1" partnerHref={partnerHref} />);
+}
+
+describe("FileHistoryTab fix history", () => {
+  it("shows the fix count and its recency, the way the wiki sidebar does", () => {
+    renderTab(makeGit({ prior_defect_count: 3, last_fix_at: daysAgo(4), change_entropy_pct: 60 }));
+    // The headline badge plus the change-history card's row: same file, same story.
+    expect(screen.getAllByText(/3 fixes · last 4d ago/)).toHaveLength(2);
+  });
+
+  it("flags a bug magnet only when an age can sit beside it", () => {
+    const { unmount } = renderTab(
+      makeGit({ prior_defect_count: 5, last_fix_at: daysAgo(6), bug_magnet: true }),
+    );
+    expect(screen.getByText(/^Bug magnet ·/)).toBeTruthy();
+    unmount();
+
+    renderTab(makeGit({ prior_defect_count: 5, last_fix_at: null, bug_magnet: true }));
+    expect(screen.queryByText(/Bug magnet/)).toBeNull();
+    expect(screen.getAllByText(/5 fixes/)).toHaveLength(2);
+  });
+
+  it("adds nothing at all to a file the index carries no fix data for", () => {
+    renderTab(makeGit());
+    expect(screen.queryByText(/fix/i)).toBeNull();
+    expect(screen.queryByText(/Change Complexity/i)).toBeNull();
+  });
+
+  it("draws a counted zero but stays silent on an unknown", () => {
+    // A file the fix pass examined and found clean still says so, because the
+    // card is already on screen for its entropy.
+    const { unmount } = renderTab(makeGit({ prior_defect_count: 0, change_entropy_pct: 60 }));
+    expect(screen.getByText(/0 fixes/)).toBeTruthy();
+    unmount();
+
+    // The tab passes an absent count through as null rather than flattening it
+    // to a zero, so a caller that can express "never counted" gets silence.
+    renderTab(makeGit({ change_entropy_pct: 60 }));
+    expect(screen.queryByText(/fixes/)).toBeNull();
+    expect(screen.getByText(/Change entropy/)).toBeTruthy();
+  });
+
+  it("carries the rename lineage and the capped-history caveat", () => {
+    renderTab(makeGit({ original_path: "src/old-foo.ts", commit_count_capped: true }));
+    expect(screen.getByText("src/old-foo.ts")).toBeTruthy();
+    expect(screen.getByText(/History capped during indexing/)).toBeTruthy();
+  });
+});
+
+describe("FileHistoryTab file age", () => {
+  it("qualifies the commit total with the span it accumulated over", () => {
+    renderTab(makeGit({ age_days: 400 }));
+    expect(screen.getByText("over 1 year 1 month")).toBeTruthy();
+  });
+
+  it("does not call an unindexed file brand new", () => {
+    // Git indexing that timed out persists column defaults, so the file lands
+    // with no commits and age 0, and `formatAgeDays(0)` reads "< 1 day".
+    renderTab(makeGit({ commit_count_total: 0, age_days: 0 }));
+    expect(screen.queryByText(/^over /)).toBeNull();
+    expect(screen.queryByText(/< 1 day/)).toBeNull();
+  });
+
+  it("says nothing about age when the payload omits it", () => {
+    renderTab(makeGit());
+    expect(screen.queryByText(/^over /)).toBeNull();
+    expect(screen.queryByText(/NaN/)).toBeNull();
+  });
+
+  it("marks a stable file", () => {
+    renderTab(makeGit({ is_stable: true }));
+    expect(screen.getByText("Stable")).toBeTruthy();
+  });
+});
+
+describe("FileHistoryTab without git", () => {
+  it("falls back to the empty state", () => {
+    renderTab(null);
+    expect(screen.getByText("No git history")).toBeTruthy();
+  });
+});

--- a/packages/ui/__tests__/wiki/git-history-panel.test.tsx
+++ b/packages/ui/__tests__/wiki/git-history-panel.test.tsx
@@ -72,3 +72,67 @@ describe("GitHistoryPanel fix history", () => {
     expect(screen.queryByText(/· last/)).toBeNull();
   });
 });
+
+describe("GitHistoryPanel age", () => {
+  it("renders a known age", () => {
+    render(<GitHistoryPanel git={meta({ age_days: 400 })} />);
+    expect(screen.getByText("1 year 1 month")).toBeTruthy();
+  });
+
+  it("keeps '< 1 day' for a file that really is new", () => {
+    render(<GitHistoryPanel git={meta({ age_days: 0, commit_count_total: 1 })} />);
+    expect(screen.getByText("< 1 day")).toBeTruthy();
+  });
+
+  it("drops the row for a file whose history never got indexed", () => {
+    // Indexing that timed out persists column defaults, so an unindexed file
+    // and a file created today are both age 0. Only one of them has commits.
+    render(<GitHistoryPanel git={meta({ age_days: 0, commit_count_total: 0 })} />);
+    expect(screen.queryByText("Age")).toBeNull();
+    expect(screen.queryByText("< 1 day")).toBeNull();
+  });
+
+  it("does not print NaN when the payload omits the age entirely", () => {
+    const { age_days: _drop, ...rest } = meta();
+    render(<GitHistoryPanel git={rest as GitMetadata} />);
+    expect(screen.queryByText(/NaN/)).toBeNull();
+  });
+});
+
+describe("GitHistoryPanel author share", () => {
+  const authors = [
+    { name: "Ada", email: "ada@example.com", commit_count: 30 },
+    { name: "Grace", email: "grace@example.com", commit_count: 10 },
+  ];
+
+  it("derives the share from commit counts when the rows carry no pct", () => {
+    // The file-detail endpoint serves these rows straight off the artifact,
+    // which has counts and no share at all.
+    render(<GitHistoryPanel git={meta({ top_authors: authors, commit_count_total: 40 })} />);
+    expect(screen.getByText("75%")).toBeTruthy();
+    expect(screen.getByText("25%")).toBeTruthy();
+    expect(screen.queryByText(/NaN/)).toBeNull();
+  });
+
+  it("prefers a served pct over the derived one", () => {
+    render(
+      <GitHistoryPanel
+        git={meta({
+          top_authors: [{ ...authors[0]!, pct: 0.5 }],
+          commit_count_total: 40,
+        })}
+      />,
+    );
+    expect(screen.getByText("50%")).toBeTruthy();
+  });
+
+  it("falls back to the raw count when there is no denominator", () => {
+    render(
+      <GitHistoryPanel
+        git={meta({ top_authors: [{ ...authors[0]!, commit_count: 0 }], commit_count_total: 0 })}
+      />,
+    );
+    expect(screen.getByText("0 commits")).toBeTruthy();
+    expect(screen.queryByText(/NaN/)).toBeNull();
+  });
+});

--- a/packages/ui/src/files/file-history-tab.tsx
+++ b/packages/ui/src/files/file-history-tab.tsx
@@ -3,9 +3,13 @@ import { EmptyState } from "../shared/empty-state";
 import { CommitCategorySparkline } from "../git/commit-category-sparkline";
 import { AgentTierBar } from "../git/agent-tier-bar";
 import { OwnershipDonut } from "../git/ownership-donut";
+import { ChangeHistoryCard } from "../git/change-history-card";
+import { FixHistoryBadge } from "../git/fix-history-badge";
 import { StatGrid, StatTile } from "../shared/stat-grid";
+import { Badge } from "../ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
-import { formatRelativeTime, truncatePath } from "../lib/format";
+import { summarizeFixHistory } from "../lib/fix-history";
+import { formatAgeDays, formatRelativeTime, truncatePath } from "../lib/format";
 import type { FileDetailGit } from "@repowise-dev/types/files";
 
 interface FileHistoryTabProps {
@@ -29,15 +33,50 @@ export function FileHistoryTab({ git, linkPrefix, partnerHref }: FileHistoryTabP
   const hasCategories = Object.values(git.commit_categories ?? {}).some((v) => v > 0);
   const agentPct =
     git.agent.agent_authored_pct != null ? Math.round(git.agent.agent_authored_pct * 100) : null;
+  // Same helper the wiki sidebar uses, so one file's fix history reads
+  // identically on both surfaces. Null means no counted fixes: render nothing.
+  const fix = summarizeFixHistory(git.prior_defect_count, git.last_fix_at, git.bug_magnet);
+  // A file whose git indexing never completed lands with zeroes across the
+  // board, and `formatAgeDays(0)` reads "< 1 day". Anchor the age to having
+  // at least one commit so an unindexed file is not called brand new.
+  const commits = git.commit_count_total ?? 0;
+  const age =
+    commits > 0 && Number.isFinite(git.age_days) ? formatAgeDays(git.age_days as number) : null;
 
   return (
     <div className="space-y-4">
+      {(fix || git.is_stable) && (
+        <div className="flex flex-wrap items-center gap-2">
+          {git.is_stable && <Badge variant="fresh">Stable</Badge>}
+          <FixHistoryBadge
+            count={git.prior_defect_count ?? null}
+            lastFixAt={git.last_fix_at ?? null}
+            bugMagnet={git.bug_magnet ?? false}
+          />
+        </div>
+      )}
+
       <StatGrid columns={4}>
-        <StatTile label="Commits (total)" value={git.commit_count_total ?? 0} />
+        <StatTile
+          label="Commits (total)"
+          value={commits}
+          {...(age ? { hint: `over ${age}` } : {})}
+        />
         <StatTile label="Commits (90d)" value={git.commit_count_90d} />
         <StatTile label="Contributors" value={git.contributor_count} />
         <StatTile label="Bus factor" value={git.bus_factor} />
       </StatGrid>
+
+      {/* Self-contained: returns null when there is nothing to say, so an
+          entropy-less, never-fixed, never-renamed file loses no space to it. */}
+      <ChangeHistoryCard
+        changeEntropyPct={git.change_entropy_pct ?? null}
+        priorDefectCount={git.prior_defect_count ?? null}
+        lastFixAt={git.last_fix_at ?? null}
+        originalPath={git.original_path ?? null}
+        commitCountCapped={git.commit_count_capped ?? false}
+        className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-3"
+      />
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <Card>

--- a/packages/ui/src/wiki/git-history-panel.tsx
+++ b/packages/ui/src/wiki/git-history-panel.tsx
@@ -5,7 +5,7 @@ import { CoChangeList } from "../git/co-change-list";
 import { ChangeHistoryCard } from "../git/change-history-card";
 import { FixHistoryBadge } from "../git/fix-history-badge";
 import { formatRelativeTime, formatDate, formatAgeDays } from "../lib/format";
-import type { GitMetadata } from "@repowise-dev/types/git";
+import type { FileAuthor, GitMetadata } from "@repowise-dev/types/git";
 
 interface GitHistoryPanelProps {
   git: GitMetadata;
@@ -59,9 +59,43 @@ function getVelocityLabel(git: GitMetadata): { label: string; color: string } {
   return { label: "Steady", color: "text-[var(--color-text-secondary)]" };
 }
 
+/**
+ * Share of the file's commits belonging to an author, 0–1.
+ *
+ * `pct` is optional in practice: the file-detail endpoint serves `top_authors`
+ * straight off the stored artifact, whose rows carry counts and no share at
+ * all. Deriving it from `commit_count` keeps the bar honest instead of
+ * rendering `NaN%`. `commit_count_total` is the denominator when it is
+ * available, because `top_authors` is truncated and its own sum overstates
+ * everyone's share on a file with a long tail of contributors.
+ */
+function authorShare(author: FileAuthor, totalCommits: number): number | null {
+  const { pct, commit_count: count } = author;
+  if (typeof pct === "number" && Number.isFinite(pct)) {
+    return Math.min(1, Math.max(0, pct));
+  }
+  if (totalCommits > 0 && typeof count === "number" && Number.isFinite(count)) {
+    return Math.min(1, Math.max(0, count / totalCommits));
+  }
+  return null;
+}
+
 export function GitHistoryPanel({ git }: GitHistoryPanelProps) {
   const commits = git.significant_commits ?? [];
   const velocity = getVelocityLabel(git);
+  // `formatAgeDays(0)` reads "< 1 day", so an unset age claims the file was
+  // created today. The column is stored NOT NULL with a 0 default and the API
+  // coerces nulls to 0, so a zero cannot be told apart from an unknown on its
+  // own — but a file with no commits recorded is not a day old either, it is
+  // a file whose history never got indexed. Require one to believe the other.
+  // 0 stays meaningful for a genuinely new file, so the caller decides.
+  const hasAge =
+    Number.isFinite(git.age_days) && (git.age_days > 0 || git.commit_count_total > 0);
+  const authors = git.top_authors ?? [];
+  const authorDenominator =
+    git.commit_count_total > 0
+      ? git.commit_count_total
+      : authors.reduce((sum, a) => sum + (a.commit_count || 0), 0);
 
   return (
     <div className="space-y-4">
@@ -83,10 +117,14 @@ export function GitHistoryPanel({ git }: GitHistoryPanelProps) {
             <span className={`text-xs ${velocity.color}`}>{velocity.label}</span>
           </div>
           <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
-            <span className="text-[var(--color-text-tertiary)]">Age</span>
-            <span className="text-[var(--color-text-secondary)] tabular-nums">
-              {formatAgeDays(git.age_days)}
-            </span>
+            {hasAge && (
+              <>
+                <span className="text-[var(--color-text-tertiary)]">Age</span>
+                <span className="text-[var(--color-text-secondary)] tabular-nums">
+                  {formatAgeDays(git.age_days)}
+                </span>
+              </>
+            )}
             <span className="text-[var(--color-text-tertiary)]">Commits (90d)</span>
             <span className="text-[var(--color-text-secondary)] tabular-nums">
               {git.commit_count_90d}
@@ -132,35 +170,42 @@ export function GitHistoryPanel({ git }: GitHistoryPanelProps) {
         </div>
       )}
 
-      {git.top_authors && git.top_authors.length > 0 && (
+      {authors.length > 0 && (
         <div>
           <p className="text-xs font-medium text-[var(--color-text-tertiary)] uppercase tracking-wider mb-2">
             Authors
           </p>
           <div className="space-y-2">
-            {git.top_authors.slice(0, 4).map((author) => (
-              <div key={author.email} className="space-y-0.5">
-                <div className="flex items-center gap-2 text-xs">
-                  <AuthorAvatar name={author.name} />
-                  <span className="flex-1 truncate text-[var(--color-text-secondary)]">
-                    {author.name}
-                  </span>
-                  <span className="text-[var(--color-text-tertiary)] tabular-nums shrink-0">
-                    {Math.round(author.pct * 100)}%
-                  </span>
+            {authors.slice(0, 4).map((author) => {
+              const share = authorShare(author, authorDenominator);
+              return (
+                <div key={author.email} className="space-y-0.5">
+                  <div className="flex items-center gap-2 text-xs">
+                    <AuthorAvatar name={author.name} />
+                    <span className="flex-1 truncate text-[var(--color-text-secondary)]">
+                      {author.name}
+                    </span>
+                    <span className="text-[var(--color-text-tertiary)] tabular-nums shrink-0">
+                      {share != null
+                        ? `${Math.round(share * 100)}%`
+                        : `${author.commit_count} commits`}
+                    </span>
+                  </div>
+                  {share != null && (
+                    <div className="h-1 w-full rounded-full bg-[var(--color-bg-elevated)] ml-7">
+                      <div
+                        className="h-1 rounded-full transition-all"
+                        style={{
+                          width: `${share * 100}%`,
+                          backgroundColor:
+                            AUTHOR_BAR_COLORS[authorColorIndex(author.name)] ?? AUTHOR_BAR_FALLBACK,
+                        }}
+                      />
+                    </div>
+                  )}
                 </div>
-                <div className="h-1 w-full rounded-full bg-[var(--color-bg-elevated)] ml-7">
-                  <div
-                    className="h-1 rounded-full transition-all"
-                    style={{
-                      width: `${Math.min(100, author.pct * 100)}%`,
-                      backgroundColor:
-                        AUTHOR_BAR_COLORS[authorColorIndex(author.name)] ?? AUTHOR_BAR_FALLBACK,
-                    }}
-                  />
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       )}
@@ -216,7 +261,7 @@ export function GitHistoryPanel({ git }: GitHistoryPanelProps) {
         </div>
       )}
 
-      {commits.length === 0 && (!git.top_authors || git.top_authors.length === 0) && (
+      {commits.length === 0 && authors.length === 0 && (
         <p className="text-xs text-[var(--color-text-tertiary)]">No commit history available.</p>
       )}
     </div>


### PR DESCRIPTION
The file page's History tab was handed a file's change-complexity and defect
columns and drew only commit counts. The wiki sidebar shows a file's bug-fix
history; clicking through to the canonical page for that same file lost all of
it. `file-history-tab.tsx` had zero references to `FixHistoryBadge` or
`ChangeHistoryCard`.

## The tab

It now composes the same two pieces the sidebar does, so one file reads the
same on both surfaces:

- A fix badge in the status row, built from `summarizeFixHistory`. No counted
  fixes means no badge, and a bug-magnet flag never ships without the age that
  makes it a recency claim.
- `ChangeHistoryCard` for change entropy, the fix count with its recency,
  rename lineage, and the capped-history caveat. It returns null when it has
  nothing to say, so a clean file's tab is visually unchanged.
- The commit total is qualified with the span it accumulated over.

Everything rendered here was already on the payload. `_hotspot_from_row` in
`routers/git.py` populates all seven fields and `HotspotResponse` carries them,
so this is presentation only, no new query and no schema change.

## Two contract fixes in `GitHistoryPanel`

The panel had no consumer in this repo, so its contracts had never been
exercised against a real payload. Both of these were wrong.

**Ownership bars rendered `NaN%`.** The panel divided `author.pct`, but
`/files/detail` serves `top_authors` straight off the stored artifact and those
rows carry `name`, `email` and `commit_count` with no share at all. Shares now
fall back to `commit_count / commit_count_total`, and `FileAuthor.pct` is
optional to match what is actually served. The denominator is exact:
`file_history.py` sets `commit_count_total = len(commits)` and accumulates the
author counts over that same list.

**A file that failed to index was reported as created today.** `age_days` is
stored NOT NULL with a `0` default and the API coerces nulls to `0`, while
`formatAgeDays(0)` reads "< 1 day". When per-file git indexing times out, the
row persists as bare column defaults, so a five-year-old file with 300 commits
rendered `Age: < 1 day`. A zero age now needs at least one recorded commit
before it is believed.

## Known and not fixed here

`prior_defect_count` is also NOT NULL with a `0` default and coerced at the API,
so "never counted" and "counted, found none" arrive identically. A file indexed
before the fix pass existed will read "0 fixes" whenever the card is on screen
for another reason. Telling those apart needs the server to serve null, which
is outside a UI change.

## Verification

`packages/ui` vitest (753 tests), type-check and lint all pass. New coverage for
the tab's fix, entropy, rename and age sections, and for the two panel
contracts above.
