### PR TITLE
release: v0.35.0 — one wiki renderer, keyless template wikis, and `repowise generate`

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.34.1",
+      "version": "0.35.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,17 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.35.0] — 2026-07-24
+
+This release rebuilds how wikis are generated. Every page now renders from structure with no key and no spend, except a single model-written subsystem layer; a new `repowise generate` command fills that layer on demand, and the web UI can generate AI docs page by page. Stores built before this change are recommended (never forced) to re-index for the newer navigable wiki.
+
+### Added
+- **`repowise generate`, scoped and cost-gated wiki generation.** A new command writes or refills the model-written subsystem pages on demand, gated behind a single cost question, and onboards a provider the same way `init` does when a docs run needs one. It is also exposed over HTTP for the web UI. (#978, #982, #983, #1060)
+- **Keyless, deterministic wikis.** `init` (and `init --index-only` / `--no-prose`) produces a complete, honest wiki with no API key and no spend: file, symbol, API, infra, cycle and layer pages all render from structure. `init --docs` opts into the model-written subsystem prose, and a template wiki renders when no provider is configured. (#972, #975, #976, #999, #1001, #1003)
+- **AI docs from the web reader.** The web UI gained provider-key settings and per-page and bulk AI documentation generation from the reader, with a coverage picker and provenance surfaces, streamed over an authenticated job channel. (#988, #991, #994, #984)
+- **Full git-history secret scanning.** `repowise security scan --history` scans the entire git history for secrets, not just the working tree. (#821)
+- **Hybrid `search_codebase`.** Full-text and vector results are now fused with reciprocal rank fusion, so search blends exact-term and semantic matches instead of picking one. (#1057)
+- **Interactive change-coupling page**, surfaced on the Overview. (#986)
+- **Fix history in the file UI.** The symbols view marks which symbols in a file keep getting fixed, and a file's governing decisions moved into their own tab. (#960, #966, #968, #977)
+- **Dead-code page rebuilt** on a shared table primitive with one confidence scale, a reopen path, and per-finding AI prompts, links and reasons. (#990, #992, #993)
+- **Disable reasoning on Ollama models** for providers that support it. (#1009)
+- **Adaptive TSX grammar fallback** so `.ts` files that contain JSX still parse. (#967)
 
 ### Changed
 - **One wiki, one renderer per page type.** The old template-vs-model split is gone. Every page except the subsystem layer is rendered from structure, always, with no key and no spend: file, symbol, API, infra, cycle and layer pages. Above them sits a derived, numbered concept tree (the `module_page` type) that is the one model-written layer: model prose when a provider is configured, structural stubs otherwise. `repowise generate` fills or refills that subsystem prose. (#1023, #1024, #1025, #1032)
+- **A re-index is recommended after upgrading.** Stores built before the subsystem-page restructure carry per-directory pages and no navigable tree, which no automatic reconcile can rebuild. Such stores are now told (never forced) that a full re-index would give them the newer wiki; ordinary updates keep working and the notice surfaces at most once. (#1035)
 - **`--prose` / `--no-prose` is the single wiki-spend switch.** `--prose` writes the subsystem pages as model prose (needs a key); `--no-prose` renders the whole wiki from structure with no model and no cost. `--index-only` and `--docs llm|deterministic` remain as deprecated hidden aliases. The interactive coverage chooser and the `--coverage` / `--top` ranked-generation flags are removed; `init` and `generate` now ask a single cost question. (#1032, #1036)
 - **Hierarchy lives in the data model.** `wiki_pages` carries `parent_page_id`, `display_order`, `section_number` and a stable `structural_key`, so MCP (`get_overview`), the web docs tree and the breadcrumbs all read one stored tree instead of each deriving their own. (#1014, #1022)
 - **Subsystem pages read like subsystem docs.** The concept tree's `module_page`s open by situating themselves against their siblings, weave in git-derived health and history signals, and close with a "Questions this page answers" section; a parent directory that spans several concept pages gets its own overview page. (#1043)
 - **`get_answer` leads subsystem questions with their concept page.** A question about a subsystem as a whole now surfaces that subsystem's page above its individual file and child pages, instead of returning the parts without the whole. (#1046)
+- **Retrieval demotes decision records and test pages**, and `get_context` reports where a file sits in the concept tree. (#1040, #1056)
+- **Dead-code confidence default is aligned** across the CLI, REST and MCP surfaces, so the same threshold applies everywhere. (#1030)
 
 ### Removed
 - **The template-vs-AI provenance axis.** `is_deterministic` and `doc_tier` are gone from the API responses and every TypeScript type; the Auto / AI / Mixed page badges, the "Auto-documented" partition, and the per-page "Write with AI" affordance are retired. The pages router's `?deterministic=` filter becomes `?has_prose=`, scoped to the model-written page types. (#1037)
+
+### Fixed
+- Idle files recover their time-decayed health on `update` instead of staying stuck. (#728, #1061)
+- The embedder is resolved from the store rather than the environment, so upgrades no longer switch models under you. (#1007)
+- OpenAI temperature is clamped to 1 for GPT-5-and-later reasoning models. (#989)
+- Ollama timeout and connection errors are wrapped so they retry. (#829)
+- Workspace repos resolve correctly in chat tool calls. (#971)
+- Stale `.update.pending` markers are cleaned up, and deferred workspace docs runs are reported honestly. (#1004, #1000)
+- The overview summary self-heals a missing indexed commit, and repository sort timestamps are normalized. (#1005, #1058)
+- Tombstoned pages no longer count in the docs tree or appear in status and export listings, and table-of-contents keys stay unique across repeated headings. (#1049, #1050, #1053)
+- Workspace file counts and top-language queries are scoped to file nodes. (#952)
+
+### Documentation
+- Plugin: added `coverage` and impacted-tests slash commands, and synced the MCP tool surface and hooks with reality. The Codex plugin was brought to parity (code-health skill and skill guidance). (#1029, #1017, #962, #1016)
+- `repowise security` documented in the CLI reference, an examples index added, and the README leads with the numbers and restores the five-layer table. (#1026, #1019, #961)
+
+### Dependencies
+- Consolidated security bumps across the dependency tree; lockfile packages pruned by the refresh were restored. (#1054, #1059)
 
 ---
 

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.34.0"
+__version__ = "0.35.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.34.0"
+__version__ = "0.35.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,17 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.35.0] — 2026-07-24
+
+This release rebuilds how wikis are generated. Every page now renders from structure with no key and no spend, except a single model-written subsystem layer; a new `repowise generate` command fills that layer on demand, and the web UI can generate AI docs page by page. Stores built before this change are recommended (never forced) to re-index for the newer navigable wiki.
+
+### Added
+- **`repowise generate`, scoped and cost-gated wiki generation.** A new command writes or refills the model-written subsystem pages on demand, gated behind a single cost question, and onboards a provider the same way `init` does when a docs run needs one. It is also exposed over HTTP for the web UI. (#978, #982, #983, #1060)
+- **Keyless, deterministic wikis.** `init` (and `init --index-only` / `--no-prose`) produces a complete, honest wiki with no API key and no spend: file, symbol, API, infra, cycle and layer pages all render from structure. `init --docs` opts into the model-written subsystem prose, and a template wiki renders when no provider is configured. (#972, #975, #976, #999, #1001, #1003)
+- **AI docs from the web reader.** The web UI gained provider-key settings and per-page and bulk AI documentation generation from the reader, with a coverage picker and provenance surfaces, streamed over an authenticated job channel. (#988, #991, #994, #984)
+- **Full git-history secret scanning.** `repowise security scan --history` scans the entire git history for secrets, not just the working tree. (#821)
+- **Hybrid `search_codebase`.** Full-text and vector results are now fused with reciprocal rank fusion, so search blends exact-term and semantic matches instead of picking one. (#1057)
+- **Interactive change-coupling page**, surfaced on the Overview. (#986)
+- **Fix history in the file UI.** The symbols view marks which symbols in a file keep getting fixed, and a file's governing decisions moved into their own tab. (#960, #966, #968, #977)
+- **Dead-code page rebuilt** on a shared table primitive with one confidence scale, a reopen path, and per-finding AI prompts, links and reasons. (#990, #992, #993)
+- **Disable reasoning on Ollama models** for providers that support it. (#1009)
+- **Adaptive TSX grammar fallback** so `.ts` files that contain JSX still parse. (#967)
 
 ### Changed
 - **One wiki, one renderer per page type.** The old template-vs-model split is gone. Every page except the subsystem layer is rendered from structure, always, with no key and no spend: file, symbol, API, infra, cycle and layer pages. Above them sits a derived, numbered concept tree (the `module_page` type) that is the one model-written layer: model prose when a provider is configured, structural stubs otherwise. `repowise generate` fills or refills that subsystem prose. (#1023, #1024, #1025, #1032)
+- **A re-index is recommended after upgrading.** Stores built before the subsystem-page restructure carry per-directory pages and no navigable tree, which no automatic reconcile can rebuild. Such stores are now told (never forced) that a full re-index would give them the newer wiki; ordinary updates keep working and the notice surfaces at most once. (#1035)
 - **`--prose` / `--no-prose` is the single wiki-spend switch.** `--prose` writes the subsystem pages as model prose (needs a key); `--no-prose` renders the whole wiki from structure with no model and no cost. `--index-only` and `--docs llm|deterministic` remain as deprecated hidden aliases. The interactive coverage chooser and the `--coverage` / `--top` ranked-generation flags are removed; `init` and `generate` now ask a single cost question. (#1032, #1036)
 - **Hierarchy lives in the data model.** `wiki_pages` carries `parent_page_id`, `display_order`, `section_number` and a stable `structural_key`, so MCP (`get_overview`), the web docs tree and the breadcrumbs all read one stored tree instead of each deriving their own. (#1014, #1022)
 - **Subsystem pages read like subsystem docs.** The concept tree's `module_page`s open by situating themselves against their siblings, weave in git-derived health and history signals, and close with a "Questions this page answers" section; a parent directory that spans several concept pages gets its own overview page. (#1043)
 - **`get_answer` leads subsystem questions with their concept page.** A question about a subsystem as a whole now surfaces that subsystem's page above its individual file and child pages, instead of returning the parts without the whole. (#1046)
+- **Retrieval demotes decision records and test pages**, and `get_context` reports where a file sits in the concept tree. (#1040, #1056)
+- **Dead-code confidence default is aligned** across the CLI, REST and MCP surfaces, so the same threshold applies everywhere. (#1030)
 
 ### Removed
 - **The template-vs-AI provenance axis.** `is_deterministic` and `doc_tier` are gone from the API responses and every TypeScript type; the Auto / AI / Mixed page badges, the "Auto-documented" partition, and the per-page "Write with AI" affordance are retired. The pages router's `?deterministic=` filter becomes `?has_prose=`, scoped to the model-written page types. (#1037)
+
+### Fixed
+- Idle files recover their time-decayed health on `update` instead of staying stuck. (#728, #1061)
+- The embedder is resolved from the store rather than the environment, so upgrades no longer switch models under you. (#1007)
+- OpenAI temperature is clamped to 1 for GPT-5-and-later reasoning models. (#989)
+- Ollama timeout and connection errors are wrapped so they retry. (#829)
+- Workspace repos resolve correctly in chat tool calls. (#971)
+- Stale `.update.pending` markers are cleaned up, and deferred workspace docs runs are reported honestly. (#1004, #1000)
+- The overview summary self-heals a missing indexed commit, and repository sort timestamps are normalized. (#1005, #1058)
+- Tombstoned pages no longer count in the docs tree or appear in status and export listings, and table-of-contents keys stay unique across repeated headings. (#1049, #1050, #1053)
+- Workspace file counts and top-language queries are scoped to file nodes. (#952)
+
+### Documentation
+- Plugin: added `coverage` and impacted-tests slash commands, and synced the MCP tool surface and hooks with reality. The Codex plugin was brought to parity (code-health skill and skill guidance). (#1029, #1017, #962, #1016)
+- `repowise security` documented in the CLI reference, an examples index added, and the README leads with the numbers and restores the five-layer table. (#1026, #1019, #961)
+
+### Dependencies
+- Consolidated security bumps across the dependency tree; lockfile packages pruned by the refresh were restored. (#1054, #1059)
 
 ---
 

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.34.0"
+__version__ = "0.35.0"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "repowise",
   "displayName": "Repowise",
   "description": "Know what your change breaks before you push. Health signals, architecture maps, and refactoring plans in your editor, and the same intelligence for your AI agent via MCP. Local and free.",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "publisher": "repowise-dev",
   "license": "AGPL-3.0-or-later",
   "homepage": "https://www.repowise.dev",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through ten task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.34.1",
+  "version": "0.35.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.35.0
+
+### Changed
+- Version bump to track the repowise 0.35.0 release.
+- `init`, `status` and the reader docs follow the one-renderer wiki model:
+  `--prose` / `--no-prose` is the single wiki-spend switch, `init` can start
+  keyless from structure, and any page upgrades to model prose later with
+  `repowise generate`. The deprecated `--index-only` / `--docs` aliases are no
+  longer written into new guidance.
+- MCP tool surface and hooks docs re-synced with the server (#1017).
+
 ## 0.34.1
 
 ### Added

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Repowise codebase intelligence for Codex.",
   "author": {
     "name": "Repowise",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.34.0"
+version = "0.35.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3054,7 +3054,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.34.0"
+version = "0.35.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Cuts v0.35.0. Version bump across the four Python packages + uv.lock + the Claude Code plugin manifests, the 0.35.0 changelog (bundled copy resynced), the Codex plugin (0.3.0) and the VS Code extension (0.6.0).

## Headline
- One deterministic renderer per wiki page type; a single model-written subsystem (concept) layer above it.
- Keyless, no-spend wikis by default; `--prose` / `--no-prose` is the one wiki-spend switch.
- New `repowise generate` command to fill or refill subsystem prose on demand.
- Stores predating the subsystem-page restructure are recommended (never forced) to re-index. Store format is already v2 with a `REINDEX_RECOMMENDED` migration (#1035).

See `docs/CHANGELOG.md` for the full set.

## Test plan
- [x] Version drift grep clean (no `0.34.0`; `0.35.0` in the four Python files + uv.lock + both plugin manifests)
- [x] `uv build --wheel` clean; wheel contains `serve_cmd`, new `generate_cmd`, `.scm`/`.j2`, and the bundled changelog
- [x] `npm ci && npm run build --workspace packages/web` passes (11/11 pages) on current deps
- [x] Bundled changelog sync guard test passes
- [x] Plugin tool-surface parity vs live `list_tools()`; plugin structural tests pass