### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MCP Toplist](https://mcptoplist.com/badge/dev.repowise%2Frepowise.svg)](https://mcptoplist.com/server/dev.repowise%2Frepowise)
+
 <!-- mcp-name: dev.repowise/repowise -->
 
 <div align="center">


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,432 MCP servers across the major
registries, and **Repowise** is currently ranked **#157**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/dev.repowise%2Frepowise.svg)](https://mcptoplist.com/server/dev.repowise%2Frepowise)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Repowise!
