### PR TITLE
feat(cli): include hierarchy columns in JSON wiki export

### DIFF
--- a/packages/cli/src/repowise/cli/commands/export_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/export_cmd.py
@@ -226,6 +226,12 @@ def export_command(
                     "title": page.title,
                     "content": page.content,
                     "target_path": page.target_path,
+                    # Hierarchy columns, so a JSON consumer can rebuild the
+                    # stored tree instead of re-deriving one from path strings.
+                    "parent_page_id": page.parent_page_id,
+                    "display_order": page.display_order,
+                    "section_number": page.section_number,
+                    "structural_key": page.structural_key,
                 }
                 if full_export:
                     entry["confidence"] = page.confidence


### PR DESCRIPTION
The JSON export dropped `parent_page_id`, `display_order`, `section_number` and `structural_key`, so a consumer could not rebuild the stored concept tree and had to re-derive one from path strings. Serialise all four on every exported page.

All four are real columns on the `Page` model; the nullable ones serialize to JSON `null` cleanly.