### PR TITLE
fix(health): classify .mts/.cts tests in coverage_gradient and move_method

### DIFF
--- a/packages/core/src/repowise/core/analysis/health/biomarkers/coverage_gradient.py
+++ b/packages/core/src/repowise/core/analysis/health/biomarkers/coverage_gradient.py
@@ -51,7 +51,19 @@ def _looks_like_test_path(path: str) -> bool:
         or "/__tests__/" in p
         or p.startswith(("test/", "tests/", "__tests__/"))
         or p.endswith(
-            ("_test.py", "_test.go", ".test.ts", ".test.tsx", ".test.js", ".spec.ts", ".spec.js")
+            (
+                "_test.py",
+                "_test.go",
+                ".test.ts",
+                ".test.tsx",
+                ".test.js",
+                ".test.mts",
+                ".test.cts",
+                ".spec.ts",
+                ".spec.js",
+                ".spec.mts",
+                ".spec.cts",
+            )
         )
         or p.rsplit("/", 1)[-1].startswith("test_")
     )

--- a/packages/core/src/repowise/core/analysis/health/refactoring/move_method.py
+++ b/packages/core/src/repowise/core/analysis/health/refactoring/move_method.py
@@ -76,8 +76,12 @@ def _is_test_path(path: str) -> bool:
                 ".test.ts",
                 ".test.tsx",
                 ".test.js",
+                ".test.mts",
+                ".test.cts",
                 ".spec.ts",
                 ".spec.js",
+                ".spec.mts",
+                ".spec.cts",
             )
         )
     )

--- a/tests/unit/health/test_mts_cts_test_classification.py
+++ b/tests/unit/health/test_mts_cts_test_classification.py
@@ -1,10 +1,28 @@
-"""`.mts`/`.cts` test files must be classified as tests across health logic (#288)."""
+"""`.mts`/`.cts` test files must be classified as tests across health logic (#288).
+
+The original version of this file asserted on four implementations, one test
+function each. Two further copies of the same predicate existed at the time and
+were not listed, so they never received the fix: ``coverage_gradient`` and
+``move_method`` still read ``foo.test.mts`` as production code. The matrix below
+covers every reachable implementation instead, so a copy that is added or edited
+without the `.mts`/`.cts` conventions fails here rather than in a user's repo.
+
+New implementations still have to be added to ``_IMPLEMENTATIONS`` by hand, which
+is the limit of this approach and the reason #1103 exists.
+"""
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
-from repowise.core.analysis.health.biomarkers.coverage_gap import _looks_like_test_path
+from repowise.core.analysis.health.biomarkers.coverage_gap import (
+    _looks_like_test_path as _coverage_gap_looks_like_test_path,
+)
+from repowise.core.analysis.health.biomarkers.coverage_gradient import (
+    _looks_like_test_path as _coverage_gradient_looks_like_test_path,
+)
 from repowise.core.analysis.health.biomarkers.hidden_coupling import (
     _is_test_path as _coupling_is_test_path,
 )
@@ -16,26 +34,57 @@ from repowise.core.analysis.health.engine import (
 from repowise.core.analysis.health.engine import (
     _is_test_file as _engine_is_test_file,
 )
+from repowise.core.analysis.health.refactoring.extract_helper import (
+    _is_test_path as _extract_helper_is_test_path,
+)
+from repowise.core.analysis.health.refactoring.move_method import (
+    _is_test_path as _move_method_is_test_path,
+)
+from repowise.core.analysis.health.refactoring.split_file import (
+    _is_test_path as _split_file_is_test_path,
+)
+
+# Every implementation of "is this path a test?" reachable from health logic.
+# Consolidating them is #1103; until then they all have to agree here.
+_IMPLEMENTATIONS: tuple[tuple[str, Callable[[str], bool]], ...] = (
+    ("engine", _engine_is_test_file),
+    ("coverage_detector", is_test_file),
+    ("hidden_coupling", _coupling_is_test_path),
+    ("coverage_gap", _coverage_gap_looks_like_test_path),
+    ("coverage_gradient", _coverage_gradient_looks_like_test_path),
+    ("split_file", _split_file_is_test_path),
+    ("move_method", _move_method_is_test_path),
+    ("extract_helper", _extract_helper_is_test_path),
+)
+
+_MTS_CTS_TEST_PATHS = (
+    "src/foo.test.mts",
+    "src/foo.test.cts",
+    "src/foo.spec.mts",
+    "src/foo.spec.cts",
+)
+
+# Same extensions, production files: the suffix has to be the whole convention,
+# not a substring, or `.mts` sources get exempted from coverage scoring wholesale.
+_MTS_CTS_PRODUCTION_PATHS = (
+    "src/foo.mts",
+    "src/foo.cts",
+    "src/testable.mts",
+)
 
 
-@pytest.mark.parametrize("path", ["src/foo.test.mts", "src/foo.test.cts", "src/foo.spec.mts", "src/foo.spec.cts"])
-def test_engine_is_test_file(path: str) -> None:
-    assert _engine_is_test_file(path)
+@pytest.mark.parametrize("path", _MTS_CTS_TEST_PATHS)
+@pytest.mark.parametrize(("name", "is_test"), _IMPLEMENTATIONS, ids=lambda v: v)
+def test_mts_cts_paths_are_tests(name: str, is_test: Callable[[str], bool], path: str) -> None:
+    assert is_test(path), f"{name} does not classify {path} as a test"
 
 
-@pytest.mark.parametrize("path", ["src/foo.test.mts", "src/foo.spec.cts"])
-def test_coverage_is_test_file(path: str) -> None:
-    assert is_test_file(path)
-
-
-@pytest.mark.parametrize("path", ["src/foo.test.mts", "src/foo.spec.cts"])
-def test_hidden_coupling_is_test_path(path: str) -> None:
-    assert _coupling_is_test_path(path)
-
-
-@pytest.mark.parametrize("path", ["src/foo.test.mts", "src/foo.spec.cts"])
-def test_coverage_gap_looks_like_test_path(path: str) -> None:
-    assert _looks_like_test_path(path)
+@pytest.mark.parametrize("path", _MTS_CTS_PRODUCTION_PATHS)
+@pytest.mark.parametrize(("name", "is_test"), _IMPLEMENTATIONS, ids=lambda v: v)
+def test_mts_cts_production_paths_are_not_tests(
+    name: str, is_test: Callable[[str], bool], path: str
+) -> None:
+    assert not is_test(path), f"{name} wrongly classifies {path} as a test"
 
 
 def test_paired_test_file_finds_mts_cts() -> None:


### PR DESCRIPTION
The `.mts`/`.cts` test conventions were added across the health test-path checks in #288, but two copies of that predicate were not in the list at the time and never received the fix:

- `biomarkers/coverage_gradient._looks_like_test_path`, whose own docstring says it matches `coverage_gap`
- `refactoring/move_method._is_test_path`

So `src/foo.test.mts` was a test file to six implementations and production code to those two:

```
path                  engine cov_det coup gap grad split move extract
src/foo.test.mts      Y      Y       Y    Y   .    Y     .    Y
src/foo.spec.cts      Y      Y       Y    Y   .    Y     .    Y
src/foo.test.ts       Y      Y       Y    Y   Y    Y     Y    Y
```

## What a user saw

- A `.test.mts` file picked up a `coverage_gradient` deduction for its own low coverage, lowering its defect score.
- Move Method proposed refactorings inside it, and proposed moving production methods into it. That surfaces in `repowise health --refactoring-targets`, `get_health(include=["refactoring"])`, `GET /api/repos/{id}/refactoring/targets`, the UI refactoring board and the VS Code lens.

Both directions only ever exempt more files, so every surface shows fewer findings, never more.

## Why it went unnoticed

The regression test for #288 asserted on four implementations, one test function each, and covered neither of these. It is now a matrix over every reachable implementation, so a copy added or edited without these conventions fails here rather than in a user's repo. It also pins the negative direction: plain `.mts`/`.cts` sources must not be classified as tests.

Verified by reverting both fixes against the new test, which fails on exactly the 8 affected cases (2 implementations x 4 paths) and passes the other 50.

Adding a new implementation still means adding a row by hand, which is the ceiling of this approach and what #1103 removes.

Refs #1103