### PR TITLE
fix(server): self-heal indexed commit in overview-summary

### DIFF
--- a/packages/server/src/repowise/server/routers/overview.py
+++ b/packages/server/src/repowise/server/routers/overview.py
@@ -404,13 +404,22 @@ async def overview_summary(
     savings = await _savings_headline(repo.local_path)
     repowise_dir = Path(repo.local_path) / ".repowise" if repo.local_path else Path(".repowise")
 
+    # Serve the same read-time self-healed "indexed commit" as /api/repos and
+    # /health/overview: prefer state.json's last_sync_commit over a possibly
+    # stale DB row so the dashboard's indexed-commit display (and any freshness
+    # signal derived from it) doesn't read "behind" after a no-op update left
+    # the repositories row un-restamped.
+    from repowise.server.mcp_server._meta import resolve_indexed_commit
+
+    indexed_commit = resolve_indexed_commit(repo.head_commit, repo.local_path)
+
     return {
         "repo": {
             "id": repo.id,
             "name": repo.name,
             "local_path": repo.local_path,
             "default_branch": repo.default_branch,
-            "head_commit": repo.head_commit,
+            "head_commit": indexed_commit,
             "updated_at": repo.updated_at.isoformat() if repo.updated_at else None,
         },
         "stats": {

--- a/tests/unit/server/test_overview_sync.py
+++ b/tests/unit/server/test_overview_sync.py
@@ -81,6 +81,55 @@ async def test_completed_sync_job_wins_over_fallback(client: AsyncClient, app) -
 
 
 @pytest.mark.asyncio
+async def test_head_commit_heals_from_state_json(client: AsyncClient, app, tmp_path) -> None:
+    """overview-summary serves state.json's last_sync_commit over a stale DB
+    head_commit, matching /api/repos and /health/overview so the dashboard's
+    indexed-commit display never reads "behind" after a no-op update left the
+    repositories row un-restamped.
+    """
+    from repowise.core.persistence.models import Repository
+
+    stale = "a" * 40
+    current = "c" * 40
+
+    repo = await create_test_repo(client, tmp_path)
+    repowise = Path(repo["local_path"]) / ".repowise"
+    repowise.mkdir(exist_ok=True)
+    (repowise / "state.json").write_text(f'{{"last_sync_commit": "{current}"}}', encoding="utf-8")
+
+    # DB row left at an older commit (the un-restamped case the heal repairs).
+    async with get_session(app.state.session_factory) as session:
+        row = (
+            await session.execute(select(Repository).where(Repository.id == repo["id"]))
+        ).scalar_one()
+        row.head_commit = stale
+
+    resp = await client.get(f"/api/repos/{repo['id']}/overview-summary")
+    assert resp.status_code == 200
+    assert resp.json()["repo"]["head_commit"] == current
+
+
+@pytest.mark.asyncio
+async def test_head_commit_falls_back_to_db_without_state_json(
+    client: AsyncClient, app, tmp_path
+) -> None:
+    """No state.json (e.g. a hosted index): fall back to the DB head_commit."""
+    from repowise.core.persistence.models import Repository
+
+    db_commit = "d" * 40
+    repo = await create_test_repo(client, tmp_path)
+    async with get_session(app.state.session_factory) as session:
+        row = (
+            await session.execute(select(Repository).where(Repository.id == repo["id"]))
+        ).scalar_one()
+        row.head_commit = db_commit
+
+    resp = await client.get(f"/api/repos/{repo['id']}/overview-summary")
+    assert resp.status_code == 200
+    assert resp.json()["repo"]["head_commit"] == db_commit
+
+
+@pytest.mark.asyncio
 async def test_sync_includes_index_storage_bytes(client: AsyncClient, tmp_path) -> None:
     """overview-summary reports total .repowise on-disk footprint."""
     repo = await create_test_repo(client, tmp_path)


### PR DESCRIPTION
## Problem

`/api/repos/{id}/overview-summary` returned the raw `repositories.head_commit`, while `/api/repos` (`repos.py`) and `/health/overview` (`overview_routes.py`) both wrap it in `resolve_indexed_commit`, which prefers `state.json`'s `last_sync_commit` over a possibly-stale DB row (a read-time self-heal).

Result: after a `repowise update` that advanced `state.json` but left the `repositories` row un-restamped, the web dashboard's indexed-commit display (fed by `overview-summary`) showed an older commit than the other surfaces, reading "behind" while the index was actually current. This was the one remaining raw read of the three endpoints that serve "the indexed commit".

## Change

Wrap `head_commit` in `resolve_indexed_commit(repo.head_commit, repo.local_path)` in `overview_summary()`, matching the other two endpoints, so all three serve one consistent value. Falls back to the DB value when there is no `state.json` (hosted indexes).

## Tests

`tests/unit/server/test_overview_sync.py`: a stale DB `head_commit` with a current `state.json` now returns the healed (state.json) commit; with no `state.json` it falls back to the DB value.