### PR TITLE
feat(cli): make init's next-steps panel react to what setup actually did

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1064,9 +1064,11 @@ and supports two transports:
 
 ### Auto-generated Config
 
-`repowise init` automatically generates `.repowise/mcp.json` with ready-to-paste
-config blocks for Claude Code (`~/.claude/claude.json`), Cursor (`.cursor/mcp.json`),
-and Cline. This config is printed at the end of `repowise init`.
+`repowise init` registers the MCP server directly where it can: Claude Code
+(`~/.claude/settings.json`), Claude Desktop (if installed), VS Code
+(`.vscode/mcp.json`), and the repo-shared `.mcp.json`. It also writes
+`.repowise/mcp.json` for clients configured by hand. The completion panel says
+which client was wired up and how Cursor or Codex connect (`repowise mcp .`).
 
 ---
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -969,7 +969,12 @@ def init_command(
     # so ask. Non-interactive runs refuse rather than guess.
     # ``--yes`` and ``--force`` both mean "do not ask me", which is the answer
     # here as much as at the cost gate.
-    _prior_docs_mode = resolve_docs_mode(load_state(repo_path))
+    _prior_state = load_state(repo_path)
+    # Whether this repo has ever been indexed, captured before the run writes
+    # its own state. Drives the completion panel's MCP note (a first index tells
+    # the user to restart Claude Code to load the tools; a re-index does not).
+    _first_index = not _prior_state.get("last_sync_commit")
+    _prior_docs_mode = resolve_docs_mode(_prior_state)
     if index_only and _prior_docs_mode == "llm" and not (force or yes):
         console.print(
             "\n[yellow]This repo already has a model-written wiki.[/yellow] "
@@ -1391,16 +1396,6 @@ def init_command(
             include_submodules=include_submodules,
         )
 
-    # ---- Completion panel ----
-    show_completion(
-        repo_path=repo_path,
-        result=result,
-        start=start,
-        effective_index_only=effective_index_only,
-        run_mode=run_mode,
-        provider=provider,
-    )
-
     _record_init_outcome(
         result=result,
         effective_index_only=effective_index_only,
@@ -1415,3 +1410,25 @@ def init_command(
     # Opt-in distill command-rewrite hook for Claude Code. The workspace flow
     # runs its own offer across all selected repos inside _workspace_init.
     offer_distill_rewrite_hook(console, [repo_path], distill_hook, yes=yes)
+
+    # ---- Completion panel (last, so it reflects what setup actually did) ----
+    # Snapshot the editor-setup state now that client registration and the two
+    # hook offers above have run, so the "what's next" panel and MCP note react
+    # to reality. `interactive` mirrors the offers' own gate: when False they
+    # were skipped, so the panel is the only place their hooks surface.
+    from repowise.cli.editor_setup import detect_editor_setup_outcome
+
+    _setup_outcome = detect_editor_setup_outcome(
+        repo_path,
+        interactive=(sys.stdin.isatty() and not yes),
+        first_index=_first_index,
+    )
+    show_completion(
+        repo_path=repo_path,
+        result=result,
+        start=start,
+        effective_index_only=effective_index_only,
+        run_mode=run_mode,
+        provider=provider,
+        setup=_setup_outcome,
+    )

--- a/packages/cli/src/repowise/cli/commands/init_cmd/reporting.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/reporting.py
@@ -15,6 +15,7 @@ from repowise.cli.ui import (
     build_analysis_summary_panel,
     build_completion_panel,
     build_contextual_next_steps,
+    build_mcp_status_lines,
     format_elapsed,
 )
 
@@ -116,8 +117,14 @@ def show_completion(
     effective_index_only: bool,
     run_mode: str,
     provider: Any,
+    setup: Any = None,
 ) -> None:
-    """Render the final completion panel (index-only or full mode)."""
+    """Render the final completion panel (index-only or full mode).
+
+    *setup* is the :class:`~repowise.cli.editor_setup.EditorSetupOutcome`
+    snapshot, so the next-step panel and the MCP status note reflect what setup
+    actually did. Passed as ``None`` only by callers with nothing to report.
+    """
     elapsed = time.monotonic() - start
 
     _graph_final = result.graph_builder.graph()
@@ -194,6 +201,7 @@ def show_completion(
             hotspot_count=_hotspot_count_final,
             decision_count=_n_decisions,
             top_hotspot=_top_hotspot,
+            setup=setup,
         )
         console.print()
         console.print(
@@ -214,6 +222,8 @@ def show_completion(
                 "  Re-run without [bold]--mode fast[/bold] to render the wiki from "
                 "structure.[/dim]"
             )
+        for _line in build_mcp_status_lines(setup):
+            console.print(_line)
         console.print()
         _render_defect_accuracy(result)
     else:
@@ -250,9 +260,8 @@ def show_completion(
             hotspot_count=_hotspot_count_final,
             decision_count=_n_decisions,
             top_hotspot=_top_hotspot,
+            setup=setup,
         )
-
-        from repowise.cli.mcp_config import format_setup_instructions
 
         console.print()
         console.print(
@@ -260,7 +269,11 @@ def show_completion(
         )
         console.print()
         _render_defect_accuracy(result)
-        console.print(format_setup_instructions(repo_path))
+        # A concise, dynamic MCP note (who is connected, how others connect)
+        # replaces the old wall of manual per-client config: init already wrote
+        # the Claude Code / VS Code registrations and repo `.mcp.json`.
+        for _line in build_mcp_status_lines(setup):
+            console.print(_line)
         console.print()
 
 
@@ -293,13 +306,13 @@ def show_workspace_completion(
 
     if index_only or provider is None:
         next_steps = [
-            ("repowise mcp <repo-path>", "start MCP server for a repo"),
+            ("repowise serve", "open the workspace dashboard at http://localhost:3000"),
             ("repowise status --workspace", "show workspace status"),
-            ("repowise init <repo> --provider gemini", "generate full docs for a repo"),
+            ("repowise generate <repo>", "upgrade a repo's wiki to model-written prose"),
         ]
     else:
         next_steps = [
-            ("repowise mcp <repo-path>", "start MCP server for a repo"),
+            ("repowise serve", "open the workspace dashboard at http://localhost:3000"),
             ("repowise status --workspace", "show workspace status"),
             ("repowise search <query>", "search across all indexed repos"),
         ]

--- a/packages/cli/src/repowise/cli/commands/mcp_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/mcp_cmd.py
@@ -115,7 +115,7 @@ def mcp_command(
     protocol: eleven by default in single-repo mode, plus two more by default
     in workspace mode. Four more are opt-in via ``--tools`` or the
     ``mcp.tools`` config block. Supports stdio
-    (for Claude Code, Codex, Cursor, Cline), streamable HTTP, and legacy SSE
+    (for Claude Code, Codex, Cursor), streamable HTTP, and legacy SSE
     transports.
 
     Loads ``<repo>/.repowise/.env`` into the environment before starting so

--- a/packages/cli/src/repowise/cli/commands/update_cmd/reporting.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/reporting.py
@@ -213,7 +213,9 @@ def show_full_completion(
         ("repowise search <query>", "search the wiki"),
     ]
     console.print()
-    console.print(build_completion_panel("repowise update complete", metrics, next_steps=next_steps))
+    console.print(
+        build_completion_panel("repowise update complete", metrics, next_steps=next_steps)
+    )
     console.print()
 
 
@@ -255,12 +257,18 @@ def show_index_only_completion(
         ("repowise serve", "browse the index at localhost:3000"),
     ]
     if template_wiki:
-        next_steps.append(("repowise update --full", "rewrite the wiki with a model (needs a key)"))
+        # The scoped, cost-gated upgrade path — a coverage, a directory or one
+        # page at a time — not the all-or-nothing `update --full`.
+        next_steps.append(
+            ("repowise generate", "upgrade the wiki to model-written prose (needs a key)")
+        )
     else:
         next_steps.append(("repowise update --docs", "regenerate docs for the changed files"))
     console.print()
     console.print(
-        build_completion_panel("repowise index-only update complete", metrics, next_steps=next_steps)
+        build_completion_panel(
+            "repowise index-only update complete", metrics, next_steps=next_steps
+        )
     )
     console.print()
 

--- a/packages/cli/src/repowise/cli/editor_setup.py
+++ b/packages/cli/src/repowise/cli/editor_setup.py
@@ -32,6 +32,81 @@ def _editor_setup_disabled() -> bool:
 
 
 @dataclass(frozen=True)
+class EditorSetupOutcome:
+    """What editor setup actually ended up doing, for the completion panel.
+
+    Snapshotted once at the authoritative moment — after client registration
+    and the interactive hook offers have run — so the "what's next" panel can
+    react to reality instead of guessing. Every field is a plain fact the panel
+    turns into a suggestion (or stays quiet about).
+    """
+
+    #: repowise registered a Claude Code MCP entry this run (init always does,
+    #: unless setup was skipped for a headless/CI run).
+    claude_code_connected: bool = False
+    #: the git post-commit auto-sync hook is present for this repo.
+    autosync_hook_installed: bool = False
+    #: the Claude Code distill command-rewrite hook is present (user-level).
+    rewrite_hook_installed: bool = False
+    #: the run could prompt (a TTY, not ``--yes``); when False the interactive
+    #: hook offers were skipped, so the panel is the only place to surface them.
+    interactive: bool = False
+    #: no prior index existed before this run (first-time onboarding).
+    first_index: bool = True
+    #: REPOWISE_SKIP_EDITOR_SETUP was set (CI/benchmark) — nothing was wired up.
+    editor_setup_disabled: bool = False
+
+
+def detect_editor_setup_outcome(
+    repo_path: Path,
+    *,
+    interactive: bool,
+    first_index: bool,
+) -> EditorSetupOutcome:
+    """Read the ground-truth editor-setup state for the completion panel.
+
+    Called after registration and the hook offers, so what it reads is final.
+    Every probe is a cheap local file read and is defensive: a failure degrades
+    to "not set up" rather than crashing ``init``.
+    """
+    disabled = _editor_setup_disabled()
+
+    autosync = False
+    try:
+        from repowise.cli.hooks import status as _hook_status
+
+        autosync = _hook_status(repo_path) == "installed"
+    except Exception:
+        pass
+
+    # The distill rewrite hook is per-agent. Treat it as present when any agent
+    # surface has it (Claude Code always, Codex only when detected), mirroring
+    # `repowise hook rewrite status`, so a Codex-only user who set it up on
+    # Codex is never nagged to install it again.
+    rewrite = False
+    try:
+        from repowise.cli.agent_adapters.claude_code import ClaudeCodeAdapter
+        from repowise.cli.agent_adapters.codex import CodexAdapter
+
+        surfaces = [ClaudeCodeAdapter()]
+        codex = CodexAdapter()
+        if codex.detect():
+            surfaces.append(codex)
+        rewrite = any(surface.rewrite_hook_installed() for surface in surfaces)
+    except Exception:
+        pass
+
+    return EditorSetupOutcome(
+        claude_code_connected=not disabled,
+        autosync_hook_installed=autosync,
+        rewrite_hook_installed=rewrite,
+        interactive=interactive,
+        first_index=first_index,
+        editor_setup_disabled=disabled,
+    )
+
+
+@dataclass(frozen=True)
 class EditorSetupOptions:
     """Options shared across editor setup integrations."""
 

--- a/packages/cli/src/repowise/cli/mcp_config.py
+++ b/packages/cli/src/repowise/cli/mcp_config.py
@@ -518,32 +518,3 @@ def _has_repowise_hook_for_matcher(hook_list: list, matcher: object) -> bool:
             if _is_repowise_hook(hook):
                 return True
     return False
-
-
-def format_setup_instructions(repo_path: Path) -> str:
-    """Return human-readable setup instructions for MCP clients."""
-    config = generate_mcp_config(repo_path)
-    server_block = json.dumps(config["mcpServers"]["repowise"], indent=4)
-    abs_path = str(repo_path.resolve()).replace("\\", "/")
-
-    return f"""
-MCP Server Configuration
-========================
-
-Project .mcp.json: automatically written for MCP clients that support repo-local discovery.
-
-Cursor (.cursor/mcp.json):
-  {server_block}
-
-Cline (cline_mcp_settings.json):
-  "mcpServers": {{
-    "repowise": {server_block}
-  }}
-
-Or run directly:
-  repowise mcp {abs_path}
-  repowise mcp {abs_path} --transport streamable-http --port 7338
-  repowise mcp {abs_path} --transport sse --port 7338
-
-Config saved to: {repo_path / ".repowise" / "mcp.json"}
-""".strip()

--- a/packages/cli/src/repowise/cli/ui/__init__.py
+++ b/packages/cli/src/repowise/cli/ui/__init__.py
@@ -52,6 +52,7 @@ from repowise.cli.ui.result_panels import (
     build_analysis_summary_panel,
     build_completion_panel,
     build_contextual_next_steps,
+    build_mcp_status_lines,
 )
 from repowise.cli.ui.workspace_selection import (
     interactive_primary_select,

--- a/packages/cli/src/repowise/cli/ui/result_panels.py
+++ b/packages/cli/src/repowise/cli/ui/result_panels.py
@@ -119,29 +119,60 @@ def build_contextual_next_steps(
     hotspot_count: int = 0,
     decision_count: int = 0,
     top_hotspot: str = "",
+    setup: Any = None,
 ) -> list[tuple[str, str]]:
-    """Build next-step suggestions based on what the analysis actually found.
+    """Build next-step suggestions from what the run actually did.
 
-    When *fast_mode* is set, the index used the essential git tier and skipped
-    LLM docs, so the suggestions lead with how to upgrade to the full result.
+    ``repowise serve`` is the headline in every mode: the dashboard is the one
+    place the graph, hotspots, dead code, decisions and wiki are all browsable.
+    The second row is the mode's natural next move (upgrade for fast/index-only,
+    search for a written wiki).
+
+    *setup* is an optional :class:`~repowise.cli.editor_setup.EditorSetupOutcome`.
+    When present, the panel reacts to it: a headless run gets a manual MCP row,
+    and a **non-interactive** run whose hooks are missing gets install rows
+    (an interactive run was already offered them live, so re-listing would nag).
+    The Claude Code "already connected, restart it" status is a note rendered
+    beside the panel, not a command row — see :func:`build_mcp_status_lines`.
     """
     steps: list[tuple[str, str]] = []
 
+    # Headline: the dashboard, always. Graph, hotspots and dead code are there
+    # even in fast/index-only mode, so it is useful before any upgrade.
+    steps.append(("repowise serve", "open the dashboard at http://localhost:3000"))
+
     if fast_mode:
-        # Fast index: graph + essential git, no docs. Tell them how to get the
-        # full thing — complete git history + generated wiki pages.
-        steps.append(("repowise init", "run full mode: complete git history + generate docs"))
-        steps.append(("repowise mcp .", "start MCP server for AI assistants now"))
+        # Fast index: graph + essential git, no docs. Point at the full result.
+        steps.append(("repowise init", "upgrade to full git history + a generated wiki"))
     elif index_only:
-        # MCP is already auto-registered by `init`, so `repowise serve` is a
-        # more useful headline next step — it launches the dashboard where the
-        # graph, hotspots, dead code, and decisions are easier to browse than
-        # via the CLI.
-        steps.append(("repowise serve", "launch the dashboard at http://localhost:3000"))
-        steps.append(("repowise update --full", "rewrite the wiki with a model (needs a key)"))
+        # `generate` is the scoped, cost-gated upgrade path — a coverage, a
+        # directory or one page at a time, each behind an estimate — not the
+        # all-or-nothing `update --full` this used to suggest.
+        steps.append(("repowise generate", "upgrade the wiki to model-written prose (needs a key)"))
     else:
-        steps.append(("repowise mcp .", "start MCP server for AI assistants"))
-        steps.append(("repowise search <query>", "search the generated wiki"))
+        steps.append(('repowise search "<query>"', "search the generated wiki"))
+
+    # MCP: only a manual row when nothing was auto-wired (headless/CI). When a
+    # client was registered, the "restart to load the tools" status goes in the
+    # note beside the panel instead of as a command.
+    if setup is not None and getattr(setup, "editor_setup_disabled", False):
+        steps.append(("repowise mcp .", "connect an MCP client (Cursor, Codex, Claude Code)"))
+
+    # Hooks the interactive offers would have covered live. Surface them here
+    # only for a non-interactive run (where the offers were skipped silently)
+    # and only when the hook is actually missing. A headless / skip-setup run
+    # opted out of all editor wiring, so it is never nagged to install hooks.
+    if (
+        setup is not None
+        and not getattr(setup, "interactive", False)
+        and not getattr(setup, "editor_setup_disabled", False)
+    ):
+        if not getattr(setup, "autosync_hook_installed", False):
+            steps.append(("repowise hook install", "auto-sync the index on every commit"))
+        if not getattr(setup, "rewrite_hook_installed", False):
+            steps.append(
+                ("repowise hook rewrite install", "compress noisy command output via distill")
+            )
 
     if dead_unreachable + dead_unused > 0:
         steps.append(
@@ -154,8 +185,35 @@ def build_contextual_next_steps(
     if decision_count > 0:
         steps.append(("repowise decisions", f"browse {decision_count} architectural decisions"))
 
-    if not steps:
-        steps.append(("repowise mcp .", "start MCP server for AI assistants"))
-        steps.append(("repowise search <query>", "search the index"))
-
     return steps
+
+
+def build_mcp_status_lines(setup: Any) -> list[str]:
+    """Rich-markup status lines about MCP wiring, shown beside the panel.
+
+    Separate from the command rows because "already connected, restart it" is a
+    state, not something to run. Returns an empty list for a headless run (the
+    manual ``repowise mcp .`` command row carries that case instead).
+    """
+    if setup is None or getattr(setup, "editor_setup_disabled", False):
+        return []
+
+    lines: list[str] = []
+    if getattr(setup, "claude_code_connected", False):
+        if getattr(setup, "first_index", True):
+            lines.append(
+                "  [dim]Claude Code is connected to this repo. Restart it (or run "
+                "[bold]/mcp[/bold]) to load the repowise tools.[/dim]"
+            )
+        else:
+            lines.append(
+                "  [dim]Claude Code stays connected; restart it only if the tools "
+                "aren't showing.[/dim]"
+            )
+    # Cursor and Codex are not auto-wired (init writes the Claude/VS Code configs
+    # and repo `.mcp.json`, not `.cursor/mcp.json`), so always point the way.
+    lines.append(
+        "  [dim]Cursor or Codex: run [bold]repowise mcp .[/bold] "
+        "(config in [bold].repowise/mcp.json[/bold]).[/dim]"
+    )
+    return lines

--- a/tests/unit/cli/test_editor_setup.py
+++ b/tests/unit/cli/test_editor_setup.py
@@ -69,6 +69,55 @@ def test_register_editor_clients_skipped_when_env_set(monkeypatch) -> None:
     assert registered == [Path("repo")]  # runs when unset
 
 
+def test_detect_editor_setup_outcome_reads_ground_truth(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    """The snapshot reflects the real hook state and the skip-setup env flag."""
+    from repowise.cli import hooks as hooks_module
+    from repowise.cli.agent_adapters import claude_code as cc_module
+    from repowise.cli.agent_adapters import codex as codex_module
+    from repowise.cli.editor_setup import detect_editor_setup_outcome
+
+    monkeypatch.setattr(hooks_module, "status", lambda _p: "installed")
+
+    class _Adapter:
+        def __init__(self, installed: bool, detected: bool = True) -> None:
+            self._installed = installed
+            self._detected = detected
+
+        def detect(self) -> bool:
+            return self._detected
+
+        def rewrite_hook_installed(self) -> bool:
+            return self._installed
+
+    monkeypatch.setattr(cc_module, "ClaudeCodeAdapter", lambda: _Adapter(installed=False))
+    # Codex is detected and has the rewrite hook, so it counts as present.
+    monkeypatch.setattr(codex_module, "CodexAdapter", lambda: _Adapter(installed=True))
+    monkeypatch.delenv("REPOWISE_SKIP_EDITOR_SETUP", raising=False)
+
+    outcome = detect_editor_setup_outcome(tmp_path, interactive=True, first_index=True)
+    assert outcome.claude_code_connected is True
+    assert outcome.editor_setup_disabled is False
+    assert outcome.autosync_hook_installed is True
+    assert outcome.rewrite_hook_installed is True  # Codex surface has it
+    assert outcome.interactive is True
+    assert outcome.first_index is True
+
+
+def test_detect_editor_setup_outcome_skip_env_reports_disconnected(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    from repowise.cli.editor_setup import detect_editor_setup_outcome
+
+    monkeypatch.setenv("REPOWISE_SKIP_EDITOR_SETUP", "1")
+    outcome = detect_editor_setup_outcome(tmp_path, interactive=False, first_index=False)
+    assert outcome.editor_setup_disabled is True
+    assert outcome.claude_code_connected is False
+
+
 def test_resolve_editor_setup_options_delegates_to_integrations() -> None:
     calls: list[tuple[str, frozenset[str], bool]] = []
 

--- a/tests/unit/cli/test_fast_mode_offer.py
+++ b/tests/unit/cli/test_fast_mode_offer.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from repowise.cli.editor_setup import EditorSetupOutcome
 from repowise.cli.ui import (
     LARGE_REPO_FILE_THRESHOLD,
     RepoScanInfo,
     build_contextual_next_steps,
+    build_mcp_status_lines,
     should_offer_fast_mode,
 )
 
@@ -27,32 +29,107 @@ def test_should_offer_fast_mode_large_repo():
     assert should_offer_fast_mode(RepoScanInfo(total_files=LARGE_REPO_FILE_THRESHOLD + 1)) is True
 
 
-def test_next_steps_fast_mode_leads_with_full_upgrade():
+def test_next_steps_serve_is_the_headline_in_every_mode():
+    """`repowise serve` (the dashboard) leads in fast, index-only and full — the
+    one place the graph, hotspots, dead code, decisions and wiki all live."""
+    for kwargs in (
+        {"index_only": True, "fast_mode": True},
+        {"index_only": True, "fast_mode": False},
+        {"index_only": False},
+    ):
+        steps = build_contextual_next_steps(**kwargs)
+        assert steps[0][0] == "repowise serve"
+
+
+def test_next_steps_fast_mode_second_row_is_full_upgrade():
     steps = build_contextual_next_steps(index_only=True, fast_mode=True)
     cmds = [c for c, _ in steps]
     descs = " ".join(d for _, d in steps).lower()
-    # Fast mode tells the user how to get the full result.
-    assert cmds[0] == "repowise init"
-    assert "full" in descs and "docs" in descs
+    # After serve, fast mode points at the full result.
+    assert cmds[1] == "repowise init"
+    assert "full" in descs and "wiki" in descs
 
 
-def test_next_steps_index_only_without_fast():
+def test_next_steps_index_only_upgrades_via_generate_not_update_full():
     steps = build_contextual_next_steps(index_only=True, fast_mode=False)
     cmds = [c for c, _ in steps]
-    assert any("update --full" in c for c in cmds)  # the upgrade-to-prose hint
-
-
-def test_next_steps_index_only_recommends_serve_as_first_step():
-    """`repowise serve` (the dashboard) is the headline next step after an
-    index-only run — MCP is already auto-registered by init."""
-    steps = build_contextual_next_steps(index_only=True, fast_mode=False)
-    assert steps[0][0] == "repowise serve"
+    assert any(c == "repowise generate" for c in cmds)  # the scoped upgrade path
+    assert not any("update --full" in c for c in cmds)  # never the all-or-nothing path
 
 
 def test_next_steps_full_mode():
     steps = build_contextual_next_steps(index_only=False)
     cmds = [c for c, _ in steps]
     assert any("search" in c for c in cmds)
+
+
+def test_next_steps_headless_run_gets_manual_mcp_row():
+    """A skipped-setup run (CI/headless) can't auto-wire a client, so the panel
+    offers the manual connect command naming the real clients."""
+    setup = EditorSetupOutcome(editor_setup_disabled=True, claude_code_connected=False)
+    cmds = [c for c, _ in build_contextual_next_steps(index_only=True, setup=setup)]
+    assert "repowise mcp ." in cmds
+    # A skip-setup run opted out of all wiring, so it is never nagged to install
+    # hooks even though it is non-interactive with none present.
+    assert not any(c.startswith("repowise hook") for c in cmds)
+
+    # A normally-wired run never shows the manual MCP command row.
+    wired = EditorSetupOutcome(claude_code_connected=True, interactive=True)
+    cmds_wired = [c for c, _ in build_contextual_next_steps(index_only=True, setup=wired)]
+    assert "repowise mcp ." not in cmds_wired
+
+
+def test_next_steps_non_interactive_surfaces_missing_hooks():
+    """When the run couldn't prompt, the skipped hook offers surface as rows —
+    but only for hooks that are actually missing."""
+    setup = EditorSetupOutcome(
+        interactive=False,
+        autosync_hook_installed=False,
+        rewrite_hook_installed=False,
+        claude_code_connected=True,
+    )
+    cmds = [c for c, _ in build_contextual_next_steps(index_only=True, setup=setup)]
+    assert "repowise hook install" in cmds
+    assert "repowise hook rewrite install" in cmds
+
+    # Already installed → not re-suggested.
+    setup_installed = EditorSetupOutcome(
+        interactive=False,
+        autosync_hook_installed=True,
+        rewrite_hook_installed=True,
+        claude_code_connected=True,
+    )
+    cmds2 = [c for c, _ in build_contextual_next_steps(index_only=True, setup=setup_installed)]
+    assert not any(c.startswith("repowise hook") for c in cmds2)
+
+
+def test_next_steps_interactive_run_does_not_nag_about_hooks():
+    """An interactive run was already asked about both hooks live, so the panel
+    stays quiet about them even when missing."""
+    setup = EditorSetupOutcome(
+        interactive=True,
+        autosync_hook_installed=False,
+        rewrite_hook_installed=False,
+        claude_code_connected=True,
+    )
+    cmds = [c for c, _ in build_contextual_next_steps(index_only=True, setup=setup)]
+    assert not any(c.startswith("repowise hook") for c in cmds)
+
+
+def test_mcp_status_lines_restart_note_only_on_first_index():
+    first = EditorSetupOutcome(claude_code_connected=True, first_index=True)
+    text = " ".join(build_mcp_status_lines(first)).lower()
+    assert "restart" in text and "claude code" in text
+    assert "cursor" in text and "codex" in text  # others are pointed the way too
+
+    rerun = EditorSetupOutcome(claude_code_connected=True, first_index=False)
+    rerun_text = " ".join(build_mcp_status_lines(rerun)).lower()
+    assert "stays connected" in rerun_text
+
+
+def test_mcp_status_lines_empty_when_headless_or_absent():
+    assert build_mcp_status_lines(None) == []
+    assert build_mcp_status_lines(EditorSetupOutcome(editor_setup_disabled=True)) == []
 
 
 def test_next_steps_rendered_lines_have_space_before_description():

--- a/tests/unit/cli/test_ui_package.py
+++ b/tests/unit/cli/test_ui_package.py
@@ -38,6 +38,7 @@ def test_facade_reexports_public_surface() -> None:
         "build_analysis_summary_panel",
         "build_completion_panel",
         "build_contextual_next_steps",
+        "build_mcp_status_lines",
         "format_bytes",
         "format_elapsed",
         "LARGE_REPO_FILE_THRESHOLD",

--- a/tests/unit/server/mcp/test_config.py
+++ b/tests/unit/server/mcp/test_config.py
@@ -23,19 +23,6 @@ def test_generate_mcp_config():
     assert "stdio" in server["args"]
 
 
-def test_format_setup_instructions():
-    from pathlib import Path
-
-    from repowise.cli.mcp_config import format_setup_instructions
-
-    instructions = format_setup_instructions(Path("/tmp/test-repo"))
-    assert "Project .mcp.json" in instructions
-    assert "Claude Code" not in instructions
-    assert "Cursor" in instructions
-    assert "Cline" in instructions
-    assert "repowise" in instructions
-
-
 @pytest.mark.asyncio
 async def test_mcp_lifespan_uses_cli_database_env_var(monkeypatch):
     """REPOWISE_DB_URL should be respected by MCP lifespan via resolve_db_url."""


### PR DESCRIPTION
## What

`repowise init`'s completion "what's next" panel was a fixed guess. Now it is built from a single snapshot of what editor setup actually did, taken after client registration and the interactive hook offers run, so the suggestions match reality.

## Why

`init` auto-registers the MCP server for Claude Code unconditionally (plus Claude Desktop if installed, VS Code, and the repo `.mcp.json`), so the old headline `repowise mcp .` was redundant for the common case. And the index-only path pointed at the all-or-nothing `update --full`, which contradicted the scoped `repowise generate` upgrade path.

## Changes

- **`repowise serve` is the headline in every mode** (fast / index-only / full / workspace); it opens the dashboard where the graph, hotspots, dead code, decisions and wiki all live. The second row is the mode's real next move: `init` for fast, `generate` for index-only (no longer `update --full`), `search` for full.
- **Dynamic via a new `EditorSetupOutcome`** read by `detect_editor_setup_outcome`. `show_completion` now runs last (after the two hook offers) so the panel reflects the final state. A headless / skip-setup run gets a manual `repowise mcp .` row; a non-interactive run whose hooks are missing gets the hook-install rows (an interactive run was already offered them live, and a skip-setup run is never nagged).
- **MCP status as a note beside the panel**: Claude Code is auto-registered, so it says to restart it (first index only); it points Cursor or Codex at `repowise mcp .`.
- **Rewrite-hook check covers both Claude Code and Codex** surfaces, so a Codex-only user is not nagged.
- Removed the dead manual per-client config block (and its last Cline mention); dropped Cline from `mcp` help.
- **`update`**: index-only on a template wiki now points at `repowise generate` instead of `update --full`.

## Tests

- `test_fast_mode_offer.py`: serve-headline-every-mode, generate-not-update-full, headless manual-MCP row with no hook nag, non-interactive missing-hook rows, interactive no-nag, status-line restart-note (first index only), empty when headless.
- `test_editor_setup.py`: `detect_editor_setup_outcome` ground-truth across both agent surfaces + skip-env.
- Full CLI unit suite green (867 passed, 1 skipped), ruff clean.