### PR TITLE
feat(server): authenticate the SSE job stream and mirror provider keys to repo .env

### DIFF
--- a/packages/api-client/src/jobs.ts
+++ b/packages/api-client/src/jobs.ts
@@ -20,7 +20,16 @@ export async function cancelJob(jobId: string): Promise<JobResponse> {
   return apiPost<JobResponse>(`/api/jobs/${jobId}/cancel`);
 }
 
-/** Returns the SSE stream URL for a job. Use with EventSource or the useSSE hook. */
-export function getJobStreamUrl(jobId: string): string {
-  return `${BASE_URL}/api/jobs/${jobId}/stream`;
+/** Returns the SSE stream URL for a job. Use with EventSource or the useSSE hook.
+ *
+ * An EventSource can't send the Authorization header, so when the server has a
+ * key set the browser authenticates the stream with a per-job `token` (from the
+ * job-launch response or `JobResponse.stream_token`) instead. The token is
+ * scoped to this one job id and expires quickly; the raw API key is never put
+ * in the query string. When no token is available (open local server) the URL
+ * is header-authenticated as before. */
+export function getJobStreamUrl(jobId: string, streamToken?: string | null): string {
+  const base = `${BASE_URL}/api/jobs/${jobId}/stream`;
+  if (!streamToken) return base;
+  return `${base}?token=${encodeURIComponent(streamToken)}`;
 }

--- a/packages/api-client/src/types/pages.ts
+++ b/packages/api-client/src/types/pages.ts
@@ -66,6 +66,10 @@ export interface JobResponse {
   updated_at: string;
   started_at: string | null;
   finished_at: string | null;
+  /** Short-lived token authorizing this job's SSE stream (an EventSource can't
+   * send the bearer header). Present only while the job is live; pass it as
+   * `?token=` on the stream URL. */
+  stream_token?: string | null;
 }
 
 export interface JobProgressEvent {

--- a/packages/cli/src/repowise/cli/ui/env_persistence.py
+++ b/packages/cli/src/repowise/cli/ui/env_persistence.py
@@ -50,48 +50,11 @@ def _strip_quotes(value: str) -> str:
 
 
 def _save_key_to_dotenv(repo_path: Path, env_var: str, value: str) -> None:
-    """Append or update a key in ``<repo>/.repowise/.env``."""
-    env_dir = repo_path / ".repowise"
-    env_dir.mkdir(parents=True, exist_ok=True)
-    env_file = env_dir / ".env"
+    """Append or update a key in ``<repo>/.repowise/.env``.
 
-    # Read existing lines
-    existing_lines: list[str] = []
-    found = False
-    if env_file.exists():
-        for line in env_file.read_text(encoding="utf-8").splitlines():
-            stripped = line.strip()
-            if stripped.startswith(f"{env_var}="):
-                existing_lines.append(f"{env_var}={value}")
-                found = True
-            else:
-                existing_lines.append(line)
+    Thin wrapper over the shared core writer so the CLI and the server persist
+    keys through one implementation (see ``core.repo_config.save_repo_env_key``).
+    """
+    from repowise.core.repo_config import save_repo_env_key
 
-    if not found:
-        existing_lines.append(f"{env_var}={value}")
-
-    env_file.write_text("\n".join(existing_lines) + "\n", encoding="utf-8")
-
-    # Ensure .repowise/.env is gitignored
-    _ensure_gitignored(repo_path)
-
-
-def _ensure_gitignored(repo_path: Path) -> None:
-    """Add ``.repowise/.env`` to ``.gitignore`` if not already present."""
-    gitignore = repo_path / ".gitignore"
-    pattern = ".repowise/.env"
-
-    if gitignore.exists():
-        content = gitignore.read_text(encoding="utf-8")
-        if pattern in content:
-            return
-        # Append to existing file
-        if not content.endswith("\n"):
-            content += "\n"
-        content += f"\n# repowise API keys (local)\n{pattern}\n"
-        gitignore.write_text(content, encoding="utf-8")
-    else:
-        gitignore.write_text(
-            f"# repowise API keys (local)\n{pattern}\n",
-            encoding="utf-8",
-        )
+    save_repo_env_key(repo_path, env_var, value)

--- a/packages/core/src/repowise/core/repo_config.py
+++ b/packages/core/src/repowise/core/repo_config.py
@@ -137,3 +137,91 @@ def _strip_quotes(value: str) -> str:
     if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
         return value[1:-1]
     return value
+
+
+def save_repo_env_key(
+    repo_path: Path | str,
+    env_var: str,
+    value: str | None,
+    *,
+    ensure_gitignored: bool = True,
+) -> None:
+    """Set (``value``) or remove (``value=None``) ``env_var`` in ``.repowise/.env``.
+
+    The reusable filesystem primitive behind both the CLI's key persistence and
+    the server's ``set_api_key``, kept here (next to :func:`load_repo_env`) so
+    neither has to hand-roll a second dotenv writer. It rewrites only the one
+    matching line, so unrelated keys in the file are preserved; setting an
+    existing key updates it in place rather than appending a duplicate.
+
+    Only the ``env_var`` line is touched: comments, ``export`` prefixes on other
+    lines, and blank lines are left as-is. Removing a key that isn't present is a
+    no-op, and never creates the file.
+
+    A ``value`` containing a newline is rejected: it would otherwise inject extra
+    ``KEY=value`` lines that a later ``load_repo_env`` would parse as separate
+    environment variables. A real API key never contains one.
+    """
+    if value is not None and ("\n" in value or "\r" in value):
+        raise ValueError("env value must not contain a newline")
+    env_dir = get_repowise_dir(repo_path)
+    env_file = env_dir / ".env"
+
+    existing_lines: list[str] = []
+    found = False
+    if env_file.exists():
+        for line in env_file.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            # Match both `KEY=` and `export KEY=` forms for the target var.
+            bare = (
+                stripped[len("export ") :].lstrip() if stripped.startswith("export ") else stripped
+            )
+            if bare.startswith(f"{env_var}="):
+                found = True
+                if value is not None:
+                    existing_lines.append(f"{env_var}={value}")
+                # value is None: drop the line (removal).
+            else:
+                existing_lines.append(line)
+
+    if value is None:
+        if not found:
+            return  # nothing to remove, don't create an empty file
+    elif not found:
+        existing_lines.append(f"{env_var}={value}")
+
+    env_dir.mkdir(parents=True, exist_ok=True)
+    env_file.write_text("\n".join(existing_lines) + "\n", encoding="utf-8")
+    # The file holds API keys; keep it owner-only where the OS honours it
+    # (best-effort: a no-op on Windows).
+    try:
+        import os
+
+        os.chmod(env_file, 0o600)
+    except OSError:
+        pass
+
+    if ensure_gitignored:
+        _ensure_env_gitignored(repo_path)
+
+
+def _ensure_env_gitignored(repo_path: Path | str) -> None:
+    """Add ``.repowise/.env`` to the repo's ``.gitignore`` if not already listed."""
+    gitignore = Path(repo_path) / ".gitignore"
+    pattern = ".repowise/.env"
+
+    if gitignore.exists():
+        content = gitignore.read_text(encoding="utf-8")
+        # Line membership, not substring, so the pattern buried in an unrelated
+        # comment doesn't suppress the real ignore rule.
+        if pattern in {line.strip() for line in content.splitlines()}:
+            return
+        if not content.endswith("\n"):
+            content += "\n"
+        content += f"\n# repowise API keys (local)\n{pattern}\n"
+        gitignore.write_text(content, encoding="utf-8")
+    else:
+        gitignore.write_text(
+            f"# repowise API keys (local)\n{pattern}\n",
+            encoding="utf-8",
+        )

--- a/packages/server/src/repowise/server/deps.py
+++ b/packages/server/src/repowise/server/deps.py
@@ -96,6 +96,25 @@ async def get_cross_repo_enricher(request: Request):
     return getattr(request.app.state, "cross_repo_enricher", None)
 
 
+def auth_is_open() -> bool:
+    """True when no key is required (no ``REPOWISE_API_KEY`` on a loopback bind)."""
+    return _API_KEY is None and _REPOWISE_HOST not in ("0.0.0.0", "::")
+
+
+def bearer_is_valid(auth: str | None) -> bool:
+    """True iff ``auth`` carries the configured API key as a bearer token.
+
+    Returns False (rather than raising) so callers that also accept another
+    credential — the SSE stream token — can fall through to it. Always False
+    when no key is configured; the open-access decision is ``auth_is_open``.
+    """
+    if _API_KEY is None:
+        return False
+    if not auth or not auth.startswith("Bearer "):
+        return False
+    return hmac.compare_digest(auth[7:], _API_KEY)
+
+
 async def verify_api_key(
     auth: str | None = Security(_header_scheme),
 ) -> None:

--- a/packages/server/src/repowise/server/provider_config.py
+++ b/packages/server/src/repowise/server/provider_config.py
@@ -1,7 +1,23 @@
 """Provider configuration management — API keys, active provider, model selection.
 
-Stores configuration in a server-side JSON file. Environment variables take
-precedence over stored keys for each provider.
+Stores configuration in a server-side JSON file (``_config_path``). Two
+resolution chains run here, both most-specific-first:
+
+**API key** (:func:`_get_key_for_provider`):
+  1. process environment (``ANTHROPIC_API_KEY`` etc.)
+  2. the target repo's ``.repowise/.env`` (read into a dict, never applied to
+     ``os.environ``, so one repo's key can't leak into another in workspace
+     mode)
+  3. the server-global stored key set through :func:`set_api_key`
+
+**Active provider/model** (:func:`_resolve_active_for_repo`): per-repo UI
+selection > the repo's ``config.yaml`` > server-global active selection >
+``REPOWISE_PROVIDER`` / ``REPOWISE_MODEL`` env > auto-detect the first provider
+with a usable key. See that function's docstring for the full rationale.
+
+Because the CLI resolves keys from ``.repowise/.env`` (step 2) and never sees
+the server store, :func:`set_api_key` mirrors a UI-added key into that file so a
+later CLI run in the repo picks it up.
 """
 
 from __future__ import annotations
@@ -120,10 +136,18 @@ _CATALOG_BY_ID = {p["id"]: p for p in PROVIDER_CATALOG}
 
 
 def _config_path() -> Path:
+    """Return the server's provider-config JSON path.
+
+    ``REPOWISE_CONFIG_DIR`` wins when set; otherwise the file lives in the
+    per-user ``~/.repowise`` config directory (the same home the CLI's global
+    store and the default database use). The previous CWD-relative fallback
+    meant a key was saved next to wherever the server happened to be launched
+    and then invisible from any other working directory.
+    """
     config_dir = os.environ.get("REPOWISE_CONFIG_DIR", "")
     if config_dir:
         return Path(config_dir) / "provider_config.json"
-    return Path("provider_config.json")
+    return Path.home() / ".repowise" / "provider_config.json"
 
 
 def _load_config() -> dict[str, Any]:
@@ -371,10 +395,31 @@ def set_active_provider(
     _save_config(config)
 
 
-def set_api_key(provider_id: str, key: str | None) -> None:
-    """Store or remove an API key for a provider."""
+def set_api_key(
+    provider_id: str,
+    key: str | None,
+    repo_path: str | Path | None = None,
+) -> None:
+    """Store or remove an API key for a provider.
+
+    Always updates the server-global store. When ``repo_path`` is given, the
+    key is *also* mirrored into that repo's ``.repowise/.env`` under the
+    provider's canonical env var, so a later ``repowise`` CLI run in that repo
+    (which reads ``.env``, not the server store) picks up a key added from the
+    web UI. A ``None`` key removes it from both places.
+
+    Writing ``.env`` is a deliberately OSS-server-only step: a hosted
+    deployment resolves keys from its own vault, so it never passes
+    ``repo_path`` here. The low-level file write is the shared
+    ``core.repo_config.save_repo_env_key`` primitive (reused by the CLI), but
+    the decision to mirror a key to disk lives here in the server layer.
+    """
     if provider_id not in _CATALOG_BY_ID:
         raise ValueError(f"Unknown provider: {provider_id}")
+    if key is not None and ("\n" in key or "\r" in key):
+        # Reject before writing anything so a bad value can't inject extra env
+        # lines nor leave a partial store update. A real key has no newline.
+        raise ValueError("API key must not contain a newline")
     config = _load_config()
     keys = config.setdefault("keys", {})
     if key:
@@ -382,6 +427,32 @@ def set_api_key(provider_id: str, key: str | None) -> None:
     else:
         keys.pop(provider_id, None)
     _save_config(config)
+
+    if repo_path is not None:
+        _mirror_key_to_repo_env(provider_id, key, repo_path)
+
+
+def _mirror_key_to_repo_env(
+    provider_id: str,
+    key: str | None,
+    repo_path: str | Path,
+) -> None:
+    """Write (or clear) a provider key in a repo's ``.repowise/.env``.
+
+    Uses the provider's first catalog env var as the canonical name (e.g.
+    ``ANTHROPIC_API_KEY``). Providers that take no key (empty ``env_keys``,
+    e.g. Ollama) have nothing to mirror. Best-effort: a filesystem error here
+    must not fail the API call, since the server store was already updated.
+    """
+    env_keys = _CATALOG_BY_ID[provider_id].get("env_keys", [])
+    if not env_keys:
+        return
+    from repowise.core.repo_config import save_repo_env_key
+
+    try:
+        save_repo_env_key(repo_path, env_keys[0], key)
+    except OSError:
+        logger.warning("Failed to mirror %s key into %s/.repowise/.env", provider_id, repo_path)
 
 
 def get_chat_provider_instance(

--- a/packages/server/src/repowise/server/routers/jobs.py
+++ b/packages/server/src/repowise/server/routers/jobs.py
@@ -6,21 +6,48 @@ import asyncio
 import json
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Security
 from sqlalchemy import func, select
 from starlette.responses import StreamingResponse
 
 from repowise.core.persistence import crud
 from repowise.core.persistence.database import get_session
 from repowise.core.persistence.models import GenerationJob, LlmCost
-from repowise.server.deps import resolve_session_factory, verify_api_key
-from repowise.server.schemas import JobResponse
-
-router = APIRouter(
-    prefix="/api/jobs",
-    tags=["jobs"],
-    dependencies=[Depends(verify_api_key)],
+from repowise.server.deps import (
+    _header_scheme,
+    auth_is_open,
+    bearer_is_valid,
+    resolve_session_factory,
+    verify_api_key,
 )
+from repowise.server.schemas import JobResponse
+from repowise.server.stream_auth import verify_stream_token
+
+# The stream route can't sit under a router-level bearer dependency: an
+# EventSource can't send the Authorization header, so it authenticates with a
+# per-job ``?token=`` instead. Every other route keeps the bearer requirement
+# via its own ``Depends(verify_api_key)``.
+router = APIRouter(prefix="/api/jobs", tags=["jobs"])
+
+
+async def authorize_job_stream(
+    job_id: str,
+    token: str | None = Query(None),
+    auth: str | None = Security(_header_scheme),
+) -> None:
+    """Allow the job stream for an open server, a valid bearer, or a job token.
+
+    The ``?token=`` is accepted only for the job id in the path (the token
+    embeds and is signed over that id), so it can't be replayed against another
+    job. A bearer key still works, so non-browser clients are unaffected.
+    """
+    if auth_is_open():
+        return
+    if bearer_is_valid(auth):
+        return
+    if verify_stream_token(token, job_id):
+        return
+    raise HTTPException(status_code=401, detail="Missing or invalid job stream credentials")
 
 
 async def _find_job_factory(app_state, job_id: str):
@@ -59,7 +86,7 @@ def _created_sort_key(job: GenerationJob) -> datetime:
     return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
 
 
-@router.get("", response_model=list[JobResponse])
+@router.get("", response_model=list[JobResponse], dependencies=[Depends(verify_api_key)])
 async def list_jobs(
     request: Request,
     repo_id: str | None = Query(None),
@@ -107,7 +134,7 @@ async def list_jobs(
     return [JobResponse.from_orm(j) for j in jobs[offset : offset + limit]]
 
 
-@router.get("/{job_id}", response_model=JobResponse)
+@router.get("/{job_id}", response_model=JobResponse, dependencies=[Depends(verify_api_key)])
 async def get_job(job_id: str, request: Request) -> JobResponse:
     """Get a single generation job by ID."""
     _, job = await _find_job_factory(request.app.state, job_id)
@@ -116,7 +143,7 @@ async def get_job(job_id: str, request: Request) -> JobResponse:
     return JobResponse.from_orm(job)
 
 
-@router.post("/{job_id}/cancel", response_model=JobResponse)
+@router.post("/{job_id}/cancel", response_model=JobResponse, dependencies=[Depends(verify_api_key)])
 async def cancel_job(job_id: str, request: Request) -> JobResponse:
     """Cancel a pending or running generation job.
 
@@ -159,7 +186,7 @@ async def cancel_job(job_id: str, request: Request) -> JobResponse:
     return JobResponse.from_orm(job)
 
 
-@router.get("/{job_id}/stream")
+@router.get("/{job_id}/stream", dependencies=[Depends(authorize_job_stream)])
 async def stream_job(job_id: str, request: Request) -> StreamingResponse:
     """SSE progress stream for a generation job.
 

--- a/packages/server/src/repowise/server/routers/pages.py
+++ b/packages/server/src/repowise/server/routers/pages.py
@@ -132,7 +132,7 @@ async def regenerate_page_by_query(
     too. Both are validated here and carried in the job config; the executor
     resolves them.
     """
-    from repowise.server.routers.repos import _ensure_no_active_job, _launch_job_task
+    from repowise.server.routers.repos import _accepted, _ensure_no_active_job, _launch_job_task
 
     page = await crud.get_page(session, page_id)
     if page is None:
@@ -168,7 +168,7 @@ async def regenerate_page_by_query(
     # job row, then launch it — the fix for the click that did nothing.
     await session.commit()
     _launch_job_task(request, job.id, page.repository_id)
-    return {"job_id": job.id, "status": "accepted"}
+    return _accepted(job.id)
 
 
 @router.get("/{page_id:path}", response_model=PageResponse)

--- a/packages/server/src/repowise/server/routers/providers.py
+++ b/packages/server/src/repowise/server/routers/providers.py
@@ -64,18 +64,32 @@ async def set_active(body: SetActiveProviderRequest, request: Request):
 
 
 @router.post("/{provider_id}/key", status_code=204)
-async def add_provider_key(provider_id: str, body: SetApiKeyRequest):
-    """Store an API key for a provider."""
+async def add_provider_key(provider_id: str, body: SetApiKeyRequest, request: Request):
+    """Store an API key for a provider.
+
+    With ``repo_id`` in the body, the key is also written to that repo's
+    ``.repowise/.env`` so a subsequent CLI run in the repo uses it.
+    """
+    repo_path = await _repo_path_for(request, body.repo_id)
     try:
-        set_api_key(provider_id, body.api_key)
+        set_api_key(provider_id, body.api_key, repo_path=repo_path)
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
 
 
 @router.delete("/{provider_id}/key", status_code=204)
-async def remove_provider_key(provider_id: str):
-    """Remove a provider's API key."""
+async def remove_provider_key(
+    provider_id: str,
+    request: Request,
+    repo_id: str | None = None,
+):
+    """Remove a provider's API key.
+
+    With ``?repo_id=``, the key is also cleared from that repo's
+    ``.repowise/.env`` (the mirror written when it was added).
+    """
+    repo_path = await _repo_path_for(request, repo_id)
     try:
-        set_api_key(provider_id, None)
+        set_api_key(provider_id, None, repo_path=repo_path)
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc

--- a/packages/server/src/repowise/server/routers/repos.py
+++ b/packages/server/src/repowise/server/routers/repos.py
@@ -454,6 +454,17 @@ async def get_repo_stats(
     )
 
 
+def _accepted(job_id: str) -> dict:
+    """Standard 202 launch payload, carrying a stream token for the new job.
+
+    The token lets a client stream ``/api/jobs/{id}/stream`` immediately without
+    a second round-trip, and without putting the API key in the query string.
+    """
+    from repowise.server.stream_auth import mint_stream_token
+
+    return {"job_id": job_id, "status": "accepted", "stream_token": mint_stream_token(job_id)}
+
+
 async def _ensure_no_active_job(session: AsyncSession, repo_id: str) -> None:
     """Raise 409 if a pending/running job already holds this repo.
 
@@ -500,7 +511,7 @@ async def sync_repo(
     # other connections, so flush() alone is not sufficient.
     await session.commit()
     _launch_job_task(request, job.id, repo_id)
-    return {"job_id": job.id, "status": "accepted"}
+    return _accepted(job.id)
 
 
 @router.post("/{repo_id}/full-resync", status_code=202)
@@ -530,7 +541,7 @@ async def full_resync(
     # see the job row.  See sync_repo comment for rationale.
     await session.commit()
     _launch_job_task(request, job.id, repo_id)
-    return {"job_id": job.id, "status": "accepted"}
+    return _accepted(job.id)
 
 
 class GenerateSelectionBody(BaseModel):
@@ -607,7 +618,7 @@ async def generate_pages(
     # job row.  See sync_repo comment for rationale.
     await session.commit()
     _launch_job_task(request, job.id, repo_id)
-    return {"job_id": job.id, "status": "accepted"}
+    return _accepted(job.id)
 
 
 @router.post("/{repo_id}/generate/estimate")
@@ -767,7 +778,7 @@ async def index_repo(
         raise HTTPException(
             status_code=409, detail="A job is already in progress for this repository"
         )
-    return {"job_id": job_id, "status": "accepted"}
+    return _accepted(job_id)
 
 
 @router.post("/{repo_id}/preflight")

--- a/packages/server/src/repowise/server/schemas/pages.py
+++ b/packages/server/src/repowise/server/schemas/pages.py
@@ -116,13 +116,25 @@ class JobResponse(BaseModel):
     updated_at: datetime
     started_at: datetime | None
     finished_at: datetime | None
+    # Short-lived token for the SSE progress stream (an EventSource can't send
+    # the bearer header). Only minted while the job is live; ``None`` once it
+    # reaches a terminal state, since there's nothing left to stream. Any client
+    # that can read this job (already authenticated) can therefore obtain a fresh
+    # stream token, which is what lets a reloaded page reconnect to the stream.
+    stream_token: str | None = None
 
     @classmethod
     def from_orm(cls, obj: object) -> JobResponse:
+        status = obj.status  # type: ignore[attr-defined]
+        stream_token: str | None = None
+        if status in ("pending", "running"):
+            from repowise.server.stream_auth import mint_stream_token
+
+            stream_token = mint_stream_token(obj.id)  # type: ignore[attr-defined]
         return cls(
             id=obj.id,  # type: ignore[attr-defined]
             repository_id=obj.repository_id,  # type: ignore[attr-defined]
-            status=obj.status,  # type: ignore[attr-defined]
+            status=status,
             provider_name=obj.provider_name,  # type: ignore[attr-defined]
             model_name=obj.model_name,  # type: ignore[attr-defined]
             total_pages=obj.total_pages,  # type: ignore[attr-defined]
@@ -135,4 +147,5 @@ class JobResponse(BaseModel):
             updated_at=obj.updated_at,  # type: ignore[attr-defined]
             started_at=obj.started_at,  # type: ignore[attr-defined]
             finished_at=obj.finished_at,  # type: ignore[attr-defined]
+            stream_token=stream_token,
         )

--- a/packages/server/src/repowise/server/schemas/ui_helpers.py
+++ b/packages/server/src/repowise/server/schemas/ui_helpers.py
@@ -20,6 +20,9 @@ class SetActiveProviderRequest(BaseModel):
 
 class SetApiKeyRequest(BaseModel):
     api_key: str
+    # When set, the key is also mirrored into this repo's ``.repowise/.env`` so
+    # a later CLI run in the repo picks it up. Omit for a server-global-only key.
+    repo_id: str | None = None
 
 
 class CostGroupResponse(BaseModel):

--- a/packages/server/src/repowise/server/stream_auth.py
+++ b/packages/server/src/repowise/server/stream_auth.py
@@ -1,0 +1,99 @@
+"""Short-lived, single-job-scoped tokens for the SSE progress stream.
+
+An ``EventSource`` cannot set request headers, so a browser can't present the
+bearer API key on ``GET /api/jobs/{id}/stream``. Instead the job-launching
+endpoints mint a token bound to one job id with a short TTL and hand it back
+with the job id; the stream route accepts it as a ``?token=`` query parameter
+alongside the normal bearer path.
+
+The token authorizes reading exactly one job's progress and nothing else, so if
+it does leak into a proxy access log (the very reason the raw API key must never
+go in the query string) the exposure is one job's page counts, and only until it
+expires. The signature covers the job id, so a token minted for one job can't be
+replayed against another.
+
+Signing secret: the ``REPOWISE_API_KEY`` when set, so tokens verify across any
+worker process that shares it; otherwise a per-process random secret (a
+single-process local ``serve`` where auth is loopback-open anyway, so the token
+path is not even reached).
+"""
+
+from __future__ import annotations
+
+import base64
+import hmac
+import os
+import secrets
+import time
+from hashlib import sha256
+
+# Bucket size for the token's expiry. Long enough to survive a page reload
+# mid-job and a slow first frame; short enough that a leaked token is stale
+# soon. Bucketing (see mint_stream_token) means the real lifetime lands between
+# one and two of these windows, i.e. one to two hours. A job that outlives it
+# re-mints on the next authenticated ``GET /api/jobs/{id}``.
+STREAM_TOKEN_TTL_SECONDS = 3600
+
+# Stable for the lifetime of the process, used only when no API key is set.
+_EPHEMERAL_SECRET = secrets.token_bytes(32)
+
+
+def _signing_secret() -> bytes:
+    key = os.environ.get("REPOWISE_API_KEY")
+    if key:
+        return key.encode("utf-8")
+    return _EPHEMERAL_SECRET
+
+
+def _b64(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _unb64(text: str) -> bytes:
+    padding = "=" * (-len(text) % 4)
+    return base64.urlsafe_b64decode(text + padding)
+
+
+def mint_stream_token(job_id: str, ttl_seconds: int = STREAM_TOKEN_TTL_SECONDS) -> str:
+    """Return a signed ``<payload>.<sig>`` token authorizing this job's stream.
+
+    The expiry is quantized to a ``ttl_seconds`` bucket so repeated mints for the
+    same job within a window return the *same* token. That stability matters:
+    the web polls the job every few seconds and re-serializes it, and if the
+    token string changed each poll the browser's EventSource URL would change and
+    force a reconnect every poll. Bucketing gives every token between one and two
+    full TTLs of life, so it never quantizes down to a near-dead token.
+    """
+    bucket = int(time.time()) // ttl_seconds
+    exp = (bucket + 2) * ttl_seconds
+    payload = f"{exp}:{job_id}"
+    sig = hmac.new(_signing_secret(), payload.encode("utf-8"), sha256).digest()
+    return f"{_b64(payload.encode('utf-8'))}.{_b64(sig)}"
+
+
+def verify_stream_token(token: str | None, job_id: str) -> bool:
+    """True iff ``token`` is a valid, unexpired token minted for ``job_id``."""
+    if not token:
+        return False
+    try:
+        payload_b64, sig_b64 = token.split(".", 1)
+        payload = _unb64(payload_b64).decode("utf-8")
+        sig = _unb64(sig_b64)
+    except (ValueError, UnicodeDecodeError):
+        return False
+
+    expected = hmac.new(_signing_secret(), payload.encode("utf-8"), sha256).digest()
+    if not hmac.compare_digest(sig, expected):
+        return False
+
+    exp_str, sep, embedded_job = payload.partition(":")
+    if not sep or not embedded_job:
+        return False
+    # Constant-time id comparison so the token for job A never authorizes job B.
+    if not hmac.compare_digest(embedded_job, job_id):
+        return False
+    try:
+        exp = int(exp_str)
+    except ValueError:
+        return False
+    return exp > int(time.time())

--- a/packages/web/src/lib/hooks/use-job.ts
+++ b/packages/web/src/lib/hooks/use-job.ts
@@ -23,7 +23,11 @@ export function useJob(jobId: string | null) {
   );
 
   const isActive = job?.status === "running" || job?.status === "pending";
-  const streamUrl = jobId && isActive ? getJobStreamUrl(jobId) : null;
+  // The job (fetched over the authenticated REST path) carries a fresh
+  // stream_token; pass it so the EventSource authenticates even when the
+  // server has REPOWISE_API_KEY set. This also covers reconnect after a
+  // reload, where we never saw the original launch response.
+  const streamUrl = jobId && isActive ? getJobStreamUrl(jobId, job?.stream_token) : null;
 
   const sse = useSSE<JobProgressEvent>(streamUrl, { enabled: !!streamUrl });
 

--- a/tests/unit/server/conftest.py
+++ b/tests/unit/server/conftest.py
@@ -43,6 +43,7 @@ def _create_test_app():
         overview,
         owners,
         pages,
+        providers,
         refactoring,
         repos,
         search,
@@ -90,6 +91,7 @@ def _create_test_app():
     app.include_router(external_systems.router)
     app.include_router(overview.router)
     app.include_router(refactoring.router)
+    app.include_router(providers.router)
 
     return app
 

--- a/tests/unit/server/test_provider_config.py
+++ b/tests/unit/server/test_provider_config.py
@@ -217,3 +217,82 @@ def test_global_selection_used_when_repo_has_no_config(clean_env, tmp_path):
 
     provider, model = pc.get_active_provider(repo_id="r1", repo_path=str(repo))
     assert (provider, model) == ("anthropic", "claude-sonnet-4-6")
+
+
+# ---------------------------------------------------------------------------
+# D6: set_api_key mirrors into the repo's .repowise/.env so the CLI sees it.
+# ---------------------------------------------------------------------------
+
+
+def test_set_api_key_mirrors_into_repo_env(clean_env, tmp_path):
+    repo = _make_repo(tmp_path / "repo", config="embedder: mock\n")
+
+    pc.set_api_key("anthropic", "sk-ant-xyz", repo_path=str(repo))
+
+    # Server store updated...
+    assert pc._get_key_for_provider("anthropic") == "sk-ant-xyz"
+    # ...and mirrored under the provider's canonical env var so a later CLI run
+    # (which reads .env, not the server store) picks it up.
+    from repowise.core.repo_config import load_repo_env
+
+    assert load_repo_env(repo)["ANTHROPIC_API_KEY"] == "sk-ant-xyz"
+
+
+def test_set_api_key_removal_clears_repo_env(clean_env, tmp_path):
+    repo = _make_repo(tmp_path / "repo", config="embedder: mock\n")
+    pc.set_api_key("anthropic", "sk-ant-xyz", repo_path=str(repo))
+
+    pc.set_api_key("anthropic", None, repo_path=str(repo))
+
+    from repowise.core.repo_config import load_repo_env
+
+    assert "ANTHROPIC_API_KEY" not in load_repo_env(repo)
+
+
+def test_set_api_key_without_repo_path_is_global_only(clean_env, tmp_path):
+    repo = _make_repo(tmp_path / "repo", config="embedder: mock\n")
+
+    pc.set_api_key("anthropic", "sk-ant-xyz")  # no repo_path
+
+    assert pc._get_key_for_provider("anthropic") == "sk-ant-xyz"
+    assert not (repo / ".repowise" / ".env").exists()
+
+
+def test_set_api_key_keyless_provider_writes_no_env(clean_env, tmp_path):
+    # Ollama takes no key (empty env_keys); there is nothing to mirror.
+    repo = _make_repo(tmp_path / "repo", config="embedder: mock\n")
+
+    pc.set_api_key("ollama", "irrelevant", repo_path=str(repo))
+
+    assert not (repo / ".repowise" / ".env").exists()
+
+
+def test_set_api_key_rejects_newline_in_value(clean_env, tmp_path):
+    # A value with a newline would inject extra env lines a later CLI run parses.
+    repo = _make_repo(tmp_path / "repo", config="embedder: mock\n")
+    with pytest.raises(ValueError, match="newline"):
+        pc.set_api_key("anthropic", "sk-ant\nEVIL=1", repo_path=str(repo))
+
+
+def test_config_path_defaults_to_home(monkeypatch, tmp_path):
+    # No REPOWISE_CONFIG_DIR: the store lives in ~/.repowise, not the CWD.
+    monkeypatch.setattr(pc.os, "environ", {})
+    monkeypatch.setattr(pc.Path, "home", classmethod(lambda cls: tmp_path))
+    assert pc._config_path() == tmp_path / ".repowise" / "provider_config.json"
+
+
+def test_list_provider_status_never_returns_key_material(clean_env, tmp_path):
+    repo = _make_repo(
+        tmp_path / "repo",
+        config="provider: openai\nmodel: gpt-5.4-nano\nembedder: openai\n",
+        env="OPENAI_API_KEY=super-secret-key\n",
+    )
+
+    status = pc.list_provider_status(repo_id="r1", repo_path=str(repo))
+
+    serialized = repr(status)
+    assert "super-secret-key" not in serialized
+    for provider in status["providers"]:
+        assert set(provider) == {"id", "name", "models", "default_model", "configured"}
+        assert "key" not in provider
+        assert "api_key" not in provider

--- a/tests/unit/server/test_provider_key_endpoint.py
+++ b/tests/unit/server/test_provider_key_endpoint.py
@@ -1,0 +1,87 @@
+"""Provider key endpoints wire ``repo_id`` through to the repo's .env (D6).
+
+Adding a key in the web UI must be visible to a later CLI run in that repo, and
+``GET /api/providers`` must never hand back key material.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from repowise.core.repo_config import load_repo_env
+from tests.unit.server.conftest import create_test_repo
+
+
+@pytest.fixture(autouse=True)
+def isolate_server_store(monkeypatch, tmp_path):
+    """Keep set_api_key's server-global JSON out of the real ~/.repowise."""
+    from repowise.server import provider_config as pc
+
+    monkeypatch.setenv("REPOWISE_CONFIG_DIR", str(tmp_path / "server-store"))
+    # Don't let a real ANTHROPIC_API_KEY on the dev box mask the stored one.
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    return pc
+
+
+@pytest.mark.asyncio
+async def test_add_key_with_repo_id_writes_repo_env(client: AsyncClient) -> None:
+    repo = await create_test_repo(client)
+
+    resp = await client.post(
+        "/api/providers/anthropic/key",
+        json={"api_key": "sk-ant-from-ui", "repo_id": repo["id"]},
+    )
+    assert resp.status_code == 204
+
+    from pathlib import Path
+
+    env = load_repo_env(Path(repo["local_path"]))
+    assert env["ANTHROPIC_API_KEY"] == "sk-ant-from-ui"
+
+
+@pytest.mark.asyncio
+async def test_add_key_without_repo_id_does_not_touch_disk(client: AsyncClient) -> None:
+    repo = await create_test_repo(client)
+
+    resp = await client.post(
+        "/api/providers/anthropic/key",
+        json={"api_key": "sk-ant-global"},
+    )
+    assert resp.status_code == 204
+
+    from pathlib import Path
+
+    assert not (Path(repo["local_path"]) / ".repowise" / ".env").exists()
+
+
+@pytest.mark.asyncio
+async def test_remove_key_with_repo_id_clears_repo_env(client: AsyncClient) -> None:
+    repo = await create_test_repo(client)
+    await client.post(
+        "/api/providers/anthropic/key",
+        json={"api_key": "sk-ant-from-ui", "repo_id": repo["id"]},
+    )
+
+    resp = await client.delete(f"/api/providers/anthropic/key?repo_id={repo['id']}")
+    assert resp.status_code == 204
+
+    from pathlib import Path
+
+    assert "ANTHROPIC_API_KEY" not in load_repo_env(Path(repo["local_path"]))
+
+
+@pytest.mark.asyncio
+async def test_get_providers_returns_no_key_material(client: AsyncClient) -> None:
+    repo = await create_test_repo(client)
+    await client.post(
+        "/api/providers/anthropic/key",
+        json={"api_key": "sk-ant-super-secret", "repo_id": repo["id"]},
+    )
+
+    resp = await client.get(f"/api/providers?repo_id={repo['id']}")
+    assert resp.status_code == 200
+    assert "sk-ant-super-secret" not in resp.text
+    for provider in resp.json()["providers"]:
+        assert "key" not in provider
+        assert "api_key" not in provider

--- a/tests/unit/server/test_stream_auth.py
+++ b/tests/unit/server/test_stream_auth.py
@@ -1,0 +1,226 @@
+"""SSE job-stream authentication (D5) and the per-job stream token.
+
+An ``EventSource`` cannot send the Authorization header, so the job progress
+stream authenticates with a short-lived, single-job-scoped ``?token=`` minted at
+launch (and re-minted on every authenticated job read). These tests cover the
+token itself, the launch responses carrying it, ``JobResponse.stream_token``, and
+the stream endpoint accepting either a bearer key or a valid token while
+rejecting a missing or cross-job one.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from repowise.core.persistence import crud
+from repowise.server import deps, stream_auth
+from tests.unit.server.conftest import create_test_repo
+
+# ---------------------------------------------------------------------------
+# The token primitive
+# ---------------------------------------------------------------------------
+
+
+def test_token_round_trips_for_its_job() -> None:
+    token = stream_auth.mint_stream_token("job-1")
+    assert stream_auth.verify_stream_token(token, "job-1") is True
+
+
+def test_token_is_not_replayable_against_another_job() -> None:
+    token = stream_auth.mint_stream_token("job-1")
+    assert stream_auth.verify_stream_token(token, "job-2") is False
+
+
+def test_tampered_or_malformed_token_rejected() -> None:
+    token = stream_auth.mint_stream_token("job-1")
+    assert stream_auth.verify_stream_token(token + "x", "job-1") is False
+    assert stream_auth.verify_stream_token("not-a-token", "job-1") is False
+    assert stream_auth.verify_stream_token("", "job-1") is False
+    assert stream_auth.verify_stream_token(None, "job-1") is False
+
+
+def test_expired_token_rejected() -> None:
+    # A token minted in a bucket already in the past has an expiry <= now.
+    token = stream_auth.mint_stream_token("job-1", ttl_seconds=1)
+    # Its expiry is (bucket+2)*1 seconds; wait past it deterministically by
+    # crafting an equivalent expired payload rather than sleeping.
+    import base64
+    import hmac
+    import time
+    from hashlib import sha256
+
+    payload = f"{int(time.time()) - 5}:job-1"
+    sig = hmac.new(stream_auth._signing_secret(), payload.encode(), sha256).digest()
+    expired = (
+        base64.urlsafe_b64encode(payload.encode()).rstrip(b"=").decode()
+        + "."
+        + base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+    )
+    assert stream_auth.verify_stream_token(expired, "job-1") is False
+    # (the freshly-minted one is still valid)
+    assert stream_auth.verify_stream_token(token, "job-1") is True
+
+
+def test_token_is_stable_within_a_bucket() -> None:
+    # Re-minting for the same job returns the same string, so the browser's
+    # EventSource URL doesn't churn on every poll.
+    assert stream_auth.mint_stream_token("job-1") == stream_auth.mint_stream_token("job-1")
+
+
+# ---------------------------------------------------------------------------
+# Launch responses + JobResponse carry the token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_launch_response_carries_stream_token(client: AsyncClient) -> None:
+    repo = await create_test_repo(client)
+    from unittest.mock import patch
+
+    with patch("repowise.server.routers.repos._launch_job_task"):
+        resp = await client.post(f"/api/repos/{repo['id']}/sync")
+    body = resp.json()
+    assert body["job_id"]
+    assert stream_auth.verify_stream_token(body["stream_token"], body["job_id"]) is True
+
+
+@pytest.mark.asyncio
+async def test_index_launch_response_carries_stream_token(client: AsyncClient, app) -> None:
+    # Regression: the /index endpoint builds the accepted payload from `job_id`
+    # (a str), not a job object; a wrong `job.id` there NameErrors into a 500.
+    from unittest.mock import AsyncMock, patch
+
+    repo = await create_test_repo(client)
+    with (
+        patch(
+            "repowise.server.repo_db.ensure_repo_registration",
+            AsyncMock(return_value=(app.state.session_factory, repo["id"])),
+        ),
+        patch("repowise.server.routers.repos._launch_job_task"),
+    ):
+        resp = await client.post(f"/api/repos/{repo['id']}/index")
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert stream_auth.verify_stream_token(body["stream_token"], body["job_id"]) is True
+
+
+@pytest.mark.asyncio
+async def test_job_response_has_token_while_active_and_not_when_terminal(
+    client: AsyncClient, app
+) -> None:
+    repo = await create_test_repo(client)
+    async with app.state.session_factory() as session:
+        active = await crud.upsert_generation_job(
+            session, repository_id=repo["id"], status="running", config={"mode": "sync"}
+        )
+        await session.commit()
+        active_id = active.id
+
+    resp = await client.get(f"/api/jobs/{active_id}")
+    assert resp.status_code == 200
+    token = resp.json()["stream_token"]
+    assert stream_auth.verify_stream_token(token, active_id) is True
+
+    # Flip to terminal: no token to hand out (nothing left to stream).
+    async with app.state.session_factory() as session:
+        await crud.update_job_status(session, active_id, "completed")
+        await session.commit()
+
+    resp = await client.get(f"/api/jobs/{active_id}")
+    assert resp.json()["stream_token"] is None
+
+
+# ---------------------------------------------------------------------------
+# The stream endpoint: bearer OR token, and nothing else
+# ---------------------------------------------------------------------------
+
+
+_TEST_KEY = "test-secret-key"
+
+
+def _enable_api_key(monkeypatch) -> str:
+    """Turn on server auth AFTER unauthenticated setup (repo/job) is done.
+
+    ``verify_api_key`` captured ``_API_KEY`` at import, so patch the module
+    attribute; ``stream_auth`` signs from the live env, so set that too, keeping
+    signing and verification consistent.
+    """
+    monkeypatch.setattr(deps, "_API_KEY", _TEST_KEY)
+    monkeypatch.setattr(deps, "_REPOWISE_HOST", "127.0.0.1")
+    monkeypatch.setenv("REPOWISE_API_KEY", _TEST_KEY)
+    return _TEST_KEY
+
+
+async def _completed_job(app, repo_id: str) -> str:
+    """A terminal job so the stream generator returns immediately."""
+    async with app.state.session_factory() as session:
+        job = await crud.upsert_generation_job(
+            session, repository_id=repo_id, status="completed", config={"mode": "sync"}
+        )
+        await session.commit()
+        return job.id
+
+
+@pytest.mark.asyncio
+async def test_stream_open_without_key_needs_no_token(client: AsyncClient, app) -> None:
+    # Default fixtures: no REPOWISE_API_KEY, loopback bind -> open access.
+    repo = await create_test_repo(client)
+    job_id = await _completed_job(app, repo["id"])
+    resp = await client.get(f"/api/jobs/{job_id}/stream")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_stream_rejected_without_credentials(client: AsyncClient, app, monkeypatch) -> None:
+    repo = await create_test_repo(client)
+    job_id = await _completed_job(app, repo["id"])
+    _enable_api_key(monkeypatch)
+    resp = await client.get(f"/api/jobs/{job_id}/stream")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_stream_accepts_valid_token(client: AsyncClient, app, monkeypatch) -> None:
+    repo = await create_test_repo(client)
+    job_id = await _completed_job(app, repo["id"])
+    _enable_api_key(monkeypatch)
+    token = stream_auth.mint_stream_token(job_id)
+    resp = await client.get(f"/api/jobs/{job_id}/stream?token={token}")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_stream_rejects_token_for_another_job(client: AsyncClient, app, monkeypatch) -> None:
+    repo = await create_test_repo(client)
+    job_id = await _completed_job(app, repo["id"])
+    other = await _completed_job(app, repo["id"])
+    _enable_api_key(monkeypatch)
+    token_for_other = stream_auth.mint_stream_token(other)
+    resp = await client.get(f"/api/jobs/{job_id}/stream?token={token_for_other}")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_stream_accepts_bearer_key(client: AsyncClient, app, monkeypatch) -> None:
+    repo = await create_test_repo(client)
+    job_id = await _completed_job(app, repo["id"])
+    key = _enable_api_key(monkeypatch)
+    resp = await client.get(
+        f"/api/jobs/{job_id}/stream",
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_other_job_routes_still_require_bearer(client: AsyncClient, app, monkeypatch) -> None:
+    # A stream token must not open the non-stream job routes.
+    repo = await create_test_repo(client)
+    job_id = await _completed_job(app, repo["id"])
+    key = _enable_api_key(monkeypatch)
+    token = stream_auth.mint_stream_token(job_id)
+    resp = await client.get(f"/api/jobs/{job_id}?token={token}")
+    assert resp.status_code == 401
+    resp = await client.get(f"/api/jobs/{job_id}", headers={"Authorization": f"Bearer {key}"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## What this does

Closes the two remaining defects that kept HTTP generation from being fully usable with an API key set.

### SSE job stream auth

An `EventSource` cannot set an `Authorization` header, so the web job stream 401d the moment `REPOWISE_API_KEY` was set. Job-creating endpoints now mint a short-lived, single-job-scoped token:

- Signed (HMAC-SHA256) over the job id, so it cannot be replayed against another job; constant-time compared.
- Bucketed expiry, so re-minting for the same job returns the identical string and the browser's EventSource URL stays stable across polls (no reconnect churn). Real lifetime is one to two hours.
- Returned alongside `job_id` and on `JobResponse` while the job is active (so a reloaded page can reconnect).
- `GET /api/jobs/{id}/stream` accepts either a valid bearer key or a `?token=` for that job id. The API key never goes in the query string. Every non-stream job route keeps its bearer requirement.
- The web `useSSE` path passes the token on the stream URL. `no-cache, no-transform` + `X-Accel-Buffering: no` headers unchanged.

### Repo-scoped provider keys

A key added through the API was invisible to the CLI, because `set_api_key` was server-global and never wrote `.repowise/.env`.

- `set_api_key` now mirrors the key into the target repo's `.repowise/.env` under the provider's canonical env var, so a later CLI run in that repo picks it up. Keyless providers are skipped; the `.env` write is best-effort.
- The `.env` writer is a single shared primitive in core (the CLI's key persistence delegates to it, so there is one dotenv writer). It updates only the matching line, preserves unrelated keys/comments, gitignores the file, and writes it owner-only.
- `repo_id` is threaded through the key endpoints. `GET /api/providers` still returns only `configured: bool`, never key material.
- The provider-config store moves off its CWD-relative fallback to `~/.repowise`, matching the CLI global store.
- A newline in a key value is rejected up front (env-injection guard). The resolution precedence chains are documented in the module docstring.

**Exit criteria met:** with `REPOWISE_API_KEY` set the stream authenticates end to end, and a key added through the API is picked up by a subsequent CLI run in that repo.

## Tests

- New `test_stream_auth.py` (token round-trip / cross-job rejection / tamper / expiry / stability; launch + `/index` responses carry a valid token; `JobResponse.stream_token` present while active and absent when terminal; the stream endpoint accepts open / bearer / token and rejects missing-creds and cross-job tokens; non-stream routes still require a bearer).
- New `test_provider_key_endpoint.py` (the key endpoints write / clear the repo's `.env`, don't touch disk without a repo, no key material in `GET /api/providers`).
- `test_provider_config.py` extended (mirror / removal / global-only / keyless-skip / newline-rejection / config-path default / no-key-material).
- api-client + web type-check and their jobs/progress tests green.

## Reviews

Correctness and security reviews were run over the diff before this PR. Correctness found one real bug (the `/index` endpoint returned a wrong reference) which is fixed and now has a regression test; security found the design sound with a few low hardening items (newline guard, owner-only `.env`, line-based gitignore check, TTL comment), all applied.