### PR TITLE
Convert the last two inline test-path checks, and close the fixture gap (Refs #1103)

### DIFF
--- a/packages/cli/src/repowise/cli/ui/repo_scanner.py
+++ b/packages/cli/src/repowise/cli/ui/repo_scanner.py
@@ -12,6 +12,7 @@ from rich.panel import Panel
 
 from repowise.core.fs_walk import PRUNED_DIRS, walk_repo
 from repowise.core.ingestion.languages.registry import REGISTRY as _LANG_REGISTRY
+from repowise.core.test_paths import is_test_related_path
 
 
 @dataclass
@@ -28,7 +29,6 @@ class RepoScanInfo:
     """(dir_name, file_count) for dirs with >50 files — used for exclude suggestions."""
 
 
-_TEST_PATTERNS = {"test_", "_test.", ".test.", "tests/", "test/", "__tests__/", "spec/"}
 _INFRA_NAMES = {"dockerfile", "makefile", "jenkinsfile", "terraform", ".tf", ".sh", ".bash"}
 # Derived from the centralised LanguageRegistry, supplemented with
 # display-only languages (HTML, CSS) not tracked by the pipeline.
@@ -86,9 +86,12 @@ def quick_repo_scan(repo_path: Path) -> RepoScanInfo:
             if lang:
                 info.language_counts[lang] = info.language_counts.get(lang, 0) + 1
 
-            # Test file detection
-            full_rel = os.path.join(rel_dir, lower).replace("\\", "/")
-            if any(p in full_rel for p in _TEST_PATTERNS):
+            # Test file detection. Original case, not `lower`: the shared rules
+            # read `Foo.Tests/` and `FooTest.java` case-sensitively on purpose.
+            # No language is known this early — the scan runs before ingestion —
+            # so `spec/` falls to the unambiguous reading.
+            full_rel = os.path.join(rel_dir, fname).replace("\\", "/")
+            if is_test_related_path(full_rel):
                 info.test_file_count += 1
 
             # Infra file detection

--- a/packages/core/src/repowise/core/generation/onboarding/subkinds/development_guide.py
+++ b/packages/core/src/repowise/core/generation/onboarding/subkinds/development_guide.py
@@ -26,12 +26,6 @@ _MIN_SUFFIX_GROUP = 3
 _TOP_SUFFIX_GROUPS = 6
 _MIN_TEST_MIRROR_RATIO = 0.5
 
-# Recognised test-tree roots — anything else with "test" in the name still
-# counts but is treated as a weaker mirror signal.
-_TEST_ROOTS: tuple[str, ...] = (
-    "tests/", "test/", "__tests__/", "spec/", "specs/",
-)
-
 
 @dataclass
 class SuffixPattern:
@@ -78,7 +72,7 @@ def _find_suffix_patterns(signals: OnboardingSignals) -> list[SuffixPattern]:
         path = pf.file_info.path
         # Skip test files — patterns inside tests/ are the mirror signal,
         # not the suffix signal.
-        if any(seg in path for seg in _TEST_ROOTS):
+        if pf.file_info.is_test:
             continue
         tokens = _split_basename(PurePosixPath(path).name)
         if len(tokens) < 2:
@@ -104,21 +98,42 @@ def _find_suffix_patterns(signals: OnboardingSignals) -> list[SuffixPattern]:
     return groups[:_TOP_SUFFIX_GROUPS]
 
 
+def _test_tree_roots(signals: OnboardingSignals) -> list[str]:
+    """Top-level directories that are test trees, in this repo's own spelling.
+
+    "Which directory is the test root" is a different question from "is this
+    path a test", so it is derived rather than read off a hardcoded list: group
+    the ingested files by first path segment and keep the segments where every
+    ingested file underneath is test material. That all-or-nothing rule is what
+    separates a real root from a directory that merely contains one — `tests/`
+    qualifies, `src/` in a `src/test/java` layout does not, and a repo naming
+    its tree `spec/` or `Foo.Tests/` is found without the list knowing about it.
+    """
+    total: dict[str, int] = defaultdict(int)
+    tests: dict[str, int] = defaultdict(int)
+    for pf in signals.parsed_files:
+        parts = PurePosixPath(pf.file_info.path).parts
+        if len(parts) < 2:  # a repo-root file is not a tree
+            continue
+        total[parts[0]] += 1
+        if pf.file_info.is_test:
+            tests[parts[0]] += 1
+    return sorted(f"{seg}/" for seg, count in tests.items() if count == total[seg])
+
+
 def _find_test_mirror(signals: OnboardingSignals) -> TestMirror | None:
     """Detect a "tests mirror source layout" convention.
 
-    For every file under a known test root, strip the root and try to
-    locate a non-test file that shares the remaining path stem. A mirror
-    is reported when ≥ 50% of test files match.
+    For every file under a test root, strip the root and try to locate a
+    non-test file that shares the remaining path stem. A mirror is reported
+    when ≥ 50% of test files match.
     """
     source_paths: set[str] = {
-        pf.file_info.path
-        for pf in signals.parsed_files
-        if not any(seg in pf.file_info.path for seg in _TEST_ROOTS)
+        pf.file_info.path for pf in signals.parsed_files if not pf.file_info.is_test
     }
 
     best: TestMirror | None = None
-    for root in _TEST_ROOTS:
+    for root in _test_tree_roots(signals):
         test_files = [pf.file_info.path for pf in signals.parsed_files if pf.file_info.path.startswith(root)]
         if len(test_files) < _MIN_SUFFIX_GROUP:
             continue

--- a/packages/core/src/repowise/core/test_paths.py
+++ b/packages/core/src/repowise/core/test_paths.py
@@ -73,6 +73,24 @@ _SUPPORT_DIR_TOKENS: frozenset[str] = frozenset(
     {"fixtures", "factories", "support", "helpers", "mocks", "__mocks__"}
 )
 
+# Scaffolding directories whose names mean test material *wherever* they sit,
+# because nothing else is ever called this. Bare ``fixtures`` deliberately stays
+# out of this set and above: it is an ordinary English word that names real
+# product directories (a sports app's fixtures list), and on this repo plus its
+# two siblings 230 of 231 ``fixtures/`` files already sit inside a test tree, so
+# the tree requirement costs nothing and the widening would buy nothing.
+# ``__fixtures__`` is the same convention with the JS dunder wrapper that
+# ``__tests__``/``__mocks__`` use, and carries no other meaning. ``testdata`` is
+# the Go convention the toolchain itself reserves - ``go build`` ignores any
+# directory of that name - which is why it needs no Go file to corroborate it:
+# the golden files inside are JSON and YAML, and asking the file's own language
+# would never fire on them.
+#
+# Support rather than test, deliberately: golden data is what a test reads, not
+# a test. So the union counts it (#1103's reporter asked for exactly that) while
+# search, which uses ``is_test_path``, still surfaces the golden file by name.
+_SUPPORT_DIR_TOKENS_ANYWHERE: frozenset[str] = frozenset({"__fixtures__", "testdata"})
+
 
 @dataclass(frozen=True, slots=True)
 class _Conventions:
@@ -225,6 +243,13 @@ def _classify(path: str, language: str | None) -> str:
         return "support"
 
     named_test = _is_test_name(filename)
+
+    # A scaffolding directory that needs no test tree around it settles the
+    # question before the tree rules run. A test-shaped filename still wins, so
+    # ``testdata/build_test.go`` stays a test.
+    if not named_test and any(seg in _SUPPORT_DIR_TOKENS_ANYWHERE for seg in segments):
+        return "support"
+
     if not named_test and not _is_test_dir(segments, original_segments, filename, language):
         return ""
 

--- a/tests/unit/generation/test_onboarding.py
+++ b/tests/unit/generation/test_onboarding.py
@@ -38,6 +38,7 @@ from repowise.core.ingestion.models import (
     RepoStructure,
     Symbol,
 )
+from repowise.core.test_paths import is_test_related_path
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -58,7 +59,9 @@ def _file(
         size_bytes=512,
         git_hash="abc",
         last_modified=datetime(2026, 1, 1, tzinfo=UTC),
-        is_test=False,
+        # Stamped the way ingestion stamps it, so subkinds that read the flag
+        # see what they would see in a real run.
+        is_test=is_test_related_path(path, language),
         is_config=False,
         is_api_contract=False,
         is_entry_point=is_entry_point,

--- a/tests/unit/test_no_test_path_copies.py
+++ b/tests/unit/test_no_test_path_copies.py
@@ -57,6 +57,12 @@ _PREDICATE_CONSTANTS = (
     "_TEST_DIR_SEGMENTS",
     "_TEST_FILE_RE",
     "_TEST_FILE_PATTERNS",
+    # Both held unanchored substrings and both were measurably wrong:
+    # `protest/`, `latest/` and `contest/` all counted as tests, while
+    # `myapp/tests.py` and `Foo.Tests/` did not. Neither name was on this list,
+    # which is why they stayed green through the whole consolidation.
+    "_TEST_PATTERNS",
+    "_TEST_ROOTS",
 )
 
 # Copies that still exist, with the reason each is still here. Shrink, never

--- a/tests/unit/test_test_paths.py
+++ b/tests/unit/test_test_paths.py
@@ -76,6 +76,22 @@ _CORPUS: tuple[tuple[str, str | None, str], ...] = (
     ("src/manifest/loader.py", None, ""),
     ("src/helpers/fmt.py", None, ""),
     ("src/fixtures/data.py", None, ""),
+    # #1103 finding 6: golden data and the dunder fixture dir, which the
+    # scaffolding tokens missed because those only count inside a test tree.
+    # Support rather than test - a golden file is what a test reads - so the
+    # union counts them while search still surfaces them by name.
+    ("testdata/golden.json", None, "support"),
+    ("pkg/parser/testdata/valid/input.go", None, "support"),
+    ("src/__fixtures__/x.ts", None, "support"),
+    # a test-shaped filename still wins over the directory
+    ("testdata/build_test.go", None, "test"),
+    # and the same finding's third path stays production code on purpose: bare
+    # `fixtures` is an ordinary word that names real product directories, so it
+    # still needs a test tree around it
+    ("fixtures/data.yml", None, ""),
+    ("app/fixtures/premier_league.py", None, ""),
+    ("src/testdata_loader.py", None, ""),
+    ("tests/testdata/golden.json", None, "support"),
 )
 
 


### PR DESCRIPTION
Finishes #1103. Three PRs (#1111, #1112, #1113) built `core/test_paths.py` and converted core and
the server onto it; this one takes the last two inline sites and settles the one open finding.

## The two inline sites

Both matched test tokens as unanchored substrings, and both were measurably wrong on this repo's
own tree:

| site | false positives cleared |
|---|---|
| `cli/ui/repo_scanner.py` | 5, including `alembic/versions/0036_test_coverage.py` and `ingestion/framework_edges/pytest_edges.py` |
| `generation/onboarding/subkinds/development_guide.py` | 47, every one of them a language spec module under `ingestion/languages/specs/` that the substring `specs/` swallowed |

The scanner's count is what `init` shows you before indexing. The guide's 47 were being dropped from
the guidance it generates as if they were test files.

They convert differently on purpose. `development_guide` holds a `FileInfo`, so it reads the stored
`is_test` rather than asking the path rules again, which is what the shared module's docstring asks
callers in that position to do. That flag cannot be stale there: `ParseCache.get` rebinds the fresh
`FileInfo` on every cache hit, so it is always what ingestion just stamped. `repo_scanner` runs
before ingestion and has only a path, so it calls the shared rules directly, and now passes the
original case rather than a lowercased path, because two of the rules read `Foo.Tests/` and
`FooTest.java` case-sensitively.

`_TEST_ROOTS` had a second use that was not a predicate. It was iterated as a list of candidate root
directories to find the mirror test tree, which is a different question from "is this path a test",
and the shared module has no equivalent. Rather than fake a roots list to make the call site look
converted, it is derived: group the ingested files by first path segment and keep the segments where
everything underneath is test material. That all-or-nothing rule separates a real root from a
directory that merely contains one, so `tests/` qualifies and `src/` in a `src/test/java` layout does
not. Checked against three real repos, it finds `tests/` here and `__tests__/` plus `e2e/` in the
frontend, neither of which the hardcoded tuple got right.

The onboarding fixture stamped `is_test=False` on every file, including `tests/test_auth_handler.py`.
It now stamps it the way `traverser.py` does, so subkinds reading the flag see what a real run gives
them.

## The fixture and golden-data gap

The report asked for `fixtures/data.yml`, `src/__fixtures__/x.ts` and `testdata/golden.json` to count
as test material. All three returned False. Two now count; one deliberately does not.

Widening bare `fixtures/` to anywhere is the change that would reclassify real product directories,
and the measurement says it buys nothing: across this repo and its two siblings there are 231 files
under a `fixtures/` segment and 230 already sit inside a test tree, so the tree requirement costs
nothing today while a sports app's fixtures list is a real directory it would take out of the docs.

`__fixtures__` and `testdata` are different. The dunder wrapper is the same JS convention as
`__tests__` and `__mocks__` and carries no other meaning; Go reserves `testdata` at the toolchain
level. `testdata` also cannot be gated on the file's own language the way `spec/` is, because the
golden files inside it are JSON and YAML.

Both classify as **support** rather than test. A golden file is what a test reads, not a test. So
`is_test_related_path` counts them, which is what the report asked for, while search uses
`is_test_path` and still surfaces the golden file by name. A test-shaped filename still wins, so
`testdata/build_test.go` stays a test.

Blast radius on this repo is 24 files, all the api-client's `__fixtures__/` JSON.

## The guard

`_TEST_PATTERNS` and `_TEST_ROOTS` were not on `_PREDICATE_CONSTANTS`, which is why both sites stayed
green through all three earlier conversions. Both names are on the list now, so this shape cannot
come back.

## Verification

Every difference between the old rules and the new was diffed over a real path corpus (`git ls-files`
plus the layouts from the report) and accounted for before keeping it.

- Full unit suite: 8698 passed, 3 skipped (33m). Baseline after #1113 was 8673; the delta is the 24
  new corpus assertions.
- `tests/integration`: 223 passed, 14 skipped (20m), matching baseline. Run locally because
  integration CI only runs on push to main.
- `ruff check` clean on all six changed files.

This changes classification, so it needs a reindex to take effect on an existing index.

Refs #1103
