### PR TITLE
fix(cli): exclude tombstoned pages from status and export listings

### DIFF
--- a/packages/cli/src/repowise/cli/commands/export_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/export_cmd.py
@@ -74,7 +74,12 @@ def export_command(
             if repo is None:
                 await engine.dispose()
                 return []
-            pages = await list_pages(session, repo.id, limit=10000)
+            # A reader-facing export drops tombstones so it does not write a
+            # page for a file that no longer exists. --full is the archival
+            # mode, so it keeps them for a complete record.
+            pages = await list_pages(
+                session, repo.id, include_tombstones=full_export, limit=10000
+            )
 
             if full_export and fmt == "json":
                 from sqlalchemy import select

--- a/packages/cli/src/repowise/cli/commands/status_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/status_cmd.py
@@ -448,7 +448,9 @@ def status_command(path: str | None, workspace: bool, no_workspace: bool) -> Non
             if repo is None:
                 await engine.dispose()
                 return counts, total_tokens
-            pages = await list_pages(session, repo.id, limit=10000)
+            pages = await list_pages(
+                session, repo.id, include_tombstones=False, limit=10000
+            )
             for p in pages:
                 counts[p.page_type] = counts.get(p.page_type, 0) + 1
                 total_tokens += (p.input_tokens or 0) + (p.output_tokens or 0)

--- a/packages/core/src/repowise/core/persistence/crud/pages.py
+++ b/packages/core/src/repowise/core/persistence/crud/pages.py
@@ -484,6 +484,7 @@ async def list_pages(
     *,
     page_type: str | None = None,
     has_prose: bool | None = None,
+    include_tombstones: bool = True,
     limit: int = 100,
     offset: int = 0,
     sort_by: str = "updated_at",
@@ -498,10 +499,17 @@ async def list_pages(
     model has written, ``has_prose=False`` the ones still stubs, and ``None``
     (default) returns every page of every type. A stub is a model-written type
     still stamped ``provider_name='template'``.
+
+    ``include_tombstones`` defaults to True to preserve the raw row set for
+    callers that reconcile against deleted files. Pass ``False`` for a
+    reader-facing count or listing, where a tombstoned page (its file is gone)
+    should not be shown or counted.
     """
     q = select(Page).where(Page.repository_id == repository_id)
     if page_type is not None:
         q = q.where(Page.page_type == page_type)
+    if not include_tombstones:
+        q = q.where(Page.freshness_status != "tombstone")
     if has_prose is not None:
         from repowise.core.generation.models import MODEL_WRITTEN_PAGE_TYPES
 

--- a/tests/unit/persistence/test_crud.py
+++ b/tests/unit/persistence/test_crud.py
@@ -250,6 +250,29 @@ async def test_list_pages_returns_all_for_repo(async_session):
     assert len(pages) == 2
 
 
+async def test_list_pages_excludes_tombstones_when_asked(async_session):
+    repo = await insert_repo(async_session)
+    await upsert_page(
+        async_session, **make_page_kwargs(repo.id, page_id="file_page:a.py", target_path="a.py")
+    )
+    await upsert_page(
+        async_session,
+        **make_page_kwargs(
+            repo.id,
+            page_id="file_page:gone.py",
+            target_path="gone.py",
+            freshness_status="tombstone",
+        ),
+    )
+    await async_session.commit()
+
+    # Default keeps the raw row set for reconciliation callers.
+    assert len(await list_pages(async_session, repo.id)) == 2
+    # A reader-facing caller opts out of the deleted-file row.
+    live = await list_pages(async_session, repo.id, include_tombstones=False)
+    assert [p.id for p in live] == ["file_page:a.py"]
+
+
 async def test_list_pages_filters_by_page_type(async_session):
     repo = await insert_repo(async_session)
     await upsert_page(


### PR DESCRIPTION
`repowise status` counted every `wiki_pages` row and `repowise export` wrote a file for each, both including tombstones (pages whose source file was deleted). So status reported a total larger than the tree shows, and a plain export emitted pages for files that no longer exist.

Add an `include_tombstones` flag to `crud.list_pages`, defaulting True to preserve the raw row set for reconciliation callers, and pass False from the two reader-facing call sites. The `--full` export keeps tombstones, since that mode is the complete archival record.

Other `list_pages` callers (doctor, editor-file fetcher, server router) are untouched and keep the include-everything default.

Tests: added a crud test asserting the default keeps tombstones and `include_tombstones=False` drops them. Full crud + server pages suites pass (32 + 14).