### PR TITLE
generate onboards a provider like init when a docs run needs one

### DIFF
--- a/packages/cli/src/repowise/cli/commands/generate_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/generate_cmd/command.py
@@ -24,7 +24,7 @@ from repowise.cli.helpers import (
     get_head_commit,
     load_config,
     load_state,
-    resolve_provider,
+    resolve_provider_or_prompt,
     resolve_reasoning,
     resolve_repo_path,
     run_async,
@@ -233,9 +233,20 @@ def generate_command(
         page_ids=page_ids,
     )
 
-    # Provider is required — a model writes these pages. A missing one is an
-    # actionable error (resolve_provider names the key-setup path), not a trace.
-    provider = resolve_provider(provider_name, model, repo_path=repo_path)
+    # Provider is required since a model writes these pages. On a real terminal, a
+    # missing one drops into init's provider + key prompt and persists the choice,
+    # so a first `generate` onboards the same way init does instead of dying.
+    # Onboarding needs a terminal on both ends: a terminal stdout (so the provider
+    # table renders) and a tty stdin (so the answer can be read). The stdin check
+    # keeps a background hook / CI / agent run from hanging even when it inherits a
+    # FORCE_COLOR that makes console.is_terminal report True; those keep the clean
+    # "No provider configured" error. Unlike the bare-run default above, this fires
+    # even with explicit page flags, so a keyless `generate --all` still onboards,
+    # not just a bare `generate`.
+    can_prompt_provider = console.is_terminal and sys.stdin.isatty() and not yes
+    provider = resolve_provider_or_prompt(
+        provider_name, model, repo_path, reasoning=reasoning, interactive=can_prompt_provider
+    )
 
     console.print(
         f"[bold]repowise generate[/bold] — {repo_path}\n"

--- a/packages/cli/src/repowise/cli/helpers.py
+++ b/packages/cli/src/repowise/cli/helpers.py
@@ -808,14 +808,24 @@ def resolve_provider_or_prompt(
     """
     try:
         return resolve_provider(provider_name, model, repo_path=repo_path)
-    except Exception:
+    except Exception as original_error:
         if not interactive:
             raise
         from repowise.cli.ui import interactive_provider_config_select
 
-        selection = interactive_provider_config_select(
-            console, model, reasoning, repo_path=repo_path
-        )
+        # ``interactive`` rests on ``isatty()``, which lies: under Git Bash,
+        # some pty wrappers, and ``docker run -t`` without -i it claims a
+        # terminal it cannot read from, and agents drive us through exactly
+        # those shapes. Treat the prompt as the probe (as init does): if stdin
+        # cannot answer, click raises EOFError/Abort, so fall back to the clean,
+        # actionable "No provider configured" error instead of a bare "Aborted!".
+        try:
+            selection = interactive_provider_config_select(
+                console, model, reasoning, repo_path=repo_path
+            )
+        except (EOFError, click.Abort):
+            raise original_error from None
+
         # Persist provider/model so future runs resolve without re-prompting.
         # The API key was already persisted to .repowise/.env by the prompt.
         save_config_partial(

--- a/tests/unit/cli/test_helpers.py
+++ b/tests/unit/cli/test_helpers.py
@@ -727,3 +727,112 @@ class TestRotateUpdateLog:
         assert len(after) < UPDATE_LOG_MAX_BYTES
         assert b"TAIL_MARKER_ZZZZ" in after
         assert after.startswith(b"... (log truncated) ...")
+
+
+# ---------------------------------------------------------------------------
+# resolve_provider_or_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestResolveProviderOrPrompt:
+    """The shared onboarding wrapper `repowise generate` / `repowise update` use.
+
+    A docs run with no provider/key should, on a real terminal, reuse init's
+    provider + key prompt and persist the choice; a hook / CI / agent run must
+    stay a clean, non-blocking failure and never hang on a prompt it cannot
+    answer (isatty lies under Git Bash / pty wrappers / `docker run -t`).
+    """
+
+    def _no_provider(self):
+        import click
+
+        def _raise(*_args, **_kwargs):
+            raise click.ClickException("No provider configured. Use --provider, ...")
+
+        return _raise
+
+    def test_non_interactive_reraises_clean_error(self, tmp_path, monkeypatch):
+        """interactive=False propagates the original error, prompt never called."""
+        import click
+
+        from repowise.cli import helpers
+
+        monkeypatch.setattr(helpers, "resolve_provider", self._no_provider())
+        called = {"prompt": 0}
+
+        def _prompt(*_a, **_k):
+            called["prompt"] += 1
+
+        monkeypatch.setattr(
+            "repowise.cli.ui.interactive_provider_config_select", _prompt, raising=False
+        )
+
+        with pytest.raises(click.ClickException, match="No provider configured"):
+            helpers.resolve_provider_or_prompt(None, None, tmp_path, interactive=False)
+        assert called["prompt"] == 0
+
+    @pytest.mark.parametrize("exc_name", ["EOFError", "Abort"])
+    def test_unanswerable_prompt_falls_back_to_clean_error(
+        self, tmp_path, monkeypatch, exc_name
+    ):
+        """A tty that lies: the prompt hits EOF/Abort, so we surface the clean
+        actionable error instead of a bare 'Aborted!' — the agent-safe path."""
+        import click
+
+        from repowise.cli import helpers
+
+        monkeypatch.setattr(helpers, "resolve_provider", self._no_provider())
+        exc = EOFError() if exc_name == "EOFError" else click.Abort()
+
+        def _prompt(*_a, **_k):
+            raise exc
+
+        monkeypatch.setattr(
+            "repowise.cli.ui.interactive_provider_config_select", _prompt, raising=False
+        )
+
+        with pytest.raises(click.ClickException, match="No provider configured"):
+            helpers.resolve_provider_or_prompt(None, None, tmp_path, interactive=True)
+
+    def test_prompt_success_persists_and_resolves(self, tmp_path, monkeypatch):
+        """A real answer: persist provider/model to config and return the provider."""
+        from repowise.cli import helpers
+        from repowise.cli.ui.provider_selection import ProviderSelection
+
+        sentinel = object()
+        calls = {"resolve": 0}
+
+        def _resolve(provider_name, model, repo_path=None):
+            calls["resolve"] += 1
+            if calls["resolve"] == 1:
+                import click
+
+                raise click.ClickException("No provider configured. ...")
+            assert provider_name == "mock"
+            assert model == "mock-model-1"
+            return sentinel
+
+        monkeypatch.setattr(helpers, "resolve_provider", _resolve)
+
+        prompt_calls = {"n": 0}
+
+        def _prompt(console, model, reasoning=None, *, repo_path=None):
+            prompt_calls["n"] += 1
+            return ProviderSelection("mock", "mock-model-1", "auto")
+
+        monkeypatch.setattr(
+            "repowise.cli.ui.interactive_provider_config_select", _prompt, raising=False
+        )
+
+        result = helpers.resolve_provider_or_prompt(
+            None, None, tmp_path, reasoning=None, interactive=True
+        )
+
+        assert result is sentinel
+        assert prompt_calls["n"] == 1
+        # provider/model persisted so a later run resolves without re-prompting.
+        from repowise.cli.helpers import load_config
+
+        cfg = load_config(tmp_path)
+        assert cfg.get("provider") == "mock"
+        assert cfg.get("model") == "mock-model-1"


### PR DESCRIPTION
## What

`repowise generate` failed with `No provider configured` when no LLM key was set, even though `repowise init` and `repowise update` already reuse init's provider + key prompt to onboard on the spot. This wires `generate` to the same shared `resolve_provider_or_prompt` helper, so a first `generate` on a terminal prompts for the provider + key, persists the choice, and continues instead of dying.

No new prompting code: it reuses the exact helper `init` and `update` use. Provider/model persist to `.repowise/config.yaml`, the key to `.repowise/.env`, so the prompt only appears once per repo.

## Safe for hooks, CI, and agents

- Onboarding requires a terminal on both ends: a terminal stdout (so the provider table renders) and a tty stdin (so the answer can be read). Background hook / CI / `--yes` runs keep the clean, actionable `No provider configured` error.
- `isatty()` lies under Git Bash, some pty wrappers, and `docker run -t` without `-i`, which is how agents often drive the CLI. The shared helper now treats the prompt as a probe: if stdin cannot answer (`EOFError` / `Abort`), it falls back to the original clean error instead of a bare `Aborted!`. This mirrors how `init` handles its first prompt and also hardens the existing `update` caller.
- Unlike the bare-run default, the provider prompt fires even with explicit page flags, so a keyless `generate --all` still onboards.

## Tests

Added `TestResolveProviderOrPrompt` covering the non-interactive clean failure, the EOF/Abort fallback, and the success path that persists provider/model. Existing generate and update provider-prompt tests still pass.