### PR TITLE
docs(commercial): acknowledge OSS full-history secret scan

### DIFF
--- a/docs/business/COMMERCIAL.md
+++ b/docs/business/COMMERCIAL.md
@@ -59,9 +59,9 @@ All of the following ship in `pip install repowise` today, free for internal use
   extraction (HTTP / gRPC / topics) with provider↔consumer matching, package
   dependency mapping, federated MCP queries (`repo="all"`), workspace dashboard and
   `CLAUDE.md`.
-- **Proactive agent hooks** — PreToolUse graph enrichment on every `Grep`/`Glob`;
-  PostToolUse stale-wiki detection after `git commit`. No LLM calls, pure local
-  SQLite.
+- **Proactive agent hooks** — SessionStart freshness/trust context, plus
+  PostToolUse enrichment after agent tool use (Bash / Grep / Glob / Read /
+  Edit / Write / Repowise MCP). No LLM calls, pure local SQLite.
 - **Auto-sync** — post-commit hook, file watcher, GitHub webhook, GitLab webhook,
   polling fallback. Typical incremental update touches 3–10 pages in under 30 s.
 - **Local dashboard** — Chat, Docs, Graph, C4, Search, Symbols, Coverage, Risk,
@@ -126,12 +126,13 @@ the items that matter most to you can be prioritized.
 | Local dashboard (incl. local security pattern scan) | ✅ | ✅ |
 | Auto-sync (hooks, watcher, webhooks) | ✅ | ✅ |
 | Auto-generated CLAUDE.md | ✅ | ✅ |
+| Local full-history secret scan (`repowise security scan --history`) | ✅ | ✅ |
 | Graph-aware enhanced security scanning | — | ✅ *(GA on hosted)* |
 | Language-specific security rulesets | — | ✅ *(dev)* |
 | CVE-aware dependency analysis (KEV / EPSS / priority-scored) | — | ✅ *(GA on hosted)* |
 | Usage-aware CVE triage (imports × dead code) | — | ✅ *(GA on hosted)* |
 | Function-level reachability triage | — | ✅ *(GA on hosted — per-language coverage)* |
-| Secret detection across full git history | — | ✅ *(GA on hosted)* |
+| Hosted secret detection (fingerprint store, incremental re-scans) | — | ✅ *(GA on hosted)* |
 | SBOM generation (CycloneDX) + VEX export + diffs | — | ✅ *(GA on hosted)* |
 | Compliance reporting (PCI-DSS / SOC 2) | — | ✅ *(GA on hosted — Teams)* |
 | Audit trail (in-product + JSON / CSV export + webhook stream) | — | ✅ *(GA on hosted — security surface)* |
@@ -214,11 +215,13 @@ the items that matter most to you can be prioritized.
   SIEM-lite stream that forwards audit events to any HTTPS endpoint as signed
   webhooks. Coverage beyond the security surface (decisions, overrides) is in
   development; native Splunk / Datadog / Elastic connectors on the roadmap.
-- **Secret-in-code detection** *(available on the hosted platform, Pro+)* —
-  scanning across full git history (not just `HEAD`), with live-at-`HEAD`
-  flagging and incremental re-scans. Only a fingerprint and a redacted preview
-  are ever stored — never the secret value. Graph integration (which services /
-  modules referenced a leaked secret) is on the roadmap.
+- **Secret-in-code detection** — **OSS / self-hosted:** `repowise security scan
+  --history` walks full git history with the same local pattern registry used
+  during `init` / `update` (working-tree scanning), and persists findings
+  locally. **Hosted platform (Pro+):** fingerprint + redacted-preview storage,
+  live-at-`HEAD` flagging, and incremental re-scans — never the secret value.
+  Graph integration (which services / modules referenced a leaked secret) is on
+  the roadmap.
 
 ### 5.2 Workflow Integrations *(rolling out)*
 

--- a/docs/business/SECURITY_COMPLIANCE.md
+++ b/docs/business/SECURITY_COMPLIANCE.md
@@ -143,7 +143,7 @@ off switches.
 | Where the index lives | `.repowise/` on your machine | Postgres + LanceDB/pgvector in your network | Repowise-operated infrastructure |
 | Who calls the LLM | you, with your key | you, with your key | the platform, or your key |
 | Outbound from your network | anonymous telemetry (disableable), your LLM provider | same, plus configured integrations | n/a, you are sending code to the platform |
-| Commercial security features (CVE triage, SBOM/VEX, secret history scan, compliance reports, audit trail) | not included | per [COMMERCIAL.md §5](COMMERCIAL.md#5-commercial-capabilities--in-detail) | GA today |
+| Commercial security features (CVE triage, SBOM/VEX, hosted secret detection, compliance reports, audit trail) | not included (local pattern + full-history scan via `repowise security scan --history` is OSS) | per [COMMERCIAL.md §5](COMMERCIAL.md#5-commercial-capabilities--in-detail) | GA today |
 
 The honest framing: **several commercial security capabilities are GA on the
 hosted platform first.** If your requirement is on-prem *and* CVE-aware


### PR DESCRIPTION
## Summary
- Mark local \`repowise security scan --history\` as available in OSS (AGPL), and keep hosted fingerprint/incremental secret detection as the commercial differentiator.
- Fix the false PreToolUse hook claim to match SessionStart + PostToolUse.
- Update SECURITY_COMPLIANCE.md so \"secret history scan\" is not listed as commercial-only for self-hosted OSS.

## Test plan
- [x] Cross-check against \`repowise security scan --help\` and \`plugins/claude-code/hooks/hooks.json\`
- [x] Grep COMMERCIAL / SECURITY_COMPLIANCE for remaining PreToolUse / commercial-only history-scan claims