### PR TITLE
feat(parser): add adaptive TSX grammar fallback for .ts files containing JSX

### DIFF
--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -300,6 +300,16 @@ class ASTParser:
                     tree = tsx_tree
                     root = tree.root_node
                     parse_errors = tsx_errors
+                    # Both grammar_tag AND language must be reassigned.
+                    # grammar_tag is consumed immediately below by
+                    # self._get_query(lang, language, grammar_tag), which
+                    # appends tsx.scm to the base typescript.scm query.
+                    # That append is what supplies the
+                    # jsx_opening_element / jsx_self_closing_element captures
+                    # that restore JSX component call-site edges.
+                    # Reassigning only ``tree`` / ``root`` would fix parse
+                    # errors but leave those edges missing — the dead-code
+                    # false-positive would remain.
                     grammar_tag = "tsx"
                     language = tsx_language
 

--- a/packages/core/src/repowise/core/ingestion/parser.py
+++ b/packages/core/src/repowise/core/ingestion/parser.py
@@ -279,6 +279,30 @@ class ASTParser:
         root = tree.root_node
 
         parse_errors = _collect_error_nodes(root)
+
+        # Adaptive TSX grammar fallback: if a .ts file contains JSX markup,
+        # tree-sitter-typescript produces ERROR nodes. Re-parse using the TSX
+        # grammar ONLY IF:
+        #   1. Initial parse yielded error nodes (parse_errors is non-empty)
+        #   2. The file is TypeScript (lang == "typescript" and grammar_tag != "tsx")
+        #   3. Source contains JSX-specific closing tokens (b"/>" or b"</")
+        if (
+            parse_errors
+            and lang == "typescript"
+            and grammar_tag != "tsx"
+            and (b"/>" in source or b"</" in source)
+        ):
+            tsx_language = _get_language("tsx")
+            if tsx_language is not None:
+                tsx_tree = Parser(tsx_language).parse(source)
+                tsx_errors = _collect_error_nodes(tsx_tree.root_node)
+                if len(tsx_errors) < len(parse_errors):
+                    tree = tsx_tree
+                    root = tree.root_node
+                    parse_errors = tsx_errors
+                    grammar_tag = "tsx"
+                    language = tsx_language
+
         query = self._get_query(lang, language, grammar_tag)
 
         # Execute the compiled query ONCE per file. The five extraction

--- a/tests/unit/ingestion/parser/test_typescript.py
+++ b/tests/unit/ingestion/parser/test_typescript.py
@@ -147,6 +147,55 @@ export function Card({ title }: { title: string }) {
         assert "Card" in names
         assert "handleClick" not in names
 
+    def test_ts_file_with_jsx_falls_back_to_tsx_grammar(self, parser: ASTParser) -> None:
+        # A .ts file (not .tsx) containing JSX markup normally produces ERROR nodes.
+        # The adaptive fallback detects parse errors and JSX tokens (/> or </)
+        # and re-parses with the TSX grammar, yielding 0 parse errors.
+        src = b"""
+export function Button({ label }: { label: string }) {
+  function handleClick() { console.log("clicked"); }
+  return <button onClick={handleClick}>{label}</button>;
+}
+"""
+        fi = _make_file_info("ui/src/Button.ts", "typescript")  # .ts extension
+        result = parser.parse_file(fi, src)
+        assert result.parse_errors == []
+        names = {s.name for s in result.symbols}
+        assert "Button" in names
+        assert "handleClick" not in names  # nested helper must not be hoisted
+
+    def test_ts_file_jsx_call_site_edges_captured_after_fallback(self, parser: ASTParser) -> None:
+        # After the TSX grammar fallback, JSX component usages (<StatRow />,
+        # <Section />) must appear in result.calls — the tsx.scm query file
+        # carries the jsx_self_closing_element and jsx_opening_element captures
+        # that map component tags to call-site edges.
+        # Without the fallback a .ts file with these components would show
+        # zero inbound callers, causing false-positive dead-code findings.
+        src = b"""
+export function StatRow({ value }: { value: number }) {
+  return <span>{value}</span>;
+}
+
+export function Section({ title }: { title: string }) {
+  return <h2>{title}</h2>;
+}
+
+export function Card() {
+  return (
+    <div>
+      <Section title="x" />
+      <StatRow value={1}></StatRow>
+    </div>
+  );
+}
+"""
+        fi = _make_file_info("ui/src/card.ts", "typescript")  # .ts NOT .tsx
+        result = parser.parse_file(fi, src)
+        assert result.parse_errors == []
+        targets = {c.target_name for c in result.calls}
+        assert "StatRow" in targets   # self-closing JSX captured as call
+        assert "Section" in targets   # paired JSX captured as call
+
     def test_jsx_element_registers_as_call_target(self, parser: ASTParser) -> None:
         # Regression: ``<StatRow ... />`` inside the same file as the
         # ``StatRow`` component definition was not registering as a call,

--- a/tests/unit/ingestion/parser/test_typescript.py
+++ b/tests/unit/ingestion/parser/test_typescript.py
@@ -196,6 +196,31 @@ export function Card() {
         assert "StatRow" in targets   # self-closing JSX captured as call
         assert "Section" in targets   # paired JSX captured as call
 
+    def test_ts_file_unrelated_syntax_error_with_html_in_string_preserves_original_parse(
+        self, parser: ASTParser
+    ) -> None:
+        # Negative / safety-net case.
+        # A .ts file whose parse error has nothing to do with JSX (here: an
+        # invalid ``@`` decorator) and that incidentally contains ``</`` inside a
+        # comment must come back with the original TypeScript parse tree
+        # intact — the fallback must NOT clear the error.
+        #
+        # The TSX grammar sees the same structural error and produces an equal
+        # or greater number of ERROR nodes, so
+        # ``len(tsx_errors) < len(parse_errors)`` is False and the original
+        # result is preserved.  This test pins that safety guarantee.
+        src = b"""
+export function f() {
+  // renders </div> elements here
+  return @invalid;
+}
+"""
+        fi = _make_file_info("src/broken.ts", "typescript")
+        result = parser.parse_file(fi, src)
+        # The real TypeScript error must still be reported — fallback did not clear it.
+        assert result.parse_errors != []
+
+
     def test_jsx_element_registers_as_call_target(self, parser: ASTParser) -> None:
         # Regression: ``<StatRow ... />`` inside the same file as the
         # ``StatRow`` component definition was not registering as a call,


### PR DESCRIPTION
## Summary

- Adds a gated adaptive TSX grammar retry to `ASTParser.parse_file` for TypeScript files (`.ts`, `.mts`, `.cts`) containing JSX markup, eliminating AST `ERROR` nodes.
- Reassigns both `grammar_tag = "tsx"` and `language = tsx_language` so `_get_query()` appends `tsx.scm`, restoring `jsx_opening_element` and `jsx_self_closing_element` call-site captures to prevent false-positive dead-code findings.
- Enforces strict safety guarantees: clean `.ts` files skip the fallback (`if parse_errors:` gate), and unrelated syntax errors containing `</` in comments/strings preserve their original parse tree (`len(tsx_errors) < len(parse_errors)` check).

## Related Issues

Fixes #965

## Test Plan

- [x] Tests pass (`pytest`)
- [x] Lint passes (`ruff check .`)

Added unit tests in `tests/unit/ingestion/parser/test_typescript.py`:
- `test_ts_file_with_jsx_falls_back_to_tsx_grammar`: Verifies zero parse errors and correct symbol extraction for `.ts` files containing JSX.
- `test_ts_file_jsx_call_site_edges_captured_after_fallback`: Asserts call targets (`StatRow`, `Section`) are registered after fallback, preventing false dead-code findings.
- `test_ts_file_unrelated_syntax_error_with_html_in_string_preserves_original_parse`: Pins negative safety net (unrelated syntax error with `</` in comments/strings keeps original parse intact).

Verified full ingestion suite: **1,517 passed in 107s**.

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
