### PR TITLE
fix(dead-code): align CLI/REST min_confidence default with MCP

### DIFF
--- a/docs/architecture/deep-dives.md
+++ b/docs/architecture/deep-dives.md
@@ -254,7 +254,7 @@ DeadCodeAnalyzer.analyze()
     ├── _detect_unused_exports()       → findings with confidence + safe_to_delete
     ├── _detect_zombie_packages()      → findings at 0.5 confidence, never safe
     │
-    ▼ apply min_confidence filter (default 0.4)
+    ▼ apply min_confidence filter (default 0.5)
     │
     ▼ persist to dead_code_findings table
     │

--- a/docs/layers/DEAD_CODE.md
+++ b/docs/layers/DEAD_CODE.md
@@ -101,11 +101,12 @@ compare numbers:
 
 | Surface | High | Medium | Low | Default floor |
 |---------|------|--------|-----|---------------|
-| CLI (`repowise dead-code`) | `>= 0.7` | `0.4` to `0.7` | `< 0.4` | `--min-confidence 0.4` |
+| CLI (`repowise dead-code`) | `>= 0.7` | `0.5` to `0.7` | `< 0.5` | `--min-confidence 0.5` |
 | MCP (`get_dead_code`) | `>= 0.8` | `0.5` to `0.8` | `< 0.5` | `min_confidence=0.5` |
 
-The MCP surface is deliberately stricter: an agent acting on a finding is riskier
-than a human reading a table.
+Both surfaces now share the same default floor (`0.5`). The MCP high/medium
+cutovers stay stricter: an agent acting on a finding is riskier than a human
+reading a table.
 
 ## What is exempt by construction
 
@@ -220,7 +221,7 @@ before deleting anything.
 
 | Flag | Description |
 |------|-------------|
-| `--min-confidence` | Minimum confidence threshold (default `0.4`) |
+| `--min-confidence` | Minimum confidence threshold (default `0.5`) |
 | `--safe-only` | Only findings marked safe to delete |
 | `--kind` | `unreachable_file`, `unused_export`, `unused_internal`, `zombie_package` |
 | `--format` | `table` (default), `json`, `md` |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -451,7 +451,7 @@ Detect dead and unused code.
 
 | Flag | Description |
 |------|-------------|
-| `--min-confidence` | Minimum confidence threshold (default: 0.4) |
+| `--min-confidence` | Minimum confidence threshold (default: 0.5) |
 | `--safe-only` | Only show findings marked safe to delete |
 | `--kind` | Filter: `unreachable_file`, `unused_export`, `unused_internal`, `zombie_package` |
 | `--format` | Output: `table` (default), `json`, `md` |

--- a/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
@@ -18,7 +18,7 @@ from repowise.cli.helpers import (
 
 @click.command("dead-code")
 @click.argument("path", required=False, type=click.Path(exists=True))
-@click.option("--min-confidence", default=0.4, type=float, help="Minimum confidence threshold.")
+@click.option("--min-confidence", default=0.5, type=float, help="Minimum confidence threshold.")
 @click.option(
     "--safe-only",
     is_flag=True,

--- a/packages/server/src/repowise/server/routers/dead_code.py
+++ b/packages/server/src/repowise/server/routers/dead_code.py
@@ -27,7 +27,7 @@ router = APIRouter(
 async def list_dead_code(
     repo_id: str,
     kind: str | None = Query(None, description="Filter by finding kind"),
-    min_confidence: float = Query(0.4, ge=0.0, le=1.0),
+    min_confidence: float = Query(0.5, ge=0.0, le=1.0),
     status: str = Query("open"),
     safe_only: bool = Query(False),
     limit: int = Query(100, ge=1, le=500),

--- a/plugins/claude-code/commands/dead-code.md
+++ b/plugins/claude-code/commands/dead-code.md
@@ -23,7 +23,7 @@ should be proposed for removal.
 - "files" → `--kind unreachable_file`
 - "exports" → `--kind unused_export`
 - "packages" / "zombie" → `--kind zombie_package`
-- "strict" → `--min-confidence 0.7` (default is 0.4)
+- "strict" → `--min-confidence 0.7` (default is 0.5)
 
 Other flags: `--format json`, `--include-internals` (aggressive, private-symbol
 scan; higher false-positive rate), `--include-zombie-packages` /


### PR DESCRIPTION
## Summary
- Change CLI and REST \`min_confidence\` defaults from \`0.4\` to \`0.5\` to match MCP \`get_dead_code\`.
- Update CLI reference, DEAD_CODE / deep-dive docs, and the Claude \`dead-code\` command text.

## Test plan
- [x] \`repowise dead-code --help\` / Click default is \`0.5\`
- [x] REST \`Query(0.5)\` verified
- [x] Docs no longer claim a CLI-only \`0.4\` floor