### PR TITLE
feat(ui): move governing decisions on file page into dedicated tab (#973)

### DIFF
--- a/packages/ui/__tests__/files/file-decisions-tab.test.tsx
+++ b/packages/ui/__tests__/files/file-decisions-tab.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FileDecisionsTab } from "../../src/files/file-decisions-tab.js";
+import { FilePage } from "../../src/files/file-page.js";
+import type { FileDetailResponse, GoverningDecisionRef } from "@repowise-dev/types/files";
+
+function makeDecision(id: string, title: string, status: string): GoverningDecisionRef {
+  return { id, title, status };
+}
+
+function makeMockFileData(decisions: GoverningDecisionRef[]): FileDetailResponse {
+  return {
+    file_path: "src/main.ts",
+    wiki_page: null,
+    health: {
+      metric: null,
+      breakdown: null,
+      findings: [],
+      trend: null,
+      signals: null,
+    },
+    git: null,
+    coverage: null,
+    graph: null,
+    symbols: [],
+    function_blame: [],
+    governing_decisions: decisions,
+    dead_code: [],
+  };
+}
+
+describe("FileDecisionsTab", () => {
+  it("renders empty state when there are no decisions", () => {
+    render(<FileDecisionsTab decisions={[]} linkPrefix="/repos/r1" />);
+    expect(screen.getByText("No governing decisions")).toBeTruthy();
+    expect(
+      screen.getByText("This file is not directly linked to any architectural governing decisions."),
+    ).toBeTruthy();
+  });
+
+  it("renders decision title, status badge, and link for provided decisions", () => {
+    const decisions = [
+      makeDecision("d1", "Use human-sounding docs style", "active"),
+      makeDecision("d2", "Skip perf validation for test scripts", "proposed"),
+    ];
+
+    render(<FileDecisionsTab decisions={decisions} linkPrefix="/repos/r1" />);
+
+    expect(screen.getByText("Use human-sounding docs style")).toBeTruthy();
+    expect(screen.getByText("Skip perf validation for test scripts")).toBeTruthy();
+    expect(screen.getByText("active")).toBeTruthy();
+    expect(screen.getByText("proposed")).toBeTruthy();
+
+    const links = screen.getAllByRole("link");
+    expect(links.some((l) => l.getAttribute("href") === "/repos/r1/decisions/d1")).toBe(true);
+    expect(links.some((l) => l.getAttribute("href") === "/repos/r1/decisions/d2")).toBe(true);
+  });
+});
+
+describe("FilePage - Governing Decisions Header & Tab", () => {
+  it("renders header summary and Decisions tab when decisions exist", () => {
+    const decisions = [
+      makeDecision("d1", "Keep branch names generic", "active"),
+      makeDecision("d2", "Use TypeScript strictly", "active"),
+    ];
+    const data = makeMockFileData(decisions);
+
+    render(<FilePage data={data} repoId="r1" />);
+
+    expect(screen.getByText("Governed by")).toBeTruthy();
+    expect(screen.getByText("2 decisions")).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /decisions 2/i })).toBeTruthy();
+  });
+
+  it("hides header summary line and Decisions tab when governing_decisions is empty", () => {
+    const data = makeMockFileData([]);
+
+    render(<FilePage data={data} repoId="r1" />);
+
+    expect(screen.queryByText("Governed by")).toBeNull();
+    expect(screen.queryByRole("tab", { name: /decisions/i })).toBeNull();
+  });
+
+  it("switches to Decisions tab when clicking header summary line", () => {
+    const decisions = [makeDecision("d1", "Single decision title", "active")];
+    const data = makeMockFileData(decisions);
+    const onTabChange = vi.fn();
+
+    render(<FilePage data={data} repoId="r1" onTabChange={onTabChange} />);
+
+    const headerButton = screen.getByRole("button", { name: /governed by 1 decision/i });
+    fireEvent.click(headerButton);
+
+    expect(onTabChange).toHaveBeenCalledWith("decisions");
+    expect(screen.getByRole("tab", { name: /decisions 1/i }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByText("Single decision title")).toBeTruthy();
+  });
+
+  it("falls back to overview if initialTab is decisions but governing_decisions is empty", () => {
+    const data = makeMockFileData([]);
+
+    render(<FilePage data={data} repoId="r1" initialTab="decisions" />);
+
+    expect(screen.getByRole("tab", { name: /overview/i }).getAttribute("aria-selected")).toBe("true");
+  });
+});

--- a/packages/ui/src/files/file-decisions-tab.tsx
+++ b/packages/ui/src/files/file-decisions-tab.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import * as React from "react";
+import { Scale } from "lucide-react";
+import { Badge } from "../ui/badge";
+import { EmptyState } from "../shared/empty-state";
+import { ResponsiveTable, type ResponsiveColumn } from "../shared/responsive-table";
+import { stripMarkdown } from "../lib/format";
+import type { GoverningDecisionRef } from "@repowise-dev/types/files";
+
+const STATUS_VARIANT: Record<string, "default" | "fresh" | "stale" | "outdated" | "outline" | "accent"> = {
+  active: "fresh",
+  proposed: "accent",
+  deprecated: "outdated",
+  superseded: "outline",
+};
+
+export interface FileDecisionsTabProps {
+  decisions: GoverningDecisionRef[] | undefined | null;
+  linkPrefix: string;
+  LinkComponent?:
+    | React.ElementType<{
+        href: string;
+        className?: string;
+        children: React.ReactNode;
+      }>
+    | undefined;
+}
+
+export function FileDecisionsTab({
+  decisions,
+  linkPrefix,
+  LinkComponent = "a",
+}: FileDecisionsTabProps) {
+  const items = decisions ?? [];
+  const Link = LinkComponent;
+
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        icon={<Scale className="h-8 w-8" />}
+        title="No governing decisions"
+        description="This file is not directly linked to any architectural governing decisions."
+      />
+    );
+  }
+
+  const columns: ResponsiveColumn<GoverningDecisionRef>[] = [
+    {
+      key: "title",
+      header: "Title",
+      priority: 1,
+      cellClassName: "min-w-[200px]",
+      render: (d) => (
+        <Link
+          href={`${linkPrefix}/decisions/${d.id}`}
+          className="font-medium text-[var(--color-text-primary)] hover:text-[var(--color-accent-primary)] hover:underline block truncate"
+          title={stripMarkdown(d.title)}
+        >
+          {stripMarkdown(d.title)}
+        </Link>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      priority: 1,
+      render: (d) => (
+        <Badge variant={STATUS_VARIANT[d.status] ?? "outline"}>{d.status}</Badge>
+      ),
+    },
+    {
+      key: "action",
+      header: "",
+      priority: 2,
+      align: "right",
+      render: (d) => (
+        <Link
+          href={`${linkPrefix}/decisions/${d.id}`}
+          className="text-xs text-[var(--color-accent-primary)] hover:underline font-medium"
+        >
+          View decision →
+        </Link>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <ResponsiveTable
+        columns={columns}
+        rows={items}
+        rowKey={(d) => d.id}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/files/file-page-tabs.ts
+++ b/packages/ui/src/files/file-page-tabs.ts
@@ -7,6 +7,7 @@ export const FILE_PAGE_TABS = [
   "doc",
   "health",
   "history",
+  "decisions",
   "graph",
   "coverage",
 ] as const;

--- a/packages/ui/src/files/file-page.tsx
+++ b/packages/ui/src/files/file-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useState, useEffect, type ReactNode } from "react";
 import { Flame, DoorOpen, Trash2, Users } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
@@ -12,6 +12,7 @@ import { FileOverviewTab } from "./file-overview-tab";
 import { FileDocTab } from "./file-doc-tab";
 import { FileHealthTab, type FindingStatus } from "./file-health-tab";
 import { FileHistoryTab } from "./file-history-tab";
+import { FileDecisionsTab } from "./file-decisions-tab";
 import { FileCoverageTab } from "./file-coverage-tab";
 import { FileGraphTab } from "./file-graph-tab";
 import type { FileDetailResponse } from "@repowise-dev/types/files";
@@ -42,7 +43,7 @@ export interface FilePageProps {
  * The canonical "everything about this file" page. A standardized entity
  * header (eyebrow, breadcrumb, identity, summary, primary health signal,
  * owner pill, governing decisions) over Overview / Doc / Health / History /
- * Graph / Coverage tabs. Overview leads so undocumented files are never empty.
+ * Decisions / Graph / Coverage tabs. Overview leads so undocumented files are never empty.
  */
 export function FilePage({
   data,
@@ -65,8 +66,24 @@ export function FilePage({
   const fileHref = (p: string) => fileEntityPath(prefix, p);
   const symbolHref = (s: string) => symbolEntityPath(prefix, s);
 
-  const defaultTab: FilePageTab =
+  const decisions = data.governing_decisions ?? [];
+  const hasDecisions = decisions.length > 0;
+
+  const rawTab: FilePageTab =
     initialTab && FILE_PAGE_TABS.includes(initialTab) ? initialTab : "overview";
+  const defaultTab: FilePageTab =
+    rawTab === "decisions" && !hasDecisions ? "overview" : rawTab;
+
+  const [activeTab, setActiveTab] = useState<FilePageTab>(defaultTab);
+
+  useEffect(() => {
+    setActiveTab(defaultTab);
+  }, [defaultTab]);
+
+  const handleTabChange = (tab: FilePageTab) => {
+    setActiveTab(tab);
+    onTabChange?.(tab);
+  };
 
   return (
     <div className="space-y-4">
@@ -127,28 +144,26 @@ export function FilePage({
           ) : undefined
         }
         decisions={
-          data.governing_decisions.length > 0 ? (
-            <div className="flex flex-wrap items-center gap-1.5">
+          hasDecisions ? (
+            <button
+              type="button"
+              onClick={() => handleTabChange("decisions")}
+              className="inline-flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-accent-primary)] hover:underline cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--color-accent-primary)] rounded"
+            >
               <span className="text-[10px] uppercase tracking-wider text-[var(--color-text-tertiary)]">
                 Governed by
               </span>
-              {data.governing_decisions.map((d) => (
-                <a
-                  key={d.id}
-                  href={`${prefix}/decisions/${d.id}`}
-                  className="rounded border border-[var(--color-border-default)] px-1.5 py-0.5 text-xs text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-accent-primary)] hover:text-[var(--color-accent-primary)]"
-                >
-                  {d.title}
-                </a>
-              ))}
-            </div>
+              <span className="font-medium text-[var(--color-text-primary)]">
+                {decisions.length} {decisions.length === 1 ? "decision" : "decisions"}
+              </span>
+            </button>
           ) : undefined
         }
         {...(LinkComponent ? { LinkComponent } : {})}
       />
 
       {/* ── Tabs ── */}
-      <Tabs defaultValue={defaultTab} onValueChange={(v) => onTabChange?.(v as FilePageTab)}>
+      <Tabs value={activeTab} onValueChange={(v) => handleTabChange(v as FilePageTab)}>
         <TabsList className="flex-wrap">
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="doc">Doc</TabsTrigger>
@@ -161,6 +176,14 @@ export function FilePage({
             )}
           </TabsTrigger>
           <TabsTrigger value="history">History</TabsTrigger>
+          {hasDecisions && (
+            <TabsTrigger value="decisions">
+              Decisions
+              <span className="ml-1 text-[10px] tabular-nums opacity-70">
+                {decisions.length}
+              </span>
+            </TabsTrigger>
+          )}
           <TabsTrigger value="graph">Graph</TabsTrigger>
           <TabsTrigger value="coverage">Coverage</TabsTrigger>
         </TabsList>
@@ -182,6 +205,15 @@ export function FilePage({
         <TabsContent value="history" className="mt-4">
           <FileHistoryTab git={data.git} linkPrefix={prefix} partnerHref={fileHref} />
         </TabsContent>
+        {hasDecisions && (
+          <TabsContent value="decisions" className="mt-4">
+            <FileDecisionsTab
+              decisions={decisions}
+              linkPrefix={prefix}
+              {...(LinkComponent ? { LinkComponent } : {})}
+            />
+          </TabsContent>
+        )}
         <TabsContent value="graph" className="mt-4">
           <FileGraphTab
             graph={data.graph}

--- a/packages/ui/src/files/index.ts
+++ b/packages/ui/src/files/index.ts
@@ -4,6 +4,7 @@ export * from "./file-overview-tab";
 export * from "./file-doc-tab";
 export * from "./file-health-tab";
 export * from "./file-history-tab";
+export * from "./file-decisions-tab";
 export * from "./file-coverage-tab";
 export * from "./file-graph-tab";
 export * from "./files-index";


### PR DESCRIPTION
## Summary

- **Header Simplification**: Replaced the wall of governing decision pills in the file page header strip (`EntityHeader`) with a single, clean summary button (`Governed by N decisions`).
- **Dedicated Decisions Tab**: Added a new `"decisions"` tab to `FilePage` (positioned between `History` and `Graph`) rendering a structured `ResponsiveTable` with decision titles, status badges (`active`, `proposed`, `deprecated`, `superseded`), and decision links.
- **Empty States & Routing**: Automatically hides the header summary line and tab trigger when `governing_decisions` is empty, and supports direct URL deep linking (`?tab=decisions`) with fallback handling.

## Related Issues

- Fixes #973

## Screenshots

<img width="955" height="509" alt="image" src="https://github.com/user-attachments/assets/1dc74219-ce61-41f3-a795-9e6f77a00a8d" />

## Test Plan

- [x] Component Unit Tests (`npm exec -w packages/ui -- vitest run __tests__/files/file-decisions-tab.test.tsx` - **6/6 PASSED**)
- [x] TypeScript Type Check (`npm exec -w packages/ui -- tsc --noEmit` - **0 ERRORS**)
- [x] Web Workspace Type Check (`npm exec -w packages/web -- tsc --noEmit` - **0 ERRORS**)
- [x] Web build passes (`npm run build`)
- [x] Visual verification on sample repository file page (`/repos/{id}/files/{path}?tab=decisions`)

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed
