### PR TITLE
test(distill): gate the executable-path shim test to Windows

### DIFF
--- a/tests/unit/distill/test_cli.py
+++ b/tests/unit/distill/test_cli.py
@@ -163,6 +163,7 @@ def test_render_command_roundtrips_argv_through_the_shell(payload: str, tmp_path
     assert list(tmp_path.iterdir()) == []
 
 
+@pytest.mark.skipif(sys.platform != "win32", reason="cmd.exe program-name resolution")
 def test_render_command_keeps_an_executable_path_with_spaces_intact(tmp_path: Path) -> None:
     """The program name needs real grouping quotes, not caret-escaped ones.
 


### PR DESCRIPTION
Follow-up to #1071. One test in it is Windows-only in substance but was not gated, so it fails on the Linux CI runners.

`test_render_command_keeps_an_executable_path_with_spaces_intact` writes a `.cmd` shim and executes it to prove cmd.exe still resolves a program name containing a space after the caret-escaping change. On POSIX that file is neither executable nor meaningful, so the shell exits 126 and the assertion fails. The other two rendering tests added in #1071 were already gated the same way; this one was missed.

No production code changes.

## On the POSIX branch

Gating the test does not leave the POSIX path unverified. `shlex.join` was checked against a real POSIX shell over the same payload set the Windows test uses, plus `$(whoami)` and backtick forms. All 20 tokens round-tripped to the child's argv exactly, and none of them caused the shell to create a file.