### PR TITLE
docs(examples): add examples index and discoverability links

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,8 @@ repowise doctor           # check setup, API keys, index drift
 ```
 
 Every command and flag: **[docs/reference/CLI_REFERENCE.md](docs/reference/CLI_REFERENCE.md)** ·
-config: **[docs/reference/CONFIG.md](docs/reference/CONFIG.md)**
+config: **[docs/reference/CONFIG.md](docs/reference/CONFIG.md)** ·
+examples: **[examples/](examples/)**
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,7 @@ your agent in under five minutes, with no API key.
 | [scale/WORKTREES.md](scale/WORKTREES.md) | Linked git worktrees seed their index from the base checkout, with no flags |
 | [scale/AUTO_SYNC.md](scale/AUTO_SYNC.md) | Keep the index fresh automatically on every commit |
 | [../docker/README.md](../docker/README.md) | Running repowise in Docker |
+| [../examples/](../examples/) | Copy-paste walkthroughs (Codex setup and more) |
 
 ## Reference
 

--- a/docs/agent/CODEX.md
+++ b/docs/agent/CODEX.md
@@ -8,6 +8,8 @@ Repowise supports Codex in three separate ways:
 
 These features use project-local files. `repowise init --codex` writes under the repository, not to global `~/.codex/config.toml`.
 
+For a short smoke walkthrough, see [examples/codex/](../../examples/codex/).
+
 ## Prerequisites
 
 Install and authenticate the Codex CLI:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,24 @@
+# Examples
+
+Copy-paste walkthroughs for common Repowise setups. Each example is a
+self-contained README under `examples/<name>/`.
+
+## Available examples
+
+| Example | What it shows |
+|---------|----------------|
+| [codex/](codex/) | Codex CLI setup: `repowise init --codex`, smoke checks, local plugin install |
+
+## Conventions
+
+- One directory per topic: `examples/<name>/README.md`.
+- Prefer real CLI commands that match `docs/reference/CLI_REFERENCE.md`.
+- Link deeper docs instead of duplicating them.
+- Keep smoke checks short and runnable without inventing fake APIs.
+
+## Related docs
+
+- [Quickstart](../docs/start/QUICKSTART.md)
+- [CLI reference](../docs/reference/CLI_REFERENCE.md)
+- [Codex integration](../docs/agent/CODEX.md)
+- [OpenCode integration](../docs/agent/OPENCODE.md)

--- a/examples/codex/README.md
+++ b/examples/codex/README.md
@@ -47,3 +47,5 @@ codex
 ```
 
 Install the Repowise plugin from the local marketplace. The plugin bundles Repowise MCP, hooks, and Codex-neutral skills; it does not add slash commands. Plugin-bundled hooks require `[features] plugin_hooks = true` in current Codex releases.
+
+Full integration notes: [docs/agent/CODEX.md](../../docs/agent/CODEX.md).


### PR DESCRIPTION
## Summary
- Add \`examples/README.md\` indexing the existing Codex walkthrough and documenting conventions.
- Link examples from the root README, docs index, and \`docs/agent/CODEX.md\`.
- Cross-link the Codex example back to the full integration guide.

## Test plan
- [x] Verify linked paths exist (\`examples/codex/\`, \`docs/agent/CODEX.md\`)
- [x] No fabricated examples — only links to content that already exists