### PR TITLE
release: v0.36.0 — bounded file-page volume, distill shell lexer, contributor fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.36.0] — 2026-07-25
+
+A smaller release that settles what 0.35.0 started. Wikis on very large repositories now bound their own file-page volume by default instead of emitting one page per file, `distill` learns a real shell lexer and gains install and infra command families, and a run of contributor fixes lands across serve, the job scheduler and dead code.
+
+### Added
+- **Install and infra command families for `distill`.** `pip`, `uv`, `poetry`, `npm`, `pnpm`, `yarn`, `cargo` and `brew` output, plus `terraform`, `tofu` and `helm` plans, are now compacted by data-driven TOML filters. A new family is a data file rather than a Python module, and the errors-first invariant is enforced mechanically so no filter can drop an error line. (#1067)
+- **A shared shell lexer behind the rewrite hook.** The hook used to scan for shell characters and could not tell a pipe from the same character inside a quoted string, so it refused anything with both a quote and punctuation. A single-pass tokenizer replaces that scan, which makes the bailouts structural and widens the safe final pipeline stage beyond `head` and `tail`. (#1070)
+
+### Changed
+- **File pages are rationed on very large repositories, by default.** A 10.8k-file monorepo produced 8,756 file pages inside a 14,027-page wiki, roughly 77 MB whose tail mostly restates the concept page above it. `max_file_pages` now scales with repo size using two thresholds derived from the size distribution of indexed repositories: an interactive run offers a leaner wiki past 2,000 files, and an automatic ceiling of 4,500 applies to runs that never get asked, such as `--yes`, agent and CI runs. Smaller repos are unaffected. (#1074, #1076)
+- **Symbol spotlight pages take the top decile, not the top fifth.** That bucket restates what a symbol's file page already renders, and at 4,996 pages it buried the pages that say something new. The bucket still floors at one, so small repos keep a spotlight. (#1069)
+- **A tidier docs nav tree.** Repeated folder glyphs are gone from concept rows where indentation already said it, top-level sections carry more weight, and a leading heading that just repeats the page title is stripped in the reader. (#1066)
+- **The health files API reports a repository's real file total** rather than however many rows the current page happened to carry, while still accepting the older bare-array response. (#1080)
+
+### Removed
+- **`--safe-only` on `repowise health`**, which never did anything. The flag remains live and functional on `repowise dead-code`. (#1027)
+
+### Fixed
+- **Command injection when `distill` rejoined argv on Windows.** The rendered command was quoted for the C runtime's argv parser rather than for `cmd.exe`, so a token carrying a metacharacter and no space, such as `--grep=a&whoami`, came back unquoted and the shell read the `&` as a separator. Verified by execution before the fix: `&` and `|` both ran injected commands and `>` created a file. Every `"&|<>^()` is now caret-escaped. (#1071)
+- **The getting-started page crashed on any repo with a dependency.** The context dict never carried the `version` key its template reads, and page rendering runs under `StrictUndefined`, so a missing key raised instead of being falsy. (#1068)
+- **`repowise serve` reclaims its preferred ports on restart.** The pre-flight probe bound without `SO_REUSEADDR`, so a port still in `TIME_WAIT` from the just-exited instance read as busy and the API silently moved to 7338 while the UI kept proxying to 7337. The result was a healthy server rendering as empty panels. The probe now matches the bind semantics uvicorn and Next.js actually use, on POSIX only, since Windows treats the option differently. (#840, #845)
+- **Persisted polling sync jobs never launched.** The fallback path discarded the job returned by `upsert_generation_job` and then referenced an undefined name, and the resulting error was swallowed by an outer handler, so the failure was silent. (#831)
+- **Subsystem pages no longer print "Questions this page answers" twice.** The requirement was stated in both the system prompt and the template, and under the doubled instruction the model emitted the heading twice on 86 of 92 measured pages. (#1073)
+- **Top-level `export const` in TypeScript and JavaScript is evaluated for dead code** instead of being exempted the way class members are. (#1065)
+- **Alias resolution in `generate_refactoring_code`**, which passed a redundant argument inside an already alias-scoped session. (#884)
+
+### Documentation
+- **The docs lead with interactive `init`.** Getting-started paths handed new users `repowise init --index-only -y` and never mentioned that a bare `init` scans the repo and offers a choice before spending anything. Every path now says `--no-prose`, since `--index-only` has been a deprecated hidden alias since #1032. (#1075)
+- **Live badges on the README.** We ask other projects to carry a Repowise badge and had none of our own. Both read live endpoints, so they follow each index rather than freezing at whatever was true when someone pasted them in. (#1079)
+
+---
+
 ## [0.35.0] — 2026-07-24
 
 This release rebuilds how wikis are generated. Every page now renders from structure with no key and no spend, except a single model-written subsystem layer; a new `repowise generate` command fills that layer on demand, and the web UI can generate AI docs page by page. Stores built before this change are recommended (never forced) to re-index for the newer navigable wiki.

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.35.0"
+__version__ = "0.36.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.35.0"
+__version__ = "0.36.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.36.0] — 2026-07-25
+
+A smaller release that settles what 0.35.0 started. Wikis on very large repositories now bound their own file-page volume by default instead of emitting one page per file, `distill` learns a real shell lexer and gains install and infra command families, and a run of contributor fixes lands across serve, the job scheduler and dead code.
+
+### Added
+- **Install and infra command families for `distill`.** `pip`, `uv`, `poetry`, `npm`, `pnpm`, `yarn`, `cargo` and `brew` output, plus `terraform`, `tofu` and `helm` plans, are now compacted by data-driven TOML filters. A new family is a data file rather than a Python module, and the errors-first invariant is enforced mechanically so no filter can drop an error line. (#1067)
+- **A shared shell lexer behind the rewrite hook.** The hook used to scan for shell characters and could not tell a pipe from the same character inside a quoted string, so it refused anything with both a quote and punctuation. A single-pass tokenizer replaces that scan, which makes the bailouts structural and widens the safe final pipeline stage beyond `head` and `tail`. (#1070)
+
+### Changed
+- **File pages are rationed on very large repositories, by default.** A 10.8k-file monorepo produced 8,756 file pages inside a 14,027-page wiki, roughly 77 MB whose tail mostly restates the concept page above it. `max_file_pages` now scales with repo size using two thresholds derived from the size distribution of indexed repositories: an interactive run offers a leaner wiki past 2,000 files, and an automatic ceiling of 4,500 applies to runs that never get asked, such as `--yes`, agent and CI runs. Smaller repos are unaffected. (#1074, #1076)
+- **Symbol spotlight pages take the top decile, not the top fifth.** That bucket restates what a symbol's file page already renders, and at 4,996 pages it buried the pages that say something new. The bucket still floors at one, so small repos keep a spotlight. (#1069)
+- **A tidier docs nav tree.** Repeated folder glyphs are gone from concept rows where indentation already said it, top-level sections carry more weight, and a leading heading that just repeats the page title is stripped in the reader. (#1066)
+- **The health files API reports a repository's real file total** rather than however many rows the current page happened to carry, while still accepting the older bare-array response. (#1080)
+
+### Removed
+- **`--safe-only` on `repowise health`**, which never did anything. The flag remains live and functional on `repowise dead-code`. (#1027)
+
+### Fixed
+- **Command injection when `distill` rejoined argv on Windows.** The rendered command was quoted for the C runtime's argv parser rather than for `cmd.exe`, so a token carrying a metacharacter and no space, such as `--grep=a&whoami`, came back unquoted and the shell read the `&` as a separator. Verified by execution before the fix: `&` and `|` both ran injected commands and `>` created a file. Every `"&|<>^()` is now caret-escaped. (#1071)
+- **The getting-started page crashed on any repo with a dependency.** The context dict never carried the `version` key its template reads, and page rendering runs under `StrictUndefined`, so a missing key raised instead of being falsy. (#1068)
+- **`repowise serve` reclaims its preferred ports on restart.** The pre-flight probe bound without `SO_REUSEADDR`, so a port still in `TIME_WAIT` from the just-exited instance read as busy and the API silently moved to 7338 while the UI kept proxying to 7337. The result was a healthy server rendering as empty panels. The probe now matches the bind semantics uvicorn and Next.js actually use, on POSIX only, since Windows treats the option differently. (#840, #845)
+- **Persisted polling sync jobs never launched.** The fallback path discarded the job returned by `upsert_generation_job` and then referenced an undefined name, and the resulting error was swallowed by an outer handler, so the failure was silent. (#831)
+- **Subsystem pages no longer print "Questions this page answers" twice.** The requirement was stated in both the system prompt and the template, and under the doubled instruction the model emitted the heading twice on 86 of 92 measured pages. (#1073)
+- **Top-level `export const` in TypeScript and JavaScript is evaluated for dead code** instead of being exempted the way class members are. (#1065)
+- **Alias resolution in `generate_refactoring_code`**, which passed a redundant argument inside an already alias-scoped session. (#884)
+
+### Documentation
+- **The docs lead with interactive `init`.** Getting-started paths handed new users `repowise init --index-only -y` and never mentioned that a bare `init` scans the repo and offers a choice before spending anything. Every path now says `--no-prose`, since `--index-only` has been a deprecated hidden alias since #1032. (#1075)
+- **Live badges on the README.** We ask other projects to carry a Repowise badge and had none of our own. Both read live endpoints, so they follow each index rather than freezing at whatever was true when someone pasted them in. (#1079)
+
+---
+
 ## [0.35.0] — 2026-07-24
 
 This release rebuilds how wikis are generated. Every page now renders from structure with no key and no spend, except a single model-written subsystem layer; a new `repowise generate` command fills that layer on demand, and the web UI can generate AI docs page by page. Stores built before this change are recommended (never forced) to re-index for the newer navigable wiki.

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.35.0"
+__version__ = "0.36.0"

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through ten task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.35.0"
+version = "0.36.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3054,7 +3054,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.35.0"
+version = "0.36.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump and changelog for 0.36.0. Bump-only diff, no functional changes.

A smaller release than 0.35.0: 19 commits, mostly settling what the wiki restructure started. File-page volume is now bounded by default on very large repositories, `distill` gained a real shell lexer plus install and infra command families, and five contributor fixes landed across serve, the job scheduler, dead code and refactoring.

## What changed in this PR

- Version bumped to 0.36.0 in the four synchronized Python files, with `uv lock` run explicitly so the self-entry moved
- Both plugin manifests bumped (`.claude-plugin/marketplace.json`, `plugins/claude-code/.claude-plugin/plugin.json`)
- Changelog section added, bundled copy resynced

Store format and parser schema versions are unchanged. Nothing this cycle needs older stores to react, and no parser logic changed in a way that would invalidate a cached parse.

The Codex plugin is left at 0.3.0, untouched this cycle. The VS Code extension is left alone as well: only one `packages/ui` commit landed since `vscode-v0.6.0` (#1066).

## Validation

- [x] Drift grep clean: no 0.35.0 residue, 0.36.0 present in all four Python files, `uv.lock` and both plugin manifests
- [x] `uv build --wheel` produces `repowise-0.36.0-py3-none-any.whl` with 78 command modules, `serve_cmd.py`, 18 tree-sitter `.scm` queries, 34 Jinja `.j2` templates and the bundled changelog
- [x] `npm ci && npm run build --workspace packages/web` passes; standalone `server.js` emitted at the nested path and workspace-package code compiled into the architecture, code-health and symbols chunks
- [x] Bundled changelog sync guard passes
- [x] Unit suite: 8427 passed, 3 skipped. One load-induced failure in `test_rewrite_perf.py::test_p95_under_150ms` while the web build was running concurrently; passes 6/6 in isolation
- [ ] Tag and publish (post-merge)

## Merge convention

Merge with a **regular merge commit, not squash**, so the tag points at a real merge of the bump-only diff and artifact provenance stays traceable.
