### PR TITLE
fix(init): degrade unanswerable prompts instead of ending the run

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/_interactive.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/_interactive.py
@@ -68,7 +68,15 @@ def offer_distill_rewrite_hook(
             f"  [dim]{scope}Each rewrite is shown for approval; raw output stays "
             "recoverable via `repowise expand`.[/dim]"
         )
-        flag = click.confirm("  Install the Claude Code rewrite hook?", default=True)
+        try:
+            flag = click.confirm("  Install the Claude Code rewrite hook?", default=True)
+        except (click.Abort, EOFError):
+            # Same unanswerable-terminal case as the post-commit hook offer
+            # above: decline an optional extra rather than fail a finished run.
+            console_obj.print(
+                "\n  [dim]Skipped. Run 'repowise hook rewrite install' later to set up.[/dim]"
+            )
+            return
 
     if flag:
         path = adapter.install_rewrite_hook()
@@ -108,6 +116,25 @@ def offer_hook_install(
     if not sys.stdin.isatty():
         return  # Non-interactive — skip
 
+    try:
+        _offer_hook_install_prompts(console_obj, repo_paths, aliases)
+    except (click.Abort, EOFError):
+        # isatty() claimed a terminal that cannot answer (Windows Git Bash
+        # ``< /dev/null``, pty wrappers, ``docker run -t`` without -i). This is
+        # the last step of a run whose index and wiki are already written, and
+        # an optional hook is not worth failing it over: decline and exit
+        # clean. Ctrl-C lands here too, which asks for the same outcome.
+        console_obj.print(
+            "\n  [dim]Skipped the hook. Run 'repowise hook install' later to set it up.[/dim]"
+        )
+
+
+def _offer_hook_install_prompts(
+    console_obj: Any,
+    repo_paths: list[Path],
+    aliases: list[str] | None,
+) -> None:
+    """Ask which repos get a post-commit hook, and install it. Prompts."""
     from repowise.cli.hooks import install, status
 
     # Filter to repos that don't already have the hook

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -333,12 +333,11 @@ def _run_generation_phase(
         console.print("[yellow]Dry run — no pages generated.[/yellow]")
         return True, False
 
-    if cost_gate_declined(est, yes=yes, message="  Estimated cost exceeds $2.00. Continue?"):
+    if cost_gate_declined(est, yes=yes, message="  Write the wiki with the model at this cost?"):
         console.print(
-            "[yellow]Skipped LLM generation.[/yellow] "
-            "[dim]Index/graph/git/dead-code will be saved; future "
-            "`repowise update` runs default to index-only so the "
-            "post-commit hook won't trigger LLM regen.[/dim]"
+            "[yellow]Not writing it with the model.[/yellow] "
+            "[dim]Future `repowise update` runs stay index-only, so the "
+            "post-commit hook won't start a model run on its own.[/dim]"
         )
         return False, True
 
@@ -826,7 +825,26 @@ def init_command(
         with console.status("  Scanning repository…", spinner=OWL_SPINNER):
             scan_info = quick_repo_scan(repo_path)
         print_scan_summary(console, scan_info)
-        mode = interactive_mode_select(console)
+
+        # ``sys.stdin.isatty()`` is not a reliable answer to "can I read from
+        # stdin". On Windows under Git Bash, ``repowise init < /dev/null``
+        # reports a TTY and then reads EOF on the first question; the same goes
+        # for some pty wrappers and ``docker run -t`` without -i. Agents drive
+        # init through exactly those shapes, so the first prompt is treated as
+        # the probe: if it cannot be answered, drop to the non-interactive path
+        # and carry on rather than dying on a question nobody can hear. Only
+        # EOFError is caught. A real Ctrl-C raises KeyboardInterrupt/Abort and
+        # must still stop the run.
+        mode = None
+        try:
+            mode = interactive_mode_select(console)
+        except EOFError:
+            is_interactive = False
+            console.print(
+                "\n[yellow]No answer available on stdin[/yellow] "
+                "[dim]— continuing with defaults. Pass --yes to skip the "
+                "questions.[/dim]"
+            )
 
         # Map the menu onto the two axes (docs on/off, customize yes/no):
         #   full       -> docs on,  optional customize
@@ -838,14 +856,17 @@ def init_command(
         elif mode == "advanced":
             generate_docs = interactive_generate_docs_toggle(console)
             customize = True
-        else:  # full
+        elif mode is not None:  # full
             generate_docs = True
             customize = interactive_customize_offer(console, generate_docs=True)
-        index_only = not generate_docs
+        if mode is not None:
+            index_only = not generate_docs
 
         # Provider selection only when docs will be generated. Index-only runs
         # auto-detect a decision-extraction provider later without prompting.
-        if generate_docs:
+        # ``is_interactive`` can have been cleared just above by an unanswerable
+        # menu, in which case every remaining question here is unanswerable too.
+        if generate_docs and is_interactive:
             selection = interactive_provider_config_select(
                 console,
                 model,
@@ -897,7 +918,7 @@ def init_command(
             if run_mode == "fast":
                 index_only = True
                 generate_docs = False
-        else:
+        elif is_interactive:
             # No customization: still offer the fast first-index on large repos.
             # Default yes for an index-only run (docs already opted out), no for a
             # full run (the user explicitly asked for docs).
@@ -913,7 +934,7 @@ def init_command(
         # Wiki style: prompt for a docs run when not already chosen (via the
         # --wiki-style flag or the advanced generation section). Index-only runs
         # generate no pages, so the question is skipped. --yes uses the default.
-        if generate_docs and wiki_style is None and not yes:
+        if generate_docs and wiki_style is None and not yes and is_interactive:
             wiki_style = prompt_wiki_style(console)
 
     # Resolve the effective style (CLI flag > interactive prompt > default) and

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -1001,6 +1001,10 @@ def init_command(
     # ---- Resolve provider ----
     provider = None
     decision_provider = None
+    # Set when a full run found no provider at all and fell back to the
+    # template renderer. Treated exactly like ``--index-only`` from the
+    # generation phase onward.
+    no_provider = False
 
     if index_only:
         try:
@@ -1032,47 +1036,66 @@ def init_command(
                     f"Decision extraction provider: [cyan]{decision_provider.provider_name}[/cyan]"
                 )
     else:
-        if not is_interactive and provider_name is None and sys.stdin.isatty():
-            from repowise.cli.ui import interactive_provider_config_select as _ipcs
-
-            selection = _ipcs(console, model, reasoning, repo_path=repo_path)
-            provider_name = selection.provider_name
-            model = selection.model
-            reasoning = selection.reasoning
-
-        provider = resolve_provider(provider_name, model, repo_path)
+        # No prompt here. ``is_interactive`` (line ~800) is already false only
+        # when the user passed --provider, --index-only or --yes, or stdin is
+        # not a terminal — so the old fallback picker in this branch fired
+        # exactly on ``--yes``, which means "do not ask me". A --yes run with
+        # no key now lands in the template wiki below rather than a question.
+        try:
+            provider = resolve_provider(provider_name, model, repo_path)
+        except click.ClickException:
+            # Nothing configured anywhere. Workspace init, workspace update
+            # and the OSS server all render a template wiki in this exact
+            # situation rather than refusing to run (#999); single-repo init
+            # was the last path that still died on it. An explicitly named
+            # --provider is a different question: the user asked for that
+            # provider by name, so the resolution failure is the real answer.
+            if provider_name is not None:
+                raise
+            no_provider = True
+            if not is_interactive:
+                console.print(f"[bold]repowise init[/bold] — {repo_path}")
+            console.print(
+                "[yellow]No model configured.[/yellow] Building the wiki from "
+                "structure instead — no key, no spend.\n"
+                "[dim]Set a key (or pass --provider) and run [bold]repowise "
+                "update --full[/bold] to have a model write it.[/dim]"
+            )
         # resolve_provider / interactive provider selection may have just set
         # the API key in os.environ. Re-resolve the embedder so the
         # display (and the embed path below) honors the key the user just
         # pasted, rather than the pre-prompt "mock" fallback.
         embedder_name_resolved = resolve_embedder(embedder_name)
-        if not is_interactive:
+        if not is_interactive and not no_provider:
             console.print(f"[bold]repowise init[/bold] — {repo_path}")
-        console.print(
-            f"  Provider: [cyan]{provider.provider_name}[/cyan] / Model: [cyan]{provider.model_name}[/cyan]"
-        )
+        if provider is not None:
+            console.print(
+                f"  Provider: [cyan]{provider.provider_name}[/cyan] / Model: [cyan]{provider.model_name}[/cyan]"
+            )
         console.print(f"  Embedder: [cyan]{embedder_name_resolved}[/cyan]")
         if language != "en":
             console.print(f"  Language: [cyan]{language}[/cyan]")
         if resolved_reasoning != "auto":
             console.print(f"  Reasoning: [cyan]{resolved_reasoning}[/cyan]")
 
-        # Validate provider connection
-        from repowise.core.providers.llm.base import ProviderError
+        # Validate provider connection. Nothing to verify when there is no
+        # provider: this run renders from templates and never calls a model.
+        if provider is not None:
+            from repowise.core.providers.llm.base import ProviderError
 
-        with console.status("  Verifying provider connection…", spinner=OWL_SPINNER):
-            try:
-                run_async(
-                    provider.generate(
-                        "You are a test.",
-                        "Reply with OK.",
-                        max_tokens=50,
-                        reasoning=resolved_reasoning,
+            with console.status("  Verifying provider connection…", spinner=OWL_SPINNER):
+                try:
+                    run_async(
+                        provider.generate(
+                            "You are a test.",
+                            "Reply with OK.",
+                            max_tokens=50,
+                            reasoning=resolved_reasoning,
+                        )
                     )
-                )
-            except ProviderError as exc:
-                raise click.ClickException(f"Provider validation failed: {exc}") from exc
-        console.print("  [green]✓[/green] Provider connection verified")
+                except ProviderError as exc:
+                    raise click.ClickException(f"Provider validation failed: {exc}") from exc
+            console.print("  [green]✓[/green] Provider connection verified")
 
     # ---- Phase 1 & 2: Ingestion + Analysis (always) ----
     # Index-only generates too, it just renders templates instead of prompting
@@ -1194,7 +1217,9 @@ def init_command(
             "render it from structure, or [bold]repowise update --full[/bold] "
             "to write it with a model.[/dim]"
         )
-    elif index_only:
+    elif index_only or no_provider:
+        # ``no_provider`` reaches here the same way ``--index-only`` does: a
+        # full run that found no key still gets the whole template wiki.
         _index_only_embedder = _run_deterministic_generation_phase(
             repo_path=repo_path,
             result=result,
@@ -1270,8 +1295,9 @@ def init_command(
 
     # ---- Persistence ----
     # `cost_declined` short-circuits any further LLM work for the rest of
-    # this run, so persistence/state below treat it as index-only.
-    effective_index_only = index_only or cost_declined
+    # this run, so persistence/state below treat it as index-only. So does
+    # `no_provider`: there is no model to do the work either way.
+    effective_index_only = index_only or cost_declined or no_provider
     print_phase_header(
         console,
         total_phases,

--- a/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
@@ -488,9 +488,7 @@ def _ingest_and_generate_repo(repo: Any, idx: int, total: int, ctx: _WorkspaceCt
             exclude_patterns=ctx.exclude_patterns if ctx.exclude_patterns else None,
             commit_limit=ctx.resolved_commit_limit if ctx.resolved_commit_limit else None,
             embedder=det_embedder,
-            embedding_model=(
-                resolve_embedding_model(det_embedder) if det_embedder else None
-            ),
+            embedding_model=(resolve_embedding_model(det_embedder) if det_embedder else None),
         )
 
     return _RepoOutcome(
@@ -566,8 +564,13 @@ def _workspace_init(
     console.print(f"  Detected [bold]{len(scan.repos)}[/bold] repositories in {root}\n")
 
     # Step 1: Select repos to index
-    # --yes or --all: take every detected repo without prompting.
-    select_all = init_all or yes
+    # --yes or --all: take every detected repo without prompting. So does a
+    # non-terminal stdin: this is the first prompt in the workspace flow, it
+    # runs before any indexing, and asking a pipe would end the run with an
+    # EOFError before the tool had done anything at all. Agents drive init
+    # this way routinely. "Every repo the scan found" is also what --all
+    # means, so the fallback matches the flag a human would have passed.
+    select_all = init_all or yes or not sys.stdin.isatty()
     selected = list(scan.repos) if select_all else interactive_repo_select(console, scan.repos)
 
     if not selected:

--- a/packages/cli/src/repowise/cli/cost_gate.py
+++ b/packages/cli/src/repowise/cli/cost_gate.py
@@ -9,6 +9,7 @@ the other's internals.
 
 from __future__ import annotations
 
+import sys
 from typing import Any
 
 import click
@@ -18,6 +19,12 @@ from repowise.cli.helpers import console
 # The LLM-cost confirmation threshold. A run whose estimate exceeds this asks
 # for confirmation (unless ``--yes``); below it generation proceeds silently.
 COST_GATE_USD = 2.00
+
+# The point where Enter-through stops meaning yes. Between COST_GATE_USD and
+# this, the gate is an FYI on a run the user just configured and the default
+# continues it. Past it, a mis-keyed Enter is an expensive mistake, so the
+# default flips and approval has to be typed.
+COST_GATE_HARD_USD = 25.00
 
 
 class CostGateDeclined(Exception):  # noqa: N818 — a control-flow signal, not an error
@@ -31,8 +38,8 @@ class CostGateDeclined(Exception):  # noqa: N818 — a control-flow signal, not 
     """
 
 
-def confirm_cost_gate(message: str) -> bool:
-    """Render the cost-gate ``[Y/n]`` prompt with visual padding.
+def confirm_cost_gate(message: str, *, estimated_usd: float | None = None) -> bool:
+    """Render the cost-gate prompt with visual padding. True means "spend it".
 
     Click's plain ``confirm`` interleaves with the trailing line of any
     prior Rich output (progress-bar frames, status spinners), making the
@@ -44,11 +51,37 @@ def confirm_cost_gate(message: str) -> bool:
     Default is Yes: the user just picked a coverage tier with the cost
     range printed next to it, so Enter-through should continue the run
     they configured — the gate exists to make the spend visible, not to
-    interrupt it.
+    interrupt it. Above :data:`COST_GATE_HARD_USD` that reverses, because
+    Enter-through approving a bill that size is the footgun the padding
+    above was added to prevent, and a default cannot be the safe answer
+    and the expensive one at the same time.
+
+    Declining is not a dead end and the prompt now says so: the caller
+    renders the wiki from templates instead, so No costs the user their
+    model pages, not their wiki.
+
+    Never prompts when stdin is not a terminal. There is nothing to read
+    there, and ``click.confirm`` would raise ``Abort`` and throw away an
+    index that is already built — which is the whole run, minutes of it.
     """
     console.line()
     console.rule(style="yellow")
-    return click.confirm(message, default=True)
+    console.print(
+        "  [dim]No builds the same wiki from structure instead: no model, "
+        "no spend. You can upgrade it later with [bold]repowise update "
+        "--full[/bold].[/dim]"
+    )
+    if not sys.stdin.isatty():
+        console.print("  [dim]Not a terminal, so nothing to ask: building from structure.[/dim]")
+        return False
+    default = True
+    if estimated_usd is not None and estimated_usd > COST_GATE_HARD_USD:
+        console.print(
+            f"  [yellow]This is over ${COST_GATE_HARD_USD:.0f}.[/yellow] "
+            "[dim]Answer yes explicitly to approve it.[/dim]"
+        )
+        default = False
+    return click.confirm(message, default=default)
 
 
 def cost_gate_declined(est: Any, *, yes: bool, message: str) -> bool:
@@ -57,7 +90,9 @@ def cost_gate_declined(est: Any, *, yes: bool, message: str) -> bool:
     Only prompts when the estimate clears :data:`COST_GATE_USD` and ``--yes``
     was not passed; a declined prompt yields ``True``.
     """
-    return est.estimated_cost_usd > COST_GATE_USD and not yes and not confirm_cost_gate(message)
+    if est.estimated_cost_usd <= COST_GATE_USD or yes:
+        return False
+    return not confirm_cost_gate(message, estimated_usd=est.estimated_cost_usd)
 
 
 def format_cost(est: Any) -> str:

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -574,7 +574,13 @@ def resolve_provider(
         cfg = load_config(repo_path)
 
     if provider_name is None:
-        provider_name = os.environ.get("REPOWISE_PROVIDER")
+        # An empty or whitespace-only value means "not set", not "a provider
+        # named ''". CI systems and agent harnesses declare env vars with empty
+        # values routinely (``REPOWISE_PROVIDER: ""`` in a workflow matrix),
+        # and the explicit-provider branch below keys off ``is not None``, so
+        # an empty string reached get_provider() and raised a bare ValueError
+        # traceback instead of falling through to auto-detection.
+        provider_name = (os.environ.get("REPOWISE_PROVIDER") or "").strip() or None
 
     if provider_name is None and cfg.get("provider"):
         provider_name = cfg["provider"]

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -110,20 +110,56 @@ class TestErrorCases:
         result = runner.invoke(cli, ["init", bad_path])
         assert result.exit_code != 0
 
-    def test_init_no_provider(self, runner, tmp_path, monkeypatch):
-        """init with no provider configured should error."""
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
-        monkeypatch.delenv("KIMI_API_KEY", raising=False)
-        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
-        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
-        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
-        monkeypatch.delenv("LITELLM_API_KEY", raising=False)
-        monkeypatch.delenv("REPOWISE_PROVIDER", raising=False)
+    @staticmethod
+    def _clear_provider_env_impl(monkeypatch):
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "KIMI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "OLLAMA_BASE_URL",
+            "LITELLM_API_KEY",
+            "REPOWISE_PROVIDER",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_init_no_provider_falls_back_to_templates(self, runner, tmp_path, monkeypatch):
+        """init with no provider renders the wiki from structure instead of dying.
+
+        Workspace init, workspace update and the OSS server have all degraded
+        this way since #999; single-repo init was the last path that refused to
+        run without a key. An explicitly named --provider still errors, which
+        the test below covers.
+        """
+        self._clear_provider_env_impl(monkeypatch)
         result = runner.invoke(cli, ["init", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "No model configured" in result.output
+
+    def test_init_explicit_provider_still_errors(self, runner, tmp_path, monkeypatch):
+        """A named --provider that cannot resolve is a real error, not a fallback.
+
+        The user asked for that provider by name, so silently rendering
+        templates instead would hide the thing they need to fix.
+        """
+        self._clear_provider_env_impl(monkeypatch)
+        result = runner.invoke(cli, ["init", str(tmp_path), "--provider", "anthropic"])
         assert result.exit_code != 0
+
+    def test_init_empty_provider_env_is_unset(self, runner, tmp_path, monkeypatch):
+        """``REPOWISE_PROVIDER=""`` means unset, not a provider named ''.
+
+        CI matrices and agent harnesses declare empty env vars routinely, and
+        this used to reach get_provider('') and raise a bare ValueError.
+        """
+        self._clear_provider_env_impl(monkeypatch)
+        monkeypatch.setenv("REPOWISE_PROVIDER", "")
+        result = runner.invoke(cli, ["init", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "Unknown provider" not in result.output
 
     def test_status_no_repowise_dir(self, runner, tmp_path):
         result = runner.invoke(cli, ["status", str(tmp_path)])

--- a/tests/unit/cli/test_init_noninteractive.py
+++ b/tests/unit/cli/test_init_noninteractive.py
@@ -1,0 +1,95 @@
+"""Prompts in `repowise init` that must degrade rather than end the run.
+
+Agents set repowise up on a user's behalf, usually as `repowise init --yes` or
+with stdin pointed at /dev/null. `sys.stdin.isatty()` is not a reliable guard:
+on Windows under Git Bash, `init < /dev/null` reports a terminal and then reads
+EOF on the first question.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import click
+
+from repowise.cli import cost_gate
+from repowise.cli.commands.init_cmd._interactive import offer_hook_install
+
+
+def _est(usd: float) -> SimpleNamespace:
+    """A stand-in for a cost estimate, which the gate only reads two fields of."""
+    return SimpleNamespace(estimated_cost_usd=usd, cost_range=None, is_calibrated=False)
+
+
+class TestCostGate:
+    def test_below_threshold_never_prompts(self, monkeypatch):
+        """A cheap run is not worth interrupting, so the gate stays out of the way."""
+
+        def _boom(*_a, **_k):
+            raise AssertionError("prompted below the cost gate threshold")
+
+        monkeypatch.setattr(click, "confirm", _boom)
+        assert cost_gate.cost_gate_declined(_est(0.10), yes=False, message="m") is False
+
+    def test_yes_never_prompts(self, monkeypatch):
+        """--yes means the spend is pre-approved."""
+
+        def _boom(*_a, **_k):
+            raise AssertionError("prompted under --yes")
+
+        monkeypatch.setattr(click, "confirm", _boom)
+        assert cost_gate.cost_gate_declined(_est(999.0), yes=True, message="m") is False
+
+    def test_non_tty_declines_without_prompting(self, monkeypatch):
+        """No terminal means no answer. Decline, do not Abort.
+
+        The gate is the only prompt that fires *after* a full index, so an
+        Abort here throws away every minute already spent. Declining hands the
+        caller back to the template renderer with the index intact.
+        """
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: False, raising=False)
+
+        def _boom(*_a, **_k):
+            raise AssertionError("prompted with no terminal attached")
+
+        monkeypatch.setattr(click, "confirm", _boom)
+        assert cost_gate.cost_gate_declined(_est(50.0), yes=False, message="m") is True
+
+    def test_default_is_yes_under_the_hard_ceiling(self, monkeypatch):
+        """The user just configured this run; Enter-through continues it."""
+        seen: dict = {}
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(
+            click, "confirm", lambda _m, default=None: seen.setdefault("default", default) or True
+        )
+        cost_gate.confirm_cost_gate("m", estimated_usd=5.0)
+        assert seen["default"] is True
+
+    def test_default_flips_above_the_hard_ceiling(self, monkeypatch):
+        """A bill this size must be typed, not defaulted into."""
+        seen: dict = {}
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+
+        def _confirm(_m, default=None):
+            seen["default"] = default
+            return False
+
+        monkeypatch.setattr(click, "confirm", _confirm)
+        cost_gate.confirm_cost_gate("m", estimated_usd=cost_gate.COST_GATE_HARD_USD + 1)
+        assert seen["default"] is False
+
+
+class TestHookOfferDegrades:
+    def test_eof_on_hook_offer_does_not_raise(self, monkeypatch, tmp_path):
+        """A finished run must not fail on an optional trailing question."""
+        monkeypatch.setattr(sys.stdin, "isatty", lambda: True, raising=False)
+        monkeypatch.setattr(
+            "repowise.cli.commands.init_cmd._interactive.click.confirm",
+            lambda *_a, **_k: (_ for _ in ()).throw(click.Abort()),
+        )
+        monkeypatch.setattr("repowise.cli.hooks.status", lambda _p: "missing")
+        # Must not raise.
+        offer_hook_install(
+            SimpleNamespace(print=lambda *_a, **_k: None), [tmp_path], None, yes=False
+        )


### PR DESCRIPTION
Stacked on #1001. Review that first; this PR's diff is against its branch.

`sys.stdin.isatty()` is not a reliable test for "can I read a reply". On Windows under Git Bash, `repowise init < /dev/null` reports a terminal and then reads EOF on the first question; pty wrappers and `docker run -t` without `-i` do the same. Agents drive the CLI through exactly those shapes, which is why EOFError skews Windows in the wild.

The mode menu now treats its first prompt as the probe. An `EOFError` there prints what is happening and continues with defaults, and clears `is_interactive` so the questions that follow are skipped rather than asked into the same void. Only `EOFError` is caught: a real Ctrl-C still raises and still stops the run.

The two trailing hook offers decline instead of aborting. Both fire after the index and wiki are written, and an optional extra is not worth failing a finished run over. Ctrl-C lands there too and asks for the same outcome.

Workspace repo selection had no terminal check at all. It auto-selected every detected repo only under `--yes` or `--all`, so a piped run died on the selection prompt before indexing anything. A non-terminal stdin now takes the same "every repo the scan found" answer that `--all` means.

The cost gate stops asking when there is nothing to ask. It is the only prompt that fires after a full index, so an `Abort` there discarded every minute already spent; it now declines, which lands on the template wiki with the index intact. Its default also flips from yes to no above $25, so Enter-through can approve a small bill but never a large one, which is the footgun the padding around this prompt was added for. The wording now says that declining builds the wiki from structure rather than leaving that to be discovered afterwards.

## Verification

- New `tests/unit/cli/test_init_noninteractive.py`: 6 tests covering the gate below threshold, under `--yes`, with no TTY, both default states, and the hook offer swallowing EOF.
- 36 passed across the new file plus `test_commands.py`.
- End to end: `repowise init < /dev/null` with no keys now exits 0 with a full wiki. On `main` it aborts.

## Notes for review

Two judgement calls worth a second opinion:

1. The menu catches `EOFError` only, so Ctrl-C still aborts. The trailing hook offers catch `click.Abort` as well, which means Ctrl-C there is treated as "skip the hook" rather than "kill the run". That seemed right for a run whose output is already on disk, but it is a semantic change.
2. Auto-declining the cost gate on a non-TTY is a behaviour change for anyone piping `init` today: they previously got a non-zero exit, and now get a template wiki and exit 0.