### PR TITLE
fix(dead-code): evaluate top-level exported const literals as unused exports in TS/JS

### DIFF
--- a/docs/layers/DEAD_CODE.md
+++ b/docs/layers/DEAD_CODE.md
@@ -43,7 +43,7 @@ get_dead_code(kind="unused_export", group_by="owner")
 | Kind | What it means | How it is computed | Base confidence |
 |------|---------------|--------------------|-----------------|
 | `unreachable_file` | No file in the repo imports this one. | File-node in-degree of 0 on the dependency graph, after entry points and the never-flag allowlist are removed. | Scored from git age (below) |
-| `unused_export` | A public symbol nothing imports. | No `imports` edge names the symbol (or `*`, or a TypeScript `export { local as alias }` rename), and no `calls` / `method_implements` / `reads` / `extends` / `implements` / `type_use` edge reaches it. | `1.00` when the containing file *does* have importers (so the file is alive and only this symbol is not), `0.70` when it does not, `0.30` when the name ends in `_DEPRECATED` / `_LEGACY` / `_COMPAT` |
+| `unused_export` | A public symbol nothing imports. | No `imports` edge names the symbol (or `*`, or a TypeScript `export { local as alias }` rename), and no `calls` / `method_implements` / `reads` / `extends` / `implements` / `type_use` edge reaches it. Member kinds (`method`, `field`, `property`, `enum_member`) are excluded from this pass across all languages since they are accessed through their container, not imported by name. Top-level `export const` primitives, objects, and arrays in TypeScript and JavaScript are fully evaluated (they are always importable by name). | `1.00` when the containing file *does* have importers (so the file is alive and only this symbol is not), `0.70` when it does not, `0.30` when the name ends in `_DEPRECATED` / `_LEGACY` / `_COMPAT` |
 | `unused_internal` | A private or underscore-prefixed symbol nothing calls. | No `calls` edge, and no cross-file importer pulls the name (which would mean a dispatch-table lookup). Off by default. | `0.65` |
 | `zombie_package` | A whole top-level package no other package imports. | No inter-package import edges into it. Never marked safe to delete. | `0.50` |
 
@@ -138,6 +138,15 @@ edges is capped at `0.40` (implementor detection is heuristic, and missing
 evidence is not evidence of absence), and COM contract methods
 (`QueryInterface`, `AddRef`, `Release`) are capped the same way because they are
 dispatched through native vtables.
+
+**Symbol-kind exemptions in the unused-export pass.** Class methods, struct
+fields, properties, and enum members are never evaluated as unused exports across
+all languages — they are only reachable through their enclosing container, not
+independently importable. Top-level `export const` declarations in TypeScript and
+JavaScript (`export const API_URL = "..."`, `export const config = {...}`) are
+*not* exempt: they are module-level named exports and are fully evaluated. Non-exported
+constants (declared without `export`) are automatically private and never reach
+the pass.
 
 Zombie-package detection additionally ignores directories that are not packages
 at all: `.github`, `.vscode`, `.devcontainer`, `docs`, `scripts`, `assets`,

--- a/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/analyzer.py
@@ -80,6 +80,10 @@ _LANGUAGE_NON_IMPORTABLE: dict[str, frozenset[str]] = {
 }
 
 
+# Kinds allowed as top-level imports in TS/JS (top-level `export const` literals/objects)
+_TS_JS_IMPORTABLE_KINDS: frozenset[str] = frozenset({"constant", "variable"})
+
+
 def _non_importable_kinds(language: str) -> frozenset[str]:
     """Per-language set of symbol kinds excluded from unused-export passes.
 
@@ -89,8 +93,11 @@ def _non_importable_kinds(language: str) -> frozenset[str]:
     """
     extra = _LANGUAGE_NON_IMPORTABLE.get(language)
     if extra is None:
+        if language in ("typescript", "javascript"):
+            return _UNIVERSAL_NON_IMPORTABLE - _TS_JS_IMPORTABLE_KINDS
         return _UNIVERSAL_NON_IMPORTABLE
     return _UNIVERSAL_NON_IMPORTABLE | extra
+
 
 
 # Preserved for tests / external callers that imported the old name.

--- a/tests/unit/analysis/test_ts_never_flag.py
+++ b/tests/unit/analysis/test_ts_never_flag.py
@@ -112,3 +112,26 @@ class TestEntryPointSymbolNames:
         from repowise.core.analysis.dead_code.analyzer import _ENTRY_POINT_SYMBOL_NAMES
         for name in ("load", "action", "loader", "meta", "metadata", "config", "headers"):
             assert name not in _ENTRY_POINT_SYMBOL_NAMES
+
+
+class TestTsUnusedExportConstants:
+    def test_non_importable_kinds_allows_ts_const_and_var(self):
+        from repowise.core.analysis.dead_code.analyzer import _non_importable_kinds
+        kinds = _non_importable_kinds("typescript")
+        assert "constant" not in kinds
+        assert "variable" not in kinds
+        assert "method" in kinds
+        assert "field" in kinds
+
+    def test_non_importable_kinds_allows_js_const_and_var(self):
+        from repowise.core.analysis.dead_code.analyzer import _non_importable_kinds
+        kinds = _non_importable_kinds("javascript")
+        assert "constant" not in kinds
+        assert "variable" not in kinds
+
+    def test_other_languages_retain_universal_non_importable(self):
+        from repowise.core.analysis.dead_code.analyzer import _non_importable_kinds
+        python_kinds = _non_importable_kinds("python")
+        assert "constant" in python_kinds
+        assert "variable" in python_kinds
+


### PR DESCRIPTION
## Summary

- Top-level `export const` literals (strings, numbers, objects, arrays) in TypeScript/JavaScript were silently skipped by the unused-export detector due to `"constant"` and `"variable"` being in the universal non-importable kind filter, causing an 80% miss rate on exported constants with zero importers.
- Fixed `_non_importable_kinds()` in `analyzer.py` to exclude `"constant"` and `"variable"` from the skip list specifically for TypeScript and JavaScript, so these symbols now undergo the normal graph importer check.
- Added regression tests and updated `DEAD_CODE.md` to document which symbol kinds are evaluated vs exempt in the unused-export pass.

## Related Issues

Closes #1012 

## Test Plan

- [x] Tests pass (`pytest`) — **473 passed, 0 failed**
- [x] Lint passes (`ruff check .`)
- [ ] Web build passes (`npm run build`) *(no frontend changes)*

**Manual verification:** a file with 5 unused `export const` declarations (`API_BASE_URL`, `defaultOptions`, `SUPPORTED_LANGS`, `DEFAULT_TIMEOUT`, `fetchUser`) now produces 5 `UNUSED_EXPORT` findings. Before this fix only 1 was detected (`fetchUser`).

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality (`TestTsUnusedExportConstants` in `test_ts_never_flag.py`)
- [x] All existing tests still pass
- [x] I have updated documentation (`docs/layers/DEAD_CODE.md`)