### PR TITLE
fix(update): report deferred workspace docs runs honestly

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import sys
 import time
+from enum import StrEnum
 from typing import Any
 
 import click
@@ -328,7 +329,9 @@ def update_command(
     workspace exists upstream of the working directory. Use --no-workspace to
     force single-repo mode and --workspace to force workspace mode.
     """
-    return run_update(
+    # Click ignores the return value, so don't forward run_update's outcome
+    # here (keeps this command's ``-> None`` annotation honest).
+    run_update(
         path=path,
         provider_name=provider_name,
         model=model,
@@ -349,6 +352,21 @@ def update_command(
         verbose=verbose,
         progress=progress,
     )
+
+
+class UpdateOutcome(StrEnum):
+    """What a single-repo :func:`run_update` actually did.
+
+    The workspace docs loop used to count every non-raising ``run_update``
+    return as a regeneration, so a run that bailed on the single-flight lock
+    (another update already in flight) still printed "N with docs
+    regenerated". Returning the real outcome lets the caller report honestly.
+    """
+
+    REGENERATED = "regenerated"  # pages/index actually rewritten
+    DEFERRED = "deferred"  # another update held the single-flight lock; queued
+    NOOP = "noop"  # already current / no relevant changes to regenerate
+    DRY_RUN = "dry_run"  # dry run, nothing written
 
 
 def run_update(
@@ -372,7 +390,7 @@ def run_update(
     verbose: bool = False,
     progress: str = "rich",
     skip_cross_repo_hooks: bool = False,
-) -> None:
+) -> UpdateOutcome:
     """Incrementally update wiki pages for files changed since last sync.
 
     If `since` is None, the base commit is read from state.json's last_sync_commit.
@@ -448,9 +466,13 @@ def run_update(
             raise
         if emitter is not None:
             emitter.done(
-                ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
+                ok=True,
+                pages_generated=0,
+                cost_usd=0.0,
+                duration_s=time.monotonic() - start,
+                outcome=UpdateOutcome.REGENERATED.value,
             )
-        return
+        return UpdateOutcome.REGENERATED
 
     # --- Single-repo path from here on. ---
     repo_path = target.repo_path
@@ -508,9 +530,13 @@ def run_update(
             raise
         if emitter is not None:
             emitter.done(
-                ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
+                ok=True,
+                pages_generated=0,
+                cost_usd=0.0,
+                duration_s=time.monotonic() - start,
+                outcome=UpdateOutcome.REGENERATED.value,
             )
-        return
+        return UpdateOutcome.REGENERATED
     # Truncate the hook-managed log if it has grown past the cap. The hook
     # appends each run unconditionally — without this opportunistic rotation
     # at the start of every CLI update, a busy repo's ``.update.log`` would
@@ -581,9 +607,13 @@ def run_update(
             _refresh_editor_stamp(repo_path, agents_md)
         if emitter is not None:
             emitter.done(
-                ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
+                ok=True,
+                pages_generated=0,
+                cost_usd=0.0,
+                duration_s=time.monotonic() - start,
+                outcome=UpdateOutcome.NOOP.value,
             )
-        return
+        return UpdateOutcome.NOOP
 
     # --- Single-flight lock ---------------------------------------------
     # A live lock from another process means a `repowise update` is already
@@ -610,13 +640,19 @@ def run_update(
         )
         console.print(
             f"[dim]HEAD {head[:8] if head else 'HEAD'} marked as pending; "
-            "the running update will roll forward to it.[/dim]"
+            "the running update will roll forward to it. This run regenerated "
+            "nothing; watch [bold].repowise/.update.log[/bold] for the one in "
+            "flight.[/dim]"
         )
         if emitter is not None:
             emitter.done(
-                ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
+                ok=True,
+                pages_generated=0,
+                cost_usd=0.0,
+                duration_s=time.monotonic() - start,
+                outcome=UpdateOutcome.DEFERRED.value,
             )
-        return
+        return UpdateOutcome.DEFERRED
 
     # We own the lock from here on: the augment hook suppresses its
     # stale-wiki warning while this run is in flight (typical case: the
@@ -705,9 +741,13 @@ def run_update(
         _refresh_editor_stamp(repo_path, agents_md)
         if emitter is not None:
             emitter.done(
-                ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
+                ok=True,
+                pages_generated=0,
+                cost_usd=0.0,
+                duration_s=time.monotonic() - start,
+                outcome=UpdateOutcome.NOOP.value,
             )
-        return
+        return UpdateOutcome.NOOP
 
     if config_changed:
         # Full re-score (not the partial update) so unchanged files pick up the
@@ -717,9 +757,13 @@ def run_update(
             console.print("[yellow]Dry run — health would be re-scored. No changes made.[/yellow]")
             if emitter is not None:
                 emitter.done(
-                    ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
+                    ok=True,
+                    pages_generated=0,
+                    cost_usd=0.0,
+                    duration_s=time.monotonic() - start,
+                    outcome=UpdateOutcome.DRY_RUN.value,
                 )
-            return
+            return UpdateOutcome.DRY_RUN
         cfg = load_config(repo_path)
         exclude_patterns = list(cfg.get("exclude_patterns") or [])
         if emitter is not None:
@@ -733,9 +777,13 @@ def run_update(
         _refresh_editor_stamp(repo_path, agents_md)
         if emitter is not None:
             emitter.done(
-                ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
+                ok=True,
+                pages_generated=0,
+                cost_usd=0.0,
+                duration_s=time.monotonic() - start,
+                outcome=UpdateOutcome.REGENERATED.value,
             )
-        return
+        return UpdateOutcome.REGENERATED
 
     render_changed_files(file_diffs, verbose=verbose)
 
@@ -792,9 +840,13 @@ def run_update(
         console.print("[yellow]Dry run — no pages regenerated.[/yellow]")
         if emitter is not None:
             emitter.done(
-                ok=True, pages_generated=0, cost_usd=0.0, duration_s=time.monotonic() - start
+                ok=True,
+                pages_generated=0,
+                cost_usd=0.0,
+                duration_s=time.monotonic() - start,
+                outcome=UpdateOutcome.DRY_RUN.value,
             )
-        return
+        return UpdateOutcome.DRY_RUN
 
     partial_health_report, dead_code_report = _run_partial_analysis(
         repo_path, graph_builder, git_meta_map, parsed_files, file_diffs
@@ -876,9 +928,7 @@ def run_update(
                 try:
                     from repowise.cli.helpers import resolve_provider
 
-                    model_provider = resolve_provider(
-                        provider_name, model, repo_path=repo_path
-                    )
+                    model_provider = resolve_provider(provider_name, model, repo_path=repo_path)
                 except Exception:
                     model_provider = None
 
@@ -994,8 +1044,9 @@ def run_update(
                 cost_usd=index_only_cost,
                 duration_s=time.monotonic() - start,
                 degraded=degraded,
+                outcome=UpdateOutcome.REGENERATED.value,
             )
-        return
+        return UpdateOutcome.REGENERATED
 
     # The generation/LLM layer is only needed past this point — importing it
     # above the index-only branch would make every index-only update (the
@@ -1522,8 +1573,9 @@ def run_update(
             cost_usd=cost_tracker.session_cost,
             duration_s=elapsed,
             degraded=degraded,
+            outcome=UpdateOutcome.REGENERATED.value,
         )
-        return
+        return UpdateOutcome.REGENERATED
     show_full_completion(
         generated_pages=generated_pages,
         decay_count=len(affected.decay_only),
@@ -1536,3 +1588,4 @@ def run_update(
     )
     if verbose:
         _render_update_report(generated_pages, affected, new_decision_markers, elapsed)
+    return UpdateOutcome.REGENERATED

--- a/packages/cli/src/repowise/cli/commands/update_cmd/reporting.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/reporting.py
@@ -131,11 +131,17 @@ class JsonProgressEmitter:
         cost_usd: float,
         duration_s: float,
         degraded: list[str] | None = None,
+        outcome: str | None = None,
     ) -> None:
+        # ``outcome`` lets a supervising agent tell a real regeneration apart
+        # from a run that only deferred to an in-flight update or found nothing
+        # to do — all three otherwise emit ``ok=True, pages_generated=0``.
+        # Mirrors the ``UpdateOutcome`` values in ``command.py``.
         self._emit(
             {
                 "event": "done",
                 "ok": ok,
+                "outcome": outcome,
                 "pages_generated": pages_generated,
                 "cost_usd": cost_usd,
                 "duration_s": duration_s,

--- a/packages/cli/src/repowise/cli/commands/update_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/workspace.py
@@ -283,11 +283,13 @@ def _workspace_docs_update(
         sync_workspace_state_from_disk,
     )
 
-    from .command import run_update
+    from .command import UpdateOutcome, run_update
 
     changed_aliases: list[str] = []
     docs_updated = 0
     docs_failed = 0
+    docs_deferred = 0  # bailed on another update's single-flight lock
+    docs_noop = 0  # already current / nothing to regenerate
 
     # --- Index-only + first-time members: fast parallel core path ----------
     # only_aliases bounds the candidate set; update_workspace still re-checks
@@ -295,8 +297,7 @@ def _workspace_docs_update(
     core_aliases = {
         entry.alias
         for entry in ws_config.repos
-        if (repo_filter is None or entry.alias == repo_filter)
-        and entry.alias not in docs_aliases
+        if (repo_filter is None or entry.alias == repo_filter) and entry.alias not in docs_aliases
     }
     core_results: list[RepoUpdateResult] = []
     if core_aliases:
@@ -338,7 +339,7 @@ def _workspace_docs_update(
         repo_path = (ws_root / entry.path).resolve()
         console.print(f"  Updating [bold]{entry.alias}[/bold] (docs)...")
         try:
-            run_update(
+            outcome = run_update(
                 path=str(repo_path),
                 provider_name=provider_name,
                 model=model,
@@ -367,8 +368,21 @@ def _workspace_docs_update(
             docs_failed += 1
             console.print(f"    [red]✗ {entry.alias}: {exc}[/red]")
             continue
-        docs_updated += 1
-        changed_aliases.append(entry.alias)
+        # Count what actually happened. A run that bailed on another update's
+        # single-flight lock (DEFERRED) regenerated nothing — folding it into
+        # ``docs_updated`` was the "N with docs regenerated" lie the user saw
+        # while a background post-commit-hook update was still in flight.
+        # run_update already printed the "another update is in flight" note for
+        # the deferred case, so don't re-announce it here.
+        if outcome == UpdateOutcome.DEFERRED:
+            docs_deferred += 1
+        elif outcome == UpdateOutcome.REGENERATED:
+            docs_updated += 1
+            # Only a real regeneration feeds the cross-repo pass; a no-op or a
+            # deferral leaves the cross-repo layer untouched.
+            changed_aliases.append(entry.alias)
+        else:  # NOOP / DRY_RUN
+            docs_noop += 1
 
     # The single-repo path only writes each repo's state.json, not the
     # workspace config, so re-sync it: the docs repos' advanced last_sync_commit
@@ -401,19 +415,36 @@ def _workspace_docs_update(
     )
 
     core_updated = sum(1 for r in core_results if r.updated)
+    core_deferred = sum(1 for r in core_results if r.skipped_reason == "in_flight")
+    deferred = docs_deferred + core_deferred
     parts: list[str] = []
     if docs_updated:
         parts.append(f"{docs_updated} with docs regenerated")
     if core_updated:
         parts.append(f"{core_updated} re-indexed")
+    if deferred:
+        parts.append(f"{deferred} deferred to an in-flight update")
+    if docs_noop:
+        parts.append(f"{docs_noop} already current")
     if docs_failed:
         parts.append(f"[red]{docs_failed} failed[/red]")
     summary = ", ".join(parts) if parts else "nothing to update"
     console.print()
-    console.print(
-        f"[green]Workspace update complete[/green]: {summary} "
-        f"[dim]({time.monotonic() - start:.1f}s)[/dim]"
-    )
+    # When every stale repo only deferred (a background update already owns the
+    # work), "complete" would overclaim — the real regeneration is still
+    # running elsewhere. Say so, and point at the log the hook writes.
+    if deferred and not (docs_updated or core_updated):
+        console.print(
+            f"[yellow]Workspace update deferred[/yellow]: {summary}. "
+            "A background update is still running; watch "
+            "[bold].repowise/.update.log[/bold]. "
+            f"[dim]({time.monotonic() - start:.1f}s)[/dim]"
+        )
+    else:
+        console.print(
+            f"[green]Workspace update complete[/green]: {summary} "
+            f"[dim]({time.monotonic() - start:.1f}s)[/dim]"
+        )
 
 
 def _refresh_workspace_editor_project_files(

--- a/tests/unit/cli/test_update_progress_json.py
+++ b/tests/unit/cli/test_update_progress_json.py
@@ -56,11 +56,22 @@ class TestJsonProgressEmitter:
         assert event == {
             "event": "done",
             "ok": True,
+            "outcome": None,
             "pages_generated": 5,
             "cost_usd": 0.42,
             "duration_s": 12.3,
             "degraded": [],
         }
+
+    def test_done_carries_outcome(self, capsys):
+        # A supervising agent needs to tell a run that regenerated nothing but
+        # deferred to an in-flight update apart from a real regeneration; both
+        # otherwise emit ok=True, pages_generated=0.
+        JsonProgressEmitter().done(
+            ok=True, pages_generated=0, cost_usd=0.0, duration_s=1.0, outcome="deferred"
+        )
+        (event,) = self._lines(capsys)
+        assert event["outcome"] == "deferred"
 
     def test_done_reports_degraded_steps(self, capsys):
         JsonProgressEmitter().done(
@@ -145,6 +156,7 @@ class TestUpdateProgressJsonCli:
         assert events[-1] == {
             "event": "done",
             "ok": True,
+            "outcome": "noop",
             "pages_generated": 0,
             "cost_usd": 0.0,
             "duration_s": events[-1]["duration_s"],

--- a/tests/unit/cli/test_workspace_docs_pointer.py
+++ b/tests/unit/cli/test_workspace_docs_pointer.py
@@ -173,6 +173,46 @@ def test_workspace_update_regenerates_docs_for_docs_enabled_repo(tmp_path: Path)
     )
 
 
+def test_workspace_docs_update_reports_deferral_not_regeneration(tmp_path: Path) -> None:
+    """A docs member whose single-flight lock is already held by an in-flight
+    update must be reported as *deferred*, never counted as "with docs
+    regenerated" (the false-success the summary used to print while a
+    background post-commit-hook update was still running), and its docs
+    pointer must not advance.
+    """
+    from repowise.core.update_lock import release_update_lock, try_acquire_update_lock
+
+    repo = _make_workspace(tmp_path)
+
+    _index_full(repo)
+    c0 = _git(repo, "rev-parse", "HEAD")
+    save_state(repo, {SYNC_POINTER_KEY: c0, DOCS_POINTER_KEY: c0, "docs_enabled": True})
+
+    c1 = _commit_change(repo, "c.py", "def gamma():\n    return 3\n", "add c.py")
+
+    # Simulate an update already in flight: hold the member's single-flight
+    # lock (alive PID) so the workspace docs run bails instead of regenerating.
+    assert try_acquire_update_lock(repo, c1) is None, "test should own the lock first"
+    try:
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(str(repo))
+            result = CliRunner().invoke(cli, ["update", "--workspace", "--provider", "mock"])
+        finally:
+            os.chdir(old_cwd)
+    finally:
+        release_update_lock(repo)
+
+    assert result.exit_code == 0, result.output
+    assert "deferred to an in-flight update" in result.output, result.output
+    assert "with docs regenerated" not in result.output, (
+        "a lock-bail must not be reported as a regeneration"
+    )
+    # Nothing regenerated -> the docs pointer stays put (the in-flight update
+    # owns advancing it once it finishes).
+    assert _state(repo).get(DOCS_POINTER_KEY) == c0
+
+
 def test_docs_early_exit_advances_docs_pointer(tmp_path: Path) -> None:
     """When a docs run finds no changed files, it must advance the docs pointer to
     HEAD (and, on legacy state, the sync pointer as well). An empty commit advances


### PR DESCRIPTION
## Problem

A workspace `repowise update` whose docs member bailed on another update's single-flight lock still printed `1 with docs regenerated`. Because the post-commit hook fires `repowise update` in the background on every commit, a user running `repowise update` manually during that window saw two things that looked broken:

- both runs reported success with nothing regenerated
- the commit count stayed "N behind" until the background run finished (staleness is measured against `state.json`, which only advances on completion)

Root cause: `run_update` returned `None`, so the workspace docs loop counted every non-raising return as a regeneration, including a lock-bail that wrote nothing.

## Change

- `run_update` returns an `UpdateOutcome` (`regenerated` / `deferred` / `noop` / `dry_run`) at every exit.
- The workspace summary counts these separately: `N deferred to an in-flight update`, `N already current`, and flips to a yellow "deferred" header when nothing actually regenerated.
- The single-flight message now points at `.repowise/.update.log` so the still-running update is discoverable.
- The `--progress json` `done` event carries the same `outcome`, so a supervising agent can tell a deferral or no-op from a real regeneration (all three otherwise emit `ok=True, pages_generated=0`).

## Tests

- New regression: `test_workspace_docs_update_reports_deferral_not_regeneration` holds the member lock and asserts the run reports deferral, not regeneration, and does not advance the docs pointer.
- Updated two `--progress json` contract assertions for the new `outcome` field.
- 106 relevant CLI update tests pass; ruff clean.