### PR TITLE
docs: correct onboarding collection slot count in docstrings

### DIFF
--- a/packages/core/src/repowise/core/generation/onboarding/__init__.py
+++ b/packages/core/src/repowise/core/generation/onboarding/__init__.py
@@ -1,13 +1,13 @@
 """Onboarding documentation collection.
 
-A curated set of up to eight pages — Project Overview, Architecture Guide,
-Getting Started, Codebase Map, Key Concepts, How It Works, Development Guide,
-Active Landscape — designed to be the first thing a new contributor (or LLM
-agent) reads.
+A curated set of up to nine pages: Project Overview, Architecture Guide,
+Guided Tour, Getting Started, Codebase Map, Key Concepts, How It Works,
+Development Guide, Active Landscape, designed to be the first thing a new
+contributor (or LLM agent) reads.
 
 Two slots ("project_overview", "architecture_guide") are *promoted*: they
 reuse the existing ``repo_overview`` and ``architecture_diagram`` pages,
-tagged via ``metadata.onboarding_slot``. The other six slots are new pages
+tagged via ``metadata.onboarding_slot``. The other seven slots are new pages
 generated at level 8 with ``page_type='onboarding'`` and a
 ``metadata.subkind`` discriminator.
 

--- a/packages/core/src/repowise/core/generation/onboarding/slots.py
+++ b/packages/core/src/repowise/core/generation/onboarding/slots.py
@@ -1,8 +1,8 @@
 """Onboarding slot identifiers and reading order.
 
-The Onboarding collection is a fixed set of eight curated pages. Two slots are
-"promoted" — they reuse the existing `repo_overview` and `architecture_diagram`
-pages, tagged via ``metadata.onboarding_slot``. The other six are new pages
+The Onboarding collection is a fixed set of nine curated slots. Two slots are
+"promoted": they reuse the existing `repo_overview` and `architecture_diagram`
+pages, tagged via ``metadata.onboarding_slot``. The other seven are new pages
 with ``page_type='onboarding'`` and a ``metadata.subkind`` discriminator.
 
 Slot identifiers are used three ways:
@@ -11,7 +11,8 @@ Slot identifiers are used three ways:
   - as the ordering key in the web UI's Onboarding folder.
 
 Keep the order list in lockstep with ``packages/ui/src/lib/page-types.ts``
-``ONBOARDING_ORDER``.
+``ONBOARDING_ORDER``. A slot without enough signal is skipped at generation
+time, so a repo can end up with fewer than nine.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
The onboarding docstrings said the collection is eight curated pages with six generated. `ONBOARDING_ORDER` lists nine slots and `PROMOTED_SLOTS` promotes two, so seven are newly generated. The `__init__` enumeration also omitted Guided Tour. Bring both docstrings in line with the code.

Comments only, no behavior change.