### PR TITLE
fix(health): remove no-op --safe-only flag

### DIFF
--- a/docs/architecture/code-health.md
+++ b/docs/architecture/code-health.md
@@ -641,7 +641,6 @@ repowise health --trend                    # last 10 snapshots + active alerts
 repowise coverage add coverage.lcov        # ingest coverage; can repeat
 repowise coverage add coverage.xml --format cobertura
 repowise health --format json | jq ...
-repowise health --safe-only                # confidence ≥ 0.8 only (placeholder)
 ```
 
 `repowise status` queries the same tables for a one-line summary:

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -561,7 +561,6 @@ Compute per-file code-health scores from 25 deterministic markers (McCabe comple
 | `--trend` | Print the last 10 health snapshots + any active alerts (declining / predicted decline) |
 | `--badge` | Print a shields.io-compatible badge URL/JSON for the repo's health score |
 | `--format` | Output: `table` (default), `json`, `md` |
-| `--safe-only` | Documented no-op placeholder for a future confidence filter; has no effect today |
 | `--repo` | In workspace mode, target a specific repo (defaults to primary) |
 | `--no-workspace` | Force single-repo mode |
 | `--verbose`, `-v` | Show debug logs from the analysis pipeline |

--- a/packages/cli/src/repowise/cli/commands/health_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/health_cmd/command.py
@@ -51,12 +51,6 @@ from .trends import _render_trend
     help="Output format.",
 )
 @click.option(
-    "--safe-only",
-    is_flag=True,
-    default=False,
-    help="Phase-3 placeholder — currently a no-op for v1 markers.",
-)
-@click.option(
     "--repo",
     "repo_alias",
     default=None,
@@ -117,7 +111,6 @@ def health_command(
     path: str | None,
     file_filter: str | None,
     fmt: str,
-    safe_only: bool,
     repo_alias: str | None,
     no_workspace: bool,
     refactoring_targets: bool,

--- a/plugins/claude-code/commands/health.md
+++ b/plugins/claude-code/commands/health.md
@@ -28,7 +28,6 @@ Handle `$ARGUMENTS`:
 - "refactoring" / "targets" → `repowise health --refactoring-targets` (ranked by impact/effort)
 - "trend" / "trends" → `repowise health --trend` (last snapshots + declining / predicted-decline alerts)
 - "module <name>" → `repowise health --module <name>`
-- "safe" → `repowise health --safe-only`
 - a coverage file (e.g. `cov.lcov`, `coverage.xml`, `.coverage`) → `repowise coverage add <file>` to ingest it (folds into health markers, and builds the per-test map when the report has contexts), then `repowise health`
 
 Other flags: `--format json` for machine-readable output, `-v, --verbose` for


### PR DESCRIPTION
## Summary
- Remove the unused \`repowise health --safe-only\` Click option (it was a silent no-op).
- Drop the misleading \`\"safe\" → --safe-only\` mapping from the Claude \`health\` command.
- Update \`CLI_REFERENCE.md\` and architecture docs that still implied a confidence filter.

## Test plan
- [x] \`repowise health --help\` no longer lists \`--safe-only\`
- [x] Grep confirms no remaining \`health --safe-only\` guidance in docs/plugins