### PR TITLE
fix(dead-code): align default min_confidence floor to RISK_CAP_CONFIDENCE (#1084)

### DIFF
--- a/docs/agent/MCP_TOOLS.md
+++ b/docs/agent/MCP_TOOLS.md
@@ -439,7 +439,7 @@ Unreachable code, unused exports, unused internals, and zombie packages, sorted 
 |-----------|------|----------|-------------|
 | `repo` | string | No | *(workspace only)* Target repo alias |
 | `kind` | string | No | Restrict to one finding kind: `unreachable_file` \| `unused_export` \| `unused_internal` \| `zombie_package` |
-| `min_confidence` | float | No | Minimum confidence floor (default `0.5`; `0.7`+ is cleanup-ready only) |
+| `min_confidence` | float | No | Minimum confidence floor (default `0.4`; `0.7`+ is cleanup-ready only) |
 | `safe_only` | boolean | No | Deletion-ready findings only, excluding anything with runtime-load risk (default `false`) |
 | `limit` | int | No | Max findings per tier, clamped to 25 (default 20) |
 | `tier` | string | No | Restrict to one tier: `high` (>= 0.8) \| `medium` \| `low` |

--- a/docs/architecture/deep-dives.md
+++ b/docs/architecture/deep-dives.md
@@ -254,7 +254,7 @@ DeadCodeAnalyzer.analyze()
     ├── _detect_unused_exports()       → findings with confidence + safe_to_delete
     ├── _detect_zombie_packages()      → findings at 0.5 confidence, never safe
     │
-    ▼ apply min_confidence filter (default 0.5)
+    ▼ apply min_confidence filter (default 0.4)
     │
     ▼ persist to dead_code_findings table
     │

--- a/docs/layers/DEAD_CODE.md
+++ b/docs/layers/DEAD_CODE.md
@@ -101,10 +101,10 @@ compare numbers:
 
 | Surface | High | Medium | Low | Default floor |
 |---------|------|--------|-----|---------------|
-| CLI (`repowise dead-code`) | `>= 0.7` | `0.5` to `0.7` | `< 0.5` | `--min-confidence 0.5` |
-| MCP (`get_dead_code`) | `>= 0.8` | `0.5` to `0.8` | `< 0.5` | `min_confidence=0.5` |
+| CLI (`repowise dead-code`) | `>= 0.7` | `0.4` to `0.7` | `< 0.4` | `--min-confidence 0.4` |
+| MCP (`get_dead_code`) | `>= 0.8` | `0.4` to `0.8` | `< 0.4` | `min_confidence=0.4` |
 
-Both surfaces now share the same default floor (`0.5`). The MCP high/medium
+Both surfaces now share the same default floor (`0.4`). The MCP high/medium
 cutovers stay stricter: an agent acting on a finding is riskier than a human
 reading a table.
 
@@ -230,7 +230,7 @@ before deleting anything.
 
 | Flag | Description |
 |------|-------------|
-| `--min-confidence` | Minimum confidence threshold (default `0.5`) |
+| `--min-confidence` | Minimum confidence threshold (default `0.4`) |
 | `--safe-only` | Only findings marked safe to delete |
 | `--kind` | `unreachable_file`, `unused_export`, `unused_internal`, `zombie_package` |
 | `--format` | `table` (default), `json`, `md` |
@@ -251,7 +251,7 @@ path, kind, confidence, line count, and a cleanup impact estimate.
 | Parameter | Default | Notes |
 |-----------|---------|-------|
 | `kind` | all | One of the four finding kinds |
-| `min_confidence` | `0.5` | `0.7` and above is cleanup-ready only |
+| `min_confidence` | `0.4` | `0.7` and above is cleanup-ready only |
 | `tier` | all | `high` (`>= 0.8`), `medium`, `low` |
 | `safe_only` | `false` | Deletion-ready only, excluding runtime-load risk |
 | `limit` | `20` | Per tier, clamped to 25 |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -441,7 +441,7 @@ Detect dead and unused code.
 
 | Flag | Description |
 |------|-------------|
-| `--min-confidence` | Minimum confidence threshold (default: 0.5) |
+| `--min-confidence` | Minimum confidence threshold (default: 0.4) |
 | `--safe-only` | Only show findings marked safe to delete |
 | `--kind` | Filter: `unreachable_file`, `unused_export`, `unused_internal`, `zombie_package` |
 | `--format` | Output: `table` (default), `json`, `md` |

--- a/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
@@ -16,9 +16,17 @@ from repowise.cli.helpers import (
 )
 
 
+from repowise.core.analysis.dead_code.risk_factors import RISK_CAP_CONFIDENCE
+
+
 @click.command("dead-code")
 @click.argument("path", required=False, type=click.Path(exists=True))
-@click.option("--min-confidence", default=0.5, type=float, help="Minimum confidence threshold.")
+@click.option(
+    "--min-confidence",
+    default=RISK_CAP_CONFIDENCE,
+    type=float,
+    help="Minimum confidence threshold.",
+)
 @click.option(
     "--safe-only",
     is_flag=True,

--- a/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
+++ b/packages/cli/src/repowise/cli/commands/dead_code_cmd.py
@@ -14,8 +14,6 @@ from repowise.cli.helpers import (
     run_async,
     silence_logs_for_machine_output,
 )
-
-
 from repowise.core.analysis.dead_code.risk_factors import RISK_CAP_CONFIDENCE
 
 
@@ -125,9 +123,7 @@ def dead_code_command(
             if primary is None:
                 raise click.ClickException("Workspace has no primary repo configured.")
             repo_path = primary
-            console.print(
-                "[dim]  (Tip: pass --repo <alias> to analyze a different repo.)[/dim]"
-            )
+            console.print("[dim]  (Tip: pass --repo <alias> to analyze a different repo.)[/dim]")
     else:
         assert target.repo_path is not None
         repo_path = target.repo_path

--- a/packages/core/src/repowise/core/analysis/dead_code/risk_factors.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/risk_factors.py
@@ -34,9 +34,10 @@ from pathlib import PurePosixPath
 SAFE_CONFIDENCE_THRESHOLD: float = 0.7
 
 # Confidence ceiling applied to a finding that carries a runtime-load risk
-# factor. 0.4 is the default ``min_confidence`` floor, so the finding still
-# surfaces (as a medium / review-required candidate) but never reads as
-# deletion-ready.
+# factor. 0.4 is the default ``min_confidence`` floor across CLI, REST router,
+# and MCP tools (which import this value as their single source of truth), so the
+# finding still surfaces (as a medium / review-required candidate) but never
+# reads as deletion-ready.
 RISK_CAP_CONFIDENCE: float = 0.4
 
 # Filename-stem tokens → risk-factor tag. Matched against the basename split on

--- a/packages/server/src/repowise/server/mcp_server/tool_dead_code.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_dead_code.py
@@ -10,6 +10,7 @@ from typing import Any
 from sqlalchemy import select
 
 from repowise.core.analysis.dead_code.risk_factors import (
+    RISK_CAP_CONFIDENCE,
     effective_safe_to_delete,
     path_risk_factors,
 )
@@ -215,7 +216,7 @@ _TIER_DESC_LOW = (
 async def get_dead_code(
     repo: str | None = None,
     kind: str | None = None,
-    min_confidence: float = 0.5,
+    min_confidence: float = RISK_CAP_CONFIDENCE,
     safe_only: bool = False,
     limit: int = 20,
     tier: str | None = None,
@@ -236,7 +237,7 @@ async def get_dead_code(
     Args:
         repo: usually omitted.
         kind: unreachable_file | unused_export | unused_internal | zombie_package.
-        min_confidence: floor, default 0.5 (0.7 = cleanup-ready only).
+        min_confidence: floor, default 0.4 (0.7 = cleanup-ready only).
         safe_only: deletion-ready findings only (no runtime-load risk).
         limit: max findings per tier (clamped to 25).
         tier: "high" (>=0.8) | "medium" | "low".

--- a/packages/server/src/repowise/server/routers/dead_code.py
+++ b/packages/server/src/repowise/server/routers/dead_code.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from repowise.core.analysis.dead_code.risk_factors import effective_safe_to_delete
+from repowise.core.analysis.dead_code.risk_factors import (
+    RISK_CAP_CONFIDENCE,
+    effective_safe_to_delete,
+)
 from repowise.core.persistence import crud
 from repowise.server.deps import get_db_session, verify_api_key
 from repowise.server.schemas import (
@@ -27,7 +30,7 @@ router = APIRouter(
 async def list_dead_code(
     repo_id: str,
     kind: str | None = Query(None, description="Filter by finding kind"),
-    min_confidence: float = Query(0.5, ge=0.0, le=1.0),
+    min_confidence: float = Query(RISK_CAP_CONFIDENCE, ge=0.0, le=1.0),
     status: str = Query("open"),
     safe_only: bool = Query(False),
     limit: int = Query(100, ge=1, le=500),

--- a/packages/types/src/dead-code.ts
+++ b/packages/types/src/dead-code.ts
@@ -26,7 +26,11 @@ export type DeadCodeStatus = "open" | "acknowledged" | "resolved" | "false_posit
 export const DEAD_CODE_CONFIDENCE = {
   /** Deletion-ready floor; matches SAFE_CONFIDENCE_THRESHOLD. */
   HIGH: 0.7,
-  /** The list endpoint's default floor; below this findings are not fetched. */
+  /**
+   * The list endpoint & CLI's default `min_confidence` floor (0.4); mirrors
+   * `RISK_CAP_CONFIDENCE` in `core/analysis/dead_code/risk_factors.py`. Below this
+   * findings are not fetched.
+   */
   MEDIUM: 0.4,
 } as const;
 

--- a/packages/ui/src/dead-code/findings-table.tsx
+++ b/packages/ui/src/dead-code/findings-table.tsx
@@ -117,8 +117,8 @@ export function FindingsTable({
   isLoading,
 }: FindingsTableProps) {
   const [activeTab, setActiveTab] = useState<string | null>(null);
-  // The slider floor is the server's own `min_confidence` default: nothing
-  // below it is ever fetched, so a lower floor would be a control over nothing.
+  // The slider floor is the server's own `min_confidence` default (0.4, derived from
+  // RISK_CAP_CONFIDENCE in risk_factors.py): nothing below it is ever fetched.
   const [minConfidence, setMinConfidence] = useState<number>(DEAD_CODE_CONFIDENCE.MEDIUM);
   const [safeOnly, setSafeOnly] = useState(false);
   const [query, setQuery] = useState("");

--- a/plugins/claude-code/commands/dead-code.md
+++ b/plugins/claude-code/commands/dead-code.md
@@ -23,7 +23,7 @@ should be proposed for removal.
 - "files" → `--kind unreachable_file`
 - "exports" → `--kind unused_export`
 - "packages" / "zombie" → `--kind zombie_package`
-- "strict" → `--min-confidence 0.7` (default is 0.5)
+- "strict" → `--min-confidence 0.7` (default is 0.4)
 
 Other flags: `--format json`, `--include-internals` (aggressive, private-symbol
 scan; higher false-positive rate), `--include-zombie-packages` /

--- a/tests/unit/analysis/test_ts_never_flag.py
+++ b/tests/unit/analysis/test_ts_never_flag.py
@@ -14,6 +14,7 @@ import fnmatch
 
 def _matches(path: str) -> bool:
     from repowise.core.analysis.dead_code.constants import _NEVER_FLAG_PATTERNS
+
     return any(fnmatch.fnmatch(path, p) for p in _NEVER_FLAG_PATTERNS)
 
 
@@ -92,6 +93,7 @@ class TestNeverFlagDoesNotLeak:
 class TestEntryPointSymbolNames:
     def test_nextjs_route_exports_included(self):
         from repowise.core.analysis.dead_code.analyzer import _ENTRY_POINT_SYMBOL_NAMES
+
         for name in (
             "generateStaticParams",
             "generateMetadata",
@@ -103,6 +105,7 @@ class TestEntryPointSymbolNames:
 
     def test_remix_route_exports_included(self):
         from repowise.core.analysis.dead_code.analyzer import _ENTRY_POINT_SYMBOL_NAMES
+
         for name in ("ErrorBoundary", "HydrateFallback", "clientLoader", "shouldRevalidate"):
             assert name in _ENTRY_POINT_SYMBOL_NAMES
 
@@ -110,6 +113,7 @@ class TestEntryPointSymbolNames:
         # These names are too common to blanket-exempt — they'd mask
         # genuine dead code in non-route files across every language.
         from repowise.core.analysis.dead_code.analyzer import _ENTRY_POINT_SYMBOL_NAMES
+
         for name in ("load", "action", "loader", "meta", "metadata", "config", "headers"):
             assert name not in _ENTRY_POINT_SYMBOL_NAMES
 
@@ -117,6 +121,7 @@ class TestEntryPointSymbolNames:
 class TestTsUnusedExportConstants:
     def test_non_importable_kinds_allows_ts_const_and_var(self):
         from repowise.core.analysis.dead_code.analyzer import _non_importable_kinds
+
         kinds = _non_importable_kinds("typescript")
         assert "constant" not in kinds
         assert "variable" not in kinds
@@ -125,13 +130,14 @@ class TestTsUnusedExportConstants:
 
     def test_non_importable_kinds_allows_js_const_and_var(self):
         from repowise.core.analysis.dead_code.analyzer import _non_importable_kinds
+
         kinds = _non_importable_kinds("javascript")
         assert "constant" not in kinds
         assert "variable" not in kinds
 
     def test_other_languages_retain_universal_non_importable(self):
         from repowise.core.analysis.dead_code.analyzer import _non_importable_kinds
+
         python_kinds = _non_importable_kinds("python")
         assert "constant" in python_kinds
         assert "variable" in python_kinds
-

--- a/tests/unit/dead_code/test_confidence_parity.py
+++ b/tests/unit/dead_code/test_confidence_parity.py
@@ -1,0 +1,55 @@
+"""Cross-language contract test for dead-code confidence threshold alignment.
+
+Verifies that TypeScript's DEAD_CODE_CONFIDENCE.MEDIUM in packages/types/src/dead-code.ts
+matches Python's RISK_CAP_CONFIDENCE in repowise.core.analysis.dead_code.risk_factors.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from repowise.core.analysis.dead_code.risk_factors import (
+    RISK_CAP_CONFIDENCE,
+    SAFE_CONFIDENCE_THRESHOLD,
+)
+
+
+def test_ts_confidence_floor_matches_python_risk_cap() -> None:
+    """Ensure DEAD_CODE_CONFIDENCE.MEDIUM in TypeScript matches RISK_CAP_CONFIDENCE (0.4)."""
+    repo_root = Path(__file__).parents[3]
+    ts_file = repo_root / "packages" / "types" / "src" / "dead-code.ts"
+    assert ts_file.exists(), f"TypeScript types file not found at {ts_file}"
+
+    content = ts_file.read_text(encoding="utf-8")
+
+    medium_match = re.search(
+        r"DEAD_CODE_CONFIDENCE\s*=\s*\{[\s\S]*?MEDIUM:\s*([0-9.]+)", content
+    )
+    assert medium_match is not None, "Could not parse DEAD_CODE_CONFIDENCE.MEDIUM from dead-code.ts"
+    ts_medium = float(medium_match.group(1))
+
+    assert ts_medium == RISK_CAP_CONFIDENCE, (
+        f"Cross-language drift detected! TypeScript DEAD_CODE_CONFIDENCE.MEDIUM is {ts_medium}, "
+        f"but Python RISK_CAP_CONFIDENCE is {RISK_CAP_CONFIDENCE}."
+    )
+
+
+def test_ts_confidence_high_matches_python_safe_threshold() -> None:
+    """Ensure DEAD_CODE_CONFIDENCE.HIGH in TypeScript matches SAFE_CONFIDENCE_THRESHOLD (0.7)."""
+    repo_root = Path(__file__).parents[3]
+    ts_file = repo_root / "packages" / "types" / "src" / "dead-code.ts"
+    assert ts_file.exists(), f"TypeScript types file not found at {ts_file}"
+
+    content = ts_file.read_text(encoding="utf-8")
+
+    high_match = re.search(
+        r"DEAD_CODE_CONFIDENCE\s*=\s*\{[\s\S]*?HIGH:\s*([0-9.]+)", content
+    )
+    assert high_match is not None, "Could not parse DEAD_CODE_CONFIDENCE.HIGH from dead-code.ts"
+    ts_high = float(high_match.group(1))
+
+    assert ts_high == SAFE_CONFIDENCE_THRESHOLD, (
+        f"Cross-language drift detected! TypeScript DEAD_CODE_CONFIDENCE.HIGH is {ts_high}, "
+        f"but Python SAFE_CONFIDENCE_THRESHOLD is {SAFE_CONFIDENCE_THRESHOLD}."
+    )


### PR DESCRIPTION
## Summary
- **Establishes a Single Source of Truth in Python:** Imported `RISK_CAP_CONFIDENCE` (`0.4`) from `risk_factors.py` directly into the REST API router (`dead_code.py`), CLI command (`dead_code_cmd.py`), and MCP tool (`tool_dead_code.py`). This guarantees that API query defaults, CLI flags, and MCP tool defaults all derive from the same constant used by the core risk-capping logic, instead of three independently hardcoded literals.
- **Fixes Silent Finding Drops & Reconnects UI Slider:** Reverts the default `min_confidence` from `0.5` back to `0.4`, so runtime-risk-flagged review candidates (e.g. database seed files, config/bootstrap files capped at 40% confidence) surface in default CLI/REST/dashboard reports again. This also reconnects the web UI confidence slider's 40%–50% range to live backend data — previously that range filtered rows the server never returned.
- **Adds CI-Enforced Cross-Language Contract Tests:** Added `tests/unit/dead_code/test_confidence_parity.py`, which parses `DEAD_CODE_CONFIDENCE.MEDIUM` and `DEAD_CODE_CONFIDENCE.HIGH` out of the TypeScript source (`packages/types/src/dead-code.ts`) via regex and asserts they match Python's `RISK_CAP_CONFIDENCE` and `SAFE_CONFIDENCE_THRESHOLD` respectively. This gives CI an automated guardrail so the frontend slider bounds and backend thresholds can't silently drift apart again — `pytest` fails loudly if either side changes without the other.

---

## Related Issues
Fixes #1084

---

## Test Plan
- [x] Contract unit tests pass (`pytest tests/unit/dead_code/test_confidence_parity.py`)
- [x] TypeScript type check passes (`npm run type-check`)
- [x] Verified CLI default flag, REST query default, and MCP tool default all return risk-capped findings at 0.4.

---

## Checklist
- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed