### PR TITLE
feat(claude-plugin): add coverage and impacted-tests slash commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through ten task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.34.1
+
+### Added
+- `/repowise:coverage` — ingest or inspect coverage reports (`coverage add` /
+  `coverage status`).
+- `/repowise:impacted-tests` — map a commit / range / staged diff to the tests
+  that exercise changed lines.
+
 ## 0.34.0
 
 ### Changed

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -52,6 +52,8 @@ defect-validated score from deterministic markers).
 | `/repowise:search` | Search the codebase wiki (fulltext, semantic, or symbol) |
 | `/repowise:reindex` | Rebuild the vector store (re-embed; no LLM calls) |
 | `/repowise:health` | Code-health KPIs, lowest-scoring files, refactoring targets, trends |
+| `/repowise:coverage` | Ingest or inspect coverage reports (lights up untested hotspots + per-test map) |
+| `/repowise:impacted-tests` | Tests whose coverage intersects a change (commit / range / staged) |
 | `/repowise:risk` | Defect-risk score for a change (commit or `base..head` range) |
 | `/repowise:dead-code` | Unreachable files, unused exports, zombie packages by confidence |
 | `/repowise:decision` | List, inspect, add, or confirm architectural decisions |

--- a/plugins/claude-code/commands/coverage.md
+++ b/plugins/claude-code/commands/coverage.md
@@ -1,0 +1,43 @@
+---
+description: Ingest or inspect test-coverage reports — LCOV, Cobertura/Clover, or coverage.py .coverage (builds the per-test map when contexts are present).
+allowed-tools: Bash, Read
+---
+
+# Repowise Coverage
+
+Ingest coverage so untested-hotspot markers light up in `repowise health` and
+so `repowise impacted-tests` can map a diff to the tests that exercise it.
+No LLM — pure report ingestion into the local index.
+
+## Steps
+
+1. If `.repowise/` doesn't exist: "This repo isn't indexed yet. Run `/repowise:init` first." Stop.
+2. Decide the mode from `$ARGUMENTS` (see below), run the command, and present
+   a short summary (files covered, line/branch %, whether a per-test map was
+   built). Don't dump raw JSON unless asked.
+
+## Modes
+
+Default / "status" — show what is already ingested:
+```
+repowise coverage status
+```
+
+Handle `$ARGUMENTS`:
+- "status" / "show" → `repowise coverage status`
+- A report path (`coverage.lcov`, `lcov.info`, `coverage.xml`, `.coverage`, …)
+  → `repowise coverage add <path>`
+- "add" with no path → `repowise coverage add` (auto-discover common report paths)
+- Multiple paths → `repowise coverage add <a> <b>` (merged; hit wins)
+
+Useful flags on `add`: `--verbose` for ingestion debug logs; `--path <dir>`
+to point at a different repo.
+
+## Notes
+
+- `coverage add` always stores per-file line/branch coverage.
+- The **per-test map** (needed by `/repowise:impacted-tests`) is built only
+  when the report carries per-test contexts — e.g. a coverage.py `.coverage`
+  written with `coverage run --contexts=test`, or a per-test lcov. Reports
+  without contexts ingest aggregates only; say so plainly.
+- After ingesting, suggest `repowise health` so untested-hotspot markers update.

--- a/plugins/claude-code/commands/impacted-tests.md
+++ b/plugins/claude-code/commands/impacted-tests.md
@@ -1,0 +1,46 @@
+---
+description: Print the tests whose coverage intersects a change's changed lines — for a commit, base..head range, or staged diff.
+allowed-tools: Bash, Read
+---
+
+# Repowise Impacted Tests
+
+Map a change to the tests that actually exercise its changed lines, using the
+per-test coverage map from `repowise coverage add`. No LLM, no network —
+an index lookup. Useful as a pre-merge / CI gate ("run these 40, not all 4,000").
+
+## Steps
+
+1. If `.repowise/` doesn't exist: "This repo isn't indexed yet. Run `/repowise:init` first." Stop.
+2. Resolve the target from `$ARGUMENTS`, run `repowise impacted-tests`, and
+   present the test ids. Be honest about gaps (see Notes).
+
+## Choosing the revspec
+
+- No args → `repowise impacted-tests` (staged changes; same as `--staged`)
+- A commit SHA → `repowise impacted-tests <sha>`
+- A range / PR / branch → `repowise impacted-tests <base>..<head>`
+  (e.g. `repowise impacted-tests main..HEAD`)
+- "staged" → `repowise impacted-tests --staged`
+
+Useful flags:
+- `--format list` — test ids one per line (pipe to `xargs pytest`)
+- `--format json` — full report
+- `--path <dir>` — point at a different repo
+
+```
+repowise impacted-tests main..HEAD --format list | xargs pytest
+```
+
+## Notes
+
+- Requires a per-test map from `repowise coverage add` on a report with
+  contexts. If none is ingested, the command prompts to run
+  `/repowise:coverage` / `repowise coverage add` — it does **not** invent an
+  empty "no tests needed" result.
+- A changed file with no coverage rows may get a filename-pattern **guess**
+  labelled as a guess — never present guesses as coverage-backed.
+- A brand-new file with neither coverage nor a paired test is "unknown, run
+  the full suite".
+- For a whole-change defect-risk score, use `/repowise:risk`. For per-file
+  blast radius / `tests_to_run`, use the `get_risk` MCP tool.

--- a/tests/unit/cli/test_claude_plugin.py
+++ b/tests/unit/cli/test_claude_plugin.py
@@ -94,10 +94,12 @@ def test_claude_plugin_commands_have_frontmatter() -> None:
     command_paths = sorted((PLUGIN_ROOT / "commands").glob("*.md"))
 
     assert {path.stem for path in command_paths} == {
+        "coverage",
         "dead-code",
         "decision",
         "doctor",
         "health",
+        "impacted-tests",
         "init",
         "reindex",
         "risk",


### PR DESCRIPTION
## Summary
- Add \`/repowise:coverage\` and \`/repowise:impacted-tests\` Claude Code commands mirroring the real CLI.
- Update plugin README, CHANGELOG, marketplace + plugin version to \`0.34.1\`.
- Extend structural command tests to expect the new files.

## Test plan
- [x] \`pytest tests/unit/cli/test_claude_plugin.py\` passes
- [x] Command flags/modes cross-checked against \`repowise coverage\` / \`impacted-tests --help\`