### PR TITLE
chore: make .gitignore OSS-safe and fix two dead doc links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ share/python-wheels/
 venv/
 ENV/
 env/
-/papers/
 # uv
 .uv/
 
@@ -83,7 +82,10 @@ next-env.d.ts
 .repowise-workspace/
 .repowise-workspace.yaml
 
-# Benchmark output (large-repo scale runs) — keep the dir, ignore results
+# repowise API keys (local)
+.repowise/.env
+
+# Benchmark output (large-repo scale runs): keep the dir, ignore results
 bench/results/
 
 # Database
@@ -114,54 +116,8 @@ docker-compose.override.yml
 Thumbs.db
 ehthumbs.db
 
-# Claude Code
-.claude/
-
-# repowise API keys (local)
-.repowise/.env
-
-# Internal docs (not for distribution)
-docs/COMPETITIVE_ANALYSIS.md
-docs/GRAPH_INTELLIGENCE_UPGRADE.md
-docs/LOCAL_DEV.md
-docs/multi-repo/
-
-# Local-only language work tracker (not for git)
-docs/LANGUAGE_REMAINING_WORK.md
-
-# Local UI/UX audit notes
-AUDIT_UI_UX.md
-docs/WEB_UI_IMPROVEMENT_PLAN.md
-docs/WORKSPACE_ROBUSTNESS.md
-
-# Local demo scripts (not for distribution)
-demo/
-
-# Local scratch — dead-code analysis & R2 tooling
-_pip_check/
-content_engine/
-analyze_findings.py
-fetch_r2.py
-upload_r2.py
-filter_dead_code.py
-inspect_*.py
-eshop_hosted_dead_code.*
-
-# Local scratch / sibling tools (not for distribution)
-GitNexus/
-graphify/
-test-repos/
-
 # Office temp / lock files
 ~$*
-*.zip
 
-# Local hosted-product planning (not for OSS distribution)
-docs/IXOPAY_FEATURES.md
-docs/IXOPAY_FEATURES.docx
-docs/HOSTED_PRODUCT_UPGRADE_PLAN.md
-docs/HOSTED_IMPLEMENTATION_GUIDE.md
-docs/HOSTED_PROGRESS.md
-scripts/md_to_docx.py
-
-# Local issue analysis scratch (not for OSS distribution)
+# Claude Code
+.claude/

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -203,8 +203,6 @@ and significant.
 
 Full methodology and confidence intervals:
 **[health-defect/COMPARISON_REPORT.md](https://github.com/repowise-dev/repowise-bench/blob/master/health-defect/COMPARISON_REPORT.md)**.
-A wider capability comparison is in
-[COMPETITIVE_ANALYSIS.md](COMPETITIVE_ANALYSIS.md).
 
 ### The per-repo self-check
 
@@ -290,7 +288,5 @@ catalogue-level, not a measured head-to-head. Data and method:
   store, and the hook.
 - [docs/agent/MCP_TOOLS.md](agent/MCP_TOOLS.md): the tools the agent-efficiency
   study exercises.
-- [docs/COMPETITIVE_ANALYSIS.md](COMPETITIVE_ANALYSIS.md): capability-level
-  comparison against CodeScene, SonarQube, DeepWiki, and others.
 - [repowise-bench](https://github.com/repowise-dev/repowise-bench): harnesses,
   raw logs, and every full report.


### PR DESCRIPTION
## Summary

- Trim the tracked `.gitignore` down to the generic patterns every contributor actually needs: language toolchains, editors, OS cruft, and repowise's own runtime artifacts (`.repowise/`, `.repowise-workspace*`, `bench/results/`, `lancedb/`, `*.db`, `.claude/`).
- Machine-local entries that only ever mattered on one maintainer's clone move to `.git/info/exclude` (untracked, not part of this PR), so they no longer ship inside the public ignore file. This drops the tracked `.gitignore` from 166 lines to ~118.
- Remove two links in `docs/BENCHMARKS.md` that pointed at a file which is not part of this repo, so they no longer 404 for anyone reading the docs.

## Why

The public `.gitignore` had accumulated a long tail of one-off, local-only paths that don't belong in a shared ignore file. Contributors don't need them, and a checked-in ignore file should only carry patterns that apply to everyone cloning the repo. Moving them to `.git/info/exclude` keeps them ignored locally without publishing them.

## Notes

- Verified no history rewrite is needed: none of the removed paths were ever committed (`git log --all` shows 0 commits for each), so this is purely a hygiene change to the ignore file plus the two doc links.
- The previous blanket `*.zip` rule was dropped from the tracked file (it would silently ignore legitimate `.zip` fixtures for every contributor); local archives are handled in `.git/info/exclude` instead.