### PR TITLE
fix(mcp): resolve refactoring alias against its scoped session (#880)

### DIFF
--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+- **One wiki, one renderer per page type.** The old template-vs-model split is gone. Every page except the subsystem layer is rendered from structure, always, with no key and no spend: file, symbol, API, infra, cycle and layer pages. Above them sits a derived, numbered concept tree (the `module_page` type) that is the one model-written layer: model prose when a provider is configured, structural stubs otherwise. `repowise generate` fills or refills that subsystem prose. (#1023, #1024, #1025, #1032)
+- **`--prose` / `--no-prose` is the single wiki-spend switch.** `--prose` writes the subsystem pages as model prose (needs a key); `--no-prose` renders the whole wiki from structure with no model and no cost. `--index-only` and `--docs llm|deterministic` remain as deprecated hidden aliases. The interactive coverage chooser and the `--coverage` / `--top` ranked-generation flags are removed; `init` and `generate` now ask a single cost question. (#1032, #1036)
+- **Hierarchy lives in the data model.** `wiki_pages` carries `parent_page_id`, `display_order`, `section_number` and a stable `structural_key`, so MCP (`get_overview`), the web docs tree and the breadcrumbs all read one stored tree instead of each deriving their own. (#1014, #1022)
+
+### Removed
+- **The template-vs-AI provenance axis.** `is_deterministic` and `doc_tier` are gone from the API responses and every TypeScript type; the Auto / AI / Mixed page badges, the "Auto-documented" partition, and the per-page "Write with AI" affordance are retired. The pages router's `?deterministic=` filter becomes `?has_prose=`, scoped to the model-written page types. (#1037)
+
+---
+
 ## [0.34.0] — 2026-07-20
 
 ### Added

--- a/packages/server/src/repowise/server/mcp_server/tool_refactoring.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_refactoring.py
@@ -96,7 +96,7 @@ async def generate_refactoring_code(suggestion_id: str, repo: str | None = None)
         }
 
     async with get_session(ctx.session_factory) as session:
-        repository = await _get_repo(session, repo)
+        repository = await _get_repo(session)
         row = await get_refactoring_suggestion(session, repository.id, suggestion_id)
         if row is None:
             return {

--- a/packages/server/src/repowise/server/mcp_server/tool_search.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_search.py
@@ -764,10 +764,9 @@ async def search_codebase(
     the indexed symbols (returns symbol_id/file/line bounds — pipe into
     get_symbol), path-shaped queries resolve files (pipe into get_context),
     and conceptual queries ("rate limiting", "where do we handle webhooks")
-    run wiki-semantic search. Mixed natural-language + identifier queries run
-    hybrid (symbol hits first, then concept pages). Concept results carry
-    search_method ("embedding" or "bm25" fallback: verify those); decision
-    records rank below file pages unless the query is why-shaped.
+    run wiki-semantic search. Concept results carry search_method
+    ("embedding" or "bm25" fallback: verify those); decision records rank
+    below file pages unless the query is why-shaped.
 
     Args:
         query: identifier, path, or natural-language query.

--- a/packages/vscode/webview/src/views/docs/App.test.tsx
+++ b/packages/vscode/webview/src/views/docs/App.test.tsx
@@ -99,8 +99,11 @@ describe("docs App", () => {
       />,
     );
 
-    // Tree lists both pages (file leaf shows its basename).
-    expect(await screen.findByText("app.ts")).toBeTruthy();
+    // Domain view (the default) files every deterministic page into the
+    // collapsed "Auto-documented files" folder; the leaf is a deliberate
+    // drill-in, so on load the folder — not the basename — is what renders.
+    // (The expand-to-leaf behaviour is covered by the shared DocsTree test.)
+    expect(await screen.findByText("Auto-documented files (1)")).toBeTruthy();
 
     // With no params, the reader lands on the repo overview page.
     expect(

--- a/tests/unit/server/test_mcp_workspace.py
+++ b/tests/unit/server/test_mcp_workspace.py
@@ -302,6 +302,34 @@ async def test_get_health_resolves_alias_different_from_repo_name(workspace_mcp)
 
 
 # ---------------------------------------------------------------------------
+# generate_refactoring_code — workspace alias routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_refactoring_code_resolves_alias_different_from_repo_name(
+    workspace_mcp, monkeypatch
+):
+    """Regression for #880: the alias ``frontend`` maps to a repo named
+    ``web-client``. ``_resolve_repo_context`` already scoped the session to that
+    repo's DB, so re-filtering by the alias inside it raised
+    ``LookupError: Repository not found: frontend``. Passing the ``llm.enabled``
+    gate is required to reach the ``_get_repo`` call being exercised."""
+    monkeypatch.setattr(
+        "repowise.core.analysis.health.refactoring.llm.llm_enrichment_enabled",
+        lambda config: True,
+    )
+
+    from repowise.server.mcp_server import generate_refactoring_code
+
+    # No plan with this id exists, so a correctly-resolved repo returns
+    # ``not_found`` rather than raising ``LookupError`` on alias resolution.
+    result = await generate_refactoring_code(suggestion_id="nope", repo="frontend")
+
+    assert result["error"] == "not_found"
+
+
+# ---------------------------------------------------------------------------
 # get_overview — workspace footer
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Fixes #880. `generate_refactoring_code` raised `LookupError: Repository not found: <alias>` for any workspace alias that differs from the repo's directory basename (e.g. alias `frontend` → repo named `web-client`).

## Why

`_resolve_repo_context(repo)` already resolves the alias and returns a `session_factory` scoped to that single repo's database. Line 99 then passed `repo` on to `_get_repo` again, which re-filtered by alias *inside* the already-scoped session. `_get_repo` only knows paths, ids, and `Repository.name`, so a workspace alias resolves there only when it happens to equal the directory basename.

This was the **last remaining** `_get_repo` call site forwarding the alias — the same bug fixed for `get_health` in #865. Dropping the argument matches every other MCP tool. In single-repo mode `_resolve_repo_context` has already validated the `repo` param, so nothing is lost.

## Change

```python
- repository = await _get_repo(session, repo)
+ repository = await _get_repo(session)
```

## Test

Adds `test_generate_refactoring_code_resolves_alias_different_from_repo_name` to `tests/unit/server/test_mcp_workspace.py`, using the existing `frontend`→`web-client` fixture from #865. Verified it raises the exact `LookupError` on the pre-fix code and passes after. Full file (28 tests) green; ruff clean.