### PR TITLE
feat(stats): rework the coding-rhythm chart and name how a repo ships

### DIFF
--- a/packages/server/src/repowise/server/routers/stats.py
+++ b/packages/server/src/repowise/server/routers/stats.py
@@ -278,13 +278,23 @@ def _longest_streak(commit_days: set[Any]) -> dict[str, Any] | None:
 
 
 def _chronotypes(
-    per_author_hours: dict[str, list[int]], names: dict[str, str]
+    per_author_hours: dict[str, list[int]],
+    per_author_weekdays: dict[str, list[int]],
+    names: dict[str, str],
 ) -> list[dict[str, Any]]:
     """Each frequent contributor's peak commit hour, with a habit label.
 
     Only meaningful once commits carry their author's UTC offset — the caller
     skips this entirely in UTC mode rather than award "night owl" to whoever
     happens to live furthest east.
+
+    Both marginal histograms ship alongside the label, because the UI names
+    people from them and weekday naming has to happen there: which days count
+    as the weekend is a reader preference, so a "weekend warrior" decided here
+    would be wrong for every team that rests Friday. The joint weekday-by-hour
+    distribution is deliberately not sent. It is 168 numbers per person to
+    sharpen a single label, and the two marginals answer the same question
+    closely enough.
     """
     out: list[dict[str, Any]] = []
     for key, hours in per_author_hours.items():
@@ -312,6 +322,8 @@ def _chronotypes(
                 "label": label,
                 "night_pct": round(night / total * 100.0, 1),
                 "early_pct": round(early / total * 100.0, 1),
+                "hour_commits": hours,
+                "weekday_commits": per_author_weekdays.get(key, [0] * 7),
             }
         )
     return sorted(out, key=lambda a: -a["commits"])[:8]
@@ -440,6 +452,7 @@ async def _commit_pass(session: AsyncSession, repo_id: str, repo: Any) -> dict[s
     commit_days: set[Any] = set()
     day_counts: dict[Any, int] = {}
     per_author_hours: dict[str, list[int]] = {}
+    per_author_weekdays: dict[str, list[int]] = {}
     for moment, offset, key in stamps:
         local = moment + timedelta(minutes=offset or 0) if local_mode else moment
         punch[local.weekday()][local.hour] += 1
@@ -448,6 +461,7 @@ async def _commit_pass(session: AsyncSession, repo_id: str, repo: Any) -> dict[s
         day_counts[day] = day_counts.get(day, 0) + 1
         if local_mode and key and key in human_keys:
             per_author_hours.setdefault(key, [0] * 24)[local.hour] += 1
+            per_author_weekdays.setdefault(key, [0] * 7)[local.weekday()] += 1
 
     busiest_day = None
     if day_counts:
@@ -506,7 +520,9 @@ async def _commit_pass(session: AsyncSession, repo_id: str, repo: Any) -> dict[s
             "longest_streak": _longest_streak(commit_days),
             "active_days": len(commit_days),
         },
-        "chronotypes": _chronotypes(per_author_hours, display_name) if local_mode else [],
+        "chronotypes": (
+            _chronotypes(per_author_hours, per_author_weekdays, display_name) if local_mode else []
+        ),
         "arrivals": arrivals,
         "biggest_commit": biggest_commit,
         "widest_commit": widest_commit,

--- a/packages/types/src/stats.ts
+++ b/packages/types/src/stats.ts
@@ -114,6 +114,12 @@ export interface StatsChronotype {
   label: "night_owl" | "early_bird" | "daylight";
   night_pct: number;
   early_pct: number;
+  /** This person's own 24-hour commit histogram. */
+  hour_commits: number[];
+  /** This person's own weekday histogram, 0=Monday. Named client-side because
+   *  which days count as the weekend is the reader's preference, not the
+   *  server's. Older payloads omit both arrays; naming degrades to null. */
+  weekday_commits: number[];
 }
 
 export interface StatsArrival {

--- a/packages/ui/__tests__/stats/archetype.test.ts
+++ b/packages/ui/__tests__/stats/archetype.test.ts
@@ -1,0 +1,183 @@
+/**
+ * The naming rules, held to their own thresholds.
+ *
+ * The failure mode worth guarding is a name that reads as personality but is
+ * really an artifact: a label handed out below the evidence floor, a "weekend
+ * warrior" that ignores the reader's weekend preset, or a nocturnal repo losing
+ * its most distinctive trait to a blander rule that happened to match first.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { StatsChronotype } from "@repowise-dev/types/stats";
+import {
+  contributorArchetype,
+  NAME_MIN_COMMITS,
+  repoArchetype,
+} from "../../src/stats/archetype.js";
+import { weekendDaysFor } from "../../src/stats/weekend.js";
+
+const SAT_SUN = weekendDaysFor("sat-sun");
+const FRI_SAT = weekendDaysFor("fri-sat");
+
+/** Empty 7x24 matrix, 0 = Monday. */
+function matrix(): number[][] {
+  return Array.from({ length: 7 }, () => Array<number>(24).fill(0));
+}
+
+/** Put `n` commits on `weekday` at `hour`. */
+function at(m: number[][], weekday: number, hour: number, n: number): number[][] {
+  m[weekday]![hour] = (m[weekday]![hour] ?? 0) + n;
+  return m;
+}
+
+function person(over: Partial<StatsChronotype> = {}): StatsChronotype {
+  return {
+    name: "Someone",
+    commits: 100,
+    peak_hour: 14,
+    label: "daylight",
+    night_pct: 0,
+    early_pct: 0,
+    hour_commits: Array<number>(24).fill(0),
+    weekday_commits: Array<number>(7).fill(0),
+    ...over,
+  };
+}
+
+describe("repoArchetype", () => {
+  it("stays silent below the evidence floor", () => {
+    const m = at(matrix(), 5, 14, NAME_MIN_COMMITS - 1);
+    expect(repoArchetype(m, SAT_SUN)).toBeNull();
+  });
+
+  it("names a weekend-led repo", () => {
+    const m = at(at(matrix(), 5, 14, 60), 2, 14, 40);
+    expect(repoArchetype(m, SAT_SUN)?.name).toBe("Weekend Project");
+  });
+
+  it("reads the weekend from the reader's preset, not from Sat/Sun", () => {
+    // All the work is on Friday, which is a weekend day in some of the world
+    // and an ordinary working day in the rest of it.
+    const m = at(matrix(), 4, 14, 80);
+    expect(repoArchetype(m, FRI_SAT)?.name).toBe("Weekend Project");
+    expect(repoArchetype(m, SAT_SUN)?.name).not.toBe("Weekend Project");
+  });
+
+  it("prefers the rarer trait when a repo is both nocturnal and weekend-heavy", () => {
+    // 35% weekend would earn "Weekend Workshop", but a third of the work
+    // landing after 10pm is the more distinctive fact about this repo.
+    const m = matrix();
+    at(m, 5, 23, 35);
+    at(m, 2, 14, 65);
+    const out = repoArchetype(m, SAT_SUN);
+    expect(out?.name).toBe("Night Shift");
+    expect(out?.because).toContain("10pm");
+  });
+
+  it("names a conventional weekday repo from working hours", () => {
+    const m = matrix();
+    [0, 1, 2, 3, 4].forEach((wd) => [10, 11, 14, 15].forEach((h) => at(m, wd, h, 10)));
+    expect(repoArchetype(m, SAT_SUN)?.name).toBe("Office Hours");
+  });
+
+  it("calls out a repo whose work never really stops", () => {
+    const m = matrix();
+    // Every waking hour, evenly, on weekdays. Deliberately not a full 24-hour
+    // spread: that would put 7 of 24 hours in the night block and earn "Night
+    // Shift" instead, which would be the correct reading of it.
+    Array.from({ length: 18 }, (_, i) => i + 6).forEach((h) => {
+      [0, 1, 2, 3, 4].forEach((wd) => at(m, wd, h, 3));
+    });
+    expect(repoArchetype(m, SAT_SUN)?.name).toBe("Always On");
+  });
+
+  it("says so plainly when no shape is distinctive", () => {
+    const m = matrix();
+    [0, 1, 2, 3, 4].forEach((wd) => [10, 14, 19, 20].forEach((h) => at(m, wd, h, 4)));
+    at(m, 5, 14, 15);
+    const out = repoArchetype(m, SAT_SUN);
+    expect(out?.name).toBe("Steady State");
+  });
+
+  it("refuses a malformed matrix rather than naming from it", () => {
+    expect(repoArchetype([], SAT_SUN)).toBeNull();
+    expect(repoArchetype([[1, 2]], SAT_SUN)).toBeNull();
+  });
+});
+
+describe("contributorArchetype", () => {
+  it("stays silent below the naming floor", () => {
+    const hours = Array<number>(24).fill(0);
+    hours[23] = NAME_MIN_COMMITS - 1;
+    const weekdays = Array<number>(7).fill(0);
+    weekdays[2] = NAME_MIN_COMMITS - 1;
+    expect(contributorArchetype(person({ hour_commits: hours, weekday_commits: weekdays }), SAT_SUN)).toBeNull();
+  });
+
+  it("stays silent on a payload predating the histograms", () => {
+    const legacy = person();
+    // @ts-expect-error deliberately modelling an older server response
+    delete legacy.hour_commits;
+    expect(contributorArchetype(legacy, SAT_SUN)).toBeNull();
+  });
+
+  it("names a night owl", () => {
+    const hours = Array<number>(24).fill(0);
+    hours[23] = 40;
+    hours[14] = 60;
+    const weekdays = Array<number>(7).fill(0);
+    weekdays[2] = 100;
+    const out = contributorArchetype(
+      person({ hour_commits: hours, weekday_commits: weekdays, peak_hour: 14 }),
+      SAT_SUN,
+    );
+    expect(out?.name).toBe("Night Owl");
+  });
+
+  it("names a weekend warrior against the reader's own weekend", () => {
+    const hours = Array<number>(24).fill(0);
+    hours[14] = 100;
+    const weekdays = Array<number>(7).fill(0);
+    weekdays[4] = 50;
+    weekdays[2] = 50;
+    const p = person({ hour_commits: hours, weekday_commits: weekdays });
+    expect(contributorArchetype(p, FRI_SAT)?.name).toBe("Weekend Warrior");
+    expect(contributorArchetype(p, SAT_SUN)?.name).not.toBe("Weekend Warrior");
+  });
+
+  it("separates a nine-to-fiver from someone merely concentrated", () => {
+    const weekdays = Array<number>(7).fill(0);
+    weekdays[1] = 100;
+
+    const office = Array<number>(24).fill(0);
+    [9, 10, 11, 13, 14, 15, 16, 17].forEach((h) => (office[h] = 12));
+    office[12] = 4;
+    expect(
+      contributorArchetype(person({ hour_commits: office, weekday_commits: weekdays }), SAT_SUN)
+        ?.name,
+    ).toBe("Nine to Fiver");
+
+    // Same tightness, but centred on the evening, so it is not office hours.
+    const evening = Array<number>(24).fill(0);
+    [18, 19, 20].forEach((h) => (evening[h] = 33));
+    evening[21] = 1;
+    expect(
+      contributorArchetype(
+        person({ hour_commits: evening, weekday_commits: weekdays, peak_hour: 19 }),
+        SAT_SUN,
+      )?.name,
+    ).toBe("Clockwork");
+  });
+
+  it("carries its evidence so the label can always show its working", () => {
+    const hours = Array<number>(24).fill(0);
+    hours[23] = 100;
+    const weekdays = Array<number>(7).fill(0);
+    weekdays[2] = 100;
+    const out = contributorArchetype(
+      person({ hour_commits: hours, weekday_commits: weekdays, peak_hour: 23 }),
+      SAT_SUN,
+    );
+    expect(out?.because).toMatch(/100%/);
+  });
+});

--- a/packages/ui/__tests__/stats/punch-card.test.tsx
+++ b/packages/ui/__tests__/stats/punch-card.test.tsx
@@ -46,11 +46,46 @@ describe("weekendShare", () => {
 describe("PunchCard", () => {
   it("defaults the weekend share to Sat/Sun", () => {
     render(<PunchCard data={makePunchCard()} />);
-    expect(screen.getByText("20% on weekends")).toBeInTheDocument();
+    expect(screen.getByText("20%")).toBeInTheDocument();
   });
 
   it("honours a Friday/Saturday weekend", () => {
     render(<PunchCard data={makePunchCard()} weekendDays={weekendDaysFor("fri-sat")} />);
-    expect(screen.getByText("30% on weekends")).toBeInTheDocument();
+    expect(screen.getByText("30%")).toBeInTheDocument();
+  });
+
+  it("puts the total in the header, so the chart's scale is never in doubt", () => {
+    render(<PunchCard data={makePunchCard()} />);
+    expect(screen.getByText("10")).toBeInTheDocument();
+  });
+
+  it("names the hottest single slot, which the lattice alone cannot show", () => {
+    render(<PunchCard data={makePunchCard()} />);
+    expect(screen.getByText("Hottest slot")).toBeInTheDocument();
+    expect(screen.getByText(/Wed 2 PM/)).toBeInTheDocument();
+  });
+
+  it("reports the stretch nobody has ever committed in", () => {
+    render(<PunchCard data={makePunchCard()} />);
+    // The fixture only ever commits at 10, 11, 12 and 14, so the longest silent
+    // run wraps midnight: 15:00 through 09:59.
+    expect(screen.getByText("Quietest stretch")).toBeInTheDocument();
+    expect(screen.getByText(/3 PM/)).toBeInTheDocument();
+  });
+
+  it("withholds a name below the naming floor rather than guess", () => {
+    render(<PunchCard data={makePunchCard()} />);
+    expect(screen.queryByText("Ships like a")).not.toBeInTheDocument();
+  });
+
+  it("names the repo once there is enough history to mean it", () => {
+    const data = makePunchCard();
+    // 40 commits, all on Saturday afternoon: unambiguously weekend-led.
+    data.matrix[5]![14] = 40;
+    data.total = 50;
+    data.peak = { weekday: 5, hour: 14, count: 40 };
+    render(<PunchCard data={data} />);
+    expect(screen.getByText("Ships like a")).toBeInTheDocument();
+    expect(screen.getByText("Weekend Project")).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/stats/archetype.ts
+++ b/packages/ui/src/stats/archetype.ts
@@ -1,0 +1,225 @@
+/**
+ * Naming the shape of when work happens.
+ *
+ * A heatmap says *when*. A name says what kind of team this is, and that is the
+ * part someone screenshots. The rule that keeps it from being a horoscope: every
+ * name is earned by a stated threshold, and the reason travels with it so the
+ * page can always show its working. When nothing is distinctive, the honest
+ * neutral label wins rather than a forced joke.
+ *
+ * Naming lives here rather than server-side for one reason that is not
+ * stylistic: half the thresholds depend on which days count as the weekend, and
+ * that is a reader preference. A "weekend warrior" decided in Python would be
+ * wrong for every team that rests Friday and Saturday.
+ */
+
+import type { StatsChronotype } from "@repowise-dev/types/stats";
+
+export interface Archetype {
+  /** Short display name. */
+  name: string;
+  /** The evidence that earned it. Rendered next to the name, always. */
+  because: string;
+}
+
+/**
+ * Below this, a label is noise rather than a habit.
+ *
+ * The chronotype list itself keeps the server's lower floor, because a peak
+ * hour off 10 commits is still a fact. A *name* off 10 commits is a guess
+ * wearing a costume, so naming holds out for more.
+ */
+export const NAME_MIN_COMMITS = 25;
+
+/** Hours counted as the night block, and as the dawn block. */
+const NIGHT_HOURS = [22, 23, 0, 1, 2, 3, 4];
+const DAWN_HOURS = [5, 6, 7, 8];
+/** Conventional working hours, 9am through 5:59pm. */
+const CORE_HOURS = [9, 10, 11, 12, 13, 14, 15, 16, 17];
+
+const sum = (ns: number[]): number => ns.reduce((a, b) => a + b, 0);
+const pct = (part: number, total: number): number =>
+  total > 0 ? Math.round((part / total) * 1000) / 10 : 0;
+
+function shareOfHours(hours: number[], picks: number[], total: number): number {
+  return pct(
+    picks.reduce((a, h) => a + (hours[h] ?? 0), 0),
+    total,
+  );
+}
+
+/**
+ * Fewest distinct hours-of-day that together hold 80% of the commits.
+ *
+ * A concentration measure that survives volume: someone with 600 commits inside
+ * a six-hour window and someone with 30 inside the same window score the same.
+ * High values mean the work never really stops.
+ */
+function hoursToCover80(hours: number[], total: number): number {
+  if (total <= 0) return 0;
+  const target = total * 0.8;
+  let acc = 0;
+  let n = 0;
+  for (const v of [...hours].sort((a, b) => b - a)) {
+    acc += v;
+    n += 1;
+    if (acc >= target) break;
+  }
+  return n;
+}
+
+function hourLabel(h: number): string {
+  const period = h < 12 ? "am" : "pm";
+  const twelve = h % 12 === 0 ? 12 : h % 12;
+  return `${twelve}${period}`;
+}
+
+const DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+
+/**
+ * Name a repository from its weekday-by-hour commit matrix.
+ *
+ * Tested in order, first match wins, so the most distinctive trait is the one
+ * that gets to name you. Ordering is by how unusual the shape is, not by how
+ * flattering it sounds: a repo that is both weekend-heavy and nocturnal is more
+ * interestingly nocturnal.
+ *
+ * Returns null when there is not enough history to say anything.
+ */
+export function repoArchetype(
+  matrix: number[][],
+  weekendDays: readonly number[],
+): Archetype | null {
+  if (!matrix || matrix.length !== 7) return null;
+
+  const dayTotals = matrix.map(sum);
+  const total = sum(dayTotals);
+  if (total < NAME_MIN_COMMITS) return null;
+
+  const hours = Array.from({ length: 24 }, (_, h) => matrix.reduce((a, r) => a + (r[h] ?? 0), 0));
+  const weekend = pct(
+    dayTotals.reduce((a, v, wd) => a + (weekendDays.includes(wd) ? v : 0), 0),
+    total,
+  );
+  const night = shareOfHours(hours, NIGHT_HOURS, total);
+  const dawn = shareOfHours(hours, DAWN_HOURS, total);
+  // The repo matrix carries the joint distribution, so "core" here is exact:
+  // working hours on working days, not two marginals multiplied together.
+  const core = pct(
+    matrix.reduce(
+      (a, row, wd) =>
+        a + (weekendDays.includes(wd) ? 0 : CORE_HOURS.reduce((b, h) => b + (row[h] ?? 0), 0)),
+      0,
+    ),
+    total,
+  );
+  const spread = hoursToCover80(hours, total);
+
+  const busiestDay = DAY_NAMES[dayTotals.indexOf(Math.max(...dayTotals))] ?? "";
+  const weekendNames = weekendDays
+    .map((d) => DAY_NAMES[d]?.slice(0, 3))
+    .filter(Boolean)
+    .join(" and ");
+
+  if (weekend >= 45) {
+    return {
+      name: "Weekend Project",
+      because: `${weekend}% of commits land on ${weekendNames}. This is somebody's nights-and-weekends thing.`,
+    };
+  }
+  if (night >= 20) {
+    return {
+      name: "Night Shift",
+      because: `${night}% of commits are written between 10pm and 5am.`,
+    };
+  }
+  if (dawn >= 20) {
+    return {
+      name: "Dawn Patrol",
+      because: `${dawn}% of commits land before 9am, most of it shipped before the day starts.`,
+    };
+  }
+  if (weekend >= 28) {
+    return {
+      name: "Weekend Workshop",
+      because: `${weekend}% of commits land on ${weekendNames}. The week does not stop on Friday.`,
+    };
+  }
+  if (core >= 65 && weekend < 15) {
+    return {
+      name: "Office Hours",
+      because: `${core}% of commits fall inside working hours on working days.`,
+    };
+  }
+  if (spread >= 14) {
+    return {
+      name: "Always On",
+      because: `It takes ${spread} different hours of the day to account for 80% of the work.`,
+    };
+  }
+  return {
+    name: "Steady State",
+    because: `Busiest on ${busiestDay}s, with no strong pull toward any part of the clock.`,
+  };
+}
+
+/**
+ * Name a single contributor from their two marginal histograms.
+ *
+ * Only the marginals are available here, so "nine to fiver" is a conjunction of
+ * two separate facts (mostly core hours, almost never at the weekend) rather
+ * than a true joint measurement. That is a deliberate trade: the exact version
+ * costs 168 numbers per person over the wire to sharpen one word.
+ *
+ * Returns null below the naming floor, or on a payload predating the arrays.
+ */
+export function contributorArchetype(
+  person: StatsChronotype,
+  weekendDays: readonly number[],
+): Archetype | null {
+  const hours = person.hour_commits;
+  const weekdays = person.weekday_commits;
+  if (!hours || hours.length !== 24 || !weekdays || weekdays.length !== 7) return null;
+
+  const total = sum(hours);
+  if (total < NAME_MIN_COMMITS) return null;
+
+  const weekend = pct(
+    weekdays.reduce((a, v, wd) => a + (weekendDays.includes(wd) ? v : 0), 0),
+    total,
+  );
+  const night = shareOfHours(hours, NIGHT_HOURS, total);
+  const dawn = shareOfHours(hours, DAWN_HOURS, total);
+  const core = shareOfHours(hours, CORE_HOURS, total);
+  const spread = hoursToCover80(hours, total);
+  const peak = person.peak_hour;
+
+  if (night >= 25 || peak >= 22 || peak <= 4) {
+    return { name: "Night Owl", because: `${night}% of their commits land between 10pm and 5am` };
+  }
+  if (dawn >= 25 || (peak >= 5 && peak <= 8)) {
+    return { name: "Dawn Patrol", because: `${dawn}% of their commits land before 9am` };
+  }
+  if (weekend >= 33) {
+    return { name: "Weekend Warrior", because: `${weekend}% of their commits land at the weekend` };
+  }
+  if (core >= 70 && weekend < 15) {
+    return {
+      name: "Nine to Fiver",
+      because: `${core}% between 9am and 6pm, and almost never at the weekend`,
+    };
+  }
+  if (spread <= 6) {
+    return {
+      name: "Clockwork",
+      because: `80% of their work fits inside ${spread} hours of the day`,
+    };
+  }
+  if (peak >= 17 && peak <= 21) {
+    return { name: "The Closer", because: `peaks at ${hourLabel(peak)}, after most people stop` };
+  }
+  if (peak >= 12 && peak <= 16) {
+    return { name: "Afternoon Regular", because: `peaks reliably around ${hourLabel(peak)}` };
+  }
+  return { name: "Daylight", because: `peaks around ${hourLabel(peak)}, no strong off-hours pull` };
+}

--- a/packages/ui/src/stats/chronotype-list.tsx
+++ b/packages/ui/src/stats/chronotype-list.tsx
@@ -1,14 +1,26 @@
-import { Moon, Sun, Sunrise } from "lucide-react";
+import { Briefcase, CalendarHeart, Clock, Moon, Sun, Sunrise, Sunset } from "lucide-react";
 import type { StatsChronotype } from "@repowise-dev/types/stats";
 import { formatNumber } from "../lib/format";
+import { DEFAULT_WEEKEND_PRESET } from "./weekend";
+import { contributorArchetype, NAME_MIN_COMMITS } from "./archetype";
 
-const LABELS: Record<
-  StatsChronotype["label"],
-  { text: string; icon: typeof Moon; color: string }
-> = {
-  night_owl: { text: "Night owl", icon: Moon, color: "var(--color-info)" },
-  early_bird: { text: "Early bird", icon: Sunrise, color: "var(--color-warning)" },
-  daylight: { text: "Daylight", icon: Sun, color: "var(--color-text-tertiary)" },
+/** Icon and colour per earned name. Anything unlisted reads as neutral. */
+const BADGES: Record<string, { icon: typeof Moon; color: string }> = {
+  "Night Owl": { icon: Moon, color: "var(--color-info)" },
+  "Dawn Patrol": { icon: Sunrise, color: "var(--color-warning)" },
+  "Weekend Warrior": { icon: CalendarHeart, color: "var(--color-accent-primary)" },
+  "Nine to Fiver": { icon: Briefcase, color: "var(--color-text-tertiary)" },
+  Clockwork: { icon: Clock, color: "var(--color-info)" },
+  "The Closer": { icon: Sunset, color: "var(--color-warning)" },
+  "Afternoon Regular": { icon: Sun, color: "var(--color-text-tertiary)" },
+  Daylight: { icon: Sun, color: "var(--color-text-tertiary)" },
+};
+
+/** Fallback for people under the naming floor, or payloads without histograms. */
+const PLAIN: Record<StatsChronotype["label"], string> = {
+  night_owl: "Night owl",
+  early_bird: "Early bird",
+  daylight: "Daylight",
 };
 
 function hourLabel(h: number): string {
@@ -18,25 +30,32 @@ function hourLabel(h: number): string {
 }
 
 /**
- * When each frequent contributor actually commits.
+ * When each frequent contributor actually commits, and what that makes them.
  *
- * Only rendered when the index carries per-commit UTC offsets — in UTC mode the
+ * Only rendered when the index carries per-commit UTC offsets. In UTC mode the
  * "night owl" award would just go to whoever lives furthest east, so the server
  * withholds the data entirely rather than let the UI publish a timezone
  * artifact as a personality trait.
  *
- * The bar is the person's own 24-hour histogram, normalised to their own peak,
- * so someone with 600 commits and someone with 20 are compared on shape rather
- * than volume.
+ * Names are earned by threshold and carry their evidence in the tooltip. Under
+ * `NAME_MIN_COMMITS` nobody gets one: a habit needs enough commits to be a
+ * habit, and the plain chronotype still says something true.
  */
-export function ChronotypeList({ people }: { people: StatsChronotype[] }) {
+export function ChronotypeList({
+  people,
+  weekendDays = DEFAULT_WEEKEND_PRESET.days,
+}: {
+  people: StatsChronotype[];
+  /** Weekday indices (0 = Monday) counted as the weekend. */
+  weekendDays?: readonly number[];
+}) {
   if (!people || people.length === 0) return null;
 
   return (
     <section aria-label="Commit-hour habits" className="flex flex-col gap-4">
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
         <h3 className="text-base font-semibold text-[var(--color-text-primary)]">
-          Night owls &amp; early birds
+          How everyone ships
         </h3>
         <span className="font-mono text-[11px] uppercase tracking-[0.1em] text-[var(--color-text-tertiary)]">
           Each person&apos;s local time
@@ -45,25 +64,31 @@ export function ChronotypeList({ people }: { people: StatsChronotype[] }) {
 
       <ul className="flex flex-col divide-y divide-[var(--color-border-default)] border-y border-[var(--color-border-default)]">
         {people.map((p) => {
-          const meta = LABELS[p.label] ?? LABELS.daylight;
-          const Icon = meta.icon;
+          const earned = contributorArchetype(p, weekendDays);
+          const badge = earned ? BADGES[earned.name] : undefined;
+          const Icon = badge?.icon ?? Sun;
+          const color = badge?.color ?? "var(--color-text-tertiary)";
+          const text = earned?.name ?? PLAIN[p.label] ?? PLAIN.daylight;
+          const why = earned
+            ? `${earned.because}, over ${formatNumber(p.commits)} commits.`
+            : `Names are only awarded above ${NAME_MIN_COMMITS} commits. ${p.night_pct}% of their commits land between 10pm and 5am.`;
           return (
             <li key={p.name} className="flex items-center gap-4 py-3">
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium text-[var(--color-text-primary)]">
                   {p.name}
                 </p>
-                <p className="text-xs text-[var(--color-text-tertiary)] tabular-nums">
+                <p className="text-xs tabular-nums text-[var(--color-text-tertiary)]">
                   {formatNumber(p.commits)} commits · peaks around {hourLabel(p.peak_hour)}
                 </p>
               </div>
               <span
-                className="flex shrink-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium"
-                style={{ color: meta.color, borderColor: meta.color }}
-                title={`${p.night_pct}% of commits between 10pm and 5am`}
+                className="flex shrink-0 cursor-help items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium"
+                style={{ color, borderColor: color }}
+                title={why}
               >
                 <Icon className="h-3.5 w-3.5" />
-                {meta.text}
+                {text}
               </span>
             </li>
           );

--- a/packages/ui/src/stats/index.ts
+++ b/packages/ui/src/stats/index.ts
@@ -14,6 +14,12 @@ export { ChronotypeList } from "./chronotype-list";
 export { ArrivalsTimeline } from "./arrivals-timeline";
 export { PunchCard } from "./punch-card";
 export {
+  repoArchetype,
+  contributorArchetype,
+  NAME_MIN_COMMITS,
+  type Archetype,
+} from "./archetype";
+export {
   WEEKEND_PRESETS,
   DEFAULT_WEEKEND_PRESET,
   weekendDaysFor,

--- a/packages/ui/src/stats/punch-card.tsx
+++ b/packages/ui/src/stats/punch-card.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import type { StatsPunchCard } from "@repowise-dev/types/stats";
 import { DEFAULT_WEEKEND_PRESET, weekendShare } from "./weekend";
+import { repoArchetype } from "./archetype";
 
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
 /** One gap value on both axes, so the cells read as an even lattice. */
@@ -14,6 +15,10 @@ const HOUR_TICKS: Array<[number, string]> = [
   [12, "12p"],
   [18, "6p"],
 ];
+/** Height of the hour-total histogram under the lattice. */
+const HIST_HEIGHT = 30;
+/** Width of the longest weekday-total bar in the right margin. */
+const DAY_BAR_WIDTH = 44;
 
 function hourLabel(h: number): string {
   const period = h < 12 ? "AM" : "PM";
@@ -25,160 +30,358 @@ function weekdayLong(i: number): string {
   return ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"][i] ?? "";
 }
 
+/** "Mar 2026 to Jul 2026", collapsing to one label when both land in a month. */
+function spanLabel(first: string | null, last: string | null): string | null {
+  if (!first || !last) return null;
+  const fmt = (iso: string) => {
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime())
+      ? null
+      : // UTC deliberately: this is a coarse month label on an absolute instant,
+        // and rendering it in the viewer's zone can slip it across a boundary.
+        d.toLocaleDateString(undefined, { month: "short", year: "numeric", timeZone: "UTC" });
+  };
+  const a = fmt(first);
+  const b = fmt(last);
+  if (!a || !b) return null;
+  return a === b ? a : `${a} to ${b}`;
+}
+
+/**
+ * Longest unbroken run of hours nobody has ever committed in.
+ *
+ * Wraps around midnight, because on most repos the quiet stretch straddles it.
+ * Returns null when every hour of the day has seen at least one commit, which
+ * is a fact worth not overstating as silence.
+ */
+function quietStretch(hours: number[]): { from: number; to: number } | null {
+  if (hours.every((n) => n > 0)) return null;
+  let best: { from: number; to: number; len: number } | null = null;
+  let start: number | null = null;
+  let len = 0;
+  // Two laps so a run spanning midnight is seen whole.
+  for (let i = 0; i < 48; i += 1) {
+    const h = i % 24;
+    if (hours[h] === 0) {
+      if (start === null) start = h;
+      len += 1;
+      if (len <= 24 && (!best || len > best.len)) best = { from: start, to: h, len };
+    } else {
+      start = null;
+      len = 0;
+    }
+  }
+  return best && best.len >= 2 ? { from: best.from, to: best.to } : null;
+}
+
 /**
  * Coding-rhythm heatmap: commit volume by weekday x hour.
  *
- * The page's signature view and its focal point — nothing else in the app shows
- * temporal shape at all. Presented as an open figure rather than inside a card:
- * the heading, the live readout and the lattice are one object, and a border
+ * The page's signature view and its focal point, since nothing else in the app
+ * shows temporal shape at all. Presented as an open figure rather than inside a
+ * card: the heading, the readout and the lattice are one object, and a border
  * around them only competes with the grid's own structure.
  *
- * Cells ramp the accent by a sqrt-scaled intensity so low-but-nonzero hours stay
- * legible against the peak; hovering reads out the exact cell and dims the rest.
+ * Three deliberate choices about how it reads.
  *
- * The clock is whatever the server resolved: `author_local` means each commit
+ * Cells ramp on ink and only the single hottest cell keeps the accent. Painting
+ * every active cell in the brand colour made the figure read as a slab of
+ * orange rather than as a chart with a point.
+ *
+ * The marginal totals are drawn rather than left to the reader. Splitting a few
+ * hundred commits across 168 cells caps every visible number in the low tens,
+ * which makes an active repo look idle. The hour and weekday totals are where
+ * the real magnitudes live, so they get shown.
+ *
+ * The lattice is fluid and the leftover width becomes a rail of real content. A
+ * fixed-width grid inside a wide container only leaves a dead gutter.
+ *
+ * The clock is whatever the server resolved. `author_local` means each commit
  * was shifted by its own author's UTC offset, which is the only version of this
  * chart that means anything across timezones. The footer always names which,
  * because a heatmap that silently changes clocks is worse than one that admits
- * it hasn't got the data yet.
+ * it has not got the data yet.
  */
 export function PunchCard({
   data,
   weekendDays = DEFAULT_WEEKEND_PRESET.days,
+  firstCommitAt = null,
+  lastCommitAt = null,
 }: {
   data: StatsPunchCard;
   /** Weekday indices (0 = Monday) counted as the weekend. */
   weekendDays?: readonly number[];
+  /** Endpoints of the history, used only for the scale line in the header. */
+  firstCommitAt?: string | null;
+  lastCommitAt?: string | null;
 }) {
   const [hover, setHover] = React.useState<{ wd: number; hr: number; count: number } | null>(null);
 
-  if (!data || data.total === 0 || !data.peak) return null;
+  const matrix = data?.matrix;
+  const derived = React.useMemo(() => {
+    if (!matrix || matrix.length !== 7) return null;
+    const hourTotals = Array.from({ length: 24 }, (_, h) =>
+      matrix.reduce((a, row) => a + (row[h] ?? 0), 0),
+    );
+    const dayTotals = matrix.map((row) => row.reduce((a, n) => a + n, 0));
+    return {
+      hourTotals,
+      dayTotals,
+      hourMax: Math.max(...hourTotals, 1),
+      dayMax: Math.max(...dayTotals, 1),
+      quiet: quietStretch(hourTotals),
+      archetype: repoArchetype(matrix, weekendDays),
+    };
+  }, [matrix, weekendDays]);
+
+  if (!data || data.total === 0 || !data.peak || !derived) return null;
 
   const max = data.peak.count || 1;
   const weekendPct = weekendShare(data.matrix, weekendDays);
   const isLocal = data.timezone_mode === "author_local";
+  const span = spanLabel(firstCommitAt, lastCommitAt);
+  const { hourTotals, dayTotals, hourMax, dayMax, quiet, archetype } = derived;
 
   const readout = hover
     ? `${weekdayLong(hover.wd)} · ${hourLabel(hover.hr)} · ${hover.count} commit${
         hover.count === 1 ? "" : "s"
-      }`
+      } · ${Math.round((hover.count / data.total) * 1000) / 10}% of all work`
     : data.busiest_weekday != null && data.peak_hour != null
       ? `Most active on ${weekdayLong(data.busiest_weekday)}s around ${hourLabel(data.peak_hour)}`
       : "Commit activity by weekday and hour";
 
   return (
-    <section aria-label="Coding rhythm" className="flex flex-col gap-4">
-      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
-        <h3 className="text-base font-semibold text-[var(--color-text-primary)]">Coding rhythm</h3>
-        <span className="font-mono text-[11px] tabular-nums text-[var(--color-text-tertiary)]">
-          {weekendPct}% on weekends
-        </span>
-      </div>
+    // Capped rather than full-bleed. The lattice is fluid so it never leaves a
+    // gutter, but 24 columns across a wide page inflate the cells to the point
+    // where the figure dominates everything under it.
+    <section
+      aria-label="Coding rhythm"
+      className="flex max-w-[840px] flex-col gap-4 lg:flex-row lg:gap-7"
+    >
+      <div className="flex min-w-0 flex-1 flex-col gap-4">
+        <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+          <h3 className="text-base font-semibold text-[var(--color-text-primary)]">Coding rhythm</h3>
+          <span className="font-mono text-[11px] tabular-nums text-[var(--color-text-tertiary)]">
+            <b className="font-medium text-[var(--color-text-secondary)]">
+              {data.total.toLocaleString()}
+            </b>{" "}
+            commits{span ? ` · ${span}` : ""} ·{" "}
+            <b className="font-medium text-[var(--color-text-secondary)]">{weekendPct}%</b> on
+            weekends
+          </span>
+        </div>
 
-      {/* The readout is the chart's title line, so it holds its height rather
-          than reflowing the lattice every time the pointer moves. */}
-      <p
-        className={`min-h-[1.25rem] text-sm transition-colors ${
-          hover
-            ? "font-medium text-[var(--color-text-primary)]"
-            : "text-[var(--color-text-secondary)]"
-        }`}
-        aria-live="polite"
-      >
-        {readout}
-      </p>
+        {/* The readout is the chart's title line, so it holds its height rather
+            than reflowing the lattice every time the pointer moves. */}
+        <p
+          className={`min-h-[1.25rem] text-sm transition-colors ${
+            hover
+              ? "font-medium text-[var(--color-text-primary)]"
+              : "text-[var(--color-text-secondary)]"
+          }`}
+          aria-live="polite"
+        >
+          {readout}
+        </p>
 
-      <div className="overflow-x-auto">
-        <div className="min-w-[420px]" onMouseLeave={() => setHover(null)}>
-          <div className="flex flex-col" style={{ gap: CELL_GAP }}>
-            {WEEKDAYS.map((day, wd) => (
-              <div key={day} className="flex items-center gap-2">
-                <span
-                  className={`w-8 shrink-0 py-px text-right font-mono text-[10px] uppercase tracking-wide transition-colors ${
-                    hover?.wd === wd
-                      ? "text-[var(--color-accent-primary)]"
-                      : "text-[var(--color-text-tertiary)]"
-                  }`}
-                >
-                  {day}
-                </span>
-                <div
-                  className="grid flex-1 grid-cols-[repeat(24,minmax(0,1fr))]"
-                  style={{ gap: CELL_GAP }}
-                >
-                  {Array.from({ length: 24 }, (_, hr) => {
-                    const count = data.matrix[wd]?.[hr] ?? 0;
-                    // sqrt keeps low-but-nonzero hours legible against the peak.
-                    const intensity = count > 0 ? Math.sqrt(count / max) : 0;
-                    const isHover = hover?.wd === wd && hover?.hr === hr;
-                    const dimmed = hover && !isHover && hover.wd !== wd && hover.hr !== hr;
-                    return (
+        <div className="overflow-x-auto">
+          <div className="min-w-[380px]" onMouseLeave={() => setHover(null)}>
+            <div>
+              <div className="flex flex-col" style={{ gap: CELL_GAP }}>
+                {WEEKDAYS.map((day, wd) => (
+                  <div key={day} className="flex items-center gap-2">
+                    <span
+                      className={`w-8 shrink-0 py-px text-right font-mono text-[10px] uppercase tracking-wide transition-colors ${
+                        hover?.wd === wd
+                          ? "text-[var(--color-accent-primary)]"
+                          : "text-[var(--color-text-tertiary)]"
+                      }`}
+                    >
+                      {day}
+                    </span>
+                    <div
+                      className="grid min-w-0 flex-1 grid-cols-[repeat(24,minmax(0,1fr))]"
+                      style={{ gap: CELL_GAP }}
+                    >
+                      {Array.from({ length: 24 }, (_, hr) => {
+                        const count = data.matrix[wd]?.[hr] ?? 0;
+                        // sqrt keeps low-but-nonzero hours legible against the peak.
+                        const intensity = count > 0 ? Math.sqrt(count / max) : 0;
+                        const isPeak = count > 0 && count === max;
+                        const isHover = hover?.wd === wd && hover?.hr === hr;
+                        const dimmed = hover && !isHover && hover.wd !== wd && hover.hr !== hr;
+                        return (
+                          <div
+                            key={hr}
+                            onMouseEnter={() => setHover({ wd, hr, count })}
+                            className={`aspect-square rounded-[2px] transition-all duration-100 ${
+                              isHover ? "scale-[1.35]" : ""
+                            }`}
+                            style={{
+                              background: isPeak
+                                ? "var(--color-accent-primary)"
+                                : count > 0
+                                  ? "var(--color-text-primary)"
+                                  : "var(--color-bg-muted)",
+                              opacity: isHover
+                                ? 1
+                                : count > 0
+                                  ? (dimmed ? 0.45 : 1) * (isPeak ? 1 : 0.12 + 0.72 * intensity)
+                                  : dimmed
+                                    ? 0.4
+                                    : 1,
+                            }}
+                          />
+                        );
+                      })}
+                    </div>
+
+                    {/* This weekday's total, inside its own row so it can never
+                        drift out of alignment with the cells it sums. */}
+                    <div className="flex w-[68px] shrink-0 items-center gap-1.5">
                       <div
-                        key={hr}
-                        onMouseEnter={() => setHover({ wd, hr, count })}
-                        className={`aspect-square rounded-[2px] transition-all duration-100 ${
-                          isHover ? "scale-[1.35] ring-1 ring-[var(--color-accent-primary)]" : ""
-                        }`}
+                        className="h-1.5 rounded-[1px]"
                         style={{
+                          width: `${Math.max(dayTotals[wd]! > 0 ? 2 : 0, Math.round((dayTotals[wd]! / dayMax) * DAY_BAR_WIDTH))}px`,
                           background:
-                            count > 0 ? "var(--color-accent-primary)" : "var(--color-bg-muted)",
-                          opacity: isHover
-                            ? 1
-                            : count > 0
-                              ? (dimmed ? 0.5 : 1) * (0.16 + 0.84 * intensity)
-                              : dimmed
-                                ? 0.4
-                                : 1,
+                            dayTotals[wd] === dayMax
+                              ? "var(--color-accent-primary)"
+                              : "var(--color-text-primary)",
+                          opacity: dayTotals[wd] === dayMax ? 1 : 0.28,
                         }}
                       />
-                    );
-                  })}
-                </div>
+                      <span
+                        className={`font-mono text-[10px] tabular-nums ${
+                          dayTotals[wd] === dayMax
+                            ? "font-semibold text-[var(--color-accent-primary)]"
+                            : "text-[var(--color-text-tertiary)]"
+                        }`}
+                      >
+                        {dayTotals[wd]}
+                      </span>
+                    </div>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
 
-          {/* Hour axis — ticks aligned to the 24-column grid. */}
-          <div className="mt-2 flex items-center gap-2">
-            <span className="w-8 shrink-0" />
-            <div className="relative grid flex-1 grid-cols-[repeat(24,minmax(0,1fr))]">
-              {HOUR_TICKS.map(([h, label]) => (
-                <span
-                  key={h}
-                  className="col-span-1 whitespace-nowrap font-mono text-[10px] tabular-nums text-[var(--color-text-tertiary)]"
-                  style={{ gridColumnStart: h + 1 }}
+              {/* Hour totals. The magnitudes the lattice cannot show. */}
+              <div className="mt-1.5 flex items-end gap-2">
+                <span className="w-8 shrink-0" />
+                <div
+                  className="grid min-w-0 flex-1 grid-cols-[repeat(24,minmax(0,1fr))] items-end"
+                  style={{ gap: CELL_GAP, height: `${HIST_HEIGHT}px` }}
                 >
-                  {label}
-                </span>
-              ))}
+                  {hourTotals.map((v, hr) => (
+                    <div
+                      key={hr}
+                      className="w-full rounded-[1px]"
+                      style={{
+                        height: `${Math.max(v > 0 ? 1 : 0, Math.round((v / hourMax) * HIST_HEIGHT))}px`,
+                        background:
+                          v === hourMax
+                            ? "var(--color-accent-primary)"
+                            : "var(--color-text-primary)",
+                        opacity: v === hourMax ? 1 : 0.28,
+                      }}
+                    />
+                  ))}
+                </div>
+                {/* Mirrors the weekday-total column so the 24 tracks below the
+                    lattice line up with the 24 tracks inside it. */}
+                <span className="w-[68px] shrink-0" />
+              </div>
+
+              {/* Hour axis, sharing the lattice's 24 tracks. */}
+              <div className="mt-1.5 flex items-center gap-2">
+                <span className="w-8 shrink-0" />
+                <div className="relative grid min-w-0 flex-1 grid-cols-[repeat(24,minmax(0,1fr))]">
+                  {HOUR_TICKS.map(([h, label]) => (
+                    <span
+                      key={h}
+                      className="col-span-4 whitespace-nowrap font-mono text-[10px] tabular-nums text-[var(--color-text-tertiary)]"
+                      style={{ gridColumnStart: h + 1 }}
+                    >
+                      {label}
+                    </span>
+                  ))}
+                </div>
+                <span className="w-[68px] shrink-0" />
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <div className="flex items-center justify-between gap-2 border-t border-[var(--color-border-default)] pt-3 text-[10px] text-[var(--color-text-tertiary)]">
-        <span
-          title={
-            isLocal
-              ? "Each commit is placed at its author's own local time, using the UTC offset git recorded with it."
-              : "This index predates the commit-offset capture, so hours fall back to UTC. Run `repowise update` to switch to author-local time."
-          }
-          className="cursor-help font-mono uppercase tracking-[0.1em]"
-        >
-          {isLocal ? "Author-local time" : "Hours in UTC"}
-        </span>
-        <div className="flex items-center gap-1.5">
-          <span>Less</span>
-          {[0.16, 0.44, 0.72, 1].map((o) => (
+        <div className="flex items-center justify-between gap-2 border-t border-[var(--color-border-default)] pt-3 text-[10px] text-[var(--color-text-tertiary)]">
+          <span
+            title={
+              isLocal
+                ? "Each commit is placed at its author's own local time, using the UTC offset git recorded with it."
+                : "This index predates the commit-offset capture, so hours fall back to UTC. Run `repowise update` to switch to author-local time."
+            }
+            className="cursor-help font-mono uppercase tracking-[0.1em]"
+          >
+            {isLocal ? "Author-local time" : "Hours in UTC"}
+          </span>
+          <div className="flex items-center gap-1.5">
+            <span>Less</span>
+            {[0.12, 0.32, 0.55, 0.84].map((o) => (
+              <span
+                key={o}
+                className="h-2.5 w-2.5 rounded-[2px]"
+                style={{ background: "var(--color-text-primary)", opacity: o }}
+              />
+            ))}
             <span
-              key={o}
               className="h-2.5 w-2.5 rounded-[2px]"
-              style={{ background: "var(--color-accent-primary)", opacity: o }}
+              style={{ background: "var(--color-accent-primary)" }}
             />
-          ))}
-          <span>More</span>
+            <span>Peak</span>
+          </div>
         </div>
       </div>
+
+      {/* The rail. Fills width that a fixed lattice would waste, with readings
+          worth having rather than padding. Drops below the chart when narrow. */}
+      <aside className="flex shrink-0 flex-col gap-5 border-t border-[var(--color-border-default)] pt-4 lg:w-48 lg:border-l lg:border-t-0 lg:pl-6 lg:pt-0">
+        {archetype && (
+          <div className="flex flex-col gap-1">
+            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+              Ships like a
+            </span>
+            <span className="text-xl font-semibold leading-tight text-[var(--color-accent-primary)]">
+              {archetype.name}
+            </span>
+            <span className="text-[11px] leading-snug text-[var(--color-text-tertiary)]">
+              {archetype.because}
+            </span>
+          </div>
+        )}
+
+        {quiet && (
+          <div className="flex flex-col gap-1.5">
+            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+              Quietest stretch
+            </span>
+            <p className="text-[13px] leading-snug text-[var(--color-text-secondary)]">
+              No commit has ever landed between{" "}
+              <span className="font-mono">{hourLabel(quiet.from)}</span> and{" "}
+              <span className="font-mono">{hourLabel((quiet.to + 1) % 24)}</span>.
+            </p>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1.5">
+          <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+            Hottest slot
+          </span>
+          <p className="text-[13px] leading-snug text-[var(--color-text-secondary)]">
+            <span className="font-mono">
+              {weekdayLong(data.peak.weekday).slice(0, 3)} {hourLabel(data.peak.hour)}
+            </span>
+            , with {data.peak.count} commits. The single busiest hour in this repo&apos;s life.
+          </p>
+        </div>
+      </aside>
     </section>
   );
 }

--- a/packages/web/src/components/stats/people-tab.tsx
+++ b/packages/web/src/components/stats/people-tab.tsx
@@ -1,8 +1,11 @@
+"use client";
+
 import Link from "next/link";
 import { AlertTriangle, Users } from "lucide-react";
 import type { StatsHighlights } from "@repowise-dev/types/stats";
 import { ArrivalsTimeline, ChronotypeList, StatCallout } from "@repowise-dev/ui/stats";
 import { formatNumber } from "@repowise-dev/ui/lib/format";
+import { useWeekendDays } from "@/lib/hooks/use-weekend";
 
 /**
  * Tab 3 — the human shape of the repo.
@@ -16,6 +19,9 @@ import { formatNumber } from "@repowise-dev/ui/lib/format";
 export function PeopleTab({ data, repoId }: { data: StatsHighlights; repoId: string }) {
   const { people } = data;
   const utcMode = data.rhythm.punch_card.timezone_mode === "utc";
+  // Same preset the punch card reads, so a person's "weekend warrior" and the
+  // repo's weekend share can never disagree about which days those are.
+  const weekendDays = useWeekendDays();
 
   return (
     <div className="flex flex-col gap-8">
@@ -53,7 +59,7 @@ export function PeopleTab({ data, repoId }: { data: StatsHighlights; repoId: str
       </div>
 
       {people.chronotypes.length > 0 ? (
-        <ChronotypeList people={people.chronotypes} />
+        <ChronotypeList people={people.chronotypes} weekendDays={weekendDays} />
       ) : (
         utcMode && (
           <p className="rounded-xl border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4 text-sm text-[var(--color-text-secondary)]">
@@ -62,7 +68,7 @@ export function PeopleTab({ data, repoId }: { data: StatsHighlights; repoId: str
             <code className="rounded bg-[var(--color-bg-muted)] px-1.5 py-0.5 font-mono text-xs">
               repowise update
             </code>{" "}
-            to backfill it — no re-index required.
+            to backfill it, no re-index required.
           </p>
         )
       )}

--- a/packages/web/src/components/stats/rhythm-tab.tsx
+++ b/packages/web/src/components/stats/rhythm-tab.tsx
@@ -38,7 +38,12 @@ export function RhythmTab({ data }: { data: StatsHighlights }) {
 
   return (
     <div className="flex flex-col gap-8">
-      <PunchCard data={rhythm.punch_card} weekendDays={weekendDays} />
+      <PunchCard
+        data={rhythm.punch_card}
+        weekendDays={weekendDays}
+        firstCommitAt={data.origin.first_commit_at}
+        lastCommitAt={data.origin.last_commit_at}
+      />
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <StatCallout

--- a/tests/unit/server/test_stats_signals.py
+++ b/tests/unit/server/test_stats_signals.py
@@ -16,6 +16,7 @@ from httpx import AsyncClient
 from repowise.core.persistence.crud import get_repository, upsert_git_commits_bulk
 from repowise.core.persistence.database import get_session
 from repowise.server.routers.stats import (
+    _chronotypes,
     _commit_pass,
     _commit_velocity,
     _people,
@@ -69,6 +70,38 @@ def test_punch_card_summary_empty() -> None:
     assert out["peak"] is None
     assert out["busiest_weekday"] is None
     assert out["total"] == 0
+
+
+def test_chronotypes_ship_both_marginals() -> None:
+    """The UI names people from these arrays, so they must survive the trip.
+
+    Weekday counts in particular cannot be derived client-side from anything
+    else in the payload, and without them a contributor can never be read as
+    working weekends.
+    """
+    hours = [0] * 24
+    hours[23] = 30
+    weekdays = [0] * 7
+    weekdays[5] = 20
+    weekdays[2] = 10
+
+    out = _chronotypes({"a@b.com": hours}, {"a@b.com": weekdays}, {"a@b.com": "Someone"})
+
+    assert len(out) == 1
+    assert out[0]["hour_commits"] == hours
+    assert out[0]["weekday_commits"] == weekdays
+    assert out[0]["commits"] == 30
+    assert out[0]["label"] == "night_owl"
+
+
+def test_chronotypes_default_weekdays_when_missing() -> None:
+    """A person present in one map but not the other must not blow up the page."""
+    hours = [0] * 24
+    hours[14] = 40
+
+    out = _chronotypes({"a@b.com": hours}, {}, {})
+
+    assert out[0]["weekday_commits"] == [0] * 7
 
 
 def test_commit_velocity_rising_and_no_prior() -> None:


### PR DESCRIPTION
The punch card splits a few hundred commits across 168 weekday-by-hour cells, so every number you can read off it is capped in the low tens. On this repo the hottest cell is 25 and the median is 6, against 853 commits total, which makes an active repo look idle. It also painted all ~110 active cells in the brand amber, so the figure read as a slab of colour rather than a chart with a point, and the fixed-width lattice left a dead gutter on a wide page.

## The chart

Marginal totals are now drawn rather than left to the reader. Hour totals sit under the lattice and weekday totals beside it, which is where the real magnitudes live: the peak hour is 109 commits and Saturday is 175, neither reachable from the grid alone. Each weekday's bar lives inside its own row, so it cannot drift out of alignment with the cells it sums.

Cells ramp on ink and only the hottest keeps the accent. The lattice is fluid but capped, and the width it no longer wastes becomes a rail carrying the repo's name, its quietest stretch and its busiest single hour. The header states the total and the date span, so nobody has to wonder whether the chart covers all of history or just the last week.

Hovering a cell now reports its share of all work alongside the count.

## Naming

Seven repo archetypes and eight contributor names, replacing the old night owl / early bird / daylight split. Every name is earned by a stated threshold and carries its evidence in the tooltip, and when nothing is distinctive the repo gets `Steady State` rather than a forced joke.

Three guardrails, because a label that reads as personality but is really an artifact is worse than no label:

- Nothing is named below 25 commits. The chronotype list keeps the server's lower floor, since a peak hour off 10 commits is still a fact, but a *name* off 10 commits is a guess wearing a costume.
- Nothing is named at all in UTC mode. On an index predating the offset capture every label would just identify whoever lives furthest east.
- Repo archetypes are tested in order of how unusual the shape is, so a repo that is both weekend-heavy and nocturnal is named for the nocturnal part.

Thresholds live in the UI package rather than the server because half of them depend on which days the reader counts as the weekend. A "weekend warrior" decided in Python would be wrong for every team that rests Friday and Saturday.

## Server

Two extra marginal histograms per contributor, accumulated in the pass that was already running. No new queries. The joint weekday-by-hour distribution is deliberately not sent: it is 168 numbers per person to sharpen a single label, and the two marginals answer the same question closely enough.

## Checks

Typecheck and ESLint clean across all packages, ruff clean, `no-raw-hex` UI gate passes. 31 UI tests including 14 new ones for the naming rules, plus the server stats and bot-filter suites.

Verified against this repo's own index: `Weekend Workshop` at 33.3% weekend, quietest stretch 2 AM to 7 AM, hottest slot Fri 2 PM at 25 commits. Contributors resolve to Weekend Warrior, Afternoon Regular and Clockwork, with a 16-commit contributor correctly falling back to the plain label.
