### PR TITLE
ci: run types and ui tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,12 @@ jobs:
       - name: Test api-client
         run: npm run test --workspace @repowise-dev/api-client
 
+      - name: Test types
+        run: npm run test --workspace @repowise-dev/types
+
+      - name: Test ui
+        run: npm run test --workspace @repowise-dev/ui
+
   # ---------------------------------------------------------------------------
   # VS Code extension — type check, bundle-size gate, and Electron smoke test
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`packages/types` and `packages/ui` both have test suites that no CI job runs. `ci.yml` covers `packages/web` lint and type-check, the api-client tests, and the VS Code extension, but nothing invokes vitest for the two shared packages.

`publish-internal.yml` does run them, but only when an internal package version is published, which happens after merge. So a PR touching either package reports all green while its tests go unexecuted.

## Change

Adds `Test types` and `Test ui` as steps on the existing `test-web` job, next to the api-client tests that are already there.

Deliberately steps on an existing job rather than a new job: no new check name appears, so branch protection needs no update and no currently-open PR gains a check it cannot satisfy.

The commands are the same ones `publish-internal.yml` already runs on ubuntu, so they are known to work on Linux runners. This only moves the gate earlier.

## Verification

Both suites pass on `main` as of 1dff06c5:

- `@repowise-dev/types` — 4 files, 36 tests, no type errors
- `@repowise-dev/ui` — 121 files, 857 tests

## Note

The `test-web` job is still named "Web UI lint + type check", which is now slightly narrow. Left alone on purpose: renaming the job renames the status check, which would break any branch-protection rule referencing it.
