### PR TITLE
fix(update): recover idle files' time-decayed health on update (#728)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/update_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/command.py
@@ -386,6 +386,25 @@ def _renderer_inputs(repo_path):
     return cfg.get("language", "en"), style.fingerprint, style.template_dir
 
 
+def _head_commit_ts(repo_path) -> float | None:
+    """Committer timestamp of the repo's HEAD, or None when git is unavailable.
+
+    Anchors the periodic idle-file health re-score gate (#728) to repo time
+    rather than wall clock, so the cadence is deterministic under
+    ``REPOWISE_GIT_WINDOW_ANCHOR`` and correct for historical checkouts.
+    """
+    try:
+        import git
+
+        repo = git.Repo(repo_path, search_parent_directories=True)
+        try:
+            return float(repo.head.commit.committed_date)
+        finally:
+            repo.close()
+    except Exception:
+        return None
+
+
 def _current_renderer_fingerprint(repo_path) -> str:
     """This release's fingerprint for the file-page renderer, or '' on failure.
 
@@ -912,6 +931,13 @@ def run_update(
     if emitter is not None:
         emitter.stage("rebuild_graph")
 
+    # Decay-only rows for idle files whose time-decayed history the anchor
+    # advance recovered (#728). Filled by the git re-index, persisted alongside
+    # the changed files' rows, and kept out of git_meta_map so partial health's
+    # repo-wide aggregates are unaffected. ``head_ts`` anchors the periodic
+    # idle-file health re-score gate.
+    git_decay_map: dict[str, dict] = {}
+    head_ts = _head_commit_ts(repo_path)
     parsed_files, source_map, graph_builder, repo_structure, file_count, git_meta_map = (
         _rebuild_graph_and_git(
             repo_path,
@@ -921,6 +947,7 @@ def run_update(
             git_tier=state.get("git_tier"),
             include_submodules=bool(state.get("include_submodules", False)),
             include_nested_repos=bool(state.get("include_nested_repos", False)),
+            idle_decay_sink=git_decay_map,
         )
     )
 
@@ -1071,6 +1098,9 @@ def run_update(
                 # not the same as having no wiki.
                 template_wiki=docs_mode == "deterministic",
                 pages_rendered=len(det_pages),
+                git_decay_map=git_decay_map,
+                exclude_patterns=exclude_patterns,
+                head_ts=head_ts,
             )
         except Exception as exc:
             if emitter is not None:
@@ -1529,11 +1559,23 @@ def run_update(
             degraded=degraded,
             decay_paths=affected.decay_only,
             parsed_files=parsed_files,
+            git_decay_map=git_decay_map,
         )
     except Exception as exc:
         if emitter is not None:
             emitter.error(str(exc))
         raise
+
+    # Periodic idle-file health re-score (#728): git_metadata is now fresh in the
+    # DB, so re-score every file's findings against the decayed inputs. Reuses
+    # the already-built graph (no second rebuild); gated to ~weekly. Stamped into
+    # ``state`` below via the final save_state.
+    from .persistence import full_rescore_due, run_decay_health_rescore
+
+    if full_rescore_due(state, head_ts) and run_decay_health_rescore(
+        repo_path, graph_builder, parsed_files, exclude_patterns
+    ):
+        state["last_full_rescore_at"] = head_ts
 
     # ---- Editor project files (best-effort) ----
     _refresh_editor_stamp(repo_path, agents_md, degraded)

--- a/packages/cli/src/repowise/cli/commands/update_cmd/incremental.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/incremental.py
@@ -74,9 +74,14 @@ def _rebuild_graph_and_git(
     git_tier: str | None = None,
     include_submodules: bool = False,
     include_nested_repos: bool = False,
+    idle_decay_sink: dict[str, dict] | None = None,
 ) -> tuple[list, dict[str, bytes], Any, Any, int, dict[str, dict]]:
     """Re-traverse + parse the repo, rebuild the graph (+ framework edges), and
     re-index git metadata for the changed files.
+
+    ``idle_decay_sink``, when provided, is filled with decay-only partial rows
+    for idle files whose time-decayed history the anchor advance recovered
+    (issue #728); the caller feeds them straight to the git persist step.
 
     ``git_tier`` is the persisted ``state.json:git_tier`` value: a fast-mode
     (ESSENTIAL) repo must not pay per-file blame on every update for signals
@@ -105,6 +110,7 @@ def _rebuild_graph_and_git(
             git_tier=git_tier,
             include_submodules=include_submodules,
             include_nested_repos=include_nested_repos,
+            idle_decay_sink=idle_decay_sink,
             log=console.print,
         )
     )

--- a/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
+++ b/packages/cli/src/repowise/cli/commands/update_cmd/persistence.py
@@ -8,6 +8,8 @@ state-file updates and console reporting stay here.
 
 from __future__ import annotations
 
+import contextlib
+import os
 import time
 from pathlib import Path
 from typing import Any
@@ -143,6 +145,9 @@ def _persist_index_only_update(
     degraded: list[str] | None = None,
     pages_rendered: int = 0,
     template_wiki: bool = False,
+    git_decay_map: dict | None = None,
+    exclude_patterns: list[str] | None = None,
+    head_ts: float | None = None,
 ) -> None:
     """Persist the index-only update (graph + symbols + git + dead-code + health + KG),
     save state, and print the completion line. No LLM regeneration.
@@ -165,6 +170,7 @@ def _persist_index_only_update(
             file_diffs=file_diffs,
             knowledge_graph_result=knowledge_graph_result,
             parsed_files=parsed_files,
+            git_decay_map=git_decay_map,
             log=console.print,
             degraded=degraded,
         )
@@ -173,9 +179,19 @@ def _persist_index_only_update(
 
     from .command import _current_renderer_fingerprint
 
+    # Periodic idle-file health re-score (#728): git_metadata is now fresh in the
+    # DB, so re-score every file's findings against the decayed inputs. Gated to
+    # ~weekly since only the findings (not their cheap git inputs) lag here.
+    last_full_rescore_at = state.get("last_full_rescore_at")
+    if full_rescore_due(state, head_ts) and run_decay_health_rescore(
+        repo_path, graph_builder, parsed_files or [], exclude_patterns or []
+    ):
+        last_full_rescore_at = head_ts
+
     new_state = {
         **state,
         "last_sync_commit": head,
+        "last_full_rescore_at": last_full_rescore_at,
         "config_fingerprint": config_fingerprint(repo_path),
         # Record the renderer this run rendered with. Without this an index-only
         # update that regenerated stale file pages leaves the stored fingerprint
@@ -310,6 +326,7 @@ def _persist_full_update(
     degraded: list[str],
     decay_paths: list[str] | None = None,
     parsed_files: list | None = None,
+    git_decay_map: dict | None = None,
 ) -> int:
     """Persist a full (LLM-regenerating) update in one transaction.
 
@@ -343,6 +360,7 @@ def _persist_full_update(
             degraded=degraded,
             decay_paths=decay_paths,
             parsed_files=parsed_files,
+            git_decay_map=git_decay_map,
         )
     )
 
@@ -364,6 +382,7 @@ async def _persist_full_update_async(
     degraded: list[str],
     decay_paths: list[str] | None = None,
     parsed_files: list | None = None,
+    git_decay_map: dict | None = None,
 ) -> int:
     from repowise.cli.helpers import get_db_url_for_repo
     from repowise.core.persistence import (
@@ -461,14 +480,21 @@ async def _persist_full_update_async(
                     _skip("Knowledge-graph persist", exc)
 
             # Updated git metadata + recomputed percentiles + new commit rows.
-            if git_meta_map:
+            if git_meta_map or git_decay_map:
                 try:
                     from repowise.core.persistence.crud import (
                         recompute_git_percentiles,
                         upsert_git_metadata_bulk,
                     )
 
-                    await upsert_git_metadata_bulk(session, repo_id, list(git_meta_map.values()))
+                    # Changed files' full rows + idle files' decay-only rows
+                    # (#728), then a repo-wide percentile re-rank over the fresh
+                    # scores.
+                    await upsert_git_metadata_bulk(
+                        session,
+                        repo_id,
+                        [*git_meta_map.values(), *(git_decay_map or {}).values()],
+                    )
                     await recompute_git_percentiles(session, repo_id)
                 except Exception as exc:
                     _skip("Git persist", exc)
@@ -711,41 +737,26 @@ def _git_metadata_to_dict(gm: Any) -> dict[str, Any]:
     }
 
 
-def _run_full_health_rescore(
+async def _rescore_health_from_db(
     repo_path: Any,
+    graph_builder: Any,
+    parsed_files: list,
     exclude_patterns: list[str],
-    state: dict,
-    head: str | None,
-    curr_fingerprint: str,
 ) -> None:
-    """Rebuild graph and re-run full health analysis when config changed.
+    """Full-replace health re-score reading git metadata from the DB.
 
-    Uses save_health_metrics / save_health_findings (full replace, not upsert)
-    so rows for newly-excluded files are removed. Loads GitMetadata from the DB
-    (so biomarkers keep accurate churn/ownership/co-change data) and removes
-    excluded rows both from the DB and the analyzer input.
+    Shared by the config-changed rebuild path and the periodic decay re-score
+    (#728): both need *every* file re-scored against the current git_metadata —
+    not just the changed files — but that metadata is already persisted, so the
+    analyzer reads it from the DB (keeping accurate churn / ownership /
+    co-change data) rather than the caller's changed-only map. Excluded rows are
+    dropped from both the DB and the analyzer input; metrics/findings are
+    full-replaced so rows for newly-excluded files disappear.
+
+    The caller supplies an already-built *graph_builder* / *parsed_files* so the
+    graph is rebuilt at most once per update.
     """
-    import time
-
-    start = time.monotonic()
-
     import pathspec
-
-    # Share the rebuild path with the incremental update so both produce the
-    # same graph (same parser, same framework-aware synthetic edges).
-    parsed_files, _source_map, graph_builder, _repo_structure, _file_count = _build_repo_graph(
-        repo_path,
-        exclude_patterns,
-        include_submodules=bool(state.get("include_submodules", False)),
-        include_nested_repos=bool(state.get("include_nested_repos", False)),
-    )
-
-    # Fan-out metric precompute (mirrors _rebuild_graph_and_git) — the
-    # rescore persists graph nodes too, which reads every metric.
-    try:
-        run_async(graph_builder.compute_metrics_parallel())
-    except Exception:
-        pass  # metrics fall back to lazy computation
 
     exclude_spec = (
         pathspec.PathSpec.from_lines("gitwildmatch", exclude_patterns) if exclude_patterns else None
@@ -846,8 +857,45 @@ def _run_full_health_rescore(
                 )
             await persist_graph_nodes(session, repo_id, graph_builder)
 
+    await _rescore()
+
+
+def _run_full_health_rescore(
+    repo_path: Any,
+    exclude_patterns: list[str],
+    state: dict,
+    head: str | None,
+    curr_fingerprint: str,
+) -> None:
+    """Rebuild graph and re-run full health analysis when config changed.
+
+    Rebuilds the graph (config edits can change parsing/excludes), then delegates
+    to :func:`_rescore_health_from_db` for the full-replace re-score. On success
+    advances ``last_sync_commit`` + ``config_fingerprint`` so the config change
+    is not re-detected; on failure leaves the fingerprint so the next update
+    retries.
+    """
+    import time
+
+    start = time.monotonic()
+
+    # Share the rebuild path with the incremental update so both produce the
+    # same graph (same parser, same framework-aware synthetic edges).
+    parsed_files, _source_map, graph_builder, _repo_structure, _file_count = _build_repo_graph(
+        repo_path,
+        exclude_patterns,
+        include_submodules=bool(state.get("include_submodules", False)),
+        include_nested_repos=bool(state.get("include_nested_repos", False)),
+    )
+
+    # Fan-out metric precompute (mirrors _rebuild_graph_and_git) — the
+    # rescore persists graph nodes too, which reads every metric. Best-effort:
+    # metrics fall back to lazy computation.
+    with contextlib.suppress(Exception):
+        run_async(graph_builder.compute_metrics_parallel())
+
     try:
-        run_async(_rescore())
+        run_async(_rescore_health_from_db(repo_path, graph_builder, parsed_files, exclude_patterns))
     except Exception as exc:
         # Return without advancing the fingerprint so the next update retries.
         console.print(f"[yellow]Health re-score failed: {exc}[/yellow]")
@@ -859,3 +907,58 @@ def _run_full_health_rescore(
     )
     elapsed = time.monotonic() - start
     console.print(f"[green]Config-triggered health re-score complete[/green] in {elapsed:.1f}s")
+
+
+# Periodic idle-file health re-score cadence (#728). The cheap git-metadata
+# decay refresh runs every update, but the health *findings* for idle files only
+# recover when the analyzer re-scores them. Those biomarkers have a ~125-180d
+# half-life, so weekly is ample. The interval is anchored to the repo's
+# newest-commit timestamp (not wall clock) so it stays deterministic under
+# REPOWISE_GIT_WINDOW_ANCHOR / historical checkouts; override for tests.
+_FULL_RESCORE_INTERVAL_DAYS = 7.0
+
+
+def _full_rescore_interval_days() -> float:
+    raw = os.environ.get("REPOWISE_FULL_RESCORE_INTERVAL_DAYS", "").strip()
+    if raw:
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            pass
+    return _FULL_RESCORE_INTERVAL_DAYS
+
+
+def full_rescore_due(state: dict, head_ts: float | None) -> bool:
+    """Whether a periodic idle-file health re-score is due this update (#728).
+
+    Absent ``head_ts`` (git unavailable) → not due. Absent stamp (never
+    re-scored, or legacy state) → due, to establish the recovered baseline.
+    """
+    if head_ts is None:
+        return False
+    last = state.get("last_full_rescore_at")
+    if not isinstance(last, (int, float)):
+        return True
+    return (head_ts - float(last)) >= _full_rescore_interval_days() * 86400.0
+
+
+def run_decay_health_rescore(
+    repo_path: Any,
+    graph_builder: Any,
+    parsed_files: list,
+    exclude_patterns: list[str],
+) -> bool:
+    """Periodic full health re-score off the already-built graph (#728).
+
+    Reuses the update's ``graph_builder`` / ``parsed_files`` (no second rebuild)
+    and reads the just-refreshed git_metadata from the DB, so idle files' health
+    findings recover in lockstep with their decayed inputs. Best-effort: returns
+    True on success so the caller can stamp ``last_full_rescore_at``; a failure
+    is logged and leaves the stamp so the next update retries.
+    """
+    try:
+        run_async(_rescore_health_from_db(repo_path, graph_builder, parsed_files, exclude_patterns))
+        return True
+    except Exception as exc:
+        console.print(f"[yellow]Idle-file health re-score skipped: {exc}[/yellow]")
+        return False

--- a/packages/core/src/repowise/core/ingestion/git_indexer/file_history.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/file_history.py
@@ -74,7 +74,28 @@ def _truncate_body(body: str) -> str:
 
 logger = structlog.get_logger(__name__)
 
-__all__ = ["index_file", "new_meta"]
+__all__ = ["DECAY_REFRESH_KEYS", "index_file", "new_meta"]
+
+# The anchor-dependent window/decay fields — the only git-metadata columns that
+# *recover* as the repo's newest-commit anchor advances (see issue #728). An
+# incremental update recomputes just these for idle (unchanged) files off the
+# repo-wide walk and persists a decay-only partial row, leaving ownership / age
+# / authorship (which need full history and are only correct from the init
+# walk) untouched. ``co_change_partners_json`` / ``change_entropy`` /
+# ``prior_defect_*`` are merged onto the metadata after the per-file pass, so
+# they refresh together with the window churn fields ``index_file`` computes.
+DECAY_REFRESH_KEYS = (
+    "commit_count_90d",
+    "commit_count_30d",
+    "lines_added_90d",
+    "lines_deleted_90d",
+    "merge_commit_count_90d",
+    "temporal_hotspot_score",
+    "prior_defect_count",
+    "prior_defect_raw_count",
+    "change_entropy",
+    "co_change_partners_json",
+)
 
 
 def new_meta(file_path: str) -> dict[str, Any]:

--- a/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
+++ b/packages/core/src/repowise/core/ingestion/git_indexer/indexer.py
@@ -30,7 +30,7 @@ from ._constants import (
 )
 from .co_change import compute_co_changes, compute_co_changes_and_entropy
 from .enrich import compute_percentiles
-from .file_history import index_file
+from .file_history import DECAY_REFRESH_KEYS, index_file
 from .prior_defects import FixWalk, PriorDefects, collect_fix_commits, compute_prior_defects
 from .records import GitIndexSummary, _CommitRec, _should_skip_index, capture_repo_totals
 from .tiers import GitIndexTier
@@ -348,6 +348,7 @@ class GitIndexer:
         changed_file_paths: list[str],
         all_files: set[str] | None = None,
         co_change_sink: dict[str, list[dict]] | None = None,
+        idle_decay_sink: dict[str, dict] | None = None,
     ) -> list[dict]:
         """Incremental update: re-index only changed files.
 
@@ -368,6 +369,18 @@ class GitIndexer:
         ones). The update path uses it to rebuild the graph's ``co_changes``
         edges for the whole repo so the update-built graph converges with the
         init-built one.
+
+        ``idle_decay_sink``, when provided (with ``all_files`` and a co-change
+        tier), receives a decay-only partial metadata row for every *idle*
+        (unchanged) file with commits in the recent window. Incremental updates
+        otherwise re-score only the changed files, so idle files never get
+        their time-decayed history fields (``temporal_hotspot_score``, the 90d
+        churn/commit windows, ``prior_defect_count``, ``change_entropy``,
+        ``co_change_partners_json``) rewritten as the anchor advances — their
+        scores can only ratchet downward and never recover (issue #728). This
+        recomputes just those fields off the walks already loaded here; the
+        persist path upserts them field-by-field so ownership / age / authorship
+        (correct only from the full init walk) are left intact.
         """
         repo = self._get_repo()
         if repo is None:
@@ -377,15 +390,30 @@ class GitIndexer:
         semaphore = asyncio.Semaphore(20)
         include_blame = self.tier.includes_blame
 
+        # Whether to refresh idle files' decay fields this run. Requires the
+        # repo-wide commit index (rename-tracking mode has none) and the
+        # co-change walk (which supplies idle files' fresh partners/entropy —
+        # skipping it would blank those fields on ESSENTIAL-tier repos).
+        refresh_idle = bool(
+            idle_decay_sink is not None
+            and all_files
+            and not self.follow_renames
+            and self.tier.includes_co_change
+        )
+
         prov_clf = self._provenance_classifier()
         commit_index: dict[str, list[_CommitRec]] = {}
         if not self.follow_renames:
             from ..git_commit_index import load_commit_index
 
+            # Bucket every tracked file (not just the changed ones) when an idle
+            # refresh is due, so idle files carry their own precomputed commits.
+            # The git subprocess is identical either way — only the in-memory
+            # bucketing set widens.
             commit_index = load_commit_index(
                 repo,
                 self.commit_limit,
-                set(changed_file_paths),
+                set(all_files) if refresh_idle else set(changed_file_paths),
                 provenance_classifier=prov_clf,
             )
         as_of_ts = self._resolve_as_of_ts(repo, commit_index)
@@ -437,12 +465,20 @@ class GitIndexer:
             else:
                 results.append(r)
 
-        # Recompute prior-defect counts for the changed files (same dedicated
-        # windowed pass as the full index — the per-file commit list can't carry
-        # this signal accurately on busy repos).
+        # Idle files (window commits, but not in this change set) whose decay
+        # fields we will refresh — computed here so the prior-defect pass below
+        # covers them in its single windowed walk.
+        changed_set = set(changed_file_paths)
+        idle_paths = [fp for fp in commit_index if fp not in changed_set] if refresh_idle else []
+
+        # Recompute prior-defect counts (same dedicated windowed pass as the
+        # full index — the per-file commit list can't carry this signal
+        # accurately on busy repos). Widen the counted set to the idle files
+        # too: the walk is one subprocess regardless, and an idle file whose
+        # only fix aged past the window must drop to 0 (handled below).
         try:
             prior_defects = compute_prior_defects(
-                repo, {m["file_path"] for m in results}, as_of_ts=as_of_ts
+                repo, {m["file_path"] for m in results} | set(idle_paths), as_of_ts=as_of_ts
             )
             for meta in results:
                 fp = meta["file_path"]
@@ -452,6 +488,7 @@ class GitIndexer:
                     meta["prior_defect_raw_count"] = prior_defects.raw_counts[fp]
         except Exception as exc:
             logger.debug("prior_defect_pass_failed", error=str(exc))
+            prior_defects = PriorDefects()
 
         # Co-change partners + change entropy ride a repo-wide walk the
         # per-file pass cannot produce. ``index_file`` resets both fields to
@@ -480,11 +517,74 @@ class GitIndexer:
                         meta["change_entropy"] = change_entropy[fp]
                 if co_change_sink is not None:
                     co_change_sink.update(co_changes)
+
+                # Idle-file decay refresh (#728): recompute only the
+                # anchor-dependent window/decay fields for every idle file with
+                # recent-window commits, reusing the walks already loaded above.
+                # index_file with precomputed commits + blame off does no git
+                # subprocess and no file I/O, so this is pure timestamp
+                # arithmetic; strip to the decay keys so the field-wise upsert
+                # never clobbers full-history columns (ownership, age, authors).
+                if refresh_idle and idle_paths:
+                    idle_decay_sink.update(
+                        await asyncio.to_thread(
+                            self._compute_idle_decay,
+                            repo,
+                            idle_paths,
+                            commit_index,
+                            as_of_ts,
+                            prov_clf,
+                            co_changes,
+                            change_entropy,
+                            prior_defects,
+                        )
+                    )
             except Exception as exc:
                 logger.debug("co_change_pass_failed", error=str(exc))
 
         repo.close()
         return results
+
+    def _compute_idle_decay(
+        self,
+        repo: Any,
+        idle_paths: list[str],
+        commit_index: dict[str, list[_CommitRec]],
+        as_of_ts: float | None,
+        prov_clf: Any,
+        co_changes: dict[str, list[dict]],
+        change_entropy: dict[str, float],
+        prior_defects: PriorDefects,
+    ) -> dict[str, dict]:
+        """Decay-only partial rows for *idle_paths* (see ``index_changed_files``).
+
+        Runs off the event loop. For each idle file, ``index_file`` recomputes
+        the window/decay churn fields from its precomputed commits (blame off →
+        no git subprocess, no file stat), then the repo-wide co-change / entropy
+        / prior-defect signals are overlaid. Only :data:`DECAY_REFRESH_KEYS` are
+        kept so the field-wise upsert leaves full-history columns untouched. A
+        signal absent from a walk resolves to its recovered baseline (``0`` /
+        ``[]``) so, e.g., a file whose only fix aged out drops to zero.
+        """
+        out: dict[str, dict] = {}
+        for fp in idle_paths:
+            meta = index_file(
+                repo,
+                fp,
+                repo_path=self.repo_path,
+                commit_limit=self.commit_limit,
+                follow_renames=self.follow_renames,
+                include_blame=False,
+                precomputed_commits=commit_index.get(fp),
+                as_of_ts=as_of_ts,
+                provenance_classifier=prov_clf,
+            )
+            meta["change_entropy"] = change_entropy.get(fp, 0.0)
+            meta["co_change_partners_json"] = json.dumps(co_changes.get(fp, []))
+            meta["prior_defect_count"] = prior_defects.counts.get(fp, 0)
+            meta["prior_defect_raw_count"] = prior_defects.raw_counts.get(fp, 0)
+            out[fp] = {"file_path": fp, **{k: meta[k] for k in DECAY_REFRESH_KEYS}}
+        return out
 
     def capture_new_commit_rows(self, *, since_ts: int | None = None) -> list[dict]:
         """Build ``git_commits`` rows for commits newer than *since_ts*.

--- a/packages/core/src/repowise/core/pipeline/incremental.py
+++ b/packages/core/src/repowise/core/pipeline/incremental.py
@@ -203,10 +203,18 @@ async def rebuild_graph_and_git(
     git_tier: str | None = None,
     include_submodules: bool = False,
     include_nested_repos: bool = False,
+    idle_decay_sink: dict[str, dict] | None = None,
     log: LogFn | None = None,
 ) -> tuple[list, dict[str, bytes], Any, Any, int, dict[str, dict]]:
     """Re-traverse + parse the repo, rebuild the graph (+ framework edges), and
     re-index git metadata for the changed files.
+
+    ``idle_decay_sink``, when provided, is filled with a decay-only partial
+    metadata row for every idle (unchanged) file whose time-decayed history
+    fields the anchor advance moved (issue #728). These rows are for the git
+    persist step only — they are deliberately kept out of the returned
+    ``git_meta_map`` so the partial health analysis (whose repo-wide aggregates
+    read every entry) is unaffected.
 
     ``git_tier`` is the persisted ``state.json:git_tier`` value: a fast-mode
     (ESSENTIAL) repo must not pay per-file blame on every update for signals
@@ -264,6 +272,7 @@ async def rebuild_graph_and_git(
             changed_paths,
             all_files=set(source_map.keys()),
             co_change_sink=co_change_full,
+            idle_decay_sink=idle_decay_sink,
         )
         git_meta_map = {m["file_path"]: m for m in updated_meta}
         if co_change_full:
@@ -848,6 +857,7 @@ async def persist_incremental_index(
     file_diffs: list[Any] | None = None,
     knowledge_graph_result: Any | None = None,
     parsed_files: list[Any] | None = None,
+    git_decay_map: dict | None = None,
     log: LogFn | None = None,
     degraded: list[str] | None = None,
 ) -> None:
@@ -918,14 +928,21 @@ async def persist_incremental_index(
             except Exception as exc:
                 _skip("Page tree rebuild", exc)
 
-            if git_meta_map:
+            if git_meta_map or git_decay_map:
                 try:
                     from repowise.core.persistence.crud import (
                         recompute_git_percentiles,
                         upsert_git_metadata_bulk,
                     )
 
-                    await upsert_git_metadata_bulk(session, repo_id, list(git_meta_map.values()))
+                    # Idle files' decay-only rows upsert alongside the changed
+                    # files' full rows; the percentile re-rank then runs over
+                    # every row against the freshly decayed scores (#728).
+                    await upsert_git_metadata_bulk(
+                        session,
+                        repo_id,
+                        [*git_meta_map.values(), *(git_decay_map or {}).values()],
+                    )
                     await recompute_git_percentiles(session, repo_id)
                 except Exception as exc:
                     _skip("Git persist", exc)

--- a/packages/core/src/repowise/core/workspace/update.py
+++ b/packages/core/src/repowise/core/workspace/update.py
@@ -366,6 +366,10 @@ async def _incremental_repo_update(
     cfg = load_repo_config(repo_path)
     merged_excludes = _merged_repo_excludes(repo_path, exclude_patterns)
 
+    # Decay-only rows for idle files the anchor advance recovered (#728);
+    # persisted alongside the changed rows, kept out of git_meta_map so partial
+    # health's repo-wide aggregates are unaffected (mirrors the CLI path).
+    git_decay_map: dict[str, dict] = {}
     (
         parsed_files,
         _source_map,
@@ -381,6 +385,7 @@ async def _incremental_repo_update(
         git_tier=state.get("git_tier"),
         include_submodules=bool(state.get("include_submodules", False)),
         include_nested_repos=bool(state.get("include_nested_repos", False)),
+        idle_decay_sink=git_decay_map,
         log=_log.info,
     )
 
@@ -423,6 +428,7 @@ async def _incremental_repo_update(
         file_diffs=file_diffs,
         knowledge_graph_result=kg,
         parsed_files=parsed_files,
+        git_decay_map=git_decay_map,
         log=_log.info,
     )
 

--- a/tests/unit/cli/test_update_e2e.py
+++ b/tests/unit/cli/test_update_e2e.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -27,6 +28,43 @@ from repowise.cli.main import cli
 def _git(repo: Path, *args: str) -> str:
     result = subprocess.run(["git", *args], cwd=str(repo), capture_output=True, text=True)
     return result.stdout.strip()
+
+
+def _git_commit_dated(repo: Path, message: str, date: str) -> None:
+    """Commit already-staged changes with a fixed author/committer date, so
+    decay-window tests can advance the repo's anchor deterministically."""
+    env = {**os.environ, "GIT_AUTHOR_DATE": date, "GIT_COMMITTER_DATE": date}
+    subprocess.run(
+        ["git", "commit", "-m", message], cwd=str(repo), env=env, capture_output=True, text=True
+    )
+
+
+async def _git_metadata(repo: Path, file_path: str) -> dict:
+    """Read one file's persisted git_metadata row as a dict."""
+    from repowise.core.persistence import create_engine, create_session_factory, get_session
+    from repowise.core.persistence.database import resolve_db_url
+    from repowise.core.persistence.models import GitMetadata
+
+    engine = create_engine(resolve_db_url(repo))
+    try:
+        sf = create_session_factory(engine)
+        async with get_session(sf) as session:
+            row = (
+                (
+                    await session.execute(
+                        select(GitMetadata).where(GitMetadata.file_path == file_path)
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            return {
+                "temporal_hotspot_score": row.temporal_hotspot_score,
+                "commit_count_90d": row.commit_count_90d,
+                "prior_defect_count": row.prior_defect_count,
+            }
+    finally:
+        await engine.dispose()
 
 
 def _make_git_repo(tmp_path: Path) -> Path:
@@ -107,9 +145,7 @@ def test_update_refreshes_every_index_layer(tmp_path: Path) -> None:
     assert "c.py" not in kg_path.read_text(encoding="utf-8")
 
     # A new file changes the graph shape, so every layer must move.
-    (repo / "c.py").write_text(
-        "from b import beta\n\n\ndef gamma():\n    return beta() * 2\n"
-    )
+    (repo / "c.py").write_text("from b import beta\n\n\ndef gamma():\n    return beta() * 2\n")
     _git(repo, "add", ".")
     _git(repo, "commit", "-m", "add c.py")
     new_head = _git(repo, "rev-parse", "HEAD")
@@ -137,6 +173,57 @@ def test_update_refreshes_every_index_layer(tmp_path: Path) -> None:
     kg_after = json.loads(kg_path.read_text(encoding="utf-8"))
     assert any("c.py" in (n.get("filePath") or n.get("id") or "") for n in kg_after["nodes"])
     assert state.get("knowledge_graph", {}).get("fingerprint")
+
+
+def test_update_recovers_idle_file_decayed_health(tmp_path: Path, monkeypatch) -> None:
+    """#728: an idle file's time-decayed history must recover on a plain git
+    update. a.py churns hard, then only b.py changes six months later — a.py is
+    never touched, yet its decayed hotspot score must shrink and the periodic
+    full re-score must fire (stamping ``last_full_rescore_at``)."""
+    # Anchor windows/decay to the repo's newest commit so the six-month gap is
+    # deterministic rather than measured against wall clock.
+    monkeypatch.setenv("REPOWISE_GIT_WINDOW_ANCHOR", "head")
+
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "user.name", "Test")
+    for i in range(4):
+        (repo / "a.py").write_text("x = 1\n" * (i + 5))
+        _git(repo, "add", ".")
+        _git_commit_dated(repo, f"churn a {i}", "2024-01-01T00:00:00")
+    (repo / "b.py").write_text("y = 0\n")
+    _git(repo, "add", ".")
+    _git_commit_dated(repo, "add b", "2024-01-02T00:00:00")
+
+    _index_full(repo)
+    base = _git(repo, "rev-parse", "HEAD")
+    before = asyncio.run(_git_metadata(repo, "a.py"))
+    assert before["temporal_hotspot_score"] > 0.0
+
+    from repowise.cli.helpers import save_state
+
+    save_state(repo, {"last_sync_commit": base, "docs_enabled": False})
+
+    # Six months later, only b.py changes. a.py is idle.
+    for i in range(3):
+        (repo / "b.py").write_text(f"y = {i + 1}\n")
+        _git(repo, "add", ".")
+        _git_commit_dated(repo, f"b only {i}", "2024-07-01T00:00:00")
+
+    result = CliRunner().invoke(cli, ["update", str(repo), "--no-workspace"])
+    assert result.exit_code == 0, result.output
+
+    after = asyncio.run(_git_metadata(repo, "a.py"))
+    # The idle file's decayed hotspot score recovered (shrank) even though no
+    # commit touched it — the ratchet #728 reported is gone.
+    assert after["temporal_hotspot_score"] < before["temporal_hotspot_score"]
+
+    # The periodic full health re-score fired (no prior stamp → due) and was
+    # anchored to the repo's HEAD timestamp.
+    state = json.loads((repo / ".repowise" / "state.json").read_text(encoding="utf-8"))
+    assert isinstance(state.get("last_full_rescore_at"), (int, float))
 
 
 def test_update_degrades_visibly_when_a_step_fails(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/ingestion/test_git_update_equivalence.py
+++ b/tests/unit/ingestion/test_git_update_equivalence.py
@@ -155,6 +155,123 @@ async def test_update_path_essential_tier_skips_co_change_walk(tmp_path) -> None
     assert meta["co_change_partners_json"] == "[]"
 
 
+# ---------------------------------------------------------------------------
+# Idle-file decay refresh (#728): an update must rewrite the time-decayed
+# history fields for *unchanged* files too, or their scores can only ratchet
+# downward and never recover as the anchor advances.
+# ---------------------------------------------------------------------------
+
+
+def _commit_dated(repo, tmp_path, files: dict[str, str], msg: str, date: str):
+    for name, content in files.items():
+        (tmp_path / name).write_text(content)
+    repo.index.add(list(files))
+    return repo.index.commit(msg, author_date=date, commit_date=date)
+
+
+def _build_repo_idle(tmp_path):
+    """a.py + b.py churn together, then only b.py keeps changing."""
+    import git as gitpython
+
+    repo = gitpython.Repo.init(tmp_path)
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", "Alice")
+        cw.set_value("user", "email", "alice@example.com")
+    for i in range(3):
+        _commit_dated(
+            repo,
+            tmp_path,
+            {"a.py": "x\n" * (i + 2), "b.py": f"y = {i}\n"},
+            f"feat: joint change {i} touching both modules",
+            "2024-01-01T00:00:00",
+        )
+    for i in range(4):
+        _commit_dated(
+            repo, tmp_path, {"b.py": f"y = {i + 9}\n"}, f"chore: b only {i}", "2024-01-05T00:00:00"
+        )
+    repo.close()
+
+
+async def test_idle_decay_refresh_matches_full_index(tmp_path, monkeypatch) -> None:
+    """The idle refresh must write exactly what a fresh full index would — the
+    correct decayed value — for an unchanged file, using decay-only keys."""
+    import json
+
+    from repowise.core.ingestion.git_indexer.file_history import DECAY_REFRESH_KEYS
+
+    monkeypatch.setenv("REPOWISE_GIT_WINDOW_ANCHOR", "head")
+    _build_repo_idle(tmp_path)
+
+    full = GitIndexer(tmp_path, tier=GitIndexTier.FULL)
+    _summary, full_meta = await full.index_repo("repo1")
+    full_by_path = {m["file_path"]: m for m in full_meta}
+
+    sink: dict[str, dict] = {}
+    upd = GitIndexer(tmp_path, tier=GitIndexTier.FULL)
+    changed = await upd.index_changed_files(
+        ["b.py"], all_files={"a.py", "b.py"}, idle_decay_sink=sink
+    )
+
+    # Only idle files land in the sink; changed files stay on the normal path.
+    assert set(sink) == {"a.py"}
+    assert {m["file_path"] for m in changed} == {"b.py"}
+
+    idle = sink["a.py"]
+    # Decay-only: never carries full-history columns the upsert would clobber.
+    assert set(idle) == set(DECAY_REFRESH_KEYS) | {"file_path"}
+
+    full_a = full_by_path["a.py"]
+    assert idle["temporal_hotspot_score"] == pytest.approx(
+        full_a["temporal_hotspot_score"], rel=1e-3
+    )
+    assert idle["commit_count_90d"] == full_a["commit_count_90d"]
+    assert idle["lines_added_90d"] == full_a["lines_added_90d"]
+    assert json.loads(idle["co_change_partners_json"]) == json.loads(
+        full_a["co_change_partners_json"]
+    )
+
+
+async def test_idle_decay_refresh_recovers_as_anchor_advances(tmp_path, monkeypatch) -> None:
+    """The reported symptom: leave a churny file alone and its decayed score
+    must shrink as new (unrelated) commits advance the anchor."""
+    import git as gitpython
+
+    monkeypatch.setenv("REPOWISE_GIT_WINDOW_ANCHOR", "head")
+
+    repo = gitpython.Repo.init(tmp_path)
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", "Alice")
+        cw.set_value("user", "email", "alice@example.com")
+    # a.py churns hard in January.
+    for i in range(4):
+        _commit_dated(
+            repo, tmp_path, {"a.py": "x\n" * (i + 5)}, f"feat: churn a {i}", "2024-01-01T00:00:00"
+        )
+    _commit_dated(repo, tmp_path, {"b.py": "y = 0\n"}, "feat: add b", "2024-01-02T00:00:00")
+    repo.close()
+
+    # Score a.py at the January anchor.
+    early = GitIndexer(tmp_path, tier=GitIndexTier.FULL)
+    _s, early_meta = await early.index_repo("repo1")
+    early_a = {m["file_path"]: m for m in early_meta}["a.py"]["temporal_hotspot_score"]
+
+    # Six months later, only b.py changes — a.py is idle.
+    repo = gitpython.Repo(tmp_path)
+    for i in range(3):
+        _commit_dated(
+            repo, tmp_path, {"b.py": f"y = {i + 1}\n"}, f"chore: b {i}", "2024-07-01T00:00:00"
+        )
+    repo.close()
+
+    sink: dict[str, dict] = {}
+    upd = GitIndexer(tmp_path, tier=GitIndexTier.FULL)
+    await upd.index_changed_files(["b.py"], all_files={"a.py", "b.py"}, idle_decay_sink=sink)
+
+    assert sink["a.py"]["temporal_hotspot_score"] < early_a, (
+        "idle file's decayed score must recover (shrink) as the anchor advances"
+    )
+
+
 def test_thread_repo_pool_reuses_per_thread_and_closes(tmp_path) -> None:
     _build_repo(tmp_path)
     indexer = GitIndexer(tmp_path)


### PR DESCRIPTION
## Problem

Several health biomarkers are deliberately **time-decayed** against the repo's newest-commit anchor (`as_of_ts`), so a file that was churny long ago but has since gone quiet recovers its score on its own: `temporal_hotspot_score`, the 90d churn/commit windows, `prior_defect_count` (trailing 180d), `change_entropy`, co-change scatter, and the rank-based `churn_percentile` / `is_hotspot`.

But a plain git `repowise update` re-ran the per-file history recompute over **changed files only**. Idle files never had their freshly re-decayed values written, so `recompute_git_percentiles` re-ranked stale scores and nothing recovered. Net effect (#728): **a one-way ratchet** — editing a file pushes its score down; idle files never get their recovery written, so scores only ever decrease between full re-indexes.

## The two fixes #728 proposed

- **Option 1 — periodic full re-score:** if the last full re-score is older than N days, re-score every file during an ordinary update (not just the changed ones).
- **Option 2 — widen the incremental path:** also re-score the decayed / co-changed *neighborhood* of the change, not just the literally-changed files.

## Why we rejected Option 2

We traced the biomarker math:

- Idle-file recovery is driven by the **decay/window anchor advancing** — a global effect hitting every file equally. There is **no coupling ripple**: a co-change partner of the edited file decays by the same factor as an unrelated file across the repo. So a coupling neighborhood targets the wrong set and misses most decayed files.
- `change_entropy_pct` and `churn_percentile` / `is_hotspot` are **repo-wide percentile ranks** — impossible to recompute correctly on a subset; `recompute_git_percentiles` already needs every row.
- Option 2 also adds new selection logic to the hottest code path — the riskiest place for a regression.

## Approach — Option 1 made cheap

**1. Git-metadata decay refresh (every update).** The update's `git log --numstat` commit-index walk now buckets **every tracked file** (identical subprocess, only the in-memory bucketing set widens), so idle files carry their own precomputed commits. For each idle file we recompute **only** the anchor-dependent window/decay fields (`DECAY_REFRESH_KEYS`) and persist a **decay-only partial row** — because `upsert_git_metadata_bulk` writes field-by-field, this leaves full-history columns (ownership, age, authors — correct only from the init walk) untouched. The existing `recompute_git_percentiles` then re-ranks over the fresh scores.

   - Idle rows are kept **out of** `git_meta_map` (fed to a separate persist map) so partial health's repo-wide aggregates are unaffected.
   - Gated to the FULL / co-change tier; rename-tracking mode (no batched index) is skipped, consistent with existing limits.

   This is the crucial correction to the plan's "free piggyback" framing: the all-files walk that already runs during update is co-change's `--name-only` pass, which carries **no churn**, so the decay fields genuinely need the numstat bucket widened — but that reuses the same subprocess, so it stays cheap.

**2. Periodic full health re-score (gated).** The *git metadata* above recovers every update, but the persisted health **findings** only recover when the analyzer re-scores idle files. Reusing the config-changed re-score path — reading the now-fresh `git_metadata` from the DB off the **already-built graph** (no second rebuild) — this runs at most ~weekly, anchored to the repo's HEAD timestamp via a new state stamp `last_full_rescore_at`. Half-life is ~125–180d, so weekly is ample.

Wired through the single-repo (docs + index-only) and workspace update paths.

## Tests

- `test_idle_decay_refresh_matches_full_index` — the idle refresh reproduces exactly what a fresh full index would write for an unchanged file, using decay-only keys.
- `test_idle_decay_refresh_recovers_as_anchor_advances` — a churny file's decayed score shrinks as unrelated commits advance the anchor.
- `test_update_recovers_idle_file_decayed_health` — end-to-end `repowise update`: an untouched file's score recovers and the periodic re-score gate fires.

Full `tests/unit/{cli,pipeline,workspace,ingestion}` suites pass; ruff clean.

## Note for reviewers

The first update after this ships re-scores health once for every repo (no prior `last_full_rescore_at` stamp → due immediately), then settles into the ~weekly cadence. Intentional self-healing, but it means one heavier update per repo initially.