### PR TITLE
perf(generation): take the top symbol decile, not the top fifth

### DIFF
--- a/packages/core/src/repowise/core/generation/models.py
+++ b/packages/core/src/repowise/core/generation/models.py
@@ -105,7 +105,19 @@ class GenerationConfig:
     # ``symbol_spotlight``. A spotlight repeats what its file's page already
     # says, so taking all of them buries the pages that say something new.
     # This bound used to be a side effect of the budget's 0.15 share.
-    top_symbol_percentile: float = 0.20
+    #
+    # Lowered 0.20 -> 0.10 on the evidence of a large monorepo: a 5.3k-file
+    # repo produced 4,996 spotlights inside a 14,027-page wiki. Doubling down
+    # on the strongest decile keeps the pages that say something new and drops
+    # the ones that restate their file's page. Small repos are unaffected in
+    # practice: the selector floors the bucket at one, so a repo with few
+    # public symbols still gets a spotlight.
+    top_symbol_percentile: float = 0.10
+    # NOTE: read by nothing today. File pages are deliberately not rationed
+    # (see selection/selector.py::select_pages -- the concept partition is a
+    # total cover of the production files). Kept because bounding the file
+    # bucket is a live question on very large repos, but bounding it is a
+    # design decision, not a default change.
     file_page_top_percentile: float = 0.10
     file_page_min_symbols: int = 1
     skip_trivial_files: bool = True

--- a/packages/core/src/repowise/core/generation/selection/selector.py
+++ b/packages/core/src/repowise/core/generation/selection/selector.py
@@ -286,7 +286,10 @@ def _build_symbol_candidates(
     # slice by PageRank. This used to fall out of the coverage budget's 0.15
     # share; with nothing costing tokens there is no budget to fall out of, so
     # the percentile that always existed on the config now does the bounding.
-    pct = getattr(inputs.config, "top_symbol_percentile", 0.20) or 0.0
+    # Fallback tracks GenerationConfig.top_symbol_percentile; a config object
+    # predating the field must not silently select a wider slice than the
+    # declared default.
+    pct = getattr(inputs.config, "top_symbol_percentile", 0.10) or 0.0
     if pct <= 0:
         return []
     if pct >= 1.0:

--- a/tests/unit/generation/test_models.py
+++ b/tests/unit/generation/test_models.py
@@ -152,7 +152,7 @@ def test_generation_config_defaults():
     assert config.cache_enabled is True
     assert config.staleness_threshold_days == 7
     assert config.expiry_threshold_days == 30
-    assert config.top_symbol_percentile == 0.20
+    assert config.top_symbol_percentile == 0.10
     assert config.large_file_source_pct == 0.4
     assert config.reasoning == "auto"
 

--- a/tests/unit/generation/test_selection_contract.py
+++ b/tests/unit/generation/test_selection_contract.py
@@ -193,6 +193,28 @@ def test_spotlights_are_bounded_by_the_percentile():
     assert tenth.symbol_spotlights == half.symbol_spotlights[: len(tenth.symbol_spotlights)]
 
 
+def test_default_config_takes_the_top_symbol_decile():
+    """The stock default is the bound large repos actually get.
+
+    A 5.3k-file monorepo produced 4,996 spotlights inside a 14,027-page wiki at
+    the old 0.20. The bucket restates what each symbol's file page already says,
+    so the default keeps the strongest decile.
+    """
+    parsed, pagerank, betweenness, community = _build_synthetic_repo(100)
+    total_symbols = sum(len(p.symbols) for p in parsed)
+
+    sel = select_pages(_inputs(parsed, pagerank, betweenness, community, GenerationConfig()))
+
+    assert len(sel.symbol_spotlights) == int(total_symbols * 0.10)
+
+
+def test_small_repo_still_gets_a_spotlight_at_the_default():
+    """The floor of one keeps a tiny repo from losing the bucket entirely."""
+    parsed, pagerank, betweenness, community = _build_synthetic_repo(1)
+    sel = select_pages(_inputs(parsed, pagerank, betweenness, community, GenerationConfig()))
+    assert len(sel.symbol_spotlights) >= 1
+
+
 def test_module_bucket_is_never_rationed():
     """The concept partition is total, so every group is emitted."""
     parsed, pagerank, betweenness, community = _build_synthetic_repo(300)


### PR DESCRIPTION
## Why

A 5.3k-file monorepo (`dust-tt/dust`) produced a **14,027-page** wiki:

```
symbol_spotlight 4996     file_page 8756     module_page 127
infra_page 70             scc_page 44        api_contract 7
repo_overview 1           architecture_diagram 1
```

`symbol_spotlight` restates what each symbol's file page already renders (signature, docstring, importer list). The field's existing comment says exactly why it is bounded:

> A spotlight repeats what its file's page already says, so taking all of them buries the pages that say something new.

At 4,996 that is precisely what is happening.

## Change

`top_symbol_percentile` 0.20 -> 0.10. One default, plus the selector's `getattr` fallback which had drifted: it read `0.20` while the declared default was the source of truth, so a config object predating the field would silently select a wider slice than the default promises.

Small repos are unaffected in practice: the selector floors the bucket at one, so a repo with few public symbols still gets a spotlight. Covered by a test.

## Scope: this does not fix large repos on its own

Worth being explicit, since the headline number invites the wrong conclusion. This removes roughly 2,500 pages from that 14,027. The dominant bucket is `file_page` at 8,756, and it is **deliberately not rationed** - `select_pages` documents that the concept partition is a total cover of the production files and "would stop being a map of the repository if it were rationed".

Related finding while checking: `file_page_top_percentile` is declared on `GenerationConfig` but **read by nothing** in the codebase. It looks like a live knob and is not one. I left it in place and commented it as dead rather than either deleting it or wiring it up, because making it live at its declared 0.10 would cut file pages from 8,756 to ~530 on that repo, which is a design decision and not a default change.

So the remaining question for a follow-up is whether to bound the file bucket, and whether to add an **absolute** page ceiling - percentiles scale with repo size, so any percentage still explodes on a large enough monorepo.

## Tests

- New: default config takes the top decile; a one-file repo still gets a spotlight.
- `tests/unit/generation` + `tests/unit/cli/test_cost_estimator.py` -> 817 passed.
- `tests/unit/server` + `tests/integration/test_generation_pipeline.py` -> 1,283 passed, 0 failures.
- `tests/integration/test_generation_pipeline.py` -> 27 passed.
- `ruff check` / `format --check` clean on the four changed files. (The generation package carries unrelated pre-existing ruff findings; none are in these files.)