### PR TITLE
fix(server): resolve the provider-key repo by id, not the request path

### DIFF
--- a/packages/server/src/repowise/server/routers/providers.py
+++ b/packages/server/src/repowise/server/routers/providers.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from repowise.core.persistence import crud
 from repowise.core.persistence.database import get_session
-from repowise.server.deps import resolve_request_session_factory, verify_api_key
+from repowise.server.deps import resolve_session_factory, verify_api_key
 from repowise.server.provider_config import (
     list_provider_status,
     set_active_provider,
@@ -27,11 +27,16 @@ async def _repo_path_for(request: Request, repo_id: str | None) -> str | None:
     Lets the providers endpoint report the active provider/model that *this*
     repo's chat will actually use. Returns ``None`` (server-global resolution)
     when no ``repo_id`` is given or the repo can't be found.
+
+    Routes by ``repo_id`` directly (not the request's path/query), so it reaches
+    a workspace repo's own ``wiki.db`` even when ``repo_id`` arrived in the body
+    (the ``POST .../key`` case). The primary DB does not hold the canonical row
+    for a non-primary workspace repo, so a request-scoped lookup would miss it.
     """
     if not repo_id:
         return None
     try:
-        factory = resolve_request_session_factory(request)
+        factory = resolve_session_factory(request.app.state, repo_id)
         async with get_session(factory) as session:
             repo = await crud.get_repository(session, repo_id)
             return repo.local_path if repo else None

--- a/tests/unit/server/test_provider_key_endpoint.py
+++ b/tests/unit/server/test_provider_key_endpoint.py
@@ -72,6 +72,47 @@ async def test_remove_key_with_repo_id_clears_repo_env(client: AsyncClient) -> N
 
 
 @pytest.mark.asyncio
+async def test_add_key_resolves_non_primary_workspace_repo(client: AsyncClient, app, tmp_path) -> None:
+    # Workspace mode: a non-primary repo's row lives only in its own wiki.db, not
+    # the primary DB. The key endpoint gets repo_id in the body, so resolution
+    # must route by repo_id (not the request path/query) to reach that DB.
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+    from sqlalchemy.pool import StaticPool
+
+    from repowise.core.persistence import crud
+    from repowise.core.persistence.database import init_db
+    from repowise.core.repo_config import load_repo_env
+
+    ws_engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    await init_db(ws_engine)
+    ws_factory = async_sessionmaker(ws_engine, expire_on_commit=False, class_=AsyncSession)
+
+    repo_dir = tmp_path / "frontend"
+    (repo_dir / ".repowise").mkdir(parents=True)
+    async with ws_factory() as s:
+        repo = await crud.upsert_repository(s, name="frontend", local_path=str(repo_dir))
+        await s.commit()
+        repo_id = repo.id
+
+    # Register the per-repo DB; its row is deliberately absent from the primary DB.
+    app.state.workspace_sessions = {repo_id: ws_factory}
+    try:
+        resp = await client.post(
+            "/api/providers/anthropic/key",
+            json={"api_key": "sk-ws-key", "repo_id": repo_id},
+        )
+        assert resp.status_code == 204
+        assert load_repo_env(repo_dir)["ANTHROPIC_API_KEY"] == "sk-ws-key"
+    finally:
+        app.state.workspace_sessions = {}
+        await ws_engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_get_providers_returns_no_key_material(client: AsyncClient) -> None:
     repo = await create_test_repo(client)
     await client.post(


### PR DESCRIPTION
## What this fixes

Follow-up to #984. Setting a provider key with a `repo_id` in the request body wrote nothing in **workspace mode**.

`POST /api/providers/{id}/key` carries `repo_id` in the body, but `_repo_path_for` resolved the session factory from the request path/query (`resolve_request_session_factory`), which for a body-carried id fell back to the primary DB. A non-primary workspace repo's canonical row lives only in its own `wiki.db`, so the lookup returned nothing, `_repo_path_for` returned `None`, and the `.repowise/.env` mirror was silently skipped. The key never reached the repo, so a later CLI run in it couldn't see it.

The fix resolves the factory from the `repo_id` argument directly (`resolve_session_factory(app.state, repo_id)`), which routes to that repo's own database in every mode:

- **Single-repo:** unchanged. The id isn't a workspace session, so it still uses the primary factory.
- **Workspace (non-primary repo):** now reaches the repo's own `wiki.db` and writes the key correctly.

This also repairs the same latent mis-routing in `PATCH /api/providers/active` (which affects only what provider/model gets reported), since it shares the helper.

## Tests

Added a workspace regression test that registers a non-primary repo whose row exists only in its own DB (absent from primary) and asserts the key lands in that repo's `.repowise/.env`. Verified it fails before the fix (the write is skipped) and passes after. Existing provider-key and provider-config tests stay green.