### PR TITLE
fix(cli): surface page generation failures and resume hint on init completion (#1094)

### DIFF
--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -13,6 +13,8 @@ returns a "declined" flag; the workspace flow prints a compact line and raises
 from __future__ import annotations
 
 import contextlib
+from collections import Counter
+from pathlib import Path
 from typing import Any
 
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
@@ -293,8 +295,39 @@ def run_repo_generation(
             )
         )
 
+    jobs_dir = Path(repo_path) / ".repowise" / "jobs"
+    failed_page_ids: list[str] = []
+    if jobs_dir.exists():
+        with contextlib.suppress(Exception):
+            from repowise.core.generation import JobSystem
+
+            js = JobSystem(jobs_dir)
+            job_id = getattr(result, "job_id", None)
+            if job_id:
+                failed_page_ids = js.get_checkpoint(job_id).failed_page_ids
+            else:
+                jobs = js.list_jobs()
+                if jobs:
+                    failed_page_ids = jobs[0].failed_page_ids
+
     result.generated_pages = generated_pages
-    if verbose:
+    result.failed_page_ids = failed_page_ids
+
+    if failed_page_ids:
+        type_counts = Counter(pid.split(":")[0] for pid in failed_page_ids)
+        console.print(
+            f"  [yellow]⚠[/yellow] Generated [bold]{len(generated_pages)}[/bold] pages "
+            f"([bold yellow]{len(failed_page_ids)} failed[/bold yellow])\n"
+        )
+        console.print("  [bold yellow]Failed pages by type:[/bold yellow]")
+        for page_type, count in sorted(type_counts.items(), key=lambda x: -x[1]):
+            console.print(f"    • {page_type}: {count}")
+        console.print(
+            "\n  [yellow]The wiki is incomplete due to provider failures.[/yellow]\n"
+            "  [dim]Run [bold]repowise init --resume[/bold] to generate missing pages "
+            "without re-spending on completed ones.[/dim]\n"
+        )
+    elif verbose:
         console.print(f"  [green]✓[/green] Generated [bold]{len(generated_pages)}[/bold] pages")
 
     # KG enrichment is layer naming and the guided tour, both pure prompting.

--- a/packages/cli/src/repowise/cli/commands/init_cmd/reporting.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/reporting.py
@@ -228,13 +228,16 @@ def show_completion(
         _render_defect_accuracy(result)
     else:
         _pages = result.generated_pages or []
+        _failed_ids = getattr(result, "failed_page_ids", []) or []
         total_tokens = sum(p.total_tokens for p in _pages)
         # Split model-written from the zero-LLM deterministic coverage tail so
         # broad coverage reads as thoroughness, not padding.
         _det = sum(1 for p in _pages if getattr(p, "provider_name", "") == "template")
         _ai = len(_pages) - _det
         _pages_label = str(len(_pages))
-        if _det:
+        if _failed_ids:
+            _pages_label = f"{len(_pages)} ({len(_failed_ids)} failed)"
+        elif _det:
             _pages_label = f"{len(_pages)} ({_ai} model-written · {_det} from structure)"
         metrics = [
             ("Pages generated", _pages_label),

--- a/tests/unit/cli/test_init_failure_reporting.py
+++ b/tests/unit/cli/test_init_failure_reporting.py
@@ -1,0 +1,277 @@
+"""Unit tests for issue #1094: failure reporting during repowise init completion."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from repowise.cli.commands.init_cmd.generation import run_repo_generation
+from repowise.cli.commands.init_cmd.reporting import show_completion
+from repowise.core.generation.job_system import JobSystem
+from repowise.core.generation.models import GeneratedPage
+
+
+def _page(page_id: str) -> GeneratedPage:
+    return GeneratedPage(
+        page_id=page_id,
+        page_type="file_page",
+        title=f"Title {page_id}",
+        content="content",
+        source_hash="hash",
+        model_name="mock-model",
+        provider_name="mock-provider",
+        input_tokens=10,
+        output_tokens=5,
+        cached_tokens=0,
+        generation_level=2,
+        target_path=f"{page_id}.py",
+        created_at="2026-07-26T00:00:00Z",
+        updated_at="2026-07-26T00:00:00Z",
+    )
+
+
+def test_run_repo_generation_reports_failures(tmp_path, monkeypatch):
+    """When job system records failed pages, run_repo_generation prints breakdown and resume hint."""
+    jobs_dir = tmp_path / ".repowise" / "jobs"
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    js = JobSystem(jobs_dir)
+    config_mock = SimpleNamespace(max_concurrency=1)
+    job_id = js.create_job(str(tmp_path), config_mock, "mock", "mock-model")
+
+    # Record some failures
+    js.fail_page(job_id, "file_page:lib/a.ts", "Provider error")
+    js.fail_page(job_id, "file_page:lib/b.ts", "Provider error")
+    js.fail_page(job_id, "module_page:lib/api", "Timeout")
+    js.fail_page(job_id, "layer_page:layer1", "Rate limit")
+    js.fail_page(job_id, "onboarding:quickstart", "403 Forbidden")
+
+    printed_lines = []
+
+    def mock_print(*args, **kwargs):
+        text = " ".join(str(a) for a in args)
+        printed_lines.append(text)
+
+    monkeypatch.setattr("repowise.cli.commands.init_cmd.generation.console.print", mock_print)
+
+    async def mock_run_gen(*args, **kwargs):
+        return [_page("file_page:lib/c.ts")]
+
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation.run_async",
+        lambda coro: [_page("file_page:lib/c.ts")],
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation._enrich_knowledge_graph",
+        lambda **kw: None,
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation.flush_cost_tracker",
+        lambda tracker: None,
+    )
+
+    result = SimpleNamespace(
+        repo_name="test_repo",
+        parsed_files=[],
+        source_map={},
+        graph_builder=MagicMock(),
+        repo_structure=MagicMock(),
+        git_meta_map={},
+    )
+    provider = SimpleNamespace(provider_name="mock", model_name="mock-model")
+    gen_config = SimpleNamespace(max_concurrency=1, deterministic=False)
+
+    pages = run_repo_generation(
+        repo_path=tmp_path,
+        result=result,
+        provider=provider,
+        gen_config=gen_config,
+        concurrency=1,
+        embedder_name_resolved="mock",
+        resume=False,
+        verbose=False,
+    )
+
+    assert len(pages) == 1
+    assert getattr(result, "failed_page_ids", None) == [
+        "file_page:lib/a.ts",
+        "file_page:lib/b.ts",
+        "module_page:lib/api",
+        "layer_page:layer1",
+        "onboarding:quickstart",
+    ]
+
+    output = "\n".join(printed_lines)
+    assert "Generated [bold]1[/bold] pages" in output
+    assert "5 failed" in output
+    assert "Failed pages by type:" in output
+    assert "file_page: 2" in output
+    assert "module_page: 1" in output
+    assert "layer_page: 1" in output
+    assert "onboarding: 1" in output
+    assert "The wiki is incomplete due to provider failures." in output
+    assert "repowise init --resume" in output
+
+
+@pytest.mark.parametrize("verbose_flag", [True, False])
+def test_run_repo_generation_zero_failures(tmp_path, monkeypatch, verbose_flag):
+    """When no pages fail, run_repo_generation prints success summary only when verbose, stays silent otherwise."""
+    jobs_dir = tmp_path / ".repowise" / "jobs"
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    js = JobSystem(jobs_dir)
+    config_mock = SimpleNamespace(max_concurrency=1)
+    js.create_job(str(tmp_path), config_mock, "mock", "mock-model")
+
+    printed_lines = []
+
+    def mock_print(*args, **kwargs):
+        text = " ".join(str(a) for a in args)
+        printed_lines.append(text)
+
+    monkeypatch.setattr("repowise.cli.commands.init_cmd.generation.console.print", mock_print)
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation.run_async",
+        lambda coro: [_page("file_page:lib/c.ts")],
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation._enrich_knowledge_graph",
+        lambda **kw: None,
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation.flush_cost_tracker",
+        lambda tracker: None,
+    )
+
+    result = SimpleNamespace(
+        repo_name="test_repo",
+        parsed_files=[],
+        source_map={},
+        graph_builder=MagicMock(),
+        repo_structure=MagicMock(),
+        git_meta_map={},
+    )
+    provider = SimpleNamespace(provider_name="mock", model_name="mock-model")
+    gen_config = SimpleNamespace(max_concurrency=1, deterministic=False)
+
+    pages = run_repo_generation(
+        repo_path=tmp_path,
+        result=result,
+        provider=provider,
+        gen_config=gen_config,
+        concurrency=1,
+        embedder_name_resolved="mock",
+        resume=False,
+        verbose=verbose_flag,
+    )
+
+    assert len(pages) == 1
+    output = "\n".join(printed_lines)
+    assert "failed" not in output
+    assert "The wiki is incomplete due to provider failures." not in output
+    if verbose_flag:
+        assert "Generated [bold]1[/bold] pages" in output
+    else:
+        assert output.strip() == ""
+
+
+def test_show_completion_panel_with_failures(monkeypatch):
+    """show_completion reflects failed count in metric line when failures exist."""
+    printed_panels = []
+
+    def mock_completion_panel(title, metrics, next_steps=None):
+        printed_panels.append(metrics)
+        return "PANEL"
+
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.reporting.build_completion_panel", mock_completion_panel
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.reporting.console.print", lambda *a, **kw: None
+    )
+
+    graph_mock = MagicMock()
+    graph_mock.number_of_nodes.return_value = 10
+    graph_mock.number_of_edges.return_value = 5
+
+    result = SimpleNamespace(
+        graph_builder=MagicMock(graph=lambda: graph_mock),
+        dead_code_report=None,
+        decision_report=None,
+        git_summary=None,
+        git_meta_map={},
+        repo_structure=SimpleNamespace(root_language_distribution={"Python": 1.0}),
+        generated_pages=[_page("file_page:a")],
+        failed_page_ids=["file_page:b", "module_page:m1"],
+    )
+    provider = SimpleNamespace(provider_name="mock", model_name="mock-model")
+
+    show_completion(
+        repo_path="/fake",
+        result=result,
+        start=0.0,
+        effective_index_only=False,
+        run_mode="standard",
+        provider=provider,
+    )
+
+    assert printed_panels
+    metrics_dict = dict(printed_panels[0])
+    assert metrics_dict.get("Pages generated") == "1 (2 failed)"
+
+
+def test_run_repo_generation_uses_exact_job_id_when_provided(tmp_path, monkeypatch):
+    """When result has a job_id attached, run_repo_generation queries that exact job checkpoint."""
+    jobs_dir = tmp_path / ".repowise" / "jobs"
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    js = JobSystem(jobs_dir)
+    config_mock = SimpleNamespace(max_concurrency=1)
+    old_job_id = js.create_job(str(tmp_path), config_mock, "mock", "mock-model")
+    js.fail_page(old_job_id, "file_page:old_failure.ts", "Old error")
+
+    # Create target job created later
+    target_job_id = js.create_job(str(tmp_path), config_mock, "mock", "mock-model")
+    js.fail_page(target_job_id, "file_page:target_failure.ts", "Target error")
+
+    monkeypatch.setattr("repowise.cli.commands.init_cmd.generation.console.print", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation.run_async",
+        lambda coro: [_page("file_page:lib/c.ts")],
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation._enrich_knowledge_graph",
+        lambda **kw: None,
+    )
+    monkeypatch.setattr(
+        "repowise.cli.commands.init_cmd.generation.flush_cost_tracker",
+        lambda tracker: None,
+    )
+
+    result = SimpleNamespace(
+        job_id=target_job_id,
+        repo_name="test_repo",
+        parsed_files=[],
+        source_map={},
+        graph_builder=MagicMock(),
+        repo_structure=MagicMock(),
+        git_meta_map={},
+    )
+    provider = SimpleNamespace(provider_name="mock", model_name="mock-model")
+    gen_config = SimpleNamespace(max_concurrency=1, deterministic=False)
+
+    run_repo_generation(
+        repo_path=tmp_path,
+        result=result,
+        provider=provider,
+        gen_config=gen_config,
+        concurrency=1,
+        embedder_name_resolved="mock",
+        resume=False,
+        verbose=False,
+    )
+
+    assert getattr(result, "failed_page_ids", None) == ["file_page:target_failure.ts"]
+


### PR DESCRIPTION
## Summary
- Surfaces page generation failure counts and a per-type breakdown (e.g., `file_page`, `module_page`, `layer_page`, `onboarding`) at the end of `repowise init` runs, instead of silently dropping them.
- Failure reporting (count, breakdown, and incomplete-wiki warning) now prints unconditionally when generation failures occur — previously this was only visible with `--verbose`.
- Displays the repair guidance hint (`repowise init --resume`) whenever failures occur, on both verbose and standard runs.
- Updates the completion panel's **Pages generated** metric to reflect failed page counts (e.g., `663 (105 failed)`).
- Zero-failure runs are unaffected — output is unchanged from current behavior, in both verbose and non-verbose modes.

## Related Issues
- Fixes #1094

## Test Plan
Added/updated unit tests in `tests/unit/cli/test_init_failure_reporting.py`:
- `test_run_repo_generation_reports_failures` — verifies failure count, per-type breakdown, and the `repowise init --resume` hint all appear on a **non-verbose** run with failures.
- `test_run_repo_generation_zero_failures` (parametrized over `verbose_flag=[True, False]`) — verifies clean success output on zero-failure runs in both modes: the summary line prints when verbose, and no output is emitted when non-verbose.
- `test_show_completion_panel_with_failures` — verifies the completion panel's "Pages generated" metric reflects the failed count.

`pytest tests/unit/cli/test_init_failure_reporting.py -v` — 4/4 passed (5 collected cases including the parametrized pair).

Manually verified CLI output rendering via simulation script (see screenshots below).

## Screenshots

**Before** (failures silently dropped, non-verbose run):
<img width="960" height="540" alt="image" src="https://github.com/user-attachments/assets/6606a1de-bab0-4136-8830-9be7d3ec5da2" />

**After** (non-verbose run with failures — count, breakdown, resume hint):
<img width="960" height="540" alt="Screenshot 2026-07-26 160756" src="https://github.com/user-attachments/assets/b3158a7f-7b89-418d-bd13-4846c25efaab" />


## Checklist
- [x] My code follows the project's code style
- [x] I have added tests for new functionality
- [x] All existing tests still pass
- [x] I have updated documentation if needed