### PR TITLE
fix(ingestion): tolerate malformed .gitignore patterns

### DIFF
--- a/packages/core/src/repowise/core/ingestion/traverser.py
+++ b/packages/core/src/repowise/core/ingestion/traverser.py
@@ -873,23 +873,6 @@ def _compile_gitignore(lines: Iterable[str]) -> pathspec.PathSpec:
         try:
             patterns.append(GitWildMatchPattern(line))
         except GitWildMatchPatternError:
-            # Git tolerates a trailing backslash (e.g. ``.godot\``) and treats it
-            # as the bare path; dropping the line entirely would leave a large
-            # generated directory un-ignored — the opposite of the author's
-            # intent. Strip trailing backslashes and retry so the pattern is
-            # still honoured, and only drop the line if it remains unparseable.
-            salvaged = line.rstrip("\\")
-            if salvaged and salvaged != line:
-                try:
-                    patterns.append(GitWildMatchPattern(salvaged))
-                    log.warning(
-                        "recovered malformed gitignore pattern",
-                        pattern=line,
-                        used=salvaged,
-                    )
-                    continue
-                except GitWildMatchPatternError:
-                    pass
             log.warning("skipping malformed gitignore pattern", pattern=line)
     return pathspec.PathSpec(patterns)
 

--- a/packages/core/src/repowise/core/ingestion/traverser.py
+++ b/packages/core/src/repowise/core/ingestion/traverser.py
@@ -18,13 +18,14 @@ from __future__ import annotations
 import configparser
 import os
 import threading
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 
 import pathspec
 import structlog
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern, GitWildMatchPatternError
 
 from .languages.registry import REGISTRY as _LANG_REGISTRY
 from .models import (
@@ -278,7 +279,7 @@ class FileTraverser:
             "gitwildmatch", _BLOCKED_FILENAME_PATTERNS
         )
         patterns = extra_exclude_patterns or []
-        self._extra_exclude = pathspec.PathSpec.from_lines("gitwildmatch", patterns)
+        self._extra_exclude = _compile_gitignore(patterns)
         # Per-directory ignore cache: absolute dir path -> PathSpec built from
         # that directory's nested .gitignore + .repowiseIgnore.
         # Pre-seed root: its .gitignore is matched full-path via self._gitignore
@@ -409,7 +410,7 @@ class FileTraverser:
                     lines.extend(
                         ignore_file.read_text(encoding="utf-8", errors="ignore").splitlines()
                     )
-            self._dir_ignore_cache[key] = pathspec.PathSpec.from_lines("gitwildmatch", lines)
+            self._dir_ignore_cache[key] = _compile_gitignore(lines)
         return self._dir_ignore_cache[key]
 
     def _should_skip_dir(
@@ -854,6 +855,28 @@ def _parse_gitmodules(repo_root: Path) -> frozenset[str]:
         return frozenset()
 
 
+def _compile_gitignore(lines: Iterable[str]) -> pathspec.PathSpec:
+    """Build a gitwildmatch ``PathSpec``, tolerating malformed patterns.
+
+    Git itself accepts ignore lines that ``pathspec`` rejects — e.g. a trailing
+    backslash like ``.godot\\`` (a real pattern found in Godot ``.gitignore``
+    files). ``PathSpec.from_lines`` raises ``GitWildMatchPatternError`` on the
+    first such line, which would abort ingestion of the entire repository over
+    one stray line that ``git status`` handles without complaint. Compile each
+    line independently and skip (with a warning) only the offending ones, so the
+    rest of the ignore file still applies.
+    """
+    patterns: list[GitWildMatchPattern] = []
+    for line in lines:
+        if not line:
+            continue
+        try:
+            patterns.append(GitWildMatchPattern(line))
+        except GitWildMatchPatternError:
+            log.warning("skipping malformed gitignore pattern", pattern=line)
+    return pathspec.PathSpec(patterns)
+
+
 def _load_gitignore_spec(repo_root: Path) -> pathspec.PathSpec:
     """Root ignore spec: ``.gitignore`` merged with ``.git/info/exclude``.
 
@@ -869,7 +892,7 @@ def _load_gitignore_spec(repo_root: Path) -> pathspec.PathSpec:
     ):
         if ignore_file.exists():
             lines.extend(ignore_file.read_text(encoding="utf-8", errors="ignore").splitlines())
-    return pathspec.PathSpec.from_lines("gitwildmatch", lines)
+    return _compile_gitignore(lines)
 
 
 def _load_extra_ignore_spec(repo_root: Path, filename: str) -> pathspec.PathSpec:
@@ -877,4 +900,4 @@ def _load_extra_ignore_spec(repo_root: Path, filename: str) -> pathspec.PathSpec
     lines: list[str] = []
     if ignore_file.exists():
         lines = ignore_file.read_text(encoding="utf-8", errors="ignore").splitlines()
-    return pathspec.PathSpec.from_lines("gitwildmatch", lines)
+    return _compile_gitignore(lines)

--- a/packages/core/src/repowise/core/ingestion/traverser.py
+++ b/packages/core/src/repowise/core/ingestion/traverser.py
@@ -873,6 +873,23 @@ def _compile_gitignore(lines: Iterable[str]) -> pathspec.PathSpec:
         try:
             patterns.append(GitWildMatchPattern(line))
         except GitWildMatchPatternError:
+            # Git tolerates a trailing backslash (e.g. ``.godot\``) and treats it
+            # as the bare path; dropping the line entirely would leave a large
+            # generated directory un-ignored — the opposite of the author's
+            # intent. Strip trailing backslashes and retry so the pattern is
+            # still honoured, and only drop the line if it remains unparseable.
+            salvaged = line.rstrip("\\")
+            if salvaged and salvaged != line:
+                try:
+                    patterns.append(GitWildMatchPattern(salvaged))
+                    log.warning(
+                        "recovered malformed gitignore pattern",
+                        pattern=line,
+                        used=salvaged,
+                    )
+                    continue
+                except GitWildMatchPatternError:
+                    pass
             log.warning("skipping malformed gitignore pattern", pattern=line)
     return pathspec.PathSpec(patterns)
 

--- a/tests/unit/ingestion/test_traverser.py
+++ b/tests/unit/ingestion/test_traverser.py
@@ -15,12 +15,26 @@ from repowise.core.ingestion.traverser import (
 
 
 class TestCompileGitignore:
-    def test_skips_malformed_line_keeps_valid(self) -> None:
+    def test_malformed_line_is_not_fatal_and_keeps_valid(self) -> None:
         spec = _compile_gitignore([".godot\\", "build/", "*.log", "", "# note"])
         assert spec.match_file("build/x")
         assert spec.match_file("a.log")
-        # The malformed line is dropped, not fatal.
+        # A malformed line never takes down its neighbours.
         assert not spec.match_file("src/main.py")
+
+    def test_trailing_backslash_is_salvaged(self) -> None:
+        # Git treats `.godot\` as `.godot`; recover that intent instead of
+        # dropping it, so the generated dir stays ignored (the motivating case).
+        spec = _compile_gitignore([".godot\\"])
+        assert spec.match_file(".godot")
+        assert spec.match_file(".godot/imported/x.res")
+        assert not spec.match_file("godot.py")
+
+    def test_unrecoverable_line_is_dropped(self) -> None:
+        # A lone backslash is unparseable and empty once stripped -> drop it,
+        # do not raise, and keep the valid neighbour.
+        spec = _compile_gitignore(["\\", "keep-me/"])
+        assert spec.match_file("keep-me/x")
 
     def test_all_valid_lines_preserved(self) -> None:
         spec = _compile_gitignore(["dist/", "*.tmp"])

--- a/tests/unit/ingestion/test_traverser.py
+++ b/tests/unit/ingestion/test_traverser.py
@@ -7,7 +7,27 @@ from pathlib import Path
 import pytest
 
 from repowise.core.ingestion import traverser as traverser_mod
-from repowise.core.ingestion.traverser import FileTraverser, _detect_language
+from repowise.core.ingestion.traverser import (
+    FileTraverser,
+    _compile_gitignore,
+    _detect_language,
+)
+
+
+class TestCompileGitignore:
+    def test_skips_malformed_line_keeps_valid(self) -> None:
+        spec = _compile_gitignore([".godot\\", "build/", "*.log", "", "# note"])
+        assert spec.match_file("build/x")
+        assert spec.match_file("a.log")
+        # The malformed line is dropped, not fatal.
+        assert not spec.match_file("src/main.py")
+
+    def test_all_valid_lines_preserved(self) -> None:
+        spec = _compile_gitignore(["dist/", "*.tmp"])
+        assert spec.match_file("dist/a")
+        assert spec.match_file("x.tmp")
+        assert not spec.match_file("keep.py")
+
 
 # ---------------------------------------------------------------------------
 # Language detection
@@ -172,6 +192,21 @@ class TestFileTraverser:
         assert any("app.py" in p for p in paths)
         assert not any("local-stash" in p for p in paths)
         assert not any("notes.scratch" in p for p in paths)
+
+    def test_malformed_gitignore_line_does_not_abort(self, tmp_path: Path) -> None:
+        # Git tolerates patterns that pathspec rejects (e.g. a trailing
+        # backslash like ``.godot\``). One such line must not crash the whole
+        # traversal; the remaining valid patterns must still apply.
+        (tmp_path / ".gitignore").write_text(".godot\\\n*.log\napp_ok.py\n")
+        (tmp_path / "app.py").write_text("pass")
+        (tmp_path / "app_ok.py").write_text("pass")
+        (tmp_path / "debug.log").write_text("logs")
+        traverser = FileTraverser(tmp_path)
+        paths = [f.path for f in traverser.traverse()]
+        # Did not raise, and the well-formed patterns after the bad line held.
+        assert any("app.py" in p for p in paths)
+        assert not any("app_ok.py" in p for p in paths)
+        assert not any("debug.log" in p for p in paths)
 
     def test_skips_oversized_files(self, tmp_path: Path) -> None:
         big = tmp_path / "big.py"

--- a/tests/unit/ingestion/test_traverser.py
+++ b/tests/unit/ingestion/test_traverser.py
@@ -22,12 +22,15 @@ class TestCompileGitignore:
         # A malformed line never takes down its neighbours.
         assert not spec.match_file("src/main.py")
 
-    def test_trailing_backslash_is_salvaged(self) -> None:
-        # Git treats `.godot\` as `.godot`; recover that intent instead of
-        # dropping it, so the generated dir stays ignored (the motivating case).
+    def test_trailing_backslash_matches_nothing(self) -> None:
+        # Git parity: git treats a dangling trailing backslash (e.g. `.godot\`)
+        # as an escape of nothing, so the pattern matches nothing — no error, no
+        # fallback to the bare path. Dropping the line reproduces that exactly.
+        # Do NOT re-add a salvage that rewrites `.godot\` -> `.godot`: that would
+        # diverge from git (it would start ignoring `.godot/` that git tracks).
         spec = _compile_gitignore([".godot\\"])
-        assert spec.match_file(".godot")
-        assert spec.match_file(".godot/imported/x.res")
+        assert not spec.match_file(".godot")
+        assert not spec.match_file(".godot/imported/x.res")
         assert not spec.match_file("godot.py")
 
     def test_unrecoverable_line_is_dropped(self) -> None:


### PR DESCRIPTION
## Problem

`repowise init` aborts on any repository whose `.gitignore` (root, nested, or `.git/info/exclude`) contains a pattern that `pathspec` rejects but **git itself accepts** — e.g. a trailing backslash `.godot\` (common in Godot projects). `pathspec.PathSpec.from_lines` raises `GitWildMatchPatternError` on the first such line and the whole ingest dies:

```
pathspec.patterns.gitwildmatch.GitWildMatchPatternError: Invalid git pattern: '.godot\'
  File ".../ingestion/traverser.py", line 872, in _load_gitignore_spec
    return pathspec.PathSpec.from_lines("gitwildmatch", lines)
```

One stray line should not make an otherwise-valid repo un-indexable; repowise should be at least as lenient as git.

## Fix

- Add `_compile_gitignore()`, which compiles each ignore line independently and **skips only the malformed ones** (emitting a `log.warning`), instead of failing the whole spec.
- Route the three user-controlled loaders through it: root `.gitignore`/`info/exclude` (`_load_gitignore_spec`), nested per-directory `.gitignore` (`_get_dir_ignore`), the extra-ignore file (`_load_extra_ignore_spec`), and config `extra_exclude_patterns`.
- Trusted hardcoded `_BLOCKED_FILENAME_PATTERNS` are left untouched.

Well-formed `.gitignore` behaviour is unchanged.

## Tests

- `TestCompileGitignore` — unit coverage that a malformed line is dropped while valid patterns still match.
- `test_malformed_gitignore_line_does_not_abort` — end-to-end: a repo with `.godot\` in `.gitignore` now traverses successfully and the valid patterns after the bad line still apply.

All 82 tests in `test_traverser.py` pass; `ruff check`/`format` clean.

## Repro

`repowise init --no-prose` on a repo whose `.gitignore` contains a line `.godot\`. Before: exit 1 with the traceback above. After: indexes normally.