### PR TITLE
docs: align wiki generation docs with the single-renderer model

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,14 +359,14 @@ or the whole thing at a time, each behind a cost estimate:
 
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."   # or OPENAI_API_KEY / GEMINI_API_KEY
-repowise generate                       # interactive chooser: pick a coverage, see the cost
-repowise generate --coverage 20         # or write the most important 20%, leave the rest as templates
+repowise generate                       # write the unwritten subsystem pages, behind one cost estimate
 repowise generate --path src/api        # or just one area first
+repowise generate --all                 # or rewrite the prose on every subsystem page
 ```
 
-Bare `repowise generate` opens a chooser (wiki state, a coverage menu with cost
-per tier, then the confirm), so a big repo is never one keystroke from writing
-every page.
+Bare `repowise generate` prints the wiki's state and writes the unwritten
+subsystem (concept) pages behind a single cost estimate. Every other page was
+already rendered from structure at index time.
 
 Or write the whole wiki as part of the first index with `repowise init --provider
 gemini|anthropic|openai`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+- **One wiki, one renderer per page type.** The old template-vs-model split is gone. Every page except the subsystem layer is rendered from structure, always, with no key and no spend: file, symbol, API, infra, cycle and layer pages. Above them sits a derived, numbered concept tree (the `module_page` type) that is the one model-written layer: model prose when a provider is configured, structural stubs otherwise. `repowise generate` fills or refills that subsystem prose. (#1023, #1024, #1025, #1032)
+- **`--prose` / `--no-prose` is the single wiki-spend switch.** `--prose` writes the subsystem pages as model prose (needs a key); `--no-prose` renders the whole wiki from structure with no model and no cost. `--index-only` and `--docs llm|deterministic` remain as deprecated hidden aliases. The interactive coverage chooser and the `--coverage` / `--top` ranked-generation flags are removed; `init` and `generate` now ask a single cost question. (#1032, #1036)
+- **Hierarchy lives in the data model.** `wiki_pages` carries `parent_page_id`, `display_order`, `section_number` and a stable `structural_key`, so MCP (`get_overview`), the web docs tree and the breadcrumbs all read one stored tree instead of each deriving their own. (#1014, #1022)
+
+### Removed
+- **The template-vs-AI provenance axis.** `is_deterministic` and `doc_tier` are gone from the API responses and every TypeScript type; the Auto / AI / Mixed page badges, the "Auto-documented" partition, and the per-page "Write with AI" affordance are retired. The pages router's `?deterministic=` filter becomes `?has_prose=`, scoped to the model-written page types. (#1037)
+
+---
+
 ## [0.34.0] — 2026-07-20
 
 ### Added

--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -262,7 +262,7 @@ the **wiki**, instead of forcing a fallback to Grep for identifiers.
 | `mode` | string | No | `auto` (default) \| `concept` \| `symbol` \| `path` \| `hybrid` |
 | `kind` | string | No | `implementation` \| `test` \| `config` \| `doc` |
 | `symbol_kind` | string | No | Restrict symbol hits by kind (`function`, `class`, `method`, ...) |
-| `page_type` | string | No | `file_page` \| `module_page` \| `symbol_spotlight` (concept mode) |
+| `page_type` | string | No | Restrict to one page type. The two you will reach for are `file_page` (the always-on per-file docs) and `module_page` (the subsystem/concept pages). Other stored types (`repo_overview`, `layer_page`, `scc_page`, `api_contract`, `infra_page`, `symbol_spotlight`) also filter. |
 | `repo` | string | No | *(workspace only)* Target repo alias, or `"all"` to search across workspace |
 
 **Modes:**

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -4,7 +4,7 @@ Complete reference for all `repowise` commands. For a guided introduction, see t
 
 Command list (in registration order): `augment`, `init`, `delete`, `generate-claude-md`, `costs`, `update`, `generate`, `dead-code`, `health`, `risk`, `decision`, `coverage`, `impacted-tests`, `search`, `distill`, `expand`, `saved`, `security`, `corrections`, `export`, `hook`, `status`, `doctor`, `watch`, `serve`, `mcp`, `reindex`, `restyle`, `wiki-styles`, `whats-new`, `telemetry`, `login`, `logout`, `whoami`, `workspace`. Two more ship as separate console scripts, not subcommands: `repowise-augment`, `repowise-rewrite` (both hook entry points, not meant to be run by hand).
 
-**Do you need an LLM key?** Most commands are pure index/analysis and never call an LLM. `init` never requires a key: without one it renders the wiki from structure. It calls an LLM only when a provider is resolvable or `--docs llm` is passed. The exceptions: `update` (unless `--index-only` or `--no-docs`), `generate`, `restyle`, `watch` (when it regenerates a page), `health --generate-code`, and `workspace add --docs`. Everything else, `search`, `dead-code`, `health`, `risk`, `impacted-tests`, `decision`, `coverage`, `security`, `export`, `mcp`, `reindex`, `doctor`, and so on, works index-only, with no provider configured.
+**Do you need an LLM key?** Most commands are pure index/analysis and never call an LLM. `init` never requires a key: without one it renders the wiki from structure. It calls an LLM only when a provider is resolvable or `--prose` is passed. The exceptions: `update` (unless `--index-only` or `--no-docs`), `generate`, `restyle`, `watch` (when it regenerates a page), `health --generate-code`, and `workspace add --docs`. Everything else, `search`, `dead-code`, `health`, `risk`, `impacted-tests`, `decision`, `coverage`, `security`, `export`, `mcp`, `reindex`, `doctor`, and so on, works index-only, with no provider configured.
 
 ## Workspace auto-detect (cross-cutting)
 
@@ -50,7 +50,7 @@ repowise init .
 
 In workspace mode, adds: repo scanning, per-repo indexing, cross-repo analysis (co-changes, contracts, package deps), workspace CLAUDE.md generation.
 
-**Interactive modes.** Running a bare `repowise init` on a TTY (no `--provider`, `--index-only`, `--docs`, or `--yes`) opens a menu:
+**Interactive modes.** Running a bare `repowise init` on a TTY (no `--provider`, `--prose`/`--no-prose`, or `--yes`) opens a menu:
 
 1. **Everything**, index + model-written docs. After picking a provider you can answer **"Customize?"** to tune any setting before the run.
 2. **Index only**, the same layers plus a wiki rendered from structure; no LLM, no key, no cost. Answer **"Customize indexing?"** to set exclude patterns, commit limit, skip-tests/infra, submodules, and fast mode.
@@ -58,7 +58,7 @@ In workspace mode, adds: repo scanning, per-repo indexing, cross-repo analysis (
 
 All three reach the indexing knobs; the LLM-only knobs appear only when model-written docs are enabled. Passing any of the flags below (or `--yes`) skips the menu and runs non-interactively. If the first prompt reads EOF (common when an agent pipes stdin), init prints a notice and continues with defaults instead of aborting.
 
-**Cost gate.** Before any tokens are spent, init shows the estimate and asks for confirmation. It never prompts when stdin is not a TTY: it auto-declines, keeps the index it already built, and renders the template wiki instead. The default answer is Yes up to $25 and flips to No above that.
+**Cost gate.** Before any tokens are spent, init shows the estimate and asks for confirmation. It never prompts when stdin is not a TTY: it auto-declines, keeps the index it already built, and renders the structural wiki instead. The default answer is Yes up to $25 and flips to No above that.
 
 **Options:**
 
@@ -67,8 +67,9 @@ All three reach the indexing knobs; the LLM-only knobs appear only when model-wr
 | `--provider` | LLM provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `kimi`, `ollama`, `litellm`, `codex_cli`, `opencode`, `mock` |
 | `--model` | Model name override (e.g., `claude-sonnet-4-6`) |
 | `--embedder` | Embedder for semantic search: `gemini`, `openai`, `openrouter`, `ollama`, `mock` (default: auto-detect) |
-| `--index-only` | No LLM calls, no API key, no spend. Parses, builds the graph, indexes git, and renders the whole wiki from that structure: file, module, layer and cycle (SCC) pages, the architecture diagram, the repo overview, API and infra pages, and the onboarding collection. Symbol spotlight pages are skipped, since the file pages already carry that content. Every page footer says it was derived from structure, and the repo overview covers composition, entry points, clusters and dependencies rather than what the project does end to end. Full-text search works; semantic search needs an embedder. Upgrade to model-written prose later, any subset at a time, with [`repowise generate`](#repowise-generate-path) (or `update --full` for the whole wiki in one shot). |
-| `--docs` | How to produce the wiki: `llm` or `deterministic`. The same choice as `--index-only`, named for what it does. `--docs llm` needs a key; `--docs deterministic` is identical to `--index-only`. Passing `--docs llm --index-only` together is a usage error (exit 2). |
+| `--prose` / `--no-prose` | The single knob over LLM spend. The file, symbol, layer and cycle (SCC), API and infra pages are rendered from structure either way, with no key and no cost. The model-written set is the subsystem (concept) tree plus the repo overview, the architecture diagram, and the onboarding collection: `--prose` writes those as model prose and needs a key; `--no-prose` leaves them as structural stubs, so the whole wiki is keyless and free. Default: prose when a key is available. Full-text search works either way; semantic search needs an embedder. Fill or refill that prose later with [`repowise generate`](#repowise-generate-path). |
+| `--index-only` | Deprecated hidden alias for `--no-prose`. |
+| `--docs` | Deprecated hidden alias: `--docs llm` == `--prose`, `--docs deterministic` == `--no-prose`. Prefer `--prose` / `--no-prose`. |
 | `--mode` | Pipeline depth: `standard` (default) or `fast` (graph + essential-git only, no per-file blame/co-change, no LLM docs, for very large repos; upgrade later with `update --full`) |
 | `--skip-tests` | Exclude test files from doc generation |
 | `--skip-infra` | Exclude infrastructure files (Dockerfiles, Makefiles, Terraform) |
@@ -76,8 +77,7 @@ All three reach the indexing knobs; the LLM-only knobs appear only when model-wr
 | `--include-submodules` | Include git submodule directories (excluded by default) |
 | `--concurrency` | Max concurrent LLM calls (default: 10) |
 | `--reasoning` | Reasoning mode for supported providers: `auto`, `off`/`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max` (default: `auto`) |
-| `--coverage` | Documentation coverage as a fraction of repo files (e.g. `0.10`, `0.20`, `0.50`). Bypasses the interactive coverage chooser. |
-| `--coverage-report` | Test-coverage report to ingest (LCOV / Cobertura / Clover). Repeatable. Auto-discovered when omitted. Distinct from `--coverage`, which controls documentation breadth. |
+| `--coverage-report` | Test-coverage report to ingest (LCOV / Cobertura / Clover). Repeatable. Auto-discovered when omitted. This is test coverage for code-health, not a documentation-breadth knob: every code file is documented either way. |
 | `--onboarding` / `--no-onboarding` | Generate the curated Onboarding collection (up to 8 overview pages). Default: on; slots without enough signal are skipped. |
 | `--harvest-decisions` / `--no-harvest-decisions` | Harvest architectural decisions during page generation (verified against source before storage). Default: on. |
 | `--wiki-style` | Documentation voice/density: `comprehensive` (default), `caveman` (token-condensed, AI-first), `reference` (API-manual), `tutorial` (beginner-friendly). Interactive full runs prompt when omitted. Saved to config so `update` keeps the style. See [WIKI_STYLES.md](../layers/WIKI_STYLES.md). |
@@ -194,57 +194,47 @@ repowise update --full --provider anthropic   # upgrade a fast index to full
 
 ### `repowise generate [PATH]`
 
-Write wiki pages with a model, on demand. This is the upgrade path for an
-`--index-only` repo: it turns the template (structure-rendered) pages into
-model-written prose, one page, one directory, a ranked slice, or the whole wiki
-at a time, each behind a cost estimate. It also fills in the template tail a
-budgeted full `init` leaves behind, and rewrites already-written pages.
+Write the subsystem (concept) pages with a model, on demand. This is the upgrade
+path for a `--no-prose` repo: it fills the subsystem stubs with model prose, one
+page, one directory, or the whole concept layer at a time, each behind a cost
+estimate, and rewrites already-written pages.
 
 Like `update --full` and `restyle`, it reuses the persisted index: the graph and
 git metadata are rehydrated from SQL, only the per-file parse and the LLM
 generation for the pages you selected run. A provider is required; a missing one
 is an actionable error naming the key-setup path.
 
-**Interactive chooser.** Run `repowise generate` with no selection flag on a
-terminal and it opens a chooser instead of writing everything: it prints the
-wiki's state (written / unwritten / stale), then the same coverage menu `init`
-uses (page counts and cost per tier, 20% recommended), asks about cascade only
-when the choice would change which pages get written, and ends at the normal cost
-confirm. A large repo is never one keystroke away from writing every page. Piped,
-`--yes`, or flagged runs stay non-interactive (the old `--unwritten` default).
+`generate` writes the subsystem pages, and only those: the numbered concept tree
+above the file level plus the repo overview. Every structural page (file, symbol,
+API, infra, cycle, layer) is rendered from structure and refreshes on `repowise
+update`, so naming one with `--page` is an actionable error rather than a silent
+LLM re-render.
 
-**Selection.** Two philosophies, and they do not mix. *Explicit* names exactly
-which pages (`--unwritten` / `--all` / `--stale` / `--path` / `--page`, combined
-as a union). *Ranked* writes the most important pages by the same importance
-ranking `init` uses (`--coverage` / `--top`).
+**Interactive chooser.** Run `repowise generate` with no selection flag on a
+terminal and it prints the wiki's state (written / unwritten / stale on the
+concept layer), writes the unwritten subsystem pages, asks about cascade only
+when the choice would change which pages get written, and ends at the normal cost
+confirm. Piped, `--yes`, or flagged runs stay non-interactive with the same
+`--unwritten` default.
+
+**Selection.** These name which subsystem pages to write, combined as a union:
 
 | Flag | Selects |
 |------|---------|
-| `--unwritten` | Every template (unwritten) page. The default for a non-interactive run. This is "finish writing the wiki". |
-| `--all` | Every page, template or already written. A full rewrite. |
-| `--stale` | Every page marked stale (its code changed since it was written). |
-| `--path <glob>` | Every page under a path prefix or glob, e.g. `--path src/api` (repeatable). |
-| `--page <id>` | One explicit page id, e.g. `--page file_page:src/app.py` (repeatable). |
-| `--coverage <pct>` | The most important unwritten pages up to this coverage, ranked the way `init` ranks coverage. `--coverage 20` writes the top 20% and leaves the rest as templates. Accepts a percent from 1 to 100 (`20`), or a fraction below 1 (`0.2`); use `100` for everything. |
-| `--top <n>` | About the `n` most important unwritten pages (a target, not an exact count: per-type floors and the always-included repo-wide/onboarding pages nudge it, and the real number shows before the gate). |
+| `--unwritten` | Every subsystem page still on a stub. The default for a non-interactive run. This is "finish writing the wiki". |
+| `--all` | Every subsystem page, stub or already written. Rewrites the prose. |
+| `--stale` | Every subsystem page marked stale (its code changed since it was written). |
+| `--path <glob>` | Subsystem pages under a path prefix or glob, e.g. `--path src/api` (repeatable). |
+| `--page <id>` | One explicit subsystem page id, e.g. `--page module_page:src/api` (repeatable). Naming a structural page is an error. |
 
-`--coverage` / `--top` rank the file / module / cycle / symbol content pages; the
-repo-wide and structural pages (overview, architecture, layer, onboarding) are
-always included when unwritten, exactly as `init` emits them at every coverage.
-They cannot be combined with an explicit selector or with each other, and they
-default to `--cascade none` (the ranked set is already a coherent slice). On a
-small repo (20 files or fewer) the coverage budget floors to the whole repo, so
-any tier writes essentially every unwritten page, same as `init`; the plan report
-shows the real count before the gate.
-
-**Cascade.** Regenerating a file page makes the pages that summarize it drift:
-its module, cycle (SCC) and layer pages, and the repo overview, architecture and
-onboarding pages. `--cascade` decides what happens to them:
+**Cascade.** Rewriting a subsystem page makes the pages that summarize it drift:
+its layer page, the repo overview, and the architecture and onboarding pages.
+`--cascade` decides what happens to them:
 
 | Value | Behavior |
 |-------|----------|
 | `none` | Generate exactly what you asked for; mark the dependents stale (truthful, free, instant). |
-| `dependents` (default) | Also regenerate the module, SCC and layer pages that contain a selected file; mark the repo-wide pages stale. |
+| `dependents` (default) | Also regenerate the overview / layer pages that summarize a regenerated concept page; mark the rest stale. |
 | `full` | Also regenerate the repo overview, architecture and onboarding pages. Nothing is left stale. |
 
 The cost estimate includes the cascade fallout, so it does not under-quote.
@@ -253,12 +243,10 @@ The cost estimate includes the cascade fallout, so it does not under-quote.
 
 | Flag | Description |
 |------|-------------|
-| `--unwritten` / `--all` / `--stale` | Explicit selection (see above). Default for a non-interactive run: `--unwritten`. |
+| `--unwritten` / `--all` / `--stale` | Selection (see above). Default for a non-interactive run: `--unwritten`. |
 | `--path <glob>` | Restrict to a path prefix or glob (repeatable). |
-| `--page <id>` | An explicit page id (repeatable). |
-| `--coverage <pct>` | Ranked: the most important unwritten pages up to this coverage. |
-| `--top <n>` | Ranked: about the `n` most important unwritten pages. |
-| `--cascade none\|dependents\|full` | Dependent-page policy. Default: `dependents` for an explicit selection, `none` for `--coverage`/`--top`. |
+| `--page <id>` | An explicit subsystem page id (repeatable). |
+| `--cascade none\|dependents\|full` | Dependent-page policy. Default: `dependents`. |
 | `--provider` / `--model` / `--reasoning` | LLM overrides for this run. |
 | `--concurrency` | Max concurrent LLM calls (default: 12). |
 | `--dry-run` | Print the plan and the cost estimate; generate nothing. |
@@ -266,14 +254,12 @@ The cost estimate includes the cascade fallout, so it does not under-quote.
 | `--verbose` / `-v` | Show pipeline debug logs. |
 
 ```bash
-repowise generate                           # interactive chooser (coverage menu)
-repowise generate --coverage 20             # write the most important 20% of templates
-repowise generate --coverage 20 --dry-run   # what would that write, and cost?
-repowise generate --unwritten               # write every unwritten page
-repowise generate --all                     # rewrite the whole wiki
-repowise generate --path src/api            # just the pages under src/api
-repowise generate --page file_page:src/app.py --cascade none   # one page, nothing else
-repowise generate --stale                   # refresh pages whose code moved on
+repowise generate                           # write the unwritten subsystem pages
+repowise generate --dry-run                 # what would that write, and cost?
+repowise generate --all                     # rewrite the prose on every subsystem page
+repowise generate --path src/api            # just the subsystem pages under src/api
+repowise generate --page module_page:src/api --cascade none   # one page, nothing else
+repowise generate --stale                   # refresh subsystem pages whose code moved on
 ```
 
 > **Embedding.** `generate` embeds the pages it writes. On a repo indexed

--- a/docs/start/QUICKSTART.md
+++ b/docs/start/QUICKSTART.md
@@ -39,15 +39,18 @@ No API key needed. If you want to be explicit that this run must not spend
 anything, spell it out:
 
 ```bash
-repowise init --yes --docs deterministic
+repowise init --yes --no-prose
 ```
 
 This is the step worth doing first, because it costs nothing and answers the
 question "is this useful on my codebase". It parses every file to an AST, builds
 the dependency graph, reads your git history, scores every file for code health,
 and finds dead code. It also renders a complete wiki from that structure: file,
-module, layer and cycle pages, the architecture diagram, the repo overview, API
-and infra pages, and the onboarding collection. No LLM calls, no key, no network.
+symbol, layer and cycle pages, the architecture diagram, the repo overview, API
+and infra pages, and the onboarding collection. Without a key the subsystem
+(concept) pages, the repo overview, the architecture diagram and the onboarding
+collection are structural stubs until you point a model at them. No LLM calls,
+no key, no network.
 
 Those pages are honest about where they came from. Each one ends with a footer
 saying it was derived from structure, and the repo overview covers composition,
@@ -146,10 +149,12 @@ file reads. That is the whole point.
 > the wiki, which step 2 already built, so they answer from pages rendered from
 > structure. `search_codebase` is full-text only until you configure an embedder.
 
-## 4. Optional: upgrade the wiki to model-written prose
+## 4. Optional: write the subsystem pages as model prose
 
-Everything so far was deterministic. When you want richer pages, point `repowise
-generate` at a provider and it rewrites the template pages as prose (and unlocks
+Every file page was already deterministic, and stays that way. The one layer a
+model adds is the subsystem (concept) tree: the numbered pages that describe how
+the codebase fits together above the file level. Without a key they are
+structural stubs; `repowise generate` fills them with prose (and unlocks
 architectural decision mining and chat). You do not have to redo anything: it
 reuses the index you already built, so the graph is not re-parsed.
 
@@ -158,21 +163,21 @@ Set a key, preview the cost, then write:
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."        # or OPENAI_API_KEY / GEMINI_API_KEY
 
-repowise generate                  # interactive: pick a coverage, see the cost, confirm
+repowise generate                  # shows the wiki state, then writes the unwritten subsystem pages
 ```
 
-Bare `generate` shows the wiki's state and a coverage menu (page counts and cost
-per tier, 20% recommended), so you choose how much to write rather than getting
-the whole repo by default. On Windows PowerShell: `$env:ANTHROPIC_API_KEY = "sk-ant-..."`
+Bare `generate` prints the wiki's state and writes every unwritten subsystem
+page behind a single cost estimate. On Windows PowerShell:
+`$env:ANTHROPIC_API_KEY = "sk-ant-..."`
 
-You do not have to write the whole wiki at once. Pick a ranked slice, an area, or
-a single page, each run behind its own cost estimate:
+You do not have to write them all at once. Restrict to an area, a single page, or
+refresh what is stale, each run behind its own cost estimate:
 
 ```bash
-repowise generate --coverage 20                     # the most important 20%, ranked like init
-repowise generate --path src/api                    # just one area
-repowise generate --page file_page:src/app.py       # or a single page
-repowise generate --all                             # or rewrite everything
+repowise generate --path src/api                    # just the subsystem pages under one area
+repowise generate --page module_page:src/api        # or a single subsystem page
+repowise generate --stale                            # refresh pages the last update marked stale
+repowise generate --all                              # or rewrite every page, structural ones included
 ```
 
 Semantic search is a separate step: configure an embedder and run `repowise

--- a/docs/start/USER_GUIDE.md
+++ b/docs/start/USER_GUIDE.md
@@ -93,17 +93,17 @@ You do not have to choose up front. Start index-only, then upgrade the wiki with
 at a time, each behind a cost estimate:
 
 ```bash
-repowise generate                  # interactive chooser: wiki state, coverage menu, cost
-repowise generate --coverage 20    # or the most important 20%, ranked like init
+repowise generate                  # write the unwritten subsystem pages, behind one cost estimate
 repowise generate --path src/api   # or just the part you care about
+repowise generate --all            # or rewrite the prose on every subsystem page
 ```
 
-Bare `generate` opens a chooser (a coverage menu with page counts and cost per
-tier) rather than writing everything, so a large repo never spends by accident.
-`generate` reuses the persisted graph instead of re-parsing it, so the upgrade is
-cheap. (`repowise update --full` still does the whole wiki in one shot if you
-prefer.) Semantic search is separate: it needs an embedder, and `repowise
-reindex` is what builds the vector store.
+Bare `generate` prints the wiki's state and writes the unwritten subsystem
+pages behind a single cost estimate. `generate` reuses the persisted graph
+instead of re-parsing it, so the upgrade is cheap. (`repowise update --full`
+still does the whole wiki in one shot if you prefer.) Semantic search is
+separate: it needs an embedder, and `repowise reindex` is what builds the vector
+store.
 
 ---
 
@@ -318,9 +318,9 @@ time, each behind a cost estimate:
 
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."
-repowise generate                  # interactive chooser: pick a coverage, see the cost
-repowise generate --coverage 20    # or the most important 20%, ranked like init
+repowise generate                  # write the unwritten subsystem pages, behind one cost estimate
 repowise generate --path src/api   # or just one area first
+repowise generate --all            # or rewrite the prose on every subsystem page
 ```
 
 Then add semantic search with `repowise reindex` once an embedder is configured.

--- a/packages/cli/src/repowise/cli/commands/generate_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/generate_cmd/command.py
@@ -1,12 +1,12 @@
-"""``repowise generate`` — write any subset of the wiki with a model.
+"""``repowise generate`` - write the subsystem (concept) pages with a model.
 
-The single, cost-gated entry point for turning template (unwritten) pages into
-LLM prose, or regenerating written ones. Selection comes in two shapes: explicit
-(all / unwritten / stale / path / page, unioned) and ranked by importance
-(coverage / top). A bare ``generate`` on a terminal opens an interactive chooser
-(wiki state + coverage menu) instead of writing everything; piped / ``--yes`` /
-flagged runs default to ``--unwritten``. The cascade mode decides what happens to
-the pages that summarize a regenerated file.
+The single, cost-gated entry point for turning subsystem stubs into LLM prose, or
+regenerating written ones. It writes only the model-written page types (the
+concept tree and the overview); a structural page id is an error. Selection is
+explicit: all / unwritten / stale / path / page, unioned. A bare ``generate`` on
+a terminal prints the wiki state and writes the unwritten subsystem pages; piped
+/ ``--yes`` / flagged runs default to ``--unwritten``. The cascade mode decides
+what happens to the pages that summarize a regenerated concept page.
 """
 
 from __future__ import annotations

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -543,8 +543,8 @@ def _run_generation_phase(
     help=(
         "Test-coverage report(s) to ingest (lcov / Cobertura / Clover). "
         "Repeatable. When omitted, common locations (coverage/lcov.info, "
-        "**/cobertura.xml, ...) are auto-discovered. Distinct from --coverage, "
-        "which controls documentation breadth."
+        "**/cobertura.xml, ...) are auto-discovered. This is test coverage for "
+        "code-health, not a documentation-breadth knob."
     ),
 )
 @click.option(
@@ -871,8 +871,8 @@ def init_command(
             is_interactive = False
             console.print(
                 "\n[yellow]No answer available on stdin[/yellow] "
-                "[dim]— continuing with defaults. Pass --yes to skip the "
-                "questions, or --docs llm/deterministic to choose directly.[/dim]"
+                "[dim]- continuing with defaults. Pass --yes to skip the "
+                "questions, or --prose / --no-prose to choose directly.[/dim]"
             )
 
         # Map the menu onto the two axes (docs on/off, customize yes/no):

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -221,19 +221,24 @@ print(f"Deletable lines: {report.deletable_lines:,}")
 
 ## Page Types
 
-repowise generates 9 distinct page types in a strict dependency-aware order:
+repowise generates these page types in a strict dependency-aware order. The
+subsystem-and-overview set (`module_page`, `repo_overview`,
+`architecture_diagram`, `onboarding`) is the one model-written layer: model prose
+when a provider is configured, structural stubs otherwise. Every other type is
+always rendered from structure, with no model and no key.
 
-| Level | Page Type | Description |
-|-------|-----------|-------------|
-| 0 | `api_contract` | OpenAPI specs, Protobuf, GraphQL schemas |
-| 1 | `symbol_spotlight` | High-PageRank symbols (top 10% by centrality) |
-| 2 | `file_page` | One page per source file |
-| 3 | `scc_page` | Circular dependency cluster summary |
-| 4 | `module_page` | Package/directory overview |
-| 5 | `cross_package` | Cross-package relationships (monorepos) |
-| 6 | `repo_overview` | Repository overview and architecture diagram |
-| 7 | `infra_page` | Dockerfile, CI YAML, Makefile documentation |
-| 8 | `index_page` | Symbol index, search index |
+| Level | Page Type | Rendered | Description |
+|-------|-----------|----------|-------------|
+| 0 | `api_contract` | structure | OpenAPI specs, Protobuf, GraphQL schemas |
+| 1 | `symbol_spotlight` | structure | High-PageRank symbols (top 10% by centrality) |
+| 2 | `file_page` | structure | One page per source file |
+| 3 | `scc_page` | structure | Circular dependency cluster summary |
+| 4 | `module_page` | **model or stub** | Subsystem (concept) tree above the file level |
+| 5 | `layer_page` | structure | Architectural layer summary |
+| 6 | `repo_overview` | model or stub | Repository overview |
+| 6 | `architecture_diagram` | model or stub | Repo-level architecture diagram |
+| 7 | `infra_page` | structure | Dockerfile, CI YAML, Makefile documentation |
+| 8 | `onboarding` | model or stub | Curated onboarding collection |
 
 ---
 

--- a/packages/server/src/repowise/server/mcp_server/tool_search.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_search.py
@@ -772,7 +772,10 @@ async def search_codebase(
     Args:
         query: identifier, path, or natural-language query.
         limit: max results (default 5).
-        page_type: file_page | module_page | symbol_spotlight (concept only).
+        page_type: restrict to one page type. Common: file_page (per-file
+            docs, always present) or module_page (subsystem/concept pages).
+            Any stored type filters (repo_overview, layer_page, scc_page,
+            api_contract, infra_page, symbol_spotlight).
         kind: implementation | test | config | doc (concept/symbol modes).
         repo: alias, or "all" for workspace-wide.
         mode: auto | concept | symbol | path | hybrid.

--- a/plugins/claude-code/DEVELOPER.md
+++ b/plugins/claude-code/DEVELOPER.md
@@ -150,9 +150,9 @@ The plugin version tracks the repowise release it ships alongside (e.g. `0.16.0`
    `docs/agent/MCP_TOOLS.md`. Never reference unexposed tools in
    commands/skills.
 6. **Verify CLI flags against the source.** Easy ones to get wrong:
-   `--index-only` (not `--no-llm`); prefer the self-describing
-   `--docs llm|deterministic` spelling when writing agent-facing commands.
-   `--concurrency` (not `--concurrent`),
+   `--prose` / `--no-prose` is the wiki-spend switch (`--index-only` and
+   `--docs llm|deterministic` are deprecated aliases; do not write them into new
+   agent-facing commands). `--concurrency` (not `--concurrent`),
    `--commit-limit` (not `--git-depth`), `--embedder` (not `--embedding-provider`).
    `dead-code` has no `--group-by` (that's a `get_dead_code` MCP param only).
 7. **`repowise risk` / MCP `get_change_risk` score a whole change**

--- a/plugins/claude-code/commands/init.md
+++ b/plugins/claude-code/commands/init.md
@@ -54,7 +54,7 @@ If the user does not answer, or you are running unattended, take option 1.
 
 Skip provider selection entirely. Construct:
 ```
-repowise init --docs deterministic --yes
+repowise init --no-prose --yes
 ```
 
 Jump to Step 5.
@@ -72,12 +72,11 @@ repowise init [PATH]
 Core flags:
   --provider NAME        LLM provider: anthropic, openai, gemini, ollama, litellm
   --model NAME           Model identifier override
-  --index-only           Build the wiki from structure instead of writing it
-                         with a model. No key, no spend.
-  --docs llm|deterministic
-                         How to produce the wiki. Same choice as --index-only,
-                         named for what it does. --docs llm needs a key.
-                         (--docs llm together with --index-only is an error.)
+  --prose / --no-prose   Write the subsystem (concept) pages as model prose
+                         (--prose, needs a key), or render the whole wiki from
+                         structure with no model and no spend (--no-prose).
+                         Every other page is structural either way.
+                         Default: prose when a key is available.
   --mode fast            Quick first pass on very large repos: no wiki at all.
 
 Embeddings:
@@ -161,12 +160,12 @@ Add any exclusions as `-x` flags.
 ## Step 6: Run it
 
 For an unattended or non-interactive run, the canonical command is
-`repowise init --yes`, plus `--docs deterministic` when you want to guarantee no
-spend. `--yes` suppresses every prompt including the cost gate. You do not need
-to guard against prompts beyond that: init treats an unanswerable question as a
-signal to continue with defaults rather than a reason to fail, and the cost gate
-declines by itself when stdin is not a terminal, keeping the finished index and
-landing on the template wiki.
+`repowise init --yes`, plus `--no-prose` when you want to guarantee no spend.
+`--yes` suppresses every prompt including the cost gate. You do not need to guard
+against prompts beyond that: init treats an unanswerable question as a signal to
+continue with defaults rather than a reason to fail, and the cost gate declines
+by itself when stdin is not a terminal, keeping the finished index and landing on
+the structural wiki.
 
 Show the user the exact command you're about to run. Ask for confirmation.
 

--- a/website/cli-reference.md
+++ b/website/cli-reference.md
@@ -47,8 +47,8 @@ repowise init [PATH] [OPTIONS]
 | `--provider` | string | auto | LLM provider: `anthropic`, `openai`, `openrouter`, `gemini`, `deepseek`, `kimi`, `ollama`, `litellm`, `codex_cli`, `opencode`, `mock` |
 | `--model` | string | — | Model override (e.g., `claude-sonnet-4-6`, `gpt-4.1`) |
 | `--embedder` | choice | auto | Embedding provider: `gemini`, `openai`, `mock` |
-| `--index-only` | flag | false | Render the wiki from structure instead of writing it with a model. No key, no spend. |
-| `--docs` | choice | — | How to produce the wiki: `llm` or `deterministic`. Same choice as `--index-only`, named for what it does. `--docs llm` needs a key. |
+| `--prose` / `--no-prose` | flag | prose if a key | Write the subsystem (concept) pages as model prose (`--prose`, needs a key), or render the whole wiki from structure with no model and no spend (`--no-prose`). Every other page is structural either way. |
+| `--index-only` / `--docs` | — | — | Deprecated hidden aliases. `--index-only` == `--no-prose`; `--docs llm` == `--prose`, `--docs deterministic` == `--no-prose`. |
 | `--dry-run` | flag | false | Show generation plan and token estimate without running |
 | `--test-run` | flag | false | Limit to top 10 files by PageRank (for validation) |
 | `--skip-tests` | flag | false | Exclude test files |
@@ -85,8 +85,8 @@ repowise init --provider openai --model qwen3 --reasoning off
 # OpenRouter with minimal reasoning effort
 repowise init --provider openrouter --model openai/gpt-5 --reasoning minimal
 
-# Analysis only — free, no API key needed
-repowise init --index-only
+# Analysis plus a structural wiki, free, no API key needed
+repowise init --no-prose
 
 # Skip tests and infra, limit concurrency
 repowise init --skip-tests --skip-infra --concurrency 3
@@ -108,7 +108,7 @@ repowise init --resume
 
 1. **Ingestion** — parses all files with tree-sitter, builds dependency graph
 2. **Analysis** — git churn/ownership, dead code detection, decision mining
-3. **Generation** — LLM writes wiki pages at repo/module/file level, or with `--index-only` / `--docs deterministic` they are rendered from parsed structure
+3. **Generation** — every page is rendered from parsed structure; with a model (the default when a key is available) the subsystem (concept) pages are written as prose instead of stubs. `--no-prose` keeps them structural.
 4. **Persistence** — writes to SQLite, builds vector index, generates managed editor instruction files
 
 ### Provider auto-detection

--- a/website/concepts.md
+++ b/website/concepts.md
@@ -121,7 +121,7 @@ Generation is the only layer that requires an LLM provider. repowise sends struc
 
 Each page is stored in the database and linked to the file it describes. Pages have a freshness score — if the underlying file changes, the page is marked stale and queued for regeneration.
 
-**Skipping generation:** You can skip this layer entirely with `repowise init --index-only`. You'll still get the full dependency graph, git intelligence, dead code, and decision data — just no narrative docs. You can add generation later by running `repowise init` on an existing index.
+**Skipping the prose:** Run `repowise init --no-prose` and every page is still rendered from structure, with no key and no spend. You get the full dependency graph, git intelligence, dead code, and decision data, and a complete wiki whose subsystem (concept) pages are structural stubs rather than model prose. Fill that prose in later with `repowise generate` (or `repowise init --prose`) on the existing index.
 
 **Cost:** For a 200-file codebase, generation typically uses 150,000–300,000 tokens. The `--dry-run` flag shows you the estimated cost before committing.
 

--- a/website/getting-started.md
+++ b/website/getting-started.md
@@ -35,10 +35,10 @@ repowise --version            # -> repowise, version 0.27.x
 
 ```bash
 cd /path/to/your/repo
-repowise init --index-only -y
+repowise init --no-prose -y
 ```
 
-Builds the dependency graph, git history, code-health score, and dead-code findings in seconds. Also renders every wiki page from structure. Want model-written prose? `repowise init --docs llm --provider gemini|anthropic|openai`.
+Builds the dependency graph, git history, code-health score, and dead-code findings in seconds. Also renders every wiki page from structure. Want the subsystem pages written as model prose? `repowise init --prose --provider gemini|anthropic|openai`.
 
 **3. Connect your agent** — the MCP server is `repowise mcp`, served from the repo dir.
 
@@ -281,14 +281,14 @@ You don't need an LLM API key at all. A bare `repowise init` with no key configu
 repowise init
 ```
 
-`repowise init --docs deterministic` is the explicit spelling of the same thing, and guarantees no spend. Either way you get the full ingestion and analysis pipeline (parsing, graph, git, dead code) plus a complete wiki. It's free, takes under a minute for most repos, and still gives you:
+`repowise init --no-prose` is the explicit spelling of the same thing, and guarantees no spend. Either way you get the full ingestion and analysis pipeline (parsing, graph, git, dead code) plus a complete wiki. It's free, takes under a minute for most repos, and still gives you:
 
 - Dependency graph
 - Hotspot detection
 - Dead code findings
 - Ownership data
 
-You can always run `repowise init --docs llm` (or `repowise generate`) later to upgrade the pages to model-written prose on top of an existing index.
+You can always run `repowise init --prose` (or `repowise generate`) later to write the subsystem pages as model prose on top of an existing index.
 
 ---
 

--- a/website/mcp-server.md
+++ b/website/mcp-server.md
@@ -331,7 +331,7 @@ Hybrid code search. Depending on the query, it searches the indexed **symbols**,
 - `mode` (optional) — `auto` (default) \| `concept` \| `symbol` \| `path` \| `hybrid`
 - `kind` (optional) — `implementation` \| `test` \| `config` \| `doc`
 - `symbol_kind` (optional) — restrict symbol hits by kind (`function`, `class`, `method`, …)
-- `page_type` (optional) — `file_page` \| `module_page` \| `symbol_spotlight` (concept mode)
+- `page_type` (optional) — restrict to one page type. The two you will reach for are `file_page` (the always-on per-file docs) and `module_page` (the subsystem/concept pages).
 
 **Modes:** `auto` routes by shape — an identifier searches indexed symbols (results carry `symbol_id` + line bounds, pipe into `get_symbol`), a path searches file pages (pipe into `get_context`), prose runs wiki-semantic search, and mixed queries run hybrid (symbols first). Force a branch with an explicit `mode`.
 

--- a/website/self-hosting.md
+++ b/website/self-hosting.md
@@ -126,14 +126,14 @@ repowise serve
 
 ## Running in CI
 
-Use `--index-only` for CI pipelines that don't need full LLM documentation — just analysis signals:
+Use `--no-prose` for CI pipelines that don't need model-written prose, just the analysis signals and a structural wiki:
 
 ```yaml
 # GitHub Actions example
 - name: Index codebase
   run: |
     pip install repowise
-    repowise init --index-only --yes
+    repowise init --no-prose --yes
 
 - name: Check dead code
   run: repowise dead-code --safe-only --format json > dead-code-report.json
@@ -243,4 +243,4 @@ alembic upgrade head
 | Node.js | 20+ (for web UI without Docker) |
 | Docker | Any version (alternative to Node.js) |
 | PostgreSQL | 14+ (optional, SQLite is the default) |
-| LLM API key | Anthropic, OpenAI, Gemini, or Ollama (not needed for `--index-only`) |
+| LLM API key | Anthropic, OpenAI, Gemini, or Ollama (not needed for `--no-prose`) |


### PR DESCRIPTION
## What

The wiki now uses one renderer per page type. Every page except the subsystem (concept) tree, the repo overview, the architecture diagram, and the onboarding collection is rendered from structure with no key and no spend. Those four are the one model-written layer: prose when a provider is configured, structural stubs otherwise. The old template-vs-model provenance axis is gone.

The docs still taught the removed surface. This brings them in line with what ships.

## Changes

- **CLI reference, quickstart, user guide, and the website**: document `--prose` / `--no-prose` as the single wiki-spend switch. `--index-only` and `--docs llm|deterministic` are labeled deprecated aliases. Removed the `--coverage` / `--top` flags and the coverage chooser, which no longer exist. Rewrote the `generate` section: it writes only the subsystem pages, and naming a structural page id is an error.
- **`packages/core` README Page Types table**: corrected the type list and marked which types are model-written.
- **MCP tool docs and the `search_codebase` docstring**: describe the `page_type` filter accurately instead of a stale three-type enumeration.
- **CHANGELOG**: added an Unreleased section recording the removal of `is_deterministic` / `doc_tier` and the provenance badges.
- Fixed stale CLI help strings that referenced the removed `--coverage` knob.

## Notes

Four source files change alongside the docs: the MCP tool docstring (the agent-facing contract) and three CLI help/prompt strings. All are docstring or help-text only, ruff-clean, with no logic change.