### PR TITLE
fix(mcp,test): green main CI — trim search_codebase docstring, fix concept key assertion

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_search.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_search.py
@@ -814,12 +814,10 @@ async def search_codebase(
     mode="auto" (default) routes the query: identifier-shaped queries search
     the indexed symbols (returns symbol_id/file/line bounds — pipe into
     get_symbol), path-shaped queries resolve files (pipe into get_context),
-    and conceptual queries ("rate limiting", "where do we handle webhooks")
-    run wiki-semantic search. Mixed natural-language + identifier queries run
-    hybrid (symbol hits first, then concept pages). Concept results carry a
-    sources list ("fts", "vector", or both — a hit found by both retrievers
-    is a stronger match); decision records rank below file pages unless the
-    query is why-shaped.
+    and conceptual queries run wiki-semantic search. Mixed queries run hybrid,
+    symbol hits first. Concept hits carry a sources list (fts, vector, or
+    both); decision records rank below file pages unless the query is
+    why-shaped. See docs/agent/MCP_TOOLS.md for detail.
 
     Args:
         query: identifier, path, or natural-language query.

--- a/tests/integration/test_wiki_idempotence.py
+++ b/tests/integration/test_wiki_idempotence.py
@@ -298,7 +298,10 @@ class TestStructuralKeys:
                 continue
             members = page.metadata.get("file_paths") or []
             assert members, f"{page.page_id} recorded no members"
-            prefix = "module" if page.page_type == "module_page" else "scc"
+            # module_page rows are minted by the concept tree, which keys them
+            # on the "concept" prefix (STRUCTURAL_KEY_PREFIX); scc pages keep
+            # their own prefix.
+            prefix = "concept" if page.page_type == "module_page" else "scc"
             assert page.structural_key == member_structural_key(members, prefix=prefix)
             checked += 1
         assert checked, "sample repo produced no member-keyed pages"


### PR DESCRIPTION
## Summary

Two failures were red on `main` CI, both fallout from recent generation work, neither related to the dependency PRs:

1. **Unit** — `test_every_tool_docstring_fits_the_schema_budget`: the `search_codebase` MCP docstring grew to 1684 chars (budget is 1600) after the RRF fusion notes from #1057. Trimmed the routing/scoring prose to 1564 and pointed to `docs/agent/MCP_TOOLS.md` for the detail, keeping the get_answer-first steer and the mode routing guidance intact.
2. **Integration** — `test_member_keyed_pages_key_on_members_not_on_their_target`: the concept tree now mints `module_page` rows with the `concept` structural-key prefix (`STRUCTURAL_KEY_PREFIX`), so the test's `module` expectation no longer matches. Updated the assertion to expect `concept` for `module_page`; `scc_page` keeps its own prefix.

## Validation

- Integration test passes locally (2.94s).
- Docstring now measures 1564 chars via `inspect.cleandoc(fn.__doc__)`, the exact computation the test uses (under the 1600 budget).

Both fixes update the stale side (the tests / the over-long docstring), since the generation behavior they now disagree with is intended.
