### PR TITLE
fix(coupling): keep ?focus= in sync with the pinned file

### DIFF
--- a/packages/ui/__tests__/coupling/coupling-explorer.test.tsx
+++ b/packages/ui/__tests__/coupling/coupling-explorer.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, waitFor, screen } from "@testing-library/react";
+import type {
+  CouplingEdge,
+  CouplingNode,
+  CouplingGraphResponse,
+} from "@repowise-dev/types/coupling";
+import { CouplingExplorer } from "../../src/coupling/coupling-explorer.js";
+
+function node(path: string): CouplingNode {
+  return {
+    file_path: path,
+    module: path.split("/")[0] ?? null,
+    score: 5,
+    nloc: 100,
+  };
+}
+
+function edge(s: string, t: string, strength = 3): CouplingEdge {
+  return {
+    source: s,
+    target: t,
+    strength,
+    last_co_change: "2026-06-01",
+  };
+}
+
+function graph(
+  nodes: CouplingNode[],
+  edges: CouplingEdge[],
+): CouplingGraphResponse {
+  return { nodes, edges, total_edges: edges.length };
+}
+
+describe("CouplingExplorer", () => {
+  it("reports pin invalidation through onFocusChange when the file leaves the payload", async () => {
+    const onFocusChange = vi.fn();
+    const initial = graph(
+      [node("a.py"), node("b.py"), node("gone.py")],
+      [edge("a.py", "b.py", 5), edge("a.py", "gone.py", 2)],
+    );
+    const { rerender } = render(
+      <CouplingExplorer
+        data={initial}
+        initialFocus="gone.py"
+        onFocusChange={onFocusChange}
+      />,
+    );
+
+    const next = graph(
+      [node("a.py"), node("b.py")],
+      [edge("a.py", "b.py", 5)],
+    );
+    rerender(
+      <CouplingExplorer
+        data={next}
+        initialFocus="gone.py"
+        onFocusChange={onFocusChange}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onFocusChange).toHaveBeenCalledWith(null);
+    });
+  });
+
+  it("treats an empty initialFocus as absent and seeds the strict top hub", () => {
+    // hub.py degree 2; a.py / b.py degree 1 — unique maximum
+    const data = graph(
+      [node("hub.py"), node("a.py"), node("b.py")],
+      [edge("a.py", "hub.py", 3), edge("b.py", "hub.py", 2)],
+    );
+    render(<CouplingExplorer data={data} initialFocus="" />);
+    const guidance = screen.getByText(/Tracing/i);
+    expect(guidance).toHaveTextContent("Tracing hub.py");
+  });
+});

--- a/packages/ui/src/coupling/coupling-explorer.tsx
+++ b/packages/ui/src/coupling/coupling-explorer.tsx
@@ -78,7 +78,10 @@ export function CouplingExplorer({
   onFocusChange,
 }: CouplingExplorerProps) {
   const defaultPin = useMemo(
-    () => (initialFocus !== undefined ? initialFocus : topHub(data.edges)),
+    () =>
+      initialFocus !== undefined && initialFocus !== ""
+        ? initialFocus
+        : topHub(data.edges),
     // Only seed once from the initial data/prop; user actions drive it after.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [],
@@ -88,6 +91,11 @@ export function CouplingExplorer({
   const [query, setQuery] = useState("");
   const [promptEdge, setPromptEdge] = useState<CouplingEdge | null>(null);
 
+  const changePin = (path: string | null) => {
+    setPinned(path);
+    onFocusChange?.(path);
+  };
+  
   // Drop a stale pin if a background revalidation returns an edge set that no
   // longer contains it, so the guidance never claims to trace a vanished file.
   const nodePaths = useMemo(
@@ -95,16 +103,14 @@ export function CouplingExplorer({
     [data.nodes],
   );
   useEffect(() => {
-    if (pinned && !nodePaths.has(pinned)) setPinned(null);
+    if (pinned && !nodePaths.has(pinned)) changePin(null);
+    // Intentionally keyed on pin + payload only; changePin always closes over
+    // the latest onFocusChange.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pinned, nodePaths]);
-
+  
   // Transient hover peeks over the sticky pin: what the ring and table light up.
   const focus = hover ?? pinned;
-
-  const changePin = (path: string | null) => {
-    setPinned(path);
-    onFocusChange?.(path);
-  };
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/packages/web/src/app/repos/[id]/architecture/page.tsx
+++ b/packages/web/src/app/repos/[id]/architecture/page.tsx
@@ -74,6 +74,7 @@ export default function ArchitecturePage({
     parseAsStringLiteral(VIEWS).withDefault("map"),
   );
   const [viewModeParam] = useQueryState("viewMode");
+  const [, setFocus] = useQueryState("focus");
 
   // The curated layers view now lives at /knowledge-graph. `?view=layers`
   // redirects there so shared links keep working.
@@ -98,6 +99,17 @@ export default function ArchitecturePage({
     [setView],
   );
 
+  const handleTabChange = useCallback(
+    (id: string) => {
+      const next = id as ArchView;
+      void setView(next);
+      if (next !== "coupling") {
+        void setFocus(null);
+      }
+    },
+    [setView, setFocus],
+  );
+
   // The active canonical tab. Map/Explore are the only graph-canvas tabs;
   // everything else resolves to its own panel.
   const activeTab: (typeof CANONICAL_VIEWS)[number]["id"] =
@@ -115,7 +127,7 @@ export default function ArchitecturePage({
         <ViewTabs
           tabs={CANONICAL_VIEWS.map((v) => ({ id: v.id, label: v.label }))}
           value={activeTab}
-          onValueChange={(id) => void setView(id as ArchView)}
+          onValueChange={handleTabChange}
         />
       </div>
 

--- a/packages/web/src/components/coupling/coupling-tab.tsx
+++ b/packages/web/src/components/coupling/coupling-tab.tsx
@@ -47,8 +47,8 @@ export function CouplingTab({ repoId }: { repoId: string }) {
           data={data}
           repoLinkPrefix={`/repos/${repoId}`}
           LinkComponent={Link}
-          // Absent `?focus=` → let the explorer open on the most-coupled hub.
-          initialFocus={focus ?? undefined}
+          // Absent / bare `?focus=` → let the explorer open on the most-coupled hub.
+          initialFocus={focus || undefined}
           onFocusChange={(path) => void setFocus(path)}
         />
       )}


### PR DESCRIPTION
## Summary

- Route CouplingExplorer pin invalidation through `changePin` / `onFocusChange` so stale `?focus=` is cleared from the URL
- Treat bare `?focus=` (empty string) as absent so the top-hub default still seeds
- Clear `?focus=` when leaving the Coupling Architecture tab

## Related Issues

Fixes #1082

## Test Plan

- [x] `packages/ui` tests pass (832)
- [x] `packages/web` tests pass (8)
- [x] Pin invalidation notifies `onFocusChange(null)`
- [x] Empty `initialFocus` seeds the top hub
- [ ] Lint (`ruff`) - N/A, no Python changes

## Checklist

- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed (N/A - no docs change required)