### PR TITLE
fix(generation): filter file dependency context

### DIFF
--- a/packages/core/src/repowise/core/generation/context/assembler.py
+++ b/packages/core/src/repowise/core/generation/context/assembler.py
@@ -55,6 +55,33 @@ _MAX_IMPORTS = 30
 _MAX_TOP_FILES = 20
 
 
+def _file_dependency_neighbors(graph: Any, path: str, *, incoming: bool) -> list[str]:
+    """Return structural file neighbors in the requested direction.
+
+    The file graph treats every file-to-file edge except ``co_changes`` as a
+    dependency. This keeps import, type-use, framework, and future structural
+    edge types while excluding symbol containment and historical association.
+    """
+    if path not in graph:
+        return []
+
+    edges = graph.in_edges(path, data=True) if incoming else graph.out_edges(path, data=True)
+    neighbors: list[str] = []
+    for source, target, edge_data in edges:
+        neighbor = source if incoming else target
+        neighbor_data = graph.nodes[neighbor]
+        if not _is_foreign_edge(neighbor, path):
+            continue
+        if neighbor_data.get("node_type", "file") != "file":
+            continue
+        if neighbor_data.get("language") == "external":
+            continue
+        if edge_data.get("edge_type", "imports") == "co_changes":
+            continue
+        neighbors.append(neighbor)
+    return neighbors
+
+
 # ---------------------------------------------------------------------------
 # ContextAssembler
 # ---------------------------------------------------------------------------
@@ -149,17 +176,10 @@ class ContextAssembler:
         else:
             import_list = []
 
-        # Graph edges
-        in_edges = list(graph.predecessors(path)) if path in graph else []
-        out_edges = list(graph.successors(path)) if path in graph else []
-        # Filter out external nodes, and edges that point back into this same
-        # file. The graph carries file->symbol edges, so a file's successors
-        # include its own symbols ("thisfile.py::Thing"). Left in, those
-        # dominate the rendered dependency list: measured over the current
-        # index, 70% of all dependency lines were self-references and 121
-        # pages listed nothing else. A file's dependencies are other files.
-        in_edges = [e for e in in_edges if _is_foreign_edge(e, path)]
-        out_edges = [e for e in out_edges if _is_foreign_edge(e, path)]
+        # Structural file dependencies only. The full graph also contains
+        # file→symbol containment and historical co-change edges.
+        in_edges = _file_dependency_neighbors(graph, path, incoming=True)
+        out_edges = _file_dependency_neighbors(graph, path, incoming=False)
 
         # Source snippet — use structural summary for large files
         source_text = source_bytes.decode("utf-8", errors="replace")

--- a/tests/unit/generation/conftest.py
+++ b/tests/unit/generation/conftest.py
@@ -151,11 +151,11 @@ def sample_graph(sample_parsed_file: ParsedFile) -> nx.DiGraph:
     calc = sample_parsed_file.file_info.path
     models = "python_pkg/models.py"
     utils = "python_pkg/utils.py"
-    g.add_node(calc, language="python", symbol_count=3, has_error=False)
-    g.add_node(models, language="python", symbol_count=2, has_error=False)
-    g.add_node(utils, language="python", symbol_count=1, has_error=False)
-    g.add_edge(calc, models, imported_names=["models"])
-    g.add_edge(calc, utils, imported_names=["utils"])
+    g.add_node(calc, node_type="file", language="python", symbol_count=3, has_error=False)
+    g.add_node(models, node_type="file", language="python", symbol_count=2, has_error=False)
+    g.add_node(utils, node_type="file", language="python", symbol_count=1, has_error=False)
+    g.add_edge(calc, models, edge_type="imports", imported_names=["models"])
+    g.add_edge(calc, utils, edge_type="imports", imported_names=["utils"])
     return g
 
 

--- a/tests/unit/generation/test_context_assembler.py
+++ b/tests/unit/generation/test_context_assembler.py
@@ -1,4 +1,4 @@
-"""Tests for generation/context_assembler.py — 22 tests."""
+"""Tests for generation/context_assembler.py."""
 
 from __future__ import annotations
 
@@ -121,6 +121,47 @@ def test_assemble_file_page_dependencies_from_graph(
     )
     assert "python_pkg/models.py" in ctx.dependencies
     assert "python_pkg/utils.py" in ctx.dependencies
+
+
+def test_assemble_file_page_filters_dependency_edges_by_semantics(
+    sample_config, sample_parsed_file, graph_metrics, sample_source_bytes
+):
+    """Only structural file-to-file edges become dependencies or dependents."""
+    path = sample_parsed_file.file_info.path
+    graph = nx.DiGraph()
+    file_nodes = (
+        path,
+        "imported.py",
+        "importer.py",
+        "type_provider.py",
+        "framework_entrypoint.py",
+        "historical_dependency.py",
+        "historical_dependent.py",
+    )
+    graph.add_nodes_from((node, {"node_type": "file"}) for node in file_nodes)
+    graph.add_node(f"{path}::Calculator", node_type="symbol")
+    graph.add_node("external:third-party", node_type="external")
+
+    graph.add_edge(path, "imported.py", edge_type="imports")
+    graph.add_edge("importer.py", path, edge_type="imports")
+    graph.add_edge(path, "type_provider.py", edge_type="type_use")
+    graph.add_edge("framework_entrypoint.py", path, edge_type="framework")
+    graph.add_edge(path, f"{path}::Calculator", edge_type="defines")
+    graph.add_edge(path, "historical_dependency.py", edge_type="co_changes")
+    graph.add_edge("historical_dependent.py", path, edge_type="co_changes")
+    graph.add_edge(path, "external:third-party", edge_type="imports")
+
+    ctx = ContextAssembler(sample_config).assemble_file_page(
+        sample_parsed_file,
+        graph,
+        graph_metrics["pagerank"],
+        graph_metrics["betweenness"],
+        graph_metrics["community"],
+        sample_source_bytes,
+    )
+
+    assert ctx.dependencies == ["imported.py", "type_provider.py"]
+    assert ctx.dependents == ["importer.py", "framework_entrypoint.py"]
 
 
 def test_assemble_file_page_token_budget_respected(
@@ -318,7 +359,9 @@ def test_assemble_module_page_threads_phase2_signals(
         sample_source_bytes,
     )
     decisions = [{"title": "X", "decision": "Y", "rationale": ""}]
-    dead = [{"symbol_name": "foo", "reason": "no callers", "confidence": 0.9, "safe_to_delete": True}]
+    dead = [
+        {"symbol_name": "foo", "reason": "no callers", "confidence": 0.9, "safe_to_delete": True}
+    ]
     externals = [{"name": "fastapi", "category": "framework", "ecosystem": "pypi"}]
     ctx = assembler.assemble_module_page(
         "auth/login",

--- a/tests/unit/generation/test_context_assembler.py
+++ b/tests/unit/generation/test_context_assembler.py
@@ -137,10 +137,12 @@ def test_assemble_file_page_filters_dependency_edges_by_semantics(
         "framework_entrypoint.py",
         "historical_dependency.py",
         "historical_dependent.py",
+        "external_file.py",
     )
     graph.add_nodes_from((node, {"node_type": "file"}) for node in file_nodes)
     graph.add_node(f"{path}::Calculator", node_type="symbol")
     graph.add_node("external:third-party", node_type="external")
+    graph.nodes["external_file.py"]["language"] = "external"
 
     graph.add_edge(path, "imported.py", edge_type="imports")
     graph.add_edge("importer.py", path, edge_type="imports")
@@ -150,6 +152,7 @@ def test_assemble_file_page_filters_dependency_edges_by_semantics(
     graph.add_edge(path, "historical_dependency.py", edge_type="co_changes")
     graph.add_edge("historical_dependent.py", path, edge_type="co_changes")
     graph.add_edge(path, "external:third-party", edge_type="imports")
+    graph.add_edge(path, "external_file.py", edge_type="imports")
 
     ctx = ContextAssembler(sample_config).assemble_file_page(
         sample_parsed_file,

--- a/tests/unit/ingestion/test_subgraph_cache.py
+++ b/tests/unit/ingestion/test_subgraph_cache.py
@@ -36,7 +36,9 @@ def _parsed(tmp_path: Path, rel: str, content: str):
 
 def _builder(tmp_path: Path) -> GraphBuilder:
     gb = GraphBuilder(str(tmp_path))
-    gb.add_file(_parsed(tmp_path, "a.py", "from b import helper\n\ndef run():\n    return helper()\n"))
+    gb.add_file(
+        _parsed(tmp_path, "a.py", "from b import helper\n\ndef run():\n    return helper()\n")
+    )
     gb.add_file(_parsed(tmp_path, "b.py", "def helper():\n    return 1\n"))
     gb.build()
     return gb
@@ -55,12 +57,27 @@ class TestSubgraphCache:
         gb = _builder(tmp_path)
         sub = gb.file_subgraph()
         assert set(sub.nodes) == {
-            n for n, d in gb.graph().nodes(data=True)
+            n
+            for n, d in gb.graph().nodes(data=True)
             if d.get("node_type", "file") in ("file", "external")
         }
-        assert not any(
-            d.get("edge_type") == "co_changes" for _, _, d in sub.edges(data=True)
-        )
+        assert not any(d.get("edge_type") == "co_changes" for _, _, d in sub.edges(data=True))
+
+    def test_file_subgraph_keeps_non_import_structural_edges(self, tmp_path: Path) -> None:
+        gb = _builder(tmp_path)
+        graph = gb.graph()
+        graph.add_node("type_provider.py", node_type="file")
+        graph.add_node("framework_entrypoint.py", node_type="file")
+        graph.add_node("history_only.py", node_type="file")
+        graph.add_edge("a.py", "type_provider.py", edge_type="type_use")
+        graph.add_edge("framework_entrypoint.py", "a.py", edge_type="framework")
+        graph.add_edge("a.py", "history_only.py", edge_type="co_changes")
+
+        sub = gb.file_subgraph()
+
+        assert sub["a.py"]["type_provider.py"]["edge_type"] == "type_use"
+        assert sub["framework_entrypoint.py"]["a.py"]["edge_type"] == "framework"
+        assert not sub.has_edge("a.py", "history_only.py")
 
     def test_invalidated_on_add_file(self, tmp_path: Path) -> None:
         gb = _builder(tmp_path)


### PR DESCRIPTION
## Summary

- Keep the upstream file-page filter for self references, symbol containment, and `external:` nodes.
- Exclude historical `co_changes` file-to-file edges from `dependencies` and `dependents`.
- Preserve `imports`, `type_use`, `framework`, and future structural file-edge types.

## Why this remains after the upstream renderer change

`ContextAssembler.assemble_file_page()` receives the full mixed graph during level-2 generation, not `GraphBuilder.file_subgraph()`. The latter already excludes `co_changes` for metrics, but the context assembler previously traversed the full graph directly. Therefore the metric filter did not prevent historical neighbors from reaching file-page dependency context.

The recently merged single-renderer work already removes a file's own symbol nodes and external nodes. This PR preserves that behavior and adds only the missing `co_changes` edge-type exclusion.

## Real repository validation

Read-only inspection of AI Foundry's `wiki.db` on 2026-07-25 found file-level incident edges for `loralab/backfill/queue_status.py` with all three relevant labels: 13 `imports`, 8 `defines`, and 11 `co_changes`. This confirms the live graph contains genuine `co_changes` attributes at generation time; the new filter removes only the historical association edges.

## Validation

- [x] `uv run pytest tests/unit/generation/test_context_assembler.py tests/unit/ingestion/test_subgraph_cache.py tests/unit/ingestion/test_graph.py -q` — 94 passed
- [x] Ruff lint and format checks on the four changed Python files
- [x] Read-only SQLite graph inspection against AI Foundry

## Checklist

- [x] Tests cover direction and edge labels
- [x] No documentation change is required