### PR TITLE
fix(server): normalize repository sort timestamps

### DIFF
--- a/packages/server/src/repowise/server/routers/_sorting.py
+++ b/packages/server/src/repowise/server/routers/_sorting.py
@@ -1,0 +1,19 @@
+"""Sorting helpers for repository API responses."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Protocol
+
+
+class _RepositoryTimestamps(Protocol):
+    updated_at: datetime | None
+    created_at: datetime | None
+
+
+def repository_sort_key(repo: _RepositoryTimestamps) -> datetime:
+    """Return a UTC-aware timestamp for repositories merged across databases."""
+    timestamp = repo.updated_at or repo.created_at
+    if timestamp is None:
+        return datetime.min.replace(tzinfo=UTC)
+    return timestamp if timestamp.tzinfo is not None else timestamp.replace(tzinfo=UTC)

--- a/packages/server/src/repowise/server/routers/repos.py
+++ b/packages/server/src/repowise/server/routers/repos.py
@@ -27,6 +27,7 @@ from repowise.core.persistence.models import (
 )
 from repowise.server.deps import get_db_session, get_fts, verify_api_key
 from repowise.server.job_executor import execute_job
+from repowise.server.routers._sorting import repository_sort_key
 from repowise.server.schemas import RepoCreate, RepoResponse, RepoStatsResponse, RepoUpdate
 
 logger = logging.getLogger(__name__)
@@ -176,8 +177,10 @@ async def list_repos(
         except Exception:
             pass
 
-    # Sort indexed repos by updated_at descending
-    repos.sort(key=lambda r: r.updated_at or r.created_at, reverse=True)
+    # Repository rows are merged across database backends in workspace mode.
+    # Normalize their timestamps before sorting because PostgreSQL returns aware
+    # datetimes while SQLite may return naive UTC values.
+    repos.sort(key=repository_sort_key, reverse=True)
     responses = [RepoResponse.from_orm(r) for r in repos]
 
     # Self-heal the freshness stamp on read: prefer each repo's state.json

--- a/tests/unit/test_repository_sorting.py
+++ b/tests/unit/test_repository_sorting.py
@@ -1,0 +1,20 @@
+"""Tests for repository API sorting helpers."""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from repowise.server.routers._sorting import repository_sort_key
+
+
+def test_repository_sort_key_handles_mixed_tz_awareness() -> None:
+    """Workspace databases can return a mix of naive and aware timestamps."""
+    aware = SimpleNamespace(
+        updated_at=datetime(2026, 7, 24, 9, 0, tzinfo=UTC),
+        created_at=None,
+    )
+    naive = SimpleNamespace(
+        updated_at=datetime(2026, 7, 24, 8, 0),
+        created_at=None,
+    )
+
+    assert sorted([naive, aware], key=repository_sort_key, reverse=True) == [aware, naive]


### PR DESCRIPTION
## Summary

- Normalize mixed PostgreSQL and SQLite repository timestamps before sorting workspace repositories, preventing `GET /api/repos` from returning 500.
- Add regression coverage for mixed timezone-aware and naive timestamps.

## Related Issues

Closes #1033

## Test Plan

- [x] Tests pass (`pytest`)
- [ ] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(if frontend changes)*

Focused pytest passes. Ruff passes on the new helper and test; the modified router retains the same five pre-existing findings as `main`.

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [ ] All existing tests still pass
- [x] I have updated documentation if needed
