### PR TITLE
fix(init): render the template wiki when no provider is configured

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -1001,6 +1001,10 @@ def init_command(
     # ---- Resolve provider ----
     provider = None
     decision_provider = None
+    # Set when a full run found no provider at all and fell back to the
+    # template renderer. Treated exactly like ``--index-only`` from the
+    # generation phase onward.
+    no_provider = False
 
     if index_only:
         try:
@@ -1032,47 +1036,66 @@ def init_command(
                     f"Decision extraction provider: [cyan]{decision_provider.provider_name}[/cyan]"
                 )
     else:
-        if not is_interactive and provider_name is None and sys.stdin.isatty():
-            from repowise.cli.ui import interactive_provider_config_select as _ipcs
-
-            selection = _ipcs(console, model, reasoning, repo_path=repo_path)
-            provider_name = selection.provider_name
-            model = selection.model
-            reasoning = selection.reasoning
-
-        provider = resolve_provider(provider_name, model, repo_path)
+        # No prompt here. ``is_interactive`` (line ~800) is already false only
+        # when the user passed --provider, --index-only or --yes, or stdin is
+        # not a terminal — so the old fallback picker in this branch fired
+        # exactly on ``--yes``, which means "do not ask me". A --yes run with
+        # no key now lands in the template wiki below rather than a question.
+        try:
+            provider = resolve_provider(provider_name, model, repo_path)
+        except click.ClickException:
+            # Nothing configured anywhere. Workspace init, workspace update
+            # and the OSS server all render a template wiki in this exact
+            # situation rather than refusing to run (#999); single-repo init
+            # was the last path that still died on it. An explicitly named
+            # --provider is a different question: the user asked for that
+            # provider by name, so the resolution failure is the real answer.
+            if provider_name is not None:
+                raise
+            no_provider = True
+            if not is_interactive:
+                console.print(f"[bold]repowise init[/bold] — {repo_path}")
+            console.print(
+                "[yellow]No model configured.[/yellow] Building the wiki from "
+                "structure instead — no key, no spend.\n"
+                "[dim]Set a key (or pass --provider) and run [bold]repowise "
+                "update --full[/bold] to have a model write it.[/dim]"
+            )
         # resolve_provider / interactive provider selection may have just set
         # the API key in os.environ. Re-resolve the embedder so the
         # display (and the embed path below) honors the key the user just
         # pasted, rather than the pre-prompt "mock" fallback.
         embedder_name_resolved = resolve_embedder(embedder_name)
-        if not is_interactive:
+        if not is_interactive and not no_provider:
             console.print(f"[bold]repowise init[/bold] — {repo_path}")
-        console.print(
-            f"  Provider: [cyan]{provider.provider_name}[/cyan] / Model: [cyan]{provider.model_name}[/cyan]"
-        )
+        if provider is not None:
+            console.print(
+                f"  Provider: [cyan]{provider.provider_name}[/cyan] / Model: [cyan]{provider.model_name}[/cyan]"
+            )
         console.print(f"  Embedder: [cyan]{embedder_name_resolved}[/cyan]")
         if language != "en":
             console.print(f"  Language: [cyan]{language}[/cyan]")
         if resolved_reasoning != "auto":
             console.print(f"  Reasoning: [cyan]{resolved_reasoning}[/cyan]")
 
-        # Validate provider connection
-        from repowise.core.providers.llm.base import ProviderError
+        # Validate provider connection. Nothing to verify when there is no
+        # provider: this run renders from templates and never calls a model.
+        if provider is not None:
+            from repowise.core.providers.llm.base import ProviderError
 
-        with console.status("  Verifying provider connection…", spinner=OWL_SPINNER):
-            try:
-                run_async(
-                    provider.generate(
-                        "You are a test.",
-                        "Reply with OK.",
-                        max_tokens=50,
-                        reasoning=resolved_reasoning,
+            with console.status("  Verifying provider connection…", spinner=OWL_SPINNER):
+                try:
+                    run_async(
+                        provider.generate(
+                            "You are a test.",
+                            "Reply with OK.",
+                            max_tokens=50,
+                            reasoning=resolved_reasoning,
+                        )
                     )
-                )
-            except ProviderError as exc:
-                raise click.ClickException(f"Provider validation failed: {exc}") from exc
-        console.print("  [green]✓[/green] Provider connection verified")
+                except ProviderError as exc:
+                    raise click.ClickException(f"Provider validation failed: {exc}") from exc
+            console.print("  [green]✓[/green] Provider connection verified")
 
     # ---- Phase 1 & 2: Ingestion + Analysis (always) ----
     # Index-only generates too, it just renders templates instead of prompting
@@ -1194,7 +1217,9 @@ def init_command(
             "render it from structure, or [bold]repowise update --full[/bold] "
             "to write it with a model.[/dim]"
         )
-    elif index_only:
+    elif index_only or no_provider:
+        # ``no_provider`` reaches here the same way ``--index-only`` does: a
+        # full run that found no key still gets the whole template wiki.
         _index_only_embedder = _run_deterministic_generation_phase(
             repo_path=repo_path,
             result=result,
@@ -1270,8 +1295,9 @@ def init_command(
 
     # ---- Persistence ----
     # `cost_declined` short-circuits any further LLM work for the rest of
-    # this run, so persistence/state below treat it as index-only.
-    effective_index_only = index_only or cost_declined
+    # this run, so persistence/state below treat it as index-only. So does
+    # `no_provider`: there is no model to do the work either way.
+    effective_index_only = index_only or cost_declined or no_provider
     print_phase_header(
         console,
         total_phases,

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -574,7 +574,13 @@ def resolve_provider(
         cfg = load_config(repo_path)
 
     if provider_name is None:
-        provider_name = os.environ.get("REPOWISE_PROVIDER")
+        # An empty or whitespace-only value means "not set", not "a provider
+        # named ''". CI systems and agent harnesses declare env vars with empty
+        # values routinely (``REPOWISE_PROVIDER: ""`` in a workflow matrix),
+        # and the explicit-provider branch below keys off ``is not None``, so
+        # an empty string reached get_provider() and raised a bare ValueError
+        # traceback instead of falling through to auto-detection.
+        provider_name = (os.environ.get("REPOWISE_PROVIDER") or "").strip() or None
 
     if provider_name is None and cfg.get("provider"):
         provider_name = cfg["provider"]

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -110,20 +110,56 @@ class TestErrorCases:
         result = runner.invoke(cli, ["init", bad_path])
         assert result.exit_code != 0
 
-    def test_init_no_provider(self, runner, tmp_path, monkeypatch):
-        """init with no provider configured should error."""
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
-        monkeypatch.delenv("KIMI_API_KEY", raising=False)
-        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
-        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
-        monkeypatch.delenv("LITELLM_API_KEY", raising=False)
-        monkeypatch.delenv("REPOWISE_PROVIDER", raising=False)
+    @staticmethod
+    def _clear_provider_env_impl(monkeypatch):
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "KIMI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "OLLAMA_BASE_URL",
+            "LITELLM_API_KEY",
+            "REPOWISE_PROVIDER",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_init_no_provider_falls_back_to_templates(self, runner, tmp_path, monkeypatch):
+        """init with no provider renders the wiki from structure instead of dying.
+
+        Workspace init, workspace update and the OSS server have all degraded
+        this way since #999; single-repo init was the last path that refused to
+        run without a key. An explicitly named --provider still errors, which
+        the test below covers.
+        """
+        self._clear_provider_env_impl(monkeypatch)
         result = runner.invoke(cli, ["init", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "No model configured" in result.output
+
+    def test_init_explicit_provider_still_errors(self, runner, tmp_path, monkeypatch):
+        """A named --provider that cannot resolve is a real error, not a fallback.
+
+        The user asked for that provider by name, so silently rendering
+        templates instead would hide the thing they need to fix.
+        """
+        self._clear_provider_env_impl(monkeypatch)
+        result = runner.invoke(cli, ["init", str(tmp_path), "--provider", "anthropic"])
         assert result.exit_code != 0
+
+    def test_init_empty_provider_env_is_unset(self, runner, tmp_path, monkeypatch):
+        """``REPOWISE_PROVIDER=""`` means unset, not a provider named ''.
+
+        CI matrices and agent harnesses declare empty env vars routinely, and
+        this used to reach get_provider('') and raise a bare ValueError.
+        """
+        self._clear_provider_env_impl(monkeypatch)
+        monkeypatch.setenv("REPOWISE_PROVIDER", "")
+        result = runner.invoke(cli, ["init", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "Unknown provider" not in result.output
 
     def test_status_no_repowise_dir(self, runner, tmp_path):
         result = runner.invoke(cli, ["status", str(tmp_path)])


### PR DESCRIPTION
Single-repo `init` was the last path that refused to run without an API key. Workspace init, workspace update and the OSS server have all rendered a template wiki in that situation since #999; `init` raised "No provider configured" and exited non-zero instead. It now falls back to the same renderer and finishes, so a keyless machine gets a complete wiki rather than an error.

Naming a provider explicitly with `--provider` still errors. The user asked for that provider by name, so a resolution failure is the answer they were looking for, not something to paper over with templates.

This also removes the provider picker that ran in the full-run branch. Its guard was `not is_interactive and provider_name is None and isatty()`, and `is_interactive` is false there only when `--provider`, `--index-only` or `--yes` was passed, so in practice it fired exactly on `--yes`, which means "do not ask me". A `--yes` run with no key now lands on the template wiki.

`REPOWISE_PROVIDER=""` is treated as unset rather than a provider named `""`. An empty value reached `get_provider()` through the explicit-provider branch, which keys off `is not None`, and raised a bare `ValueError` traceback. CI matrices and agent harnesses declare empty env vars routinely.

## Verification

- `tests/unit/cli/test_commands.py`: 30 passed. The old `test_init_no_provider` asserted the previous contract (must exit non-zero) and is replaced by three tests covering the fallback, the explicit-provider error, and the empty env var.
- End to end on a scratch repo with every provider env var unset: `repowise init --yes` exits 0 and writes the full wiki.

## Notes for review

The one product decision here is whether `init` should degrade or fail when it finds no key. Everything else follows from it. First of three stacked PRs; the other two build on this branch.