### PR TITLE
fix(ui): use stored concept tree for pages parented to repo root (#1081)

### DIFF
--- a/packages/ui/__tests__/docs/doc-nav.test.ts
+++ b/packages/ui/__tests__/docs/doc-nav.test.ts
@@ -123,9 +123,9 @@ describe("computeDocNav", () => {
     expect(nav.breadcrumbs[0]?.pageId).toBe(mod.id);
   });
 
-  it("keeps the directory trail for a page hanging off the repo root", () => {
-    // The tree places files no module claimed directly under the overview. A
-    // lone basename crumb would say less than the path the page still carries.
+  it("uses the stored tree for pages parented to the repo root", () => {
+    // Pages parented to the repo root use the stored tree (omitting the root crumb,
+    // which the caller prepends).
     const loose = makePage({
       id: "file_page:docs/design/contrast_check.py",
       title: "contrast_check.py",
@@ -133,11 +133,7 @@ describe("computeDocNav", () => {
       parent_page_id: ROOT.id,
     });
     const nav = computeDocNav(loose, [ROOT, loose]);
-    expect(nav.breadcrumbs.map((b) => b.label)).toEqual([
-      "docs",
-      "design",
-      "contrast_check.py",
-    ]);
+    expect(nav.breadcrumbs.map((b) => b.label)).toEqual(["contrast_check.py"]);
   });
 
   it("labels ancestors with their page type so callers need not guess", () => {
@@ -164,13 +160,48 @@ describe("computeDocNav", () => {
     expect(nav.breadcrumbs.at(-1)?.label).toBe("Circular Dependency: scc-1050");
   });
 
-  it("shows a single label for a page with no path and no parent", () => {
-    const overview = makePage({
-      id: "o",
-      page_type: "repo_overview",
-      title: "Overview",
-      target_path: "",
+  it("shows prev/next sibling links for root-level pages using display_order", () => {
+    const tour = makePage({
+      id: "onboarding:tour",
+      page_type: "onboarding",
+      title: "Guided Tour",
+      target_path: "docs/guided_tour.md",
+      parent_page_id: ROOT.id,
+      display_order: 1,
     });
-    expect(computeDocNav(overview, [overview]).breadcrumbs).toEqual([{ label: "Overview" }]);
+    const map = makePage({
+      id: "onboarding:map",
+      page_type: "onboarding",
+      title: "Codebase Map",
+      target_path: "docs/codebase_map.md",
+      parent_page_id: ROOT.id,
+      display_order: 2,
+    });
+    const nav = computeDocNav(tour, [ROOT, tour, map]);
+    expect(nav.prev).toBeUndefined();
+    expect(nav.next?.pageId).toBe(map.id);
+    expect(nav.next?.title).toBe("Codebase Map");
+  });
+
+  it("provides prev/next navigation between root-level layer pages", () => {
+    const layer1 = makePage({
+      id: "layer_page:layer:ui",
+      page_type: "layer_page",
+      title: "Layer: UI",
+      target_path: "layer:ui",
+      parent_page_id: ROOT.id,
+      display_order: 1,
+    });
+    const layer2 = makePage({
+      id: "layer_page:layer:core",
+      page_type: "layer_page",
+      title: "Layer: Core",
+      target_path: "layer:core",
+      parent_page_id: ROOT.id,
+      display_order: 2,
+    });
+    const nav = computeDocNav(layer1, [ROOT, layer1, layer2]);
+    expect(nav.next?.pageId).toBe(layer2.id);
+    expect(nav.next?.title).toBe("Layer: Core");
   });
 });

--- a/packages/ui/__tests__/docs/doc-nav.test.ts
+++ b/packages/ui/__tests__/docs/doc-nav.test.ts
@@ -160,6 +160,16 @@ describe("computeDocNav", () => {
     expect(nav.breadcrumbs.at(-1)?.label).toBe("Circular Dependency: scc-1050");
   });
 
+  it("shows a single label for a page with no path and no parent", () => {
+    const overview = makePage({
+      id: "o",
+      page_type: "repo_overview",
+      title: "Overview",
+      target_path: "",
+    });
+    expect(computeDocNav(overview, [overview]).breadcrumbs).toEqual([{ label: "Overview" }]);
+  });
+
   it("shows prev/next sibling links for root-level pages using display_order", () => {
     const tour = makePage({
       id: "onboarding:tour",

--- a/packages/ui/src/docs/doc-nav.ts
+++ b/packages/ui/src/docs/doc-nav.ts
@@ -79,10 +79,10 @@ export function computeDocNav(page: DocPage, pages: DocPage[]): DocNavInfo {
   const byId = new Map(pages.map((p) => [p.id, p]));
   const chain = page.parent_page_id ? ancestors(page, byId) : [];
 
-  // Only when there is a documented ancestor to show. A page hanging directly
-  // off the repo root has none, and a lone basename crumb would say less than
-  // the directory trail the path still carries, so those keep the path split.
-  if (chain.length > 0) {
+  // Use the stored tree when page.parent_page_id exists and is in the store.
+  // Root children have an empty ancestor chain (root crumb omitted), but still
+  // rely on parent_page_id for display_order sibling sorting and clean labels.
+  if (page.parent_page_id && byId.has(page.parent_page_id)) {
     const breadcrumbs: DocNavSegment[] = [
       ...chain.map((a) => ({
         label: crumbLabel(a),


### PR DESCRIPTION
## Summary
- Fixes `computeDocNav` gate in `packages/ui/src/docs/doc-nav.ts` so pages parented to the repo root use the stored concept tree instead of falling back to path-split sorting.
- Restores curated `display_order` reading order for root-level onboarding chapters (e.g., *Guided Tour* → *Codebase Map*).
- Restores missing Prev/Next navigation links for synthetic root-level pages (Layer pages, cycle pages, and architecture diagrams).

### Visual Verification (Screenshots)

#### 1. Onboarding Chapter Navigation (Guided Tour)
| Before Fix | After Fix |
|---|---|
| ![Before Onboarding](https://github.com/user-attachments/assets/d8843696-3e60-4e62-ade3-a64a62e2afc7) | ![After Layer](https://github.com/user-attachments/assets/a2945788-65e0-4da3-9e15-e83253580c6c) |
| *Next button incorrectly linked to How It Works* | *Next button correctly links to Codebase Map* |

#### 2. Layer Page Prev/Next Links (Layer: UI)
| Before Fix | After Fix |
|---|---|
| ![Before Layer](https://github.com/user-attachments/assets/ce0ecdf4-60f1-4955-811c-170ccace9026) |![After Onboarding](https://github.com/user-attachments/assets/09559ae3-1e98-4bc1-9100-cb73e69d4b86) | 
| *No Prev/Next buttons visible* | *Prev/Next buttons visible and linking to Layer: Core* |

---

## Related Issues
Fixes #1081

---

## Test Plan
- [x] Unit tests pass (`npx vitest run packages/ui/__tests__/docs/doc-nav.test.ts`)
- [x] Type check passes (`npm run type-check`)
- [x] Verified manually in browser UI via `repowise serve` + `npm run dev`

---

## Checklist
- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed