### PR TITLE
test: drop the removed file_page_top_percentile from two test configs

### DIFF
--- a/tests/integration/test_generation_pipeline.py
+++ b/tests/integration/test_generation_pipeline.py
@@ -255,7 +255,10 @@ async def test_embedding_latency_does_not_gate_llm_concurrency():
         token_budget=1000,
         max_concurrency=2,
         embed_concurrency=1,
-        file_page_top_percentile=1.0,
+        # 0 is the explicit "every eligible file" answer, which is what this test
+        # wants: the point is concurrency, so no page should be missing because a
+        # size policy trimmed the bucket.
+        max_file_pages=0,
         top_symbol_percentile=0.01,
         # coverage_pct / max_pages_pct are inert: selection no longer rations by
         # coverage. Set here only to exercise the config round-trip.

--- a/tests/unit/cli/test_cost_estimator.py
+++ b/tests/unit/cli/test_cost_estimator.py
@@ -47,7 +47,9 @@ class FakeParsedFile:
 @dataclass
 class FakeConfig:
     top_symbol_percentile: float = 0.10
-    file_page_top_percentile: float = 0.20
+    # None, like the real GenerationConfig: the file-page volume policy decides,
+    # and it leaves a fixture this size alone.
+    max_file_pages: int | None = None
     file_page_min_symbols: int = 1
     max_pages_pct: float = 0.10
 


### PR DESCRIPTION
Main has been red since #1074. One failure, one cause:

```
tests/integration/test_generation_pipeline.py::test_embedding_latency_does_not_gate_llm_concurrency
E   TypeError: GenerationConfig.__init__() got an unexpected keyword argument 'file_page_top_percentile'
```

#1074 replaced `file_page_top_percentile` (which nothing read) with
`max_file_pages`, and two test configs still named the old field:

- `tests/integration/test_generation_pipeline.py` passed it to a real
  `GenerationConfig`, so the constructor raised. The test wanted no file-page
  rationing, which is now `max_file_pages=0`, the explicit refusal. That is the
  right value here for its own sake: the test is about concurrency, so no page
  should go missing because a size policy trimmed the bucket.
- `tests/unit/cli/test_cost_estimator.py` has a duck-typed `FakeConfig` that
  carried it as a dead attribute. It now mirrors the real default of `None`, so it
  cannot drift into claiming a field the real config does not have.

## Why this got to main

The integration job is gated on `if: github.event_name == 'push'`, so it never runs
on a pull request. All four PRs in this arc went green and main went red on merge.
The unit jobs on main (3.11, 3.12, 3.13) all pass, so this one file is the whole
failure on both red runs.

Verified by running the full suite locally rather than trusting PR CI:
**222 passed, 14 skipped** in `tests/integration`.

Worth considering separately: running the integration job on pull requests when
`packages/core/**` changes. It is a 16-minute job, so it is a real cost-versus-blast
-radius tradeoff rather than an obvious win, and it is a CI policy call.