### PR TITLE
fix(ui): keep table-of-contents keys unique across repeated headings

### DIFF
--- a/packages/ui/src/wiki/table-of-contents.tsx
+++ b/packages/ui/src/wiki/table-of-contents.tsx
@@ -59,8 +59,11 @@ export function TableOfContents({ content }: { content: string }) {
       </p>
       {/* Left rail: a hairline the active item's accent bar sits on. */}
       <ul className="border-l border-[var(--color-border-default)]">
-        {headings.map(({ id, text, level }) => (
-          <li key={id}>
+        {/* A page can repeat a heading (two "Examples" sections, or a
+            duplicated section from generation), which slugifies to the same
+            id, so the list index keeps the React key unique. */}
+        {headings.map(({ id, text, level }, index) => (
+          <li key={`${id}-${index}`}>
             <a
               href={`#${id}`}
               className={cn(


### PR DESCRIPTION
The on-page contents keyed each entry by the slugified heading text, so a page with two identical headings produced duplicate React keys and the "two children with the same key" console warning (which can duplicate or omit list children). Fold the list index into the key so repeated headings stay distinct.

This is a robustness fix independent of any single page: markdown can legitimately repeat a heading. It surfaced on concept pages that occasionally carry a duplicated "Questions this page answers" section.