### PR TITLE
docs(claude-plugin): sync MCP tool surface and hooks with reality

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://repowise.dev"
   },
   "metadata": {
-    "description": "The codebase intelligence layer for AI coding agents — graph, git, docs, decisions, and a defect-validated code-health score, exposed to Claude through nine task-shaped MCP tools.",
+    "description": "The codebase intelligence layer for AI coding agents — graph, git, docs, decisions, and a defect-validated code-health score, exposed to Claude through ten task-shaped MCP tools.",
     "homepage": "https://repowise.dev"
   },
   "plugins": [

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "repowise",
-  "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through nine task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
+  "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through ten task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
   "version": "0.34.0",
   "author": {
     "name": "Repowise",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Repowise Claude Code plugin are documented here.
 ## 0.34.0
 
 ### Changed
+- Plugin docs: MCP tool surface is the **ten flagship tools** (including
+  `get_change_risk`) plus `list_repos`; hooks docs now match bundled
+  `SessionStart` + full `PostToolUse` matcher.
 - Version bump to track the repowise 0.34.0 release.
 - `pre-modification` skill reads the new `defect_profile` block on `get_risk`
   (fix count, last fix age, `bug_magnet`, `top_symbols`) and leads with it.

--- a/plugins/claude-code/DEVELOPER.md
+++ b/plugins/claude-code/DEVELOPER.md
@@ -23,7 +23,7 @@ repowise/                              # main repo root
 └── plugins/claude-code/               # the plugin
     ├── .claude-plugin/
     │   └── plugin.json                # plugin identity (name, version, author)
-    ├── .mcp.json                      # auto-registers the repowise MCP server (9 tools)
+    ├── .mcp.json                      # auto-registers the repowise MCP server (10 flagship + list_repos)
     ├── hooks/
     │   └── hooks.json                 # PostToolUse → repowise-augment (proactive context)
     ├── commands/                      # user-invoked slash commands (/repowise:<name>)
@@ -56,14 +56,17 @@ and metadata. Do **not** put a `marketplace.json` next to it — the marketplace
 lives at the repo root.
 
 **`.mcp.json`** — When the plugin is enabled, Claude Code auto-starts
-`repowise mcp` as an MCP server, giving Claude the **9 tools** (`get_overview`,
-`get_answer`, `get_context`, `get_symbol`, `search_codebase`, `get_risk`,
-`get_why`, `get_dead_code`, `get_health`). Uses the `mcpServers` wrapper key.
+`repowise mcp` as an MCP server, giving Claude the **ten flagship tools**
+(`get_overview`, `get_answer`, `get_context`, `get_symbol`, `search_codebase`,
+`get_risk`, `get_change_risk`, `get_why`, `get_dead_code`, `get_health`) plus
+`list_repos` by default. Uses the `mcpServers` wrapper key.
 The `repowise` binary must be on PATH (`/repowise:init` installs it).
 
-**`hooks/hooks.json`** — Registers a `PostToolUse` hook
-(`Bash|Grep|Glob|Read|Edit|Write` → `repowise-augment`) so context enrichment works as soon as
-the plugin is installed. This mirrors the hook `repowise init` writes to
+**`hooks/hooks.json`** — Registers `SessionStart`
+(`startup|resume|clear` → `repowise-augment`) and `PostToolUse`
+(`Bash|PowerShell|Grep|Glob|Read|Edit|Write|mcp__.*[Rr]epowise.*__.*` →
+`repowise-augment`) so context enrichment works as soon as the plugin is
+installed. This mirrors the hooks `repowise init` writes to
 `~/.claude/settings.json`; both firing is safe — see "Hook de-duplication".
 
 **`commands/*.md`** — Become `/repowise:<filename>`. Frontmatter sets
@@ -140,18 +143,20 @@ The plugin version tracks the repowise release it ships alongside (e.g. `0.16.0`
 4. **Only `plugin.json` goes in `plugins/claude-code/.claude-plugin/`.** Everything
    else (`commands/`, `skills/`, `hooks/`) sits at the plugin root. The
    **marketplace** manifest lives at the **repo** root, not the plugin's.
-5. **There are 13 exposed MCP tools** (10 single-repo, plus 3 workspace-only:
-   `get_blast_radius`, `get_conformance`, `get_architecture`). `get_dependency_path`
-   and `get_execution_flows` exist in the server but are **not** exposed — never
-   reference them in commands/skills.
+5. **Default single-repo surface is 11 tools** (the ten flagship tools plus
+   `list_repos`). Workspace mode adds `get_architecture` and
+   `get_blast_radius` automatically (13). Opt-in tools such as
+   `get_conformance` stay off unless configured — see
+   `docs/agent/MCP_TOOLS.md`. Never reference unexposed tools in
+   commands/skills.
 6. **Verify CLI flags against the source.** Easy ones to get wrong:
    `--index-only` (not `--no-llm`); prefer the self-describing
    `--docs llm|deterministic` spelling when writing agent-facing commands.
    `--concurrency` (not `--concurrent`),
    `--commit-limit` (not `--git-depth`), `--embedder` (not `--embedding-provider`).
    `dead-code` has no `--group-by` (that's a `get_dead_code` MCP param only).
-7. **`repowise risk` scores a whole change** (commit or `base..head`), not a
-   file, and is **CLI/REST only** — it is *not* an MCP tool. The MCP `get_risk`
-   is per-file blast radius + the PR `directive` block.
+7. **`repowise risk` / MCP `get_change_risk` score a whole change**
+   (commit or `base..head`), not a file. MCP `get_risk` is per-file blast
+   radius + the PR `directive` block.
 8. **Graceful degradation.** Skills/commands must handle repowise-not-installed
    and repo-not-indexed, pointing back to `/repowise:init`.

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -63,14 +63,16 @@ Claude uses these when relevant — no slash command needed:
 
 - **Codebase exploration** — routes questions to `get_overview` / `get_answer` / `search_codebase` / `get_context` / `get_symbol` instead of raw file reads.
 - **Pre-modification check** — calls `get_risk` (and `get_health` for refactors) before editing to assess blast radius.
-- **Change review** — for a PR / branch / working-tree diff, combines `repowise risk` (whole-change score) with `get_risk`'s per-file `directive` block (will-break / missing co-changes / missing tests).
+- **Change review** — for a PR / branch / working-tree diff, combines `get_change_risk` (whole-change score) with `get_risk`'s per-file `directive` block (will-break / missing co-changes / missing tests).
 - **Code health** — answers quality / complexity / "what to refactor" via `get_health`.
 - **Architectural decisions** — queries `get_why` for the *why* before architectural changes.
 - **Dead-code cleanup** — uses `get_dead_code`, conservatively, during cleanup.
 
-### MCP tools (9)
+### MCP tools (10 flagship + `list_repos`)
 
-Registered automatically when the plugin is enabled:
+Registered automatically when the plugin is enabled. The default single-repo
+surface is the ten flagship tools below plus `list_repos` (see
+[MCP_TOOLS.md](../../docs/agent/MCP_TOOLS.md)):
 
 | Tool | What it answers |
 |------|-----------------|
@@ -80,6 +82,7 @@ Registered automatically when the plugin is enabled:
 | `get_symbol` | Raw source of one symbol with exact line bounds |
 | `search_codebase` | Hybrid code search — `mode="auto"` routes identifiers to indexed symbols, paths to files, prose to semantic wiki search |
 | `get_risk` | Per-file hotspot, dependents, co-changes, owners; PR `directive` block with `changed_files` |
+| `get_change_risk` | Whole-change defect-risk score for a commit or `base..head` range |
 | `get_why` | Architectural decisions — search, path-anchored, or health dashboard |
 | `get_dead_code` | Unused/unreachable findings tiered by confidence |
 | `get_health` | 1–10 code-health score and marker findings per file |
@@ -99,11 +102,18 @@ you choose.
 
 ## Proactive context (hooks)
 
-The plugin registers a `PostToolUse` hook that runs `repowise-augment` after
-`Bash` / `Grep` / `Glob`. It stays silent unless it has something asymmetric to
-add — rescuing a zero-result grep with the closest indexed symbol, ranking a
-flood of matches by graph centrality, or flagging a stale index after a commit.
-No LLM, no network. (`repowise init` installs the same hook in
+The plugin registers two hooks that run `repowise-augment`:
+
+- **`SessionStart`** (`startup|resume|clear`) — emits live index-freshness /
+  trust context at session start.
+- **`PostToolUse`** after
+  `Bash|PowerShell|Grep|Glob|Read|Edit|Write|mcp__.*[Rr]epowise.*__.*` —
+  stays silent unless it has something asymmetric to add (rescuing a
+  zero-result grep with the closest indexed symbol, ranking a flood of
+  matches by graph centrality, flagging a stale read, or recording
+  read-after-served MCP traffic).
+
+No LLM, no network. (`repowise init` installs the same hooks in
 `~/.claude/settings.json`; running both is safe — duplicate enrichment is
 de-duplicated.)
 


### PR DESCRIPTION
## Summary
- Update Claude plugin README / DEVELOPER / plugin.json / marketplace copy from stale \"nine tools\" to the ten flagship tools (including \`get_change_risk\`) plus \`list_repos\`.
- Document \`SessionStart\` and the full \`PostToolUse\` matcher to match \`hooks/hooks.json\` and the installer.
- Correct DEVELOPER gotchas so workspace / opt-in tool counts match \`docs/agent/MCP_TOOLS.md\`.

## Test plan
- [x] \`pytest tests/unit/cli/test_claude_plugin.py\` — all 5 pass
- [x] Cross-check tool list against \`docs/agent/MCP_TOOLS.md\`
- [x] Cross-check hooks against \`plugins/claude-code/hooks/hooks.json\`