### PR TITLE
docs: onboard contributors through repowise itself, trim README badges

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,6 +34,79 @@ uv run repowise --version
 uv run pytest tests/unit/
 ```
 
+## Getting oriented
+
+This is a ~3,000 file codebase, and reading it front to back is not the plan. Repowise
+exists to make that unnecessary, so use it on itself.
+
+### Without installing anything
+
+We keep a public, always-fresh index of this repository at
+**[repowise.dev/repo/repowise-dev/repowise](https://repowise.dev/repo/repowise-dev/repowise)**.
+It re-indexes on every push. Pick the tab that matches your question:
+
+| Your question | Where to look |
+|---|---|
+| What are the moving parts? | [Overview](https://repowise.dev/repo/repowise-dev/repowise/overview) and [Architecture](https://repowise.dev/repo/repowise-dev/repowise/architecture) |
+| Where does this symbol live? | [Files](https://repowise.dev/repo/repowise-dev/repowise/files) |
+| Which files are dangerous to touch? | [Code Health](https://repowise.dev/repo/repowise-dev/repowise/code-health), and the hotspot table on the landing page |
+| Who knows this area? | [People & History](https://repowise.dev/repo/repowise-dev/repowise/owners) |
+| Why is it built this way? | [Decisions](https://repowise.dev/repo/repowise-dev/repowise/decisions) |
+| What changed recently, and how risky was it? | [Commits](https://repowise.dev/repo/repowise-dev/repowise/commits) |
+
+### Locally, with your agent
+
+Better still, index this repo with the tool you are contributing to. It is free, needs
+no API key, and takes a couple of minutes:
+
+```bash
+uv run repowise init --no-prose -y   # graph, git history, health, decisions. No LLM, no spend.
+uv run repowise serve                # dashboard + MCP server on localhost
+```
+
+Then point your coding agent at the MCP server (see the
+[Quickstart](../README.md#quickstart-under-5-minutes-no-api-key) for Claude Code, Codex
+and others) and ask it questions directly:
+
+```
+get_context for packages/core/src/repowise/core/pipeline/orchestrator.py
+get_why "why is doc generation split from ingestion?"
+```
+
+If something about this experience is bad, that is a bug worth reporting. Contributors
+are the only people who use repowise on repowise with fresh eyes.
+
+### Then read
+
+- [docs/architecture/](../docs/architecture/README.md) for the written architecture
+- [docs/layers/INTELLIGENCE_LAYERS.md](../docs/layers/INTELLIGENCE_LAYERS.md) for what
+  each of the five layers computes and where its code lives
+- [docs/reference/CLI_REFERENCE.md](../docs/reference/CLI_REFERENCE.md) for every
+  command and flag
+
+## Looking for something to work on
+
+- **[Good first issues](https://github.com/repowise-dev/repowise/labels/good%20first%20issue)** on the tracker.
+- **[The refactoring backlog](https://repowise.dev/repo/repowise-dev/repowise/refactoring).**
+  Repowise ranks its own concrete refactoring plans (Extract Class, Split File, Break
+  Cycle, and so on) with the blast radius attached. Each card has a copy-to-agent
+  button. Picking one off that list is a genuinely useful contribution, and it is the
+  fastest way to learn how the health layer thinks.
+- **Language support.** Adding a language is one `.scm` query file and one config entry.
+  See [docs/layers/LANGUAGE_SUPPORT.md](../docs/layers/LANGUAGE_SUPPORT.md).
+
+Before you start, check the file you are about to edit:
+
+```bash
+uv run repowise health --file <path>   # score, markers, findings
+uv run repowise risk HEAD              # or ask get_risk from your agent
+```
+
+Some files in this repo are bug magnets: high churn, a long run of prior fixes, often a
+bus factor of one. The
+[hotspot table](https://repowise.dev/repo/repowise-dev/repowise/code-health) names the
+current ones. Changes there are welcome, but expect closer review and bring tests.
+
 ## Development Workflow
 
 1. **Fork** the repository
@@ -48,7 +121,17 @@ uv run pytest tests/unit/
    npm run lint
    npm run type-check
    ```
-5. **Push** to your fork and open a **Pull Request** against `main`
+5. **Check your own change** with the tool you are contributing to:
+   ```bash
+   uv run repowise risk main..HEAD        # 0-10 defect score, plus will_break,
+                                          # missing_cochanges and missing_tests
+   uv run repowise impacted-tests --staged  # the tests your diff actually exercises
+   uv run repowise health --file <path>   # did the file you touched get worse?
+   ```
+   None of this is a gate, and none of it calls an LLM. It is the same signal the
+   reviewer will be looking at, and running it yourself catches the boring problems
+   (a forgotten companion file, an untested hotspot) before anyone else has to.
+6. **Push** to your fork and open a **Pull Request** against `main`
 
 ## Branch Naming
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,14 @@
 
 <p align="center">
   <a href="https://www.repowise.dev"><img src="https://img.shields.io/badge/LIVE_DEMO-repowise.dev-F59520?style=for-the-badge&labelColor=0A0A0A" alt="Live demo: repowise.dev" /></a>
-  <a href="https://github.com/repowise-dev/repowise"><img src="https://img.shields.io/badge/Star_this_repo-1E293B?style=for-the-badge&logo=github&logoColor=white&labelColor=0A0A0A" alt="Star repowise on GitHub" /></a>
 </p>
 
 <p align="center">
   <a href="https://repowise.dev/repo/repowise-dev/repowise"><img src="https://api.repowise.dev/badge/wiki/repowise-dev/repowise.svg?style=for-the-badge" alt="repowise: explore code" /></a>
   <a href="https://repowise.dev/repo/repowise-dev/repowise/code-health"><img src="https://api.repowise.dev/badge/health/repowise-dev/repowise.svg?style=for-the-badge" alt="Code health" /></a>
+  <a href="https://github.com/repowise-dev/repowise/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/repowise-dev/repowise/ci.yml?branch=main&style=for-the-badge&label=CI&labelColor=0A0A0A" alt="CI status" /></a>
   <a href="https://pypi.org/project/repowise/"><img src="https://img.shields.io/pypi/v/repowise?style=for-the-badge&color=1E293B&labelColor=0A0A0A&logo=pypi&logoColor=white" alt="PyPI version" /></a>
   <a href="https://www.gnu.org/licenses/agpl-3.0"><img src="https://img.shields.io/badge/License-AGPL--v3-059669?style=for-the-badge&labelColor=0A0A0A" alt="License: AGPL v3" /></a>
-  <a href="https://pypi.org/project/repowise/"><img src="https://img.shields.io/badge/Python-3.11%2B-1E293B?style=for-the-badge&labelColor=0A0A0A&logo=python&logoColor=white" alt="Python 3.11+" /></a>
-  <a href="https://modelcontextprotocol.io"><img src="https://img.shields.io/badge/MCP-compatible-1E293B?style=for-the-badge&labelColor=0A0A0A" alt="MCP compatible" /></a>
   <a href="https://github.com/repowise-dev/repowise/stargazers"><img src="https://img.shields.io/github/stars/repowise-dev/repowise?style=for-the-badge&logo=github&color=1E293B&labelColor=0A0A0A&logoColor=white" alt="GitHub stars" /></a>
 </p>
 
@@ -573,6 +571,13 @@ uv sync --all-packages
 uv run repowise --version
 uv run pytest tests/unit/
 ```
+
+New here? You do not have to read 3,000 files to start. We keep a public index of this
+repo built by repowise itself, re-indexed on every push:
+[**explore repowise with repowise →**](https://repowise.dev/repo/repowise-dev/repowise)
+(architecture, hotspots, ownership, decisions, and a ranked
+[refactoring backlog](https://repowise.dev/repo/repowise-dev/repowise/refactoring) you
+are welcome to pick from).
 
 Full guide, including how to add languages and LLM providers:
 [CONTRIBUTING.md](.github/CONTRIBUTING.md) · architecture:


### PR DESCRIPTION
## Why

We claim repowise makes onboarding a large codebase easy. Our own `CONTRIBUTING.md` was a competent but entirely generic OSS guide (prereqs, branch prefixes, ruff, PR rules) that never once mentioned the tool it ships with. A new contributor lands there after a README promising "your agent stops guessing" and gets told to go read 3,000 files.

This makes the contributor path dogfood the product.

## CONTRIBUTING.md

Two new sections, plus one new workflow step. Nothing removed.

**Getting oriented** (after Local Setup). Two ways in:

- *No install:* a question-to-tab table for the public index of this repo, which re-indexes on every push. Architecture, Files, Code Health, People & History, Decisions, Commits.
- *Local:* `repowise init --no-prose -y` then `repowise serve`, wire up the MCP server, ask it questions. Free, no API key. Ends by asking contributors to report it as a bug if the experience is bad, since they are the only people who use repowise on repowise with fresh eyes.

**Looking for something to work on.** Good-first-issue label, language support, and the ranked refactoring backlog framed as a contribution queue. Each card there is a concrete plan with blast radius attached and a copy-to-agent button, which is a better newcomer queue than a label. Closes with a pointer to `health --file` and a warning that some files in this repo are bug magnets and will get closer review.

**Development Workflow** gains a step 5, before push:

```bash
repowise risk main..HEAD
repowise impacted-tests --staged
repowise health --file <path>
```

Explicitly not a gate and explicitly zero-LLM. It is the same signal the reviewer sees, so running it yourself catches the boring stuff (forgotten companion file, untested hotspot) first.

## README badges: 9 to 6

| Change | Badge | Reason |
|---|---|---|
| Removed | Star this repo | Duplicate of the star-count badge, and it linked to the page the reader is already on |
| Removed | MCP compatible | Self-declared, no data behind it, and there is a ten-row MCP tool table 40 lines below |
| Removed | Python 3.11+ | Implied by `pip install`, already on PyPI and in the prereqs |
| Added | CI status | `ci.yml` runs on every PR but nothing surfaced it. For a project whose pitch is "we tell you what is safe to merge", a visible green build is on-message |
| Reordered | Explore code, Code health | The only two badges generated by the product being advertised now lead the row instead of sitting between License and Python version |

Every remaining badge carries live data. `labelColor=0A0A0A` is unchanged across all of them so the row still matches our own badge renderer's `#0a0a0a` in light and dark.

## Deliberately not included

No link to the Docs tab. This repo is currently indexed without narrative prose, so that tab reports "narrative prose is not generated for this repository" and serves structure-only pages. Sending newcomers there would undercut the point. There is separate work in flight to fix that; adding a Docs row to the tab table is a one-line follow-up once it lands. The commit body notes this so it does not get "helpfully" re-added.

No link to Chat either. It is sign-in gated, and a paywall inside CONTRIBUTING reads badly for an AGPL project.

## Verification

- All 54 URLs across both files resolve, checked with follow-redirects. Local relative paths all exist.
- CLI flags checked against source rather than the README. `health` takes `--file` with a single relative path, not a file list. `impacted-tests` has `--staged`, which suits a pre-push step better than a revspec.
- Badge endpoints fetched and their rendered text confirmed: `EXPLORE CODE`, `CODE HEALTH 7.5/10`, `CI PASSING`, `v0.36.0`, `4.2k`.
- Dropped an initial link to `docs/LOCAL_DEV.md` after finding it is untracked and local-only. Links `docs/reference/CLI_REFERENCE.md` instead.

Docs only, no code paths touched.
