### PR TITLE
fix(ui): mark Button as a client component

### DIFF
--- a/packages/ui/src/ui/button.tsx
+++ b/packages/ui/src/ui/button.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";


### PR DESCRIPTION
Radix Slot 1.3.1 (bumped from 1.3.0 in the recent dependency security refresh) now calls `createContext` at module load. `packages/ui/src/ui/button.tsx` wraps `Slot` but had no `"use client"` directive, so any server component that imports `Button` (directly or through shared components like `EmptyState`) evaluates it in the react-server environment and `next build` crashes during static page-data collection with `TypeError: createContext is not a function`.

Slot 1.3.0 deferred the context creation, so this stayed latent until the bump. It fails the full `packages/web` production build (first page hit was `/workspace`), which only runs at release tag time in `publish.yml`, not in the regular CI or internal-prerelease workflows, so it did not surface on merge.

Adding `"use client"` to `button.tsx` keeps the client primitive out of the server component graph. Verified with a clean `npm ci && npm run build --workspace packages/web` on current `main` deps (react 19.2.8, next 15.5.21, @radix-ui/react-slot 1.3.1): all 11 pages generate and the build passes. No dependency pin needed, so every security bump is retained.