### PR TITLE
feat(ollama): support disabling reasoning

### DIFF
--- a/packages/core/src/repowise/core/providers/llm/ollama.py
+++ b/packages/core/src/repowise/core/providers/llm/ollama.py
@@ -53,6 +53,7 @@ from repowise.core.reasoning import ReasoningMode
 log = structlog.get_logger(__name__)
 
 _DEFAULT_BASE_URL = "http://localhost:11434"
+_OLLAMA_REASONING_MODES: tuple[ReasoningMode, ...] = ("off",)
 
 
 def _normalize_base_url(url: str) -> str:
@@ -63,11 +64,22 @@ def _normalize_base_url(url: str) -> str:
     return url
 
 
+def _ollama_reasoning_kwargs(reasoning: ReasoningMode) -> dict[str, Any]:
+    """Translate a validated repowise reasoning intent to Ollama kwargs."""
+    if reasoning == "off":
+        return {"reasoning_effort": "none"}
+    return {}
+
+
 def _ollama_model_options(
     base_url: str,
     fallback_model: str,
 ) -> tuple[ProviderModelOption, ...]:
-    fallback = fallback_model_option(fallback_model)
+    reasoning_modes = ("auto", *_OLLAMA_REASONING_MODES)
+    fallback = fallback_model_option(
+        fallback_model,
+        reasoning_modes=reasoning_modes,
+    )
     try:
         import httpx
 
@@ -101,7 +113,7 @@ def _ollama_model_options(
             ProviderModelOption(
                 model=model_id,
                 label=model_id,
-                reasoning_modes=("auto",),
+                reasoning_modes=reasoning_modes,
                 recommended=model_id == fallback_model,
                 source="local",
                 notes=notes,
@@ -151,6 +163,9 @@ class OllamaProvider(BaseProvider):
     def model_name(self) -> str:
         return self._model
 
+    def supported_reasoning_modes(self) -> tuple[ReasoningMode, ...]:
+        return ("auto", *_OLLAMA_REASONING_MODES)
+
     def available_model_options(self) -> tuple[ProviderModelOption, ...]:
         return _ollama_model_options(self._base_url, self._model)
 
@@ -164,7 +179,16 @@ class OllamaProvider(BaseProvider):
         reasoning: ReasoningMode = "auto",
         cache_hints: tuple = (),
     ) -> GeneratedResponse:
-        ensure_reasoning_supported("ollama", self._model, reasoning)
+        reasoning_mode = ensure_reasoning_supported(
+            "ollama",
+            self._model,
+            reasoning,
+            _OLLAMA_REASONING_MODES,
+            detail=(
+                "Ollama maps reasoning='off' to reasoning_effort='none' "
+                "through its OpenAI-compatible chat completions API."
+            ),
+        )
         if self._rate_limiter:
             await self._rate_limiter.acquire(estimated_tokens=max_tokens)
 
@@ -182,6 +206,7 @@ class OllamaProvider(BaseProvider):
                 max_tokens=max_tokens,
                 temperature=temperature,
                 request_id=request_id,
+                reasoning=reasoning_mode,
             )
         except RetryError as exc:
             raise ProviderError(
@@ -220,17 +245,20 @@ class OllamaProvider(BaseProvider):
         max_tokens: int,
         temperature: float,
         request_id: str | None,
+        reasoning: ReasoningMode,
     ) -> GeneratedResponse:
         try:
-            response = await self._client.chat.completions.create(
-                model=self._model,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                messages=[
+            request_kwargs: dict[str, Any] = {
+                "model": self._model,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "messages": [
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_prompt},
                 ],
-            )
+            }
+            request_kwargs.update(_ollama_reasoning_kwargs(reasoning))
+            response = await self._client.chat.completions.create(**request_kwargs)
         except _OpenAIRateLimitError as exc:
             raise RateLimitError(
                 "ollama",

--- a/tests/unit/test_providers/test_ollama_provider.py
+++ b/tests/unit/test_providers/test_ollama_provider.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -13,6 +13,12 @@ from openai import APIConnectionError, APIError, APIStatusError, APITimeoutError
 
 from repowise.core.providers.llm.base import ProviderError
 from repowise.core.providers.llm.ollama import OllamaProvider
+
+
+def test_supported_reasoning_modes_are_auto_and_off():
+    provider = OllamaProvider(model="test")
+
+    assert provider.supported_reasoning_modes() == ("auto", "off")
 
 
 def test_available_model_options_reads_local_tags(monkeypatch):
@@ -51,7 +57,52 @@ def test_available_model_options_reads_local_tags(monkeypatch):
     llama = options[0]
     assert llama.source == "local"
     assert llama.notes == "llama, 3B"
-    assert llama.reasoning_modes == ("auto",)
+    assert llama.reasoning_modes == ("auto", "off")
+
+
+def _make_mock_chat_response(text: str = "# Doc\nContent.") -> MagicMock:
+    usage = MagicMock()
+    usage.prompt_tokens = 120
+    usage.completion_tokens = 60
+
+    choice = MagicMock()
+    choice.message.content = text
+
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = usage
+    return response
+
+
+async def test_generate_auto_preserves_existing_request_shape():
+    provider = OllamaProvider(model="test")
+    provider._client.chat.completions.create = AsyncMock(return_value=_make_mock_chat_response())
+
+    await provider.generate("system", "user", reasoning="auto")
+
+    request_kwargs = provider._client.chat.completions.create.await_args.kwargs
+    assert "reasoning_effort" not in request_kwargs
+
+
+async def test_generate_off_disables_reasoning():
+    provider = OllamaProvider(model="test")
+    provider._client.chat.completions.create = AsyncMock(return_value=_make_mock_chat_response())
+
+    await provider.generate("system", "user", reasoning="off")
+
+    request_kwargs = provider._client.chat.completions.create.await_args.kwargs
+    assert request_kwargs["reasoning_effort"] == "none"
+
+
+@pytest.mark.parametrize("reasoning", ["none", "minimal", "low"])
+async def test_generate_rejects_unsupported_reasoning_modes(reasoning):
+    provider = OllamaProvider(model="test")
+    provider._client.chat.completions.create = AsyncMock()
+
+    with pytest.raises(ProviderError, match=f"reasoning='{reasoning}' is not supported"):
+        await provider.generate("system", "user", reasoning=reasoning)
+
+    provider._client.chat.completions.create.assert_not_called()
 
 
 async def _assert_generate_wraps(exc: Exception) -> None:


### PR DESCRIPTION
## Summary

- advertise exactly `auto` and `off` for Ollama models
- preserve the existing field-free request shape for `auto`
- map Repowise `off` to Ollama `reasoning_effort="none"`
- reject other explicit reasoning modes before issuing a completion request

## Prior art

This is the missing Ollama provider integration for the provider-neutral design established by [Feature: expose a reasoning-disable knob for chat completions providers (Qwen3 / DeepSeek-R1 thinking mode)](https://github.com/repowise-dev/repowise/issues/137) and merged in [Add reasoning mode configuration](https://github.com/repowise-dev/repowise/pull/175). It does not change the shared reasoning contract or generation pipeline.

## Validation

- `uv run pytest tests/unit/test_providers/ -q` — 196 passed
- focused Ollama provider tests cover discovery, `auto`, `off`, and pre-request rejection of unsupported modes
- `uv run ruff check` and `uv run ruff format --check` on both changed files
- `uv run mypy packages/core/src/repowise/core/providers/llm/ollama.py`

Live Ollama 0.31.2 check with `nemotron-cascade-2:30b-a3b-q4_K_M`, the existing `operational-reference` style, and `max_tokens=2048`:

- request captured `reasoning_effort="none"`
- 3,933 prompt tokens; 666 completion tokens
- 2,934 content characters / 284 words; zero reasoning characters
- `finish_reason="stop"`; all four required headings present in order
- no repeated nonblank lines or repeated 12-word shingles

The check did not modify AI Foundry's Repowise config or wiki database, and the model loaded for validation was unloaded afterward.
