### PR TITLE
Cleaner docs nav tree and de-duplicated page headers

### DIFF
--- a/packages/ui/src/docs/doc-nav.ts
+++ b/packages/ui/src/docs/doc-nav.ts
@@ -112,6 +112,15 @@ export function computeDocNav(page: DocPage, pages: DocPage[]): DocNavInfo {
     return { breadcrumbs: [{ label: page.title }] };
   }
 
+  // A layer or cycle hanging off the root carries a synthetic target_path
+  // ("layer:ui", "scc-103") rather than a directory trail. Splitting it would
+  // show that raw id as a crumb; use the same clean label the tree does. The
+  // pageId is the current page's own, so the reader renders it as plain text
+  // (it only links crumbs whose pageId differs from the page).
+  if (!page.target_path.includes("/")) {
+    return { breadcrumbs: [{ label: crumbLabel(page), pageId: page.id }] };
+  }
+
   // Index module pages by the directory they represent so an ancestor
   // directory segment can deep-link to its module overview.
   const moduleByPath = new Map<string, DocPage>();

--- a/packages/ui/src/docs/docs-reader.tsx
+++ b/packages/ui/src/docs/docs-reader.tsx
@@ -35,6 +35,23 @@ const RELATED_REASON_LABELS: Record<RelatedReason, string> = {
   "same-module": "same module",
 };
 
+// Remove a leading level-1 heading whose text is exactly the page title. The
+// title is already rendered above the body, so this heading is a duplicate.
+// Only the first heading is considered and only on an exact (case-insensitive)
+// match, so a section that legitimately reuses the title text is never cut.
+function stripLeadingTitleHeading(content: string, title: string): string {
+  const wanted = title.trim().toLowerCase();
+  if (!wanted) return content;
+  const lines = content.split("\n");
+  let i = 0;
+  while (i < lines.length && lines[i]!.trim() === "") i++;
+  const heading = lines[i]?.match(/^#\s+(.+?)\s*$/);
+  if (!heading || heading[1]!.trim().toLowerCase() !== wanted) return content;
+  lines.splice(0, i + 1);
+  while (lines.length > 0 && lines[0]!.trim() === "") lines.shift();
+  return lines.join("\n");
+}
+
 /** Router-aware anchor — host injects Next.js Link / in-app interception. */
 export type ReaderLinkComponent = React.ElementType<{
   href: string;
@@ -178,9 +195,18 @@ function DocsReaderBody({
   const nav = useMemo(() => computeDocNav(page, pages), [page, pages]);
   const wikiLinks = useMemo(() => getWikiLinks(page.metadata), [page.metadata]);
 
+  // The reader renders the page title as the H1 above the body, but generated
+  // content often opens with its own "# <title>" line (the deterministic
+  // templates do), so the same heading shows twice. Drop a leading H1 that
+  // exactly matches the title before anything else reads the content.
+  const bodyContent = useMemo(
+    () => stripLeadingTitleHeading(page.content, page.title),
+    [page.content, page.title],
+  );
+
   const visibleContent = useMemo(
-    () => filterMarkdownByPersona(page.content, persona),
-    [page.content, persona],
+    () => filterMarkdownByPersona(bodyContent, persona),
+    [bodyContent, persona],
   );
 
   // The nearest ancestor that is actually a module. Breadcrumbs now come from
@@ -476,7 +502,7 @@ function DocsReaderBody({
       {sidebarOpen && (
         <div className="hidden lg:block border-l border-[var(--color-border-default)] bg-[var(--color-bg-surface)] shrink-0 w-[260px] overflow-auto">
           <div className="space-y-6 p-4">
-            <TableOfContents content={page.content} />
+            <TableOfContents content={bodyContent} />
             {sources.length > 0 && (
               <div>
                 <div className="flex items-center gap-1.5 mb-2">

--- a/packages/ui/src/docs/docs-tree.tsx
+++ b/packages/ui/src/docs/docs-tree.tsx
@@ -311,6 +311,17 @@ const SPINE_TYPES = new Set([
 
 const isSpinePage = (page: DocPage) => SPINE_TYPES.has(page.page_type);
 
+// Concept content rows (the modules and cycles nested under a layer) all carry
+// the same folder glyph, so a run of them reads as a column of identical icons
+// that says nothing the indentation does not already say. Dropping the icon on
+// just these rows lets the outline read by its shape. Layers keep their icon as
+// the section anchor, onboarding chapters keep theirs, and the deterministic
+// file tree keeps its file/folder glyphs — only this middle rung goes quiet.
+const CONCEPT_CONTENT_TYPES = new Set(["module_page", "scc_page"]);
+
+const hidesTreeIcon = (page?: DocPage): boolean =>
+  page ? CONCEPT_CONTENT_TYPES.has(page.page_type) : false;
+
 // The single bottom folder holding every deterministic page. Namespaced like
 // the other synthetic keys so it can never collide with a real page id.
 const AUTO_ROOT_KEY = "@group:auto-documented";
@@ -531,6 +542,10 @@ function TreeItem({
           {...(node.page && node.page.title !== node.name ? { title: node.page.title } : {})}
           className={cn(
             "flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-[var(--color-bg-elevated)]",
+            // Top-level sections (layers, the Onboarding folder, the bottom
+            // Auto-documented folder) get air above them so each group reads as
+            // a distinct block rather than one long list.
+            depth === 0 && "mt-2 first:mt-0",
             isSelected
               ? "bg-[var(--color-accent-muted)] text-[var(--color-accent-primary)]"
               : "text-[var(--color-text-secondary)]",
@@ -549,9 +564,11 @@ function TreeItem({
           <SectionNumber depth={depth} section={node.section} />
           {node.path === ONBOARDING_DIR_KEY ? (
             <Compass className="h-3.5 w-3.5 shrink-0 text-[var(--color-accent-primary)]" />
-          ) : node.page ? (
-            // A dir that is itself a page (layer, module, cycle) keeps its page
-            // type's icon — a folder glyph would say less than the type does.
+          ) : hidesTreeIcon(node.page) ? null : node.page ? (
+            // A layer keeps its section icon as the anchor for its group; a
+            // concept content dir (a module with children) drops its folder
+            // glyph so the outline is not a column of identical icons. The
+            // chevron already marks it as expandable.
             <PageIcon
               pageType={node.page.page_type}
               className="h-3.5 w-3.5 shrink-0 text-[var(--color-accent-primary)]"
@@ -564,8 +581,10 @@ function TreeItem({
           <span
             className={cn(
               "truncate font-medium",
+              // A top-level section is the parent of everything indented under
+              // it, so it carries the strongest weight in the tree.
               (node.path === ONBOARDING_DIR_KEY || depth === 0) &&
-                "text-[var(--color-text-primary)]",
+                "font-semibold text-[var(--color-text-primary)]",
             )}
           >
             {node.name}
@@ -610,13 +629,17 @@ function TreeItem({
       style={{ paddingLeft: `${depth * 16 + 8 + 16}px` }}
     >
       <SectionNumber depth={depth} section={node.section} />
-      <PageIcon
-        pageType={node.page?.page_type ?? "file_page"}
-        className={cn(
-          "h-3.5 w-3.5 shrink-0",
-          isSelected ? "text-[var(--color-accent-primary)]" : "text-[var(--color-text-tertiary)]",
-        )}
-      />
+      {!hidesTreeIcon(node.page) && (
+        <PageIcon
+          pageType={node.page?.page_type ?? "file_page"}
+          className={cn(
+            "h-3.5 w-3.5 shrink-0",
+            isSelected
+              ? "text-[var(--color-accent-primary)]"
+              : "text-[var(--color-text-tertiary)]",
+          )}
+        />
+      )}
       <span className="truncate">{node.name}</span>
       {showFreshness && node.page && (
         <FreshnessDot status={node.page.freshness_status as FreshnessStatus} />


### PR DESCRIPTION
Tidies the wiki sidebar and the layer page header so the doc tree reads as a document outline rather than a list of typed objects.

## Docs tree sidebar
- Removes the repeated folder glyph on concept content rows (modules, cycles). A column of identical icons added no information the indentation did not already carry. Layers keep their icon as the section anchor, the onboarding chapters keep theirs, and the deterministic file tree keeps its file and folder glyphs.
- Gives top-level sections more visual weight: a heavier title and space above each group, so it is clear they are the parent of the rows indented beneath them.

## Page reader
- Strips a leading level-1 heading that exactly matches the page title. The reader already renders the title above the body, so pages whose content opened with their own title heading (the layer pages, for example) showed it twice. The strip runs before the table of contents reads the content, so the on-page outline drops the duplicate too. This fixes existing indexed pages without a re-index.

## Breadcrumb
- A layer or cycle that hangs directly off the root carries a synthetic `target_path` such as `layer:ui`, which the path-split fallback rendered as a raw crumb. It now shows the same clean label the tree uses.

## Verification
- Typecheck passes (`tsc --noEmit` in `packages/ui`).
- UI design gates pass (74 pairs, 0 failures).
- Checked live against the running web app: concept rows lose the folder icon, layer sections stand out as parents, the layer page shows its title once, and the breadcrumb reads `UI` instead of `layer:ui`.