### PR TITLE
feat(init): add --docs, and stop telling agents a key is required

### DIFF
--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -4,7 +4,7 @@ Complete reference for all `repowise` commands. For a guided introduction, see t
 
 Command list (in `--help` order): `augment`, `init`, `delete`, `generate-claude-md`, `costs`, `update`, `dead-code`, `health`, `risk`, `decision`, `coverage`, `impacted-tests`, `search`, `distill`, `expand`, `saved`, `corrections`, `export`, `hook`, `status`, `doctor`, `watch`, `serve`, `mcp`, `reindex`, `restyle`, `wiki-styles`, `whats-new`, `telemetry`, `login`, `logout`, `whoami`, `workspace`. Two more ship as separate console scripts, not subcommands: `repowise-augment`, `repowise-rewrite` (both hook entry points, not meant to be run by hand).
 
-**Do you need an LLM key?** Most commands are pure index/analysis and never call an LLM. The exceptions: `init` (unless `--index-only` or `--mode fast`), `update` (unless `--index-only` or `--no-docs`), `generate`, `restyle`, `watch` (when it regenerates a page), `health --generate-code`, and `workspace add --docs`. Everything else, `search`, `dead-code`, `health`, `risk`, `impacted-tests`, `decision`, `coverage`, `export`, `mcp`, `reindex`, `doctor`, and so on, works index-only, with no provider configured.
+**Do you need an LLM key?** Most commands are pure index/analysis and never call an LLM. `init` never requires a key: without one it renders the wiki from structure. It calls an LLM only when a provider is resolvable or `--docs llm` is passed. The exceptions: `update` (unless `--index-only` or `--no-docs`), `generate`, `restyle`, `watch` (when it regenerates a page), `health --generate-code`, and `workspace add --docs`. Everything else, `search`, `dead-code`, `health`, `risk`, `impacted-tests`, `decision`, `coverage`, `export`, `mcp`, `reindex`, `doctor`, and so on, works index-only, with no provider configured.
 
 ## Workspace auto-detect (cross-cutting)
 
@@ -50,13 +50,15 @@ repowise init .
 
 In workspace mode, adds: repo scanning, per-repo indexing, cross-repo analysis (co-changes, contracts, package deps), workspace CLAUDE.md generation.
 
-**Interactive modes.** Running a bare `repowise init` on a TTY (no `--provider`, `--index-only`, or `--yes`) opens a menu:
+**Interactive modes.** Running a bare `repowise init` on a TTY (no `--provider`, `--index-only`, `--docs`, or `--yes`) opens a menu:
 
 1. **Everything**, index + model-written docs. After picking a provider you can answer **"Customize?"** to tune any setting before the run.
 2. **Index only**, the same layers plus a wiki rendered from structure; no LLM, no key, no cost. Answer **"Customize indexing?"** to set exclude patterns, commit limit, skip-tests/infra, submodules, and fast mode.
 3. **Advanced**, full control. First choose **"Generate model-written wiki docs?"**; the prompts then split into an **Indexing** section (always) and a **Generation** section (provider, concurrency, embedder, wiki style, onboarding, decision harvesting, tiering, only when model-written docs are on).
 
-All three reach the indexing knobs; the LLM-only knobs appear only when model-written docs are enabled. Passing any of the flags below (or `--yes`) skips the menu and runs non-interactively.
+All three reach the indexing knobs; the LLM-only knobs appear only when model-written docs are enabled. Passing any of the flags below (or `--yes`) skips the menu and runs non-interactively. If the first prompt reads EOF (common when an agent pipes stdin), init prints a notice and continues with defaults instead of aborting.
+
+**Cost gate.** Before any tokens are spent, init shows the estimate and asks for confirmation. It never prompts when stdin is not a TTY: it auto-declines, keeps the index it already built, and renders the template wiki instead. The default answer is Yes up to $25 and flips to No above that.
 
 **Options:**
 
@@ -66,6 +68,7 @@ All three reach the indexing knobs; the LLM-only knobs appear only when model-wr
 | `--model` | Model name override (e.g., `claude-sonnet-4-6`) |
 | `--embedder` | Embedder for semantic search: `gemini`, `openai`, `openrouter`, `ollama`, `mock` (default: auto-detect) |
 | `--index-only` | No LLM calls, no API key, no spend. Parses, builds the graph, indexes git, and renders the whole wiki from that structure: file, module, layer and cycle (SCC) pages, the architecture diagram, the repo overview, API and infra pages, and the onboarding collection. Symbol spotlight pages are skipped, since the file pages already carry that content. Every page footer says it was derived from structure, and the repo overview covers composition, entry points, clusters and dependencies rather than what the project does end to end. Full-text search works; semantic search needs an embedder. Upgrade to model-written prose later, any subset at a time, with [`repowise generate`](#repowise-generate-path) (or `update --full` for the whole wiki in one shot). |
+| `--docs` | How to produce the wiki: `llm` or `deterministic`. The same choice as `--index-only`, named for what it does. `--docs llm` needs a key; `--docs deterministic` is identical to `--index-only`. Passing `--docs llm --index-only` together is a usage error (exit 2). |
 | `--mode` | Pipeline depth: `standard` (default) or `fast` (graph + essential-git only, no per-file blame/co-change, no LLM docs, for very large repos; upgrade later with `update --full`) |
 | `--skip-tests` | Exclude test files from doc generation |
 | `--skip-infra` | Exclude infrastructure files (Dockerfiles, Makefiles, Terraform) |

--- a/docs/start/DASHBOARD.md
+++ b/docs/start/DASHBOARD.md
@@ -26,13 +26,16 @@ Repowise can index a repo without generating a wiki (`repowise init
 the AST, the dependency graph, and git history works in both modes. The views
 that read generated pages are the difference:
 
-| Needs a generated wiki | Works index-only |
+| Needs a model or an embedder | Works on any indexed repo |
 |---|---|
-| Docs, Doc freshness, Present mode, Chat, semantic Search | Overview, Architecture, Knowledge Graph, Code Health, Refactoring, Files, Symbols, Commits, Contributors, Decisions, Stats, Usage, Settings, all Workspace views |
+| Chat (needs a provider), semantic Search (needs an embedder) | Docs, Doc freshness, Present mode, Overview, Architecture, Knowledge Graph, Code Health, Refactoring, Files, Symbols, Commits, Contributors, Decisions, Stats, Usage, Settings, all Workspace views |
 
-In index-only mode the docs-related counters honestly read `0` rather than
-hiding, and the Docs view offers to run a generation job. You can upgrade an
-index-only repo to a full one later without re-indexing from scratch.
+Every indexed repo has a wiki, including one indexed without a key, so the Docs
+views are populated either way. What a keyless index lacks is model-written
+prose and semantic search: the Docs view offers to upgrade pages with
+`repowise generate`, and `repowise reindex` builds semantic search once an
+embedder is configured. Either upgrade works in place, with no re-index from
+scratch.
 
 ## Overview
 

--- a/docs/start/QUICKSTART.md
+++ b/docs/start/QUICKSTART.md
@@ -28,11 +28,18 @@ Check it landed:
 repowise --version
 ```
 
-## 2. Index your repo, with no API key
+## 2. Index your repo
 
 ```bash
 cd /path/to/your-repo
-repowise init --index-only -y
+repowise init --yes
+```
+
+No API key needed. If you want to be explicit that this run must not spend
+anything, spell it out:
+
+```bash
+repowise init --yes --docs deterministic
 ```
 
 This is the step worth doing first, because it costs nothing and answers the
@@ -272,8 +279,12 @@ repowise status          # what is indexed, and how stale it is
 
 ## Environment variables
 
+None of these are required. Every one of them is only needed for a model-written
+wiki.
+
 | Variable | When needed | Description |
 |----------|-------------|-------------|
+| `REPOWISE_PROVIDER` | Optional | Provider name. An empty value is treated as unset. |
 | `ANTHROPIC_API_KEY` | Using Anthropic | Anthropic API key |
 | `OPENAI_API_KEY` | Using OpenAI | OpenAI API key |
 | `GEMINI_API_KEY` | Using Gemini | Google Gemini API key |

--- a/docs/start/USER_GUIDE.md
+++ b/docs/start/USER_GUIDE.md
@@ -137,7 +137,7 @@ Grouped by what you are trying to do. Every flag for every command lives in the
 
 | Command | What it is for |
 |---|---|
-| `repowise init` | First index. Interactive: asks for a provider, shows a cost estimate, waits for confirmation. `--index-only` builds the same wiki from structure, with no LLM. |
+| `repowise init` | First index. Runs keyless by default; asks for a provider only when you want model-written pages, then shows a cost estimate and waits for confirmation. `--index-only` builds the same wiki from structure, with no LLM. |
 | `repowise generate` | Write wiki pages with a model, on demand. The upgrade path for an index-only repo: `--unwritten` (default) writes everything still on a template, `--path`/`--page` writes a subset, all behind a cost estimate. |
 | `repowise update` | Incremental catch-up after pulling or committing. Seconds, not minutes. |
 | `repowise watch` | File watcher that updates continuously while you work. |

--- a/packages/cli/src/repowise/cli/commands/generate_cmd/engine.py
+++ b/packages/cli/src/repowise/cli/commands/generate_cmd/engine.py
@@ -110,7 +110,7 @@ async def run_scoped_generation(
         if rehydrated is None:
             console.print(
                 "[yellow]This repo has no wiki pages yet.[/yellow] "
-                "Run `repowise init --index-only` or `repowise update --full` first."
+                "Run `repowise init --docs deterministic` or `repowise update --full` first."
             )
             return None
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -419,7 +419,18 @@ def _run_generation_phase(
     "--index-only",
     is_flag=True,
     default=False,
-    help="Index files, git history, graph, and dead code — skip LLM page generation.",
+    help="Build the wiki from structure instead of writing it with a model. No key, no spend.",
+)
+@click.option(
+    "--docs",
+    "docs_opt",
+    type=click.Choice(["llm", "deterministic"]),
+    default=None,
+    help=(
+        "How to produce the wiki: 'llm' writes it with a model (needs a key), "
+        "'deterministic' renders it from structure for free. Same choice as "
+        "--index-only, named for what it does. Use --mode fast for no wiki at all."
+    ),
 )
 @click.option(
     "--mode",
@@ -627,6 +638,7 @@ def init_command(
     reasoning: str | None,
     test_run: bool,
     index_only: bool,
+    docs_opt: str | None,
     run_mode: str,
     exclude: tuple[str, ...],
     commit_limit: int | None,
@@ -653,9 +665,18 @@ def init_command(
     """Generate wiki documentation for a codebase.
 
     PATH defaults to the current directory.
-    Use --index-only to run ingestion (AST, graph, git, dead code) without LLM generation.
+    Use --docs deterministic (or --index-only) to render the wiki from structure
+    with no model and no key; --docs llm writes it with a model.
     Use --mode fast for a quick graph + essential-git index of a very large repo.
     """
+    # ``--docs`` is the same switch as ``--index-only`` named for what it
+    # produces rather than what it skips, since an index-only run has rendered
+    # a full wiki since #975. Kept as two spellings because --index-only is in
+    # every existing script and doc; they must not disagree.
+    if docs_opt is not None:
+        if index_only and docs_opt == "llm":
+            raise click.UsageError("--docs llm contradicts --index-only. Pass one.")
+        index_only = docs_opt == "deterministic"
     # --mode fast is a graph + essential-git index with no LLM work, so it
     # implies index-only on the CLI side; the orchestrator mode below switches
     # the git tier to ESSENTIAL.
@@ -843,7 +864,7 @@ def init_command(
             console.print(
                 "\n[yellow]No answer available on stdin[/yellow] "
                 "[dim]— continuing with defaults. Pass --yes to skip the "
-                "questions.[/dim]"
+                "questions, or --docs llm/deterministic to choose directly.[/dim]"
             )
 
         # Map the menu onto the two axes (docs on/off, customize yes/no):
@@ -1051,7 +1072,9 @@ def init_command(
             print_index_only_intro(console, has_provider=has_provider)
         else:
             console.print(f"[bold]repowise index-only[/bold] — {repo_path}")
-            console.print("[yellow]Skipping LLM page generation (--index-only)[/yellow]")
+            console.print(
+                "[yellow]Building the wiki from structure[/yellow] [dim]— no model, no spend.[/dim]"
+            )
             if decision_provider:
                 console.print(
                     f"Decision extraction provider: [cyan]{decision_provider.provider_name}[/cyan]"
@@ -1060,8 +1083,11 @@ def init_command(
         # No prompt here. ``is_interactive`` (line ~800) is already false only
         # when the user passed --provider, --index-only or --yes, or stdin is
         # not a terminal — so the old fallback picker in this branch fired
-        # exactly on ``--yes``, which means "do not ask me". A --yes run with
-        # no key now lands in the template wiki below rather than a question.
+        # exactly on ``--yes``, which means "do not ask me". On shells where
+        # isatty() claims a terminal it cannot actually read from (Windows
+        # mintty, ``docker run -t`` without -i) that prompt hit EOF and killed
+        # the run instead. A --yes run with no key now lands in the template
+        # wiki below rather than in a question or a crash.
         try:
             provider = resolve_provider(provider_name, model, repo_path)
         except click.ClickException:

--- a/packages/server/src/repowise/server/mcp_server/_failure_shield.py
+++ b/packages/server/src/repowise/server/mcp_server/_failure_shield.py
@@ -34,9 +34,10 @@ def _shape_not_indexed() -> dict[str, Any]:
     return {
         "error": "This repository has no repowise index yet.",
         "remedy": (
-            "The user can build one by running 'repowise init' in the repo "
-            "root. Indexing is the user's decision — suggest it once, do not "
-            "run it yourself."
+            "The user can build one by running 'repowise init --yes' in the "
+            "repo root. No API key is required: without one it renders the "
+            "whole wiki from the code's structure. Indexing is the user's "
+            "decision — suggest it once, do not run it yourself."
         ),
         "guidance": (
             "Until an index exists, every repowise tool will return this "

--- a/packages/server/src/repowise/server/mcp_server/_server.py
+++ b/packages/server/src/repowise/server/mcp_server/_server.py
@@ -392,7 +392,10 @@ mcp = FastMCP(
         "repowise is a codebase documentation engine. Use these tools to query "
         "the wiki for architecture overviews, contextual docs on files/modules/"
         "symbols, modification risk assessment, architectural decision rationale, "
-        "semantic search, dependency paths, dead code, and architecture diagrams."
+        "semantic search, dependency paths, dead code, and architecture diagrams. "
+        "If the tools report that the repo has no index, tell the user to run "
+        "'repowise init --yes' in the repo root; it needs no API key. Suggest it, "
+        "do not run it yourself."
     ),
     lifespan=_lifespan,
 )

--- a/packages/vscode/src/features/mcp.ts
+++ b/packages/vscode/src/features/mcp.ts
@@ -168,7 +168,7 @@ async function configureMcp(ctx: RepowiseContext): Promise<void> {
 
   const note = repoRoot
     ? ""
-    : " The repo is not indexed yet, so the server points at the workspace folder; run repowise init to index it.";
+    : " The repo is not indexed yet, so the server points at the workspace folder; run `repowise init --yes` to index it (no API key needed).";
   const choice = await vscode.window.showInformationMessage(
     `Repowise MCP server configured in .vscode/mcp.json.${note}`,
     "Open File",

--- a/plugins/claude-code/DEVELOPER.md
+++ b/plugins/claude-code/DEVELOPER.md
@@ -145,7 +145,9 @@ The plugin version tracks the repowise release it ships alongside (e.g. `0.16.0`
    and `get_execution_flows` exist in the server but are **not** exposed — never
    reference them in commands/skills.
 6. **Verify CLI flags against the source.** Easy ones to get wrong:
-   `--index-only` (not `--no-llm`), `--concurrency` (not `--concurrent`),
+   `--index-only` (not `--no-llm`); prefer the self-describing
+   `--docs llm|deterministic` spelling when writing agent-facing commands.
+   `--concurrency` (not `--concurrent`),
    `--commit-limit` (not `--git-depth`), `--embedder` (not `--embedding-provider`).
    `dead-code` has no `--group-by` (that's a `get_dead_code` MCP param only).
 7. **`repowise risk` scores a whole change** (commit or `base..head`), not a

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -88,12 +88,13 @@ Registered automatically when the plugin is enabled:
 
 | Mode | What you get | Requirements |
 |------|-------------|-------------|
-| **Index-only** | Graph + Git + Code Health + Dead Code | Nothing (no LLM) |
-| **Full** | Index-only **plus** Docs, semantic search, and Decisions | LLM API key |
-| **Local (Ollama)** | Full mode, fully offline | Ollama running |
+| **Default (keyless)** | Graph + Git + Code Health + Dead Code + a full wiki rendered from structure | Nothing |
+| **Model-written wiki** | Same, with LLM-written pages and decision mining | Provider key |
+| **Local (Ollama)** | Model-written wiki, fully offline | Ollama running |
 
-Index-only builds with zero LLM calls; full mode adds the documentation layer on
-top, which can continue in the background. Run `/repowise:init` and Claude helps
+The keyless default makes zero LLM calls and still produces a complete wiki; a
+provider key changes who writes the pages, not whether you get them, and that
+layer can continue in the background. Run `/repowise:init` and Claude helps
 you choose.
 
 ## Proactive context (hooks)
@@ -119,9 +120,9 @@ MCP server, but the `repowise` binary must be installed and on PATH.
 
 **`pip install` fails on Windows:** try `python -m pip install repowise`.
 
-**Semantic search / `get_answer` returns nothing:** the repo may be in index-only
-mode (no wiki). Re-run `/repowise:init` with an LLM provider, or `/repowise:reindex`
-if pages exist but embeddings are missing.
+**Semantic search / `get_answer` returns nothing:** the wiki may be
+template-rendered (no embeddings). Run `/repowise:reindex`, or `repowise generate`
+to upgrade pages with a model.
 
 **Stale results after code changes:** run `/repowise:update`.
 

--- a/plugins/claude-code/commands/doctor.md
+++ b/plugins/claude-code/commands/doctor.md
@@ -27,6 +27,7 @@ whether the index and stores are consistent with the repo.
 - **repowise not installed / not on PATH** → suggest `pip install repowise` (or
   `python -m pip install repowise` on Windows), then `/repowise:init`.
 - **No API key for the configured provider** → show the exact `export` for the
-  provider in `.repowise/config.yaml`.
+  provider in `.repowise/config.yaml`. This is not fatal for `init`, which falls
+  back to the template wiki. Only an explicitly named `--provider` errors out.
 - **Index drift (HEAD ahead of last sync)** → run `/repowise:update`.
 - **Missing embeddings / store drift** → `/repowise:reindex`.

--- a/plugins/claude-code/commands/init.md
+++ b/plugins/claude-code/commands/init.md
@@ -34,21 +34,27 @@ Then stop — do not continue to Step 3 unless the user asks to re-index.
 
 If `.repowise/` doesn't exist, move to Step 3.
 
-## Step 3: Ask about mode
+## Step 3: Offer the mode, but do not block on it
 
-Ask the user ONE question:
+Repowise needs **no API key at all**. Never make a key a precondition for
+setting it up, and never stop and wait if you cannot get an answer.
 
-"How would you like to set up Repowise?
+Tell the user:
 
-1. **Index-only mode** — no LLM needed. Builds the dependency graph, mines git history, scores code health, and detects dead code. Fast. You get graph intelligence, git ownership, hotspots, the 1–10 code-health score, and dead-code detection — but no generated documentation or semantic search.
-2. **Full mode** — everything in index-only **plus** an LLM-generated wiki, semantic search, and architectural-decision mining. Requires an API key (Anthropic, OpenAI, Google Gemini, or Ollama for local). The graph/git/health layers are ready in minutes; the documentation layer runs after and can continue in the background.
-3. **I'll configure it myself** — just show me the available flags."
+"Repowise indexes your repo and writes a complete wiki with no API key. I'll run
+`repowise init --yes` unless you'd rather pick:
 
-### If Index-only mode:
+1. **Default (no key)** — full index plus a wiki rendered from your code's structure. Free, fast, nothing to configure.
+2. **Model-written wiki** — everything above, but an LLM writes the wiki prose instead of rendering it from structure, which also enables decision mining. Needs a provider key (Anthropic, OpenAI, Gemini, or Ollama locally). You can start keyless and upgrade any page later with `repowise generate`.
+3. **Show me the flags.**"
 
-Skip provider selection. Construct:
+If the user does not answer, or you are running unattended, take option 1.
+
+### If Default (no key):
+
+Skip provider selection entirely. Construct:
 ```
-repowise init --index-only
+repowise init --docs deterministic --yes
 ```
 
 Jump to Step 5.
@@ -66,13 +72,19 @@ repowise init [PATH]
 Core flags:
   --provider NAME        LLM provider: anthropic, openai, gemini, ollama, litellm
   --model NAME           Model identifier override
-  --index-only           Analysis-only mode. No docs generation, no API key needed.
+  --index-only           Build the wiki from structure instead of writing it
+                         with a model. No key, no spend.
+  --docs llm|deterministic
+                         How to produce the wiki. Same choice as --index-only,
+                         named for what it does. --docs llm needs a key.
+                         (--docs llm together with --index-only is an error.)
+  --mode fast            Quick first pass on very large repos: no wiki at all.
 
 Embeddings:
   --embedder NAME        Embedding provider: gemini, openai, mock (default: auto-detect)
 
 Cost control:
-  --concurrency N        Max parallel LLM calls (default: 5)
+  --concurrency N        Max parallel LLM calls (default: 10)
   --test-run             Limit to top 10 files by PageRank for quick validation
 
 Exclusions:
@@ -100,7 +112,13 @@ Dry run:
 
 Then ask if they want you to construct a command or if they'll handle it.
 
-## Step 4: Provider selection (full mode only)
+## Step 4: Provider selection (model-written wiki only)
+
+**Skip this entire step unless the user chose the model-written wiki.** A
+missing key is not a blocker: `init` renders the template wiki and exits 0
+without one. If you cannot find a key, do not stop and do not ask again. Run
+`repowise init --yes` and tell the user their wiki is rendered from structure
+and can be upgraded per-page later with `repowise generate`.
 
 Check which API keys are already set by running:
 ```bash
@@ -141,6 +159,14 @@ Before running the command, ask:
 Add any exclusions as `-x` flags.
 
 ## Step 6: Run it
+
+For an unattended or non-interactive run, the canonical command is
+`repowise init --yes`, plus `--docs deterministic` when you want to guarantee no
+spend. `--yes` suppresses every prompt including the cost gate. You do not need
+to guard against prompts beyond that: init treats an unanswerable question as a
+signal to continue with defaults rather than a reason to fail, and the cost gate
+declines by itself when stdin is not a terminal, keeping the finished index and
+landing on the template wiki.
 
 Show the user the exact command you're about to run. Ask for confirmation.
 

--- a/plugins/claude-code/commands/search.md
+++ b/plugins/claude-code/commands/search.md
@@ -31,6 +31,16 @@ Other flags:
 
 Show results as a clean list with the page title, type, and a brief snippet.
 
-## Analysis-only mode
+## When search comes up empty
 
-If the search returns no results and the repo appears to be in analysis-only mode (no wiki pages), tell the user: "Semantic and full-text search require documentation to be generated. Your repo is in analysis-only mode. Run `/repowise:init` again with an LLM provider to enable full documentation and search. Symbol search (`--mode symbol`) may still work."
+Search needs wiki pages, and every indexed repo has them: a keyless run renders
+the whole wiki from structure. So an empty result is usually not a missing wiki.
+
+- **No pages at all** means the index never finished, or the repo was indexed
+  with `--mode fast`, which is the one mode that writes no wiki. Suggest
+  `repowise init --yes` (no API key needed), or `repowise init --resume` if a
+  previous run was interrupted.
+- **Pages exist but semantic search finds nothing** means the wiki was embedded
+  with the mock embedder, which keeps full-text search working and leaves
+  semantic search to be built later. Suggest `repowise reindex` with an embedder
+  configured. Full-text and symbol search (`--mode symbol`) work regardless.

--- a/plugins/claude-code/commands/status.md
+++ b/plugins/claude-code/commands/status.md
@@ -19,6 +19,6 @@ Check if Repowise is set up for this project and report its health.
 
 4. Present the results to the user in a readable summary.
 
-5. If total pages is 0 and no provider is shown, this was likely an index-only run. Tell the user: "Your repo is in analysis-only mode (graph + git + dead code). Run `/repowise:init` again with an LLM provider to generate full documentation and enable semantic search."
+5. If pages exist but no provider is shown, the wiki is template-rendered. Tell the user: "Your wiki is rendered from structure. Run `repowise generate` to upgrade any subset to model-written prose." If total pages is 0, the run did not finish, so suggest `repowise init --resume`.
 
 6. If the user provides arguments like "$ARGUMENTS", check if they're asking for a specific path and pass it: `repowise status $ARGUMENTS`

--- a/plugins/claude-code/skills/code-health/SKILL.md
+++ b/plugins/claude-code/skills/code-health/SKILL.md
@@ -58,5 +58,5 @@ not just *bigger*.
 ## Error handling
 
 If `get_health` reports no repository, suggest `/repowise:init`. Code health is
-computed even in index-only mode (no LLM needed), so it should be available
+computed even with a template-rendered wiki (no LLM needed), so it should be available
 whenever the repo is indexed.

--- a/plugins/claude-code/skills/codebase-exploration/SKILL.md
+++ b/plugins/claude-code/skills/codebase-exploration/SKILL.md
@@ -52,8 +52,9 @@ Otherwise the response is current — act on it.
 ## Error handling
 
 - "No repositories found. Run 'repowise init' first." → suggest `/repowise:init`.
-- `get_answer`/`search_codebase` come back empty → the repo may be in index-only
-  mode (no wiki). Fall back to `get_context` with explicit paths, and note that
-  full mode (`/repowise:init` with an LLM provider) unlocks docs + semantic search.
+- `get_answer`/`search_codebase` come back empty → the repo may have a
+  template-rendered wiki. Fall back to `get_context` with explicit paths, and note
+  that model-written pages (`repowise generate`, or `/repowise:init` with an LLM
+  provider) unlock richer docs + semantic search.
 - Tools fail to connect at all → the `repowise` binary may not be installed;
   suggest `/repowise:init`.

--- a/plugins/claude-code/skills/dead-code-cleanup/SKILL.md
+++ b/plugins/claude-code/skills/dead-code-cleanup/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: false
 
 # Dead Code Cleanup with Repowise
 
-Repowise detects dead code through graph analysis — no LLM needed, works even in index-only mode.
+Repowise detects dead code through graph analysis — no LLM needed, works even with a template-rendered wiki.
 
 ## When the user asks about dead/unused code
 

--- a/plugins/codex/skills/change-review/SKILL.md
+++ b/plugins/codex/skills/change-review/SKILL.md
@@ -34,4 +34,4 @@ Lead with a risk level and the `directive` findings, each tied to a concrete fil
 
 ## Error Handling
 
-If `get_risk` or `get_change_risk` errors or returns nothing, the MCP server may be down or the repo unindexed. Say so, review from the raw diff, and suggest running `repowise init` if the repo is not indexed.
+If `get_risk` or `get_change_risk` errors or returns nothing, the MCP server may be down or the repo unindexed. Say so, review from the raw diff, and suggest running `repowise init --yes` if the repo is not indexed.

--- a/plugins/codex/skills/code-health/SKILL.md
+++ b/plugins/codex/skills/code-health/SKILL.md
@@ -52,6 +52,6 @@ not just *bigger*.
 
 ## Error handling
 
-If `get_health` reports no repository, suggest `repowise init`. Code health is
-computed even in index-only mode (no LLM needed), so it should be available
+If `get_health` reports no repository, suggest `repowise init --yes`. Code health is
+computed even with a template-rendered wiki (no LLM needed), so it should be available
 whenever the repo is indexed.

--- a/plugins/codex/skills/codebase-exploration/SKILL.md
+++ b/plugins/codex/skills/codebase-exploration/SKILL.md
@@ -23,6 +23,6 @@ Call `get_context(targets=["path/or/symbol"], include=["callers", "callees"])` w
 
 ## Error Handling
 
-- If tools report that no repositories were found, suggest running `repowise init`.
-- If `search_codebase` has no useful results, the repository may be index-only; fall back to `get_context` with specific paths.
+- If tools report that no repositories were found, suggest running `repowise init --yes`.
+- If `search_codebase` has no useful results, the repository may have a template-rendered wiki; fall back to `get_context` with specific paths.
 - If MCP tools are unavailable, proceed with normal source inspection and mention that Repowise context was unavailable.

--- a/tests/unit/cli/test_init_noninteractive.py
+++ b/tests/unit/cli/test_init_noninteractive.py
@@ -12,9 +12,12 @@ import sys
 from types import SimpleNamespace
 
 import click
+import pytest
+from click.testing import CliRunner
 
 from repowise.cli import cost_gate
 from repowise.cli.commands.init_cmd._interactive import offer_hook_install
+from repowise.cli.main import cli
 
 
 def _est(usd: float) -> SimpleNamespace:
@@ -93,3 +96,42 @@ class TestHookOfferDegrades:
         offer_hook_install(
             SimpleNamespace(print=lambda *_a, **_k: None), [tmp_path], None, yes=False
         )
+
+
+class TestDocsFlag:
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        return CliRunner()
+
+    def test_docs_llm_conflicts_with_index_only(self, runner, tmp_path):
+        """Contradictory flags are a usage error, not a silent winner.
+
+        Exit 2 also keeps this out of the telemetry error bucket, which #907
+        split usage errors away from.
+        """
+        result = runner.invoke(cli, ["init", str(tmp_path), "--docs", "llm", "--index-only"])
+        assert result.exit_code == 2
+        assert "contradicts" in result.output
+
+    def test_docs_deterministic_needs_no_key(self, runner, tmp_path, monkeypatch):
+        """`--docs deterministic` is the scriptable spelling of --index-only."""
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "KIMI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "OLLAMA_BASE_URL",
+            "LITELLM_API_KEY",
+            "REPOWISE_PROVIDER",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        result = runner.invoke(cli, ["init", str(tmp_path), "--docs", "deterministic", "--yes"])
+        assert result.exit_code == 0, result.output
+
+    def test_docs_choice_is_constrained(self, runner, tmp_path):
+        """An unknown value is rejected by Click rather than reaching the pipeline."""
+        result = runner.invoke(cli, ["init", str(tmp_path), "--docs", "magic"])
+        assert result.exit_code == 2

--- a/website/cli-reference.md
+++ b/website/cli-reference.md
@@ -47,7 +47,8 @@ repowise init [PATH] [OPTIONS]
 | `--provider` | string | auto | LLM provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `kimi`, `ollama`, `litellm`, `codex_cli`, `opencode`, `mock` |
 | `--model` | string | — | Model override (e.g., `claude-sonnet-4-6`, `gpt-4.1`) |
 | `--embedder` | choice | auto | Embedding provider: `gemini`, `openai`, `mock` |
-| `--index-only` | flag | false | Skip LLM generation — parse, graph, git, dead code only |
+| `--index-only` | flag | false | Render the wiki from structure instead of writing it with a model. No key, no spend. |
+| `--docs` | choice | — | How to produce the wiki: `llm` or `deterministic`. Same choice as `--index-only`, named for what it does. `--docs llm` needs a key. |
 | `--dry-run` | flag | false | Show generation plan and token estimate without running |
 | `--test-run` | flag | false | Limit to top 10 files by PageRank (for validation) |
 | `--skip-tests` | flag | false | Exclude test files |
@@ -107,7 +108,7 @@ repowise init --resume
 
 1. **Ingestion** — parses all files with tree-sitter, builds dependency graph
 2. **Analysis** — git churn/ownership, dead code detection, decision mining
-3. **Generation** — LLM writes wiki pages at repo/module/file level (skipped with `--index-only`)
+3. **Generation** — LLM writes wiki pages at repo/module/file level, or with `--index-only` / `--docs deterministic` they are rendered from parsed structure
 4. **Persistence** — writes to SQLite, builds vector index, generates managed editor instruction files
 
 ### Provider auto-detection

--- a/website/getting-started.md
+++ b/website/getting-started.md
@@ -38,7 +38,7 @@ cd /path/to/your/repo
 repowise init --index-only -y
 ```
 
-Builds the dependency graph, git history, code-health score, and dead-code findings in seconds. (Want the generated wiki + semantic search? Use `repowise init --provider gemini|anthropic|openai` with the matching key.)
+Builds the dependency graph, git history, code-health score, and dead-code findings in seconds. Also renders every wiki page from structure. Want model-written prose? `repowise init --docs llm --provider gemini|anthropic|openai`.
 
 **3. Connect your agent** — the MCP server is `repowise mcp`, served from the repo dir.
 
@@ -71,7 +71,7 @@ Or: `codex mcp add repowise -- repowise mcp`
 
 **4. First real call.** Ask your agent: *"Use repowise `get_overview` to summarize this repo,"* or *"`get_context` for `src/auth.py`."* You get graph-grounded architecture and per-file triage instead of a flurry of greps. ✅
 
-> `get_overview` / `get_context` work in **index-only mode** (no key) — they synthesize from the graph/git/health layers. `search_codebase` / `get_answer` / `get_why` need full mode (the generated wiki).
+> `get_overview` and `get_context` work in index-only mode with no key, synthesized from the graph, git and health layers. `search_codebase` and `get_answer` read the wiki, which index-only mode does build, but they answer from pages rendered from structure rather than model-written prose, and `search_codebase` is full-text only until you configure an embedder.
 
 Ready for the full picture? Run `repowise init --provider …` for the generated wiki + semantic search, or skip key management entirely with the [hosted tier](https://www.repowise.dev). The detailed setup paths below walk through each editor and mode.
 
@@ -273,22 +273,22 @@ Then add the MCP server to your editor's configuration. See [MCP Server →](mcp
 
 ---
 
-## Analysis-only mode (no API key needed)
+## The keyless path (the default)
 
-If you don't have an LLM API key — or just want the git intelligence and dead code detection without generated docs — use `--index-only`:
+You don't need an LLM API key at all. A bare `repowise init` with no key configured succeeds and produces a wiki, rendered from the parsed structure of your code:
 
 ```bash
-repowise init --index-only
+repowise init
 ```
 
-This runs the full ingestion and analysis pipeline (parsing, graph, git, dead code) but skips LLM generation. It's free, takes under a minute for most repos, and still gives you:
+`repowise init --docs deterministic` is the explicit spelling of the same thing, and guarantees no spend. Either way you get the full ingestion and analysis pipeline (parsing, graph, git, dead code) plus a complete wiki. It's free, takes under a minute for most repos, and still gives you:
 
 - Dependency graph
 - Hotspot detection
 - Dead code findings
 - Ownership data
 
-You can always run `repowise init` later to add docs on top of an existing index.
+You can always run `repowise init --docs llm` (or `repowise generate`) later to upgrade the pages to model-written prose on top of an existing index.
 
 ---
 


### PR DESCRIPTION
Stacked on #1002, which is stacked on #1001. Review those first; this PR's diff is against #1002's branch.

`--index-only` has rendered a complete wiki since #975, but it is named for what it skips rather than what it makes, and its help and banner still said "skip LLM page generation". `--docs llm|deterministic` is the same switch named for its output, which is the spelling worth putting in a script or an agent's instructions. Both remain, since `--index-only` is in every existing doc, and `--docs llm` together with `--index-only` is a usage error rather than a silent winner.

The rest is the same correction applied to everything an agent reads. This matters more than it looks: the `/repowise:init` skill opened by asking the user to choose a mode, called the model-written wiki "Requires an API key", and offered index-only as the keyless consolation with "no generated documentation or semantic search". An agent following that would stop and ask for a key that is not needed, which makes the behaviour change in #1001 invisible no matter how well it works. That skill now states there is no key requirement, names `repowise init --yes` as the command it runs, and treats provider selection as a step to skip rather than a gate to clear. Its flag list was independently wrong: no `--docs`, and a `--concurrency` default of 5 against an actual 10.

The two runtime strings an agent actually hits carry it too: the MCP failure shield's remedy for an unindexed repo, and the FastMCP server instructions, neither of which hinted that init works without a key. Same for the VS Code not-indexed notice and `generate`'s hint.

`/repowise:search` was the worst of them, telling users that empty results meant analysis-only mode and to re-run init with an LLM provider. Both halves are false: every indexed repo has a wiki, and an empty semantic search means a mock embedder, which `reindex` fixes. `docs/start/DASHBOARD.md` likewise listed Docs under "needs a generated wiki" and claimed the counters read 0.

Also updates the plugin README and troubleshooting, status and doctor guidance, six skills, and both CLI references, which gain `--docs` and the cost-gate behaviour.

## Verification

- 893 passed, 1 skipped across `tests/unit/cli`.
- Three new tests: the `--docs llm --index-only` conflict exits 2, `--docs deterministic` succeeds with no key, and an unknown value is rejected by Click.
- Swept the tree afterwards for the old claims ("no docs generation", "requires an API key", "analysis-only mode", "skip LLM generation") and for contradictions left beside edited tables.