### PR TITLE
fix(generation): place parent-dir rollup pages under their children's layer

### DIFF
--- a/packages/core/src/repowise/core/generation/page_tree.py
+++ b/packages/core/src/repowise/core/generation/page_tree.py
@@ -254,6 +254,23 @@ def assign_page_tree(
         members = [m for m in members if isinstance(m, str)]
         if not members:
             members = claimed.get(page.page_id, [])
+        if not members:
+            # A rollup overview owns no files of its own, so it has no members
+            # to place it and would otherwise land on the root. Borrow the
+            # members of the concept pages nested under its directory, so it
+            # sits under the same layer as the children it summarises.
+            prefix = page.target_path + "/"
+            borrowed: list[str] = []
+            for other in module_pages:
+                if other is page or not other.target_path.startswith(prefix):
+                    continue
+                child_members = (
+                    other.metadata.get("file_paths")
+                    or other.metadata.get("files")
+                    or claimed.get(other.page_id, [])
+                )
+                borrowed.extend(m for m in child_members if isinstance(m, str))
+            members = borrowed
         page.parent_page_id = layer_parent(_dominant_layer(members, layer_of_file))
 
     # A spotlight belongs to the file it documents: "path/to/file.py::Symbol".

--- a/tests/unit/generation/test_page_tree.py
+++ b/tests/unit/generation/test_page_tree.py
@@ -340,3 +340,40 @@ class TestConceptReadingOrder:
 
         assert self._ordered(nodes) == ["src/zzz", "src/mmm", "src/aaa"]
         assert [n.section_number for n in nodes if n.page_type == "module_page"]
+
+
+def _wiki_with_rollup() -> list[GeneratedPage]:
+    """Two leaf concept pages under a parent-dir rollup that owns no files.
+
+    A rollup overview is a ``module_page`` whose ``target_path`` is a parent
+    directory; it carries no ``file_paths`` because its children own them.
+    """
+    return [
+        _page("repo_overview", "demo"),
+        _page("layer_page", "layer:service"),
+        _page("layer_page", "layer:ui"),
+        _page("module_page", "src"),
+        _page("module_page", "src/ingest", file_paths=["src/ingest/a.py", "src/ingest/b.py"]),
+        _page("module_page", "src/web", file_paths=["src/web/app.tsx"]),
+        _page("file_page", "src/ingest/a.py", layer_id="layer:service"),
+        _page("file_page", "src/ingest/b.py", layer_id="layer:service"),
+        _page("file_page", "src/web/app.tsx", layer_id="layer:ui"),
+    ]
+
+
+class TestRollupPlacement:
+    def test_rollup_sits_under_its_children_layer_not_root(self):
+        """A file-less rollup borrows its children's layer instead of the root."""
+        pages = _wiki_with_rollup()
+        assign_page_tree(pages, LAYER_ORDER)
+        rollup = _by_id(pages)["module_page:src"]
+        # service wins 2 member files to 1 across the two child modules.
+        assert rollup.parent_page_id == "layer_page:layer:service"
+
+    def test_rollup_does_not_claim_its_children_files(self):
+        """Borrowing members for placement must not re-home the files."""
+        pages = _wiki_with_rollup()
+        assign_page_tree(pages, LAYER_ORDER)
+        by_id = _by_id(pages)
+        assert by_id["file_page:src/ingest/a.py"].parent_page_id == "module_page:src/ingest"
+        assert by_id["file_page:src/web/app.tsx"].parent_page_id == "module_page:src/web"


### PR DESCRIPTION
A rollup overview page owns no files, so its member list is empty and the tree placed it directly under the repo root instead of under the layer its child concept pages sit in. This is the "stray page at the top rung" symptom.

Borrow the members of the concept pages nested beneath the rollup's directory to resolve its dominant layer, matching the documented intent that a rollup sits alongside its children under their shared layer. Placement only: it does not claim the children's files, and the prefix match (`target_path + "/"`) does not over-match sibling directories.

Note on scope: the fallback applies to any `module_page` that recorded no members and has other module pages nested under its `target_path`. In practice that is the rollup case; a legacy member-less module page with no nested children keeps landing on the root as before.

Tests: added `TestRollupPlacement` asserting the rollup lands under its children's dominant layer and does not re-home the children's files. Full page-tree suite passes (28).