### PR TITLE
fix(api-client): accept the health/files envelope, keep its real total

### DIFF
--- a/packages/api-client/src/hosted.test.ts
+++ b/packages/api-client/src/hosted.test.ts
@@ -246,6 +246,46 @@ describe("request wiring", () => {
     expect(res).toMatchObject({ total: 0, offset: 0, limit: 10, files: [] });
   });
 
+  it("keeps the server's total when the route returns the envelope", async () => {
+    // The bare-array era could only report the page size, so a 3k-file repo
+    // capped at 500 reported 500 files.
+    const row = { file_path: "a.ts", score: 5, nloc: 10 };
+    const { p } = provider([
+      REPOS_ROUTE,
+      ["/health/files", { total: 3013, offset: 0, limit: 2000, files: [row] }],
+    ]);
+    const res = await p.listHealthFiles("repo-1", { limit: 10 });
+    expect(res.total).toBe(3013);
+    expect(res.files).toHaveLength(1);
+  });
+
+  it("still reads an older deployment's bare array", async () => {
+    const rows = [
+      { file_path: "a.ts", score: 5, nloc: 10 },
+      { file_path: "b.ts", score: 6, nloc: 20 },
+    ];
+    const { p } = provider([REPOS_ROUTE, ["/health/files", rows]]);
+    const res = await p.listHealthFiles("repo-1", { limit: 10 });
+    expect(res.total).toBe(2);
+    expect(res.files).toHaveLength(2);
+  });
+
+  it("recounts the total when it narrows the set client-side", async () => {
+    // A module filter is applied here, not by the server, so the server's
+    // total would overstate what the caller actually receives.
+    const row = (file_path: string) => ({ file_path, score: 5, nloc: 10 });
+    const { p } = provider([
+      REPOS_ROUTE,
+      [
+        "/health/files",
+        { total: 3013, offset: 0, limit: 2000, files: [row("src/a.ts"), row("web/b.ts")] },
+      ],
+    ]);
+    const res = await p.listHealthFiles("repo-1", { limit: 10, module: "src/" });
+    expect(res.total).toBe(1);
+    expect(res.files.map((f) => f.file_path)).toEqual(["src/a.ts"]);
+  });
+
   it("surfaces API errors as ApiClientError with the detail", async () => {
     const { impl } = makeFetch([REPOS_ROUTE]);
     const p = createHostedProvider({ baseUrl: "https://api.example.dev", fetch: impl });

--- a/packages/api-client/src/hosted.ts
+++ b/packages/api-client/src/hosted.ts
@@ -609,10 +609,10 @@ export function createHostedProvider(config: HostedProviderConfig): HostedProvid
       return items;
     },
     async listHealthFiles(repoId, opts): Promise<HealthFilesResponse> {
-      // Hosted returns a bare (server-sliced) list with its own param names;
-      // the local route returns a windowed envelope. Fetch a wide window and
-      // apply the local windowing semantics client-side. Ceiling: repos with
-      // more than 500 scored files see the worst 500 (server sort: score).
+      // This route used to return a bare (server-sliced) list and now returns
+      // the same windowed envelope the local route does. Accept both, since an
+      // older deployment still answers with the array. Fetch a wide window and
+      // apply the local windowing semantics client-side.
       const filter = opts?.only_hotspots
         ? "hotspots"
         : opts?.only_untested
@@ -620,18 +620,32 @@ export function createHostedProvider(config: HostedProviderConfig): HostedProvid
           : opts?.only_failing
             ? "failing"
             : undefined;
-      const rows = await snapGet<HealthFilesResponse["files"]>(repoId, "/health/files", {
-        limit: 500,
-        sort: opts?.sort,
-        q: opts?.search,
-        filter,
-      });
-      let files = rows ?? [];
-      if (opts?.module) files = files.filter((f) => f.file_path.startsWith(opts.module as string));
+      const res = await snapGet<HealthFilesResponse | HealthFilesResponse["files"]>(
+        repoId,
+        "/health/files",
+        {
+          limit: 2000,
+          sort: opts?.sort,
+          q: opts?.search,
+          filter,
+        },
+      );
+      const envelope = Array.isArray(res) ? null : res;
+      let files: HealthFilesResponse["files"] = Array.isArray(res)
+        ? res
+        : (res?.files ?? []);
+      // The server's total counts what it filtered; a client-side module
+      // filter narrows further, so only trust the server total when we did not
+      // narrow the set ourselves.
+      let total = envelope?.total ?? files.length;
+      if (opts?.module) {
+        files = files.filter((f) => f.file_path.startsWith(opts.module as string));
+        total = files.length;
+      }
       if (opts?.order === "desc") files = [...files].reverse();
       const offset = opts?.offset ?? 0;
       const limit = opts?.limit ?? 50;
-      return { total: files.length, offset, limit, files: files.slice(offset, offset + limit) };
+      return { total, offset, limit, files: files.slice(offset, offset + limit) };
     },
     getHealthFileBreakdown: (repoId, filePath) =>
       snapGet(repoId, "/health/files/breakdown", { file_path: filePath }),


### PR DESCRIPTION
`listHealthFiles` in this provider reports the size of the page it received as if it were the size of the repository.

The `/health/files` route it reads is moving from a bare array to the same `{total, offset, limit, files}` envelope the local route already returns. Two things follow.

**It would break.** The current code does `rows ?? []` and then `.filter(...)`, so an object response throws.

**The total was already wrong.** With a bare array there is nothing to count but `rows.length`, so a repository with thousands of scored files reported however many rows the server sliced to. `total` on the envelope is the count after filtering but before the slice, which is the number a caller actually wants.

## What changed

Reads the server's `total` when the response carries one, and still accepts the array from a deployment that has not picked up the route change, so the two can roll out in either order.

Two details:

- The requested window moves from 500 to 2000, matching the local route's cap and what the shared code-health map pulls in one go.
- The `module` filter is applied here rather than by the server, so `total` is recomputed when this adapter narrows the set itself. Trusting the server's total there would overstate what the caller receives.

## Scope

`createHostedProvider` is exported from the package but has no importer anywhere in the repo beyond its own tests, so nothing shipped depends on the old branch today. This keeps the published surface correct rather than leaving a latent throw for whoever picks it up first.

## Tests

Three added to `hosted.test.ts`: the envelope's total is preserved, a legacy bare array still reads, and a client-side module filter recounts instead of reporting the server total. `packages/api-client` suite green (44 tests).
