### PR TITLE
fix(generation): read the real dependency keys in getting-started context

### DIFF
--- a/packages/core/src/repowise/core/generation/onboarding/subkinds/getting_started.py
+++ b/packages/core/src/repowise/core/generation/onboarding/subkinds/getting_started.py
@@ -110,9 +110,7 @@ def _extract_setup_sections(readme: bytes) -> list[ReadmeSection]:
             j += 1
         body = "\n".join(body_lines).strip()
         if body:
-            sections.append(
-                ReadmeSection(heading=canonical, body=body[:_MAX_README_SECTION_CHARS])
-            )
+            sections.append(ReadmeSection(heading=canonical, body=body[:_MAX_README_SECTION_CHARS]))
         i = j
     return sections
 
@@ -122,8 +120,16 @@ def _partition_dependencies(
 ) -> tuple[list[str], list[dict], list[dict]]:
     """Split external_systems into (package_managers, runtime_deps, dev_deps).
 
-    The manifest parsers already record ``ecosystem`` (npm/pypi/cargo/…)
-    and ``is_dev``. Anything we can't classify falls into runtime.
+    The manifest parsers already record ``ecosystem`` (npm/pypi/cargo/…),
+    ``version`` and ``is_dev_dep``. Anything we can't classify falls into
+    runtime.
+
+    Key names must match what the orchestrator actually emits (see
+    ``pipeline/orchestrator.py``, which builds these dicts straight off
+    ``ExternalSystemRecord``). Reading ``is_dev`` instead of ``is_dev_dep``
+    silently sorted every dev dependency into runtime, and omitting
+    ``version`` made the template's ``{% if d.version %}`` raise under
+    StrictUndefined, which lost the whole getting-started page.
     """
     package_managers: list[str] = []
     runtime: list[dict] = []
@@ -139,8 +145,12 @@ def _partition_dependencies(
             "name": sys.get("name", ""),
             "ecosystem": eco,
             "category": sys.get("category", "library"),
+            # Always present, so the template can test it without tripping
+            # StrictUndefined. Normalized to "" because the record's version is
+            # Optional and a None would render as "None".
+            "version": str(sys.get("version") or "").strip(),
         }
-        if sys.get("is_dev"):
+        if sys.get("is_dev_dep"):
             dev.append(entry)
         else:
             runtime.append(entry)

--- a/packages/core/src/repowise/core/generation/templates/stub/onboarding/getting_started.j2
+++ b/packages/core/src/repowise/core/generation/templates/stub/onboarding/getting_started.j2
@@ -33,14 +33,14 @@ Quoted verbatim from the repository's own README.
 {% if ctx.runtime_dependencies %}
 ## Runtime dependencies
 {% for d in ctx.runtime_dependencies[:30] %}
-- `{{ d.name }}`{% if d.version %} {{ d.version }}{% endif %}
+- `{{ d.name }}`{% if d.version is defined and d.version %} {{ d.version }}{% endif %}
 {% endfor %}
 {% endif %}
 
 {% if ctx.dev_dependencies %}
 ## Development dependencies
 {% for d in ctx.dev_dependencies[:30] %}
-- `{{ d.name }}`{% if d.version %} {{ d.version }}{% endif %}
+- `{{ d.name }}`{% if d.version is defined and d.version %} {{ d.version }}{% endif %}
 {% endfor %}
 {% endif %}
 {% include "stub/_footer.j2" %}

--- a/tests/unit/generation/test_onboarding.py
+++ b/tests/unit/generation/test_onboarding.py
@@ -122,7 +122,8 @@ def _signals(
         root_language_distribution={"python": 1.0},
         total_files=len(files),
         total_loc=len(files) * 50,
-        entry_points=entry_points or [f.file_info.path for f in files if f.file_info.is_entry_point],
+        entry_points=entry_points
+        or [f.file_info.path for f in files if f.file_info.is_entry_point],
     )
     return OnboardingSignals(
         repo_name="testrepo",
@@ -264,8 +265,18 @@ def test_getting_started_fires_on_manifest() -> None:
     sig = _signals(
         files=[_file("src/a.py")],
         external_systems=(
-            {"name": "fastapi", "ecosystem": "pypi", "category": "framework"},
-            {"name": "pytest", "ecosystem": "pypi", "is_dev": True},
+            # Key names must match what pipeline/orchestrator.py actually emits
+            # off ExternalSystemRecord. This test previously passed "is_dev",
+            # which no producer ever sets, so it asserted against a shape
+            # production never produces and hid the misclassification below.
+            {
+                "name": "fastapi",
+                "ecosystem": "pypi",
+                "category": "framework",
+                "version": "0.110.0",
+                "is_dev_dep": False,
+            },
+            {"name": "pytest", "ecosystem": "pypi", "is_dev_dep": True},
         ),
     )
     ctx = spec.build_context(sig)
@@ -273,6 +284,69 @@ def test_getting_started_fires_on_manifest() -> None:
     assert "pypi" in ctx.package_managers
     assert any(d["name"] == "fastapi" for d in ctx.runtime_dependencies)
     assert any(d["name"] == "pytest" for d in ctx.dev_dependencies)
+    # A dev dependency must not leak into the runtime list.
+    assert not any(d["name"] == "pytest" for d in ctx.runtime_dependencies)
+
+
+def test_getting_started_dependency_entries_always_carry_a_version_key() -> None:
+    """The stub template tests ``d.version`` under StrictUndefined.
+
+    A missing key raises "'dict object' has no attribute 'version'" and loses
+    the whole page, which is what happened in production.
+    """
+    spec = onboarding.get_spec(SLOT_GETTING_STARTED)
+    assert spec is not None
+    sig = _signals(
+        files=[_file("src/a.py")],
+        external_systems=(
+            {"name": "fastapi", "ecosystem": "pypi", "version": "0.110.0"},
+            # No version at all, and an explicit None: both must normalize.
+            {"name": "requests", "ecosystem": "pypi"},
+            {"name": "httpx", "ecosystem": "pypi", "version": None},
+        ),
+    )
+    ctx = spec.build_context(sig)
+    assert ctx is not None
+
+    for dep in [*ctx.runtime_dependencies, *ctx.dev_dependencies]:
+        assert "version" in dep, f"{dep['name']} has no version key"
+        assert isinstance(dep["version"], str), "version must never be None"
+
+    by_name = {d["name"]: d for d in ctx.runtime_dependencies}
+    assert by_name["fastapi"]["version"] == "0.110.0"
+    assert by_name["requests"]["version"] == ""
+    assert by_name["httpx"]["version"] == ""
+
+
+def test_getting_started_stub_renders_under_strict_undefined() -> None:
+    """End-to-end guard on the exact production failure: it must not raise."""
+    templates_dir = Path(onboarding.__file__).resolve().parents[1] / "templates"
+    env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(templates_dir)),
+        undefined=jinja2.StrictUndefined,
+        autoescape=False,
+    )
+
+    spec = onboarding.get_spec(SLOT_GETTING_STARTED)
+    assert spec is not None
+    sig = _signals(
+        files=[_file("src/a.py")],
+        external_systems=(
+            {"name": "fastapi", "ecosystem": "pypi", "version": "0.110.0"},
+            {"name": "requests", "ecosystem": "pypi"},
+            {"name": "pytest", "ecosystem": "pypi", "is_dev_dep": True},
+        ),
+    )
+    ctx = spec.build_context(sig)
+    assert ctx is not None
+
+    rendered = env.get_template("stub/onboarding/getting_started.j2").render(ctx=ctx)
+
+    assert "fastapi" in rendered
+    assert "0.110.0" in rendered
+    assert "pytest" in rendered
+    # A versionless dependency renders its name with no trailing "None".
+    assert "None" not in rendered
 
 
 def test_getting_started_fires_on_readme_install_section() -> None:
@@ -626,12 +700,24 @@ def test_how_it_works_renders_curated_tour_steps() -> None:
         entry_points=["src/main.py"],
     )
     curated_steps = (
-        {"order": 1, "target_path": "README.md", "page_type": "repo_overview",
-         "title": "README.md", "depth": 0, "kind": "overview",
-         "reason": "Start here for the end-to-end picture."},
-        {"order": 2, "target_path": "src/main.py", "page_type": "file_page",
-         "title": "main.py", "depth": 1, "kind": "code",
-         "reason": "An entry point — execution and imports fan out from here."},
+        {
+            "order": 1,
+            "target_path": "README.md",
+            "page_type": "repo_overview",
+            "title": "README.md",
+            "depth": 0,
+            "kind": "overview",
+            "reason": "Start here for the end-to-end picture.",
+        },
+        {
+            "order": 2,
+            "target_path": "src/main.py",
+            "page_type": "file_page",
+            "title": "main.py",
+            "depth": 1,
+            "kind": "code",
+            "reason": "An entry point — execution and imports fan out from here.",
+        },
     )
     sig = dataclasses.replace(sig, kg_tour_steps=curated_steps)
     ctx = spec.build_context(sig)
@@ -656,9 +742,12 @@ def test_how_it_works_renders_legacy_tour_steps() -> None:
         entry_points=["src/main.py"],
     )
     legacy_steps = (
-        {"order": 1, "title": "Start Here",
-         "description": "Begin with the entry point.",
-         "nodeIds": ["file:src/main.py"]},
+        {
+            "order": 1,
+            "title": "Start Here",
+            "description": "Begin with the entry point.",
+            "nodeIds": ["file:src/main.py"],
+        },
     )
     sig = dataclasses.replace(sig, kg_tour_steps=legacy_steps)
     ctx = spec.build_context(sig)


### PR DESCRIPTION
## What broke

Two bugs in `_partition_dependencies`, both from reading key names the producer never emits. `pipeline/orchestrator.py` builds these dicts directly off `ExternalSystemRecord`, with `version` and `is_dev_dep`.

**1. Missing `version` key lost the entire page.** The entry dict never carried `version`, but the stub template does `{% if d.version %}`. Page rendering runs under `StrictUndefined`, so a missing key *raises* rather than being falsy:

```
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'version'
```

That killed the whole getting-started page for any repo with at least one dependency, which is essentially every repo that reaches this template (the gate requires a manifest or a README setup section). Seen in production as:

```
page_generation_failed error='dict object' has no attribute 'version'
page_id=onboarding:onboarding/getting_started
```

**2. Every dev dependency was misclassified.** The split read `sys.get("is_dev")`, which nothing sets. So dev dependencies all fell through to runtime and the "Development dependencies" section was always empty.

## Fix

`version` is now populated and normalized to `""`, so an `Optional[str]` `None` never renders as the literal string `"None"`. The template intended to show versions all along; the data plumbing just dropped them, so this also turns the feature on for the first time.

The dev/runtime split reads `is_dev_dep`.

The template is additionally hardened with `d.version is defined`, matching the caution already documented in `how_it_works.j2`:

> indexing it unguarded raises under StrictUndefined and loses the page

so a future missing key degrades to an omitted version instead of losing the page.

## Why the tests did not catch it

`test_getting_started_fires_on_manifest` passed throughout because it fed `is_dev`, a shape no producer emits. It asserted against invented data and hid both bugs.

It now uses the orchestrator's real keys and asserts dev dependencies do not leak into runtime. Two tests added:

- `test_getting_started_dependency_entries_always_carry_a_version_key` — covers absent and explicit-`None` versions
- `test_getting_started_stub_renders_under_strict_undefined` — renders the actual template through a `StrictUndefined` environment, which is the exact production failure

Against the unfixed source all three fail with the production error; against the fix all 32 pass.

## Tests

- `tests/unit/generation/test_onboarding.py` — 32 passed
- `tests/unit/generation` — 804 passed
- `ruff check` / `ruff format` clean