### PR TITLE
feat(ui): rebuild the contributor profile and commit detail on the section design language

### DIFF
--- a/packages/ui/src/commits/commit-detail-card.tsx
+++ b/packages/ui/src/commits/commit-detail-card.tsx
@@ -1,99 +1,49 @@
-import { Bug, GitCommitHorizontal, User } from "lucide-react";
+import { Bug } from "lucide-react";
 import { AgentBadge, NewContributorBadge, isNewContributor } from "./agent-badge";
 import { PriorityBadge } from "./priority-badge";
-import { RiskDriverBreakdown } from "./risk-driver-breakdown";
-import { formatDateTime, formatLOC } from "../lib/format";
+import { RiskDriverBreakdown, describeDriver } from "./risk-driver-breakdown";
+import { PageLede } from "../shared/page-lede";
+import { OverviewSection } from "../overview/section";
+import { formatDateTime } from "../lib/format";
 import type { CommitDetail } from "@repowise-dev/types/git";
 
 export interface CommitDetailCardProps {
   commit: CommitDetail;
+  /**
+   * Raw score at this repo's moderate/high boundary — `CommitStats.high_cut`.
+   * Optional: without it the card states the score on its own rather than
+   * inventing a comparison.
+   */
+  reviewCut?: number | null | undefined;
   className?: string;
 }
 
-/** 1 -> "1st", 2 -> "2nd", 93 -> "93rd", 11 -> "11th". */
-function ordinal(n: number): string {
-  const suffix =
-    n % 100 >= 10 && n % 100 <= 20
-      ? "th"
-      : ({ 1: "st", 2: "nd", 3: "rd" }[n % 10] ?? "th");
-  return `${n}${suffix}`;
-}
-
-/** Lead clause: where this commit sits in its own repo's risk distribution. */
-const PRIORITY_LEAD: Record<string, string> = {
-  low: "Lower risk than a typical commit in this repo",
-  moderate: "About as risky as a typical commit in this repo",
-  high: "Riskier than most commits in this repo",
-};
-
 /**
- * One-line, plain-English read of the score: the repo-relative standing first
- * (the signal users should act on), then a short, honest note on why the raw
- * model score landed where it did. Built entirely from fields already on the
- * commit — no extra fetch.
+ * Drill-down for one commit.
+ *
+ * Rebuilt on the section style, and reorganised around one rule: say each fact
+ * once. The card used to state the percentile four times over — a 24px
+ * `100%ile`, a priority pill, "Riskier than 100% of this repo's commits", and
+ * then "Riskier than most commits in this repo (100th percentile)" — with the
+ * summary paragraph restating the box immediately above it.
+ *
+ * What leads is now the raw score against this repo's own review line, for two
+ * reasons. The queue this sheet opens from already carries a percentile column
+ * per row, so repeating it here spends the largest figure on the page on
+ * something the reader just clicked past. And the percentile cannot honestly be
+ * turned into a rank: the raw score is rounded to one decimal before ranking,
+ * so 886 commits share 86 distinct percentiles, and "the 1st riskiest of 886"
+ * would be a computed guess printed as a measurement.
+ *
+ * The tercile still appears, once, as the badge beside the figure.
  */
-function riskSummary(c: CommitDetail): string {
-  const lead = PRIORITY_LEAD[c.review_priority] ?? PRIORITY_LEAD.moderate;
-  let out = `${lead} (${ordinal(Math.round(c.risk_percentile))} percentile).`;
-
-  if (c.change_risk_score != null) {
-    // `drivers` arrive strongest-first; the risk-raising ones explain the score.
-    const raising = c.drivers.filter(
-      (d) => d.value !== null && d.contribution > 0,
-    );
-    const raw = c.change_risk_score.toFixed(1);
-    if (raising.length === 0) {
-      out += ` Its raw model score (${raw}/10) stays low across every driver.`;
-    } else {
-      const reasons = raising
-        .slice(0, 2)
-        .map((d) => d.label)
-        .join(" and ");
-      out += ` Its raw model score (${raw}/10) is driven mainly by ${reasons}`;
-      out +=
-        ", measured against the model's baseline commit rather than this repo.";
-    }
-  }
-
-  if (isNewContributor(c.author_commit_count)) {
-    out += " The author is new to this code.";
-  }
-  return out;
-}
-
-function Stat({
-  label,
-  value,
-  title,
-}: {
-  label: string;
-  value: string;
-  title?: string;
-}) {
-  return (
-    <div title={title}>
-      <div className="text-[10px] uppercase tracking-wider text-[var(--color-text-tertiary)]">
-        {label}
-      </div>
-      <div className="text-sm tabular-nums text-[var(--color-text-primary)]">
-        {value}
-      </div>
-    </div>
-  );
-}
-
-/**
- * Drill-down for one commit: header, repo-relative risk summary, the Kamei
- * change features, and the exact per-feature risk-driver breakdown.
- */
-export function CommitDetailCard({ commit, className }: CommitDetailCardProps) {
+export function CommitDetailCard({ commit, reviewCut, className }: CommitDetailCardProps) {
   const c = commit;
+
   return (
     <div className={className}>
-      {/* Header */}
-      <div className="mb-4 space-y-1.5">
-        <div className="flex items-center gap-2">
-          <GitCommitHorizontal className="h-4 w-4 text-[var(--color-text-tertiary)]" />
+      <div className="flex flex-col gap-1.5">
+        <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
           <span className="font-mono text-xs text-[var(--color-text-secondary)]">
             {c.short_sha}
           </span>
@@ -103,15 +53,6 @@ export function CommitDetailCard({ commit, className }: CommitDetailCardProps) {
               fix
             </span>
           )}
-        </div>
-        <p className="text-sm font-medium text-[var(--color-text-primary)] break-words">
-          {c.subject || "(no subject)"}
-        </p>
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-[var(--color-text-tertiary)]">
-          <span className="inline-flex items-center gap-1">
-            <User className="h-3 w-3" />
-            {c.author_name || "unknown"}
-          </span>
           {c.agent_name && (
             <AgentBadge
               agentName={c.agent_name}
@@ -122,93 +63,97 @@ export function CommitDetailCard({ commit, className }: CommitDetailCardProps) {
           {!c.agent_name && isNewContributor(c.author_commit_count) && (
             <NewContributorBadge commitCount={c.author_commit_count as number} />
           )}
-          {c.committed_at && <span>{formatDateTime(c.committed_at)}</span>}
         </div>
+        {/* The subject wraps. It is the one thing on this sheet a reader has to
+            be able to read in full, so it never gets an ellipsis. */}
+        <p className="text-base font-semibold leading-snug text-[var(--color-text-primary)] [overflow-wrap:anywhere] [text-wrap:pretty]">
+          {c.subject || "(no subject)"}
+        </p>
+        <p className="text-xs text-[var(--color-text-tertiary)]">
+          {c.author_name || "unknown"}
+          {c.committed_at ? ` · ${formatDateTime(c.committed_at)}` : ""}
+        </p>
         {c.agent_name && c.agent_channel && (
           <p className="text-xs text-[var(--color-text-tertiary)]">
-            Attribution channel: {c.agent_channel}
-            {c.agent_confidence ? ` · ${c.agent_confidence} confidence` : ""}
+            Attributed through {c.agent_channel}
+            {c.agent_confidence ? `, ${c.agent_confidence} confidence` : ""}
           </p>
         )}
       </div>
 
-      {/* Risk summary */}
-      <div className="mb-4 flex items-center gap-4 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-3">
-        <div className="text-center">
-          <div className="text-2xl font-semibold tabular-nums text-[var(--color-text-primary)]">
-            {c.risk_percentile.toFixed(0)}
-            <span className="text-sm text-[var(--color-text-tertiary)]">
-              %ile
-            </span>
-          </div>
-          <div className="mt-0.5">
-            <PriorityBadge priority={c.review_priority} />
-          </div>
-        </div>
-        <div className="flex-1 text-xs text-[var(--color-text-secondary)]">
-          Riskier than{" "}
-          <span className="font-medium text-[var(--color-text-primary)] tabular-nums">
-            {c.risk_percentile.toFixed(0)}%
-          </span>{" "}
-          of this repo&apos;s commits.
-          {c.change_risk_score != null && (
-            <span
-              className="ml-1 text-[var(--color-text-tertiary)]"
-              title="Raw calibrated score (0–10). Anchored to the calibration corpus, so it skews high on repos with large typical commits — use the repo-relative percentile above for review order."
-            >
-              (raw {c.change_risk_score.toFixed(1)}/10)
-            </span>
-          )}
-        </div>
+      <div className="mt-7">
+        <PageLede
+          label="Change-risk score"
+          value={c.change_risk_score != null ? c.change_risk_score.toFixed(1) : "—"}
+          unit="out of 10"
+          badge={<PriorityBadge priority={c.review_priority} />}
+        >
+          <p>{riskSentence(c, reviewCut)}</p>
+        </PageLede>
       </div>
 
-      {/* Plain-English read — repo-relative standing first, then the why. */}
-      <p className="mb-4 text-xs leading-relaxed text-[var(--color-text-secondary)]">
-        {riskSummary(c)}
-      </p>
-
-      {/* Kamei change features */}
-      <div className="mb-4 grid grid-cols-3 gap-3 sm:grid-cols-4">
-        <Stat
-          label="Lines"
-          value={`+${formatLOC(c.lines_added)} -${formatLOC(c.lines_deleted)}`}
-        />
-        <Stat label="Files" value={String(c.files_changed)} />
-        <Stat
-          label="Dirs"
-          value={String(c.dirs_changed)}
-          title="Distinct directories touched"
-        />
-        <Stat
-          label="Subsystems"
-          value={String(c.subsystems_changed)}
-          title="Distinct top-level subsystems touched"
-        />
-        <Stat
-          label="Entropy"
-          value={c.entropy.toFixed(2)}
-          title="Shannon entropy of the per-file churn distribution — how scattered the change is"
-        />
-        {c.author_experience != null && (
-          <Stat
-            label="Author exp"
-            value={String(c.author_experience)}
-            title="The author's prior commits at the time of this commit, counted across the indexed history"
-          />
-        )}
-      </div>
-
-      {/* Risk drivers */}
-      <div>
-        <p className="mb-1 text-xs font-medium uppercase tracking-wider text-[var(--color-text-tertiary)]">
-          Why this score
-        </p>
-        <p className="mb-2 text-xs text-[var(--color-text-tertiary)]">
-          Each driver compares this change to the model&apos;s baseline commit.
-          Red raised the raw score; green lowered it.
-        </p>
+      {/* No stat ribbon above this, deliberately. The model's feature set is
+          lines added, lines deleted, files, directories, subsystems, scatter
+          and author experience — which is every figure a ribbon here could
+          carry. A row of them above this table restates the table, and does it
+          without the one thing the table adds: what each measurement did to
+          the score. `CommitsLede` skipped its ribbon for the same reason. */}
+      <OverviewSection
+        className="mt-7"
+        title="What changed, and what it cost"
+        description="Every measurement the model reads, and the exact signed points each one moved the raw score by. Red raised it, green lowered it, both against the model's baseline commit."
+      >
         <RiskDriverBreakdown drivers={c.drivers} />
-      </div>
+      </OverviewSection>
     </div>
   );
+}
+
+/**
+ * The sentence that makes the score mean something.
+ *
+ * It leads with where the commit sits in this repo rather than with the raw
+ * number, because the raw number is anchored to a calibration corpus and skews
+ * high on any repo whose typical commit is large — this index has 296 of 884
+ * commits in the top tercile and a score distribution piled against the 10
+ * ceiling. The percentile is deliberately absent: the queue row the reader
+ * arrived from already carried it.
+ */
+function riskSentence(c: CommitDetail, reviewCut: number | null | undefined): string {
+  const tercile: Record<string, string> = {
+    high: "sits in the top third of this repo's own risk distribution, the band worth reviewing",
+    moderate:
+      "sits in the middle third of this repo's own risk distribution, so it is about as risky as the work around it",
+    low: "sits in the bottom third of this repo's own risk distribution",
+  };
+  let out = `This commit ${tercile[c.review_priority] ?? tercile.moderate}`;
+
+  // `high_cut` is the moderate/high boundary and nothing else, so it only
+  // describes where *this* commit's band begins when the commit is in the top
+  // one. Appending it to a moderate commit would name the middle third's floor
+  // as a number that is actually its ceiling.
+  if (reviewCut != null && c.review_priority === "high") {
+    out += `, which here starts at ${reviewCut.toFixed(1)} out of 10`;
+  }
+  out += ".";
+
+  if (c.change_risk_score != null) {
+    // `drivers` arrive strongest-first, and only the risk-raising ones explain
+    // why the score landed where it did.
+    const raising = c.drivers.filter((d) => d.value !== null && d.contribution > 0);
+    if (raising.length === 0) {
+      out += " The raw score stays low across every driver.";
+    } else {
+      // The same wording as the table below, not the server's baseline-relative
+      // labels. Two vocabularies for one set of drivers, a paragraph apart,
+      // reads as two different lists.
+      const reasons = raising.slice(0, 2).map(describeDriver).join(" and ");
+      out += ` What pushed the raw score up was mainly ${reasons}. That score is measured against the model's baseline commit rather than against this repo, so read it as the shape of the change rather than a verdict on it.`;
+    }
+  }
+
+  if (!c.agent_name && isNewContributor(c.author_commit_count)) {
+    out += " The author is new to this code.";
+  }
+  return out;
 }

--- a/packages/ui/src/commits/commit-distribution.tsx
+++ b/packages/ui/src/commits/commit-distribution.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+import type { Commit, CommitStats } from "@repowise-dev/types/git";
+import { CommitRiskHistogram } from "./commit-risk-histogram";
+import { CommitRiskScatter } from "./commit-risk-scatter";
+
+export interface CommitDistributionProps {
+  stats: CommitStats | null;
+  /** A recency sample, not the risk-sorted feed — see the note below. */
+  recent: Commit[];
+  /** Opening one commit. The host decides what that means. */
+  onSelect?: ((sha: string) => void) | undefined;
+}
+
+/**
+ * The two views of how the change-risk score behaves in this repo.
+ *
+ * They stay a pair. The histogram says where the tercile cuts fall, the
+ * scatter says what commit shape lands you above them, and neither answers the
+ * question alone — showing one leaves a half-width chart beside dead space,
+ * which is the empty state the old collapsible produced whenever a repo
+ * predated the histogram aggregate.
+ *
+ * This lives in the shared package rather than in the web app because it is
+ * mostly *content*: two headings and two paragraphs explaining a scoring model
+ * that behaves identically wherever it runs. Left in the app, a second surface
+ * showing the same charts had to copy the prose, and a copied explanation of a
+ * model is an explanation that drifts out of step with it.
+ *
+ * Portability: it takes data and one callback. The host owns how a selected
+ * commit is expressed — the OSS web app writes `?commit=` for its detail sheet
+ * to pick up — so there is no platform flag here and no dead branch.
+ */
+export function CommitDistribution({ stats, recent, onSelect }: CommitDistributionProps) {
+  const hasHistogram = (stats?.risk_histogram?.length ?? 0) > 0;
+  if (!hasHistogram || !stats || recent.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-1 gap-7 lg:grid-cols-2 lg:gap-10">
+      <div className="flex flex-col gap-2">
+        <h3 className="text-[13px] font-semibold text-[var(--color-text-primary)]">
+          Score distribution
+        </h3>
+        <p className="max-w-[62ch] text-xs leading-relaxed text-[var(--color-text-tertiary)]">
+          Every scored commit, binned on the raw 0 to 10 score rather than the
+          percentile. Percentile ranks are uniform by construction, so that axis
+          has no shape to draw. The dashed lines are the tercile cuts behind each
+          row&apos;s priority pill.
+        </p>
+        <CommitRiskHistogram stats={stats} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <h3 className="text-[13px] font-semibold text-[var(--color-text-primary)]">
+          Size against diffusion
+        </h3>
+        <p className="max-w-[62ch] text-xs leading-relaxed text-[var(--color-text-tertiary)]">
+          The {recent.length.toLocaleString()} most recent commits, on their own
+          recency sample rather than the feed above: that defaults to risk-sorted,
+          so reusing it would plot only the top tercile and call it the spread.
+          Big and scattered is what the model penalises.
+          {onSelect ? " Click a dot to open it." : ""}
+        </p>
+        <CommitRiskScatter commits={recent} onSelect={onSelect} />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/commits/commit-risk-scatter.tsx
+++ b/packages/ui/src/commits/commit-risk-scatter.tsx
@@ -41,7 +41,7 @@ export function CommitRiskScatter({
   className,
 }: {
   commits: Commit[];
-  onSelect?: (sha: string) => void;
+  onSelect?: ((sha: string) => void) | undefined;
   className?: string;
 }) {
   const [hover, setHover] = React.useState<string | null>(null);

--- a/packages/ui/src/commits/index.ts
+++ b/packages/ui/src/commits/index.ts
@@ -9,3 +9,4 @@ export * from "./agent-badge";
 export * from "./agent-trend-strip";
 export * from "./commit-risk-histogram";
 export * from "./commit-risk-scatter";
+export * from "./commit-distribution";

--- a/packages/ui/src/commits/risk-driver-breakdown.tsx
+++ b/packages/ui/src/commits/risk-driver-breakdown.tsx
@@ -1,4 +1,5 @@
 import { cn } from "../lib/cn";
+import { formatLOC } from "../lib/format";
 import type { RiskDriver } from "@repowise-dev/types/git";
 
 export interface RiskDriverBreakdownProps {
@@ -7,10 +8,60 @@ export interface RiskDriverBreakdownProps {
 }
 
 /**
- * Per-feature change-risk attribution. The model is a linear logistic, so each
- * driver's signed contribution is exact: positive (red, right) pushed risk up,
- * negative (green, left) pulled it down. Bars are scaled to the strongest
- * contribution in the set. NaN-valued (unknown) features are skipped.
+ * Restates a driver as what it did, not as what it is.
+ *
+ * The server's labels describe the *input* relative to the model's baseline
+ * commit: "more files than baseline". The bar and the signed figure beside it
+ * describe the *effect* on the score. On a real commit those two disagree on
+ * three rows out of seven — "more files than baseline" carries −1.12 and
+ * renders green — so a reader following the colour reads the row backwards.
+ * Naming the measured value instead ("311 files touched") leaves the direction
+ * to the one place that encodes it.
+ *
+ * Falls back to the server's label for any feature this does not know, so a
+ * new driver appears with its own wording rather than disappearing.
+ */
+export function describeDriver(driver: RiskDriver): string {
+  const v = driver.value;
+  if (v === null) return driver.label;
+  const n = Math.round(v);
+  switch (driver.feature) {
+    case "la":
+      return `${formatLOC(n)} lines added`;
+    case "ld":
+      return n === 0 ? "nothing deleted" : `${formatLOC(n)} lines deleted`;
+    case "nf":
+      return `${n.toLocaleString()} ${n === 1 ? "file" : "files"} touched`;
+    case "nd":
+      return `${n.toLocaleString()} ${n === 1 ? "directory" : "directories"} touched`;
+    case "ns":
+      return `${n.toLocaleString()} ${n === 1 ? "subsystem" : "subsystems"} touched`;
+    case "entropy":
+      // Shannon entropy of the per-file churn, in bits and not normalised:
+      // k equally-changed files score log2(k), so every bit is a doubling of
+      // how widely the change spread.
+      return `spread of ${v.toFixed(2)} bits across its files`;
+    case "exp":
+      return n === 0
+        ? "author's first commit here"
+        : `author had ${n.toLocaleString()} prior ${n === 1 ? "commit" : "commits"}`;
+    default:
+      return driver.label;
+  }
+}
+
+/**
+ * Per-feature change-risk attribution.
+ *
+ * The model is a linear logistic, so each driver's signed contribution is
+ * exact: positive (red, right of the baseline) pushed the score up, negative
+ * (green, left) pulled it down. Bars are scaled to the strongest contribution
+ * in the set. Features whose value is unknown are skipped.
+ *
+ * Rendered as a table rather than a flex row of `w-28 truncate` labels. The
+ * label is the primary column here, and it was losing the end of every driver
+ * it named to an ellipsis at exactly the width where the wording stops being
+ * guessable.
  */
 export function RiskDriverBreakdown({ drivers, className }: RiskDriverBreakdownProps) {
   const shown = drivers.filter((d) => d.value !== null);
@@ -19,45 +70,73 @@ export function RiskDriverBreakdown({ drivers, className }: RiskDriverBreakdownP
   const maxAbs = Math.max(...shown.map((d) => Math.abs(d.contribution)), 1e-6);
 
   return (
-    <div className={cn("space-y-1.5", className)}>
-      {shown.map((d) => {
-        const pct = (Math.abs(d.contribution) / maxAbs) * 50; // half-width per side
-        const raises = d.contribution >= 0;
-        return (
-          <div key={d.feature} className="flex items-center gap-2 text-xs">
-            <span
-              className="w-28 shrink-0 truncate text-[var(--color-text-secondary)]"
-              title={d.label}
-            >
-              {d.label}
-            </span>
-            {/* Diverging bar centered on a zero baseline. */}
-            <div className="relative h-3 flex-1 rounded bg-[var(--color-bg-elevated)]">
-              <div className="absolute inset-y-0 left-1/2 w-px bg-[var(--color-border-default)]" />
-              <div
+    <table className={cn("w-full border-collapse text-xs", className)}>
+      <caption className="sr-only">
+        Each measurement the change-risk model reads, and its signed contribution
+        to this commit&apos;s raw score
+      </caption>
+      <thead>
+        <tr>
+          <th
+            scope="col"
+            className="border-b border-[var(--color-border-default)] pb-2 pr-3 text-left font-mono text-[10px] font-normal uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]"
+          >
+            Measurement
+          </th>
+          <th className="max-sm:hidden" />
+          <th
+            scope="col"
+            title="Signed points on the raw 0 to 10 score, against the model's baseline commit"
+            className="cursor-help border-b border-[var(--color-border-default)] pb-2 pl-3 text-right font-mono text-[10px] font-normal uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]"
+          >
+            Points
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {shown.map((d) => {
+          const width = (Math.abs(d.contribution) / maxAbs) * 50; // half-width per side
+          const raises = d.contribution >= 0;
+          return (
+            <tr key={d.feature} className="border-b border-[var(--color-border-default)] last:border-0">
+              <td className="py-2 pr-3 align-middle text-[var(--color-text-secondary)] [text-wrap:pretty]">
+                {describeDriver(d)}
+              </td>
+              {/* The bar is the redundant encoding — the signed figure and its
+                  colour already carry direction — so it is the first thing to
+                  yield when the label needs the width. */}
+              <td className="w-[120px] px-3 align-middle max-sm:hidden">
+                <span className="relative block h-1.5 rounded-full bg-[var(--color-bg-inset)]">
+                  <span
+                    aria-hidden
+                    className="absolute inset-y-[-2px] left-1/2 w-px bg-[var(--color-border-hover)]"
+                  />
+                  <span
+                    className={cn(
+                      "absolute inset-y-0 rounded-full",
+                      raises ? "bg-[var(--color-error)]" : "bg-[var(--color-success)]",
+                    )}
+                    style={
+                      raises
+                        ? { left: "50%", width: `${width}%` }
+                        : { right: "50%", width: `${width}%` }
+                    }
+                  />
+                </span>
+              </td>
+              <td
                 className={cn(
-                  "absolute inset-y-0 rounded",
-                  raises ? "bg-[var(--color-error)]/60" : "bg-[var(--color-success)]/60",
+                  "whitespace-nowrap py-2 pl-3 text-right align-middle tabular-nums",
+                  raises ? "text-[var(--color-error)]" : "text-[var(--color-success)]",
                 )}
-                style={
-                  raises
-                    ? { left: "50%", width: `${pct}%` }
-                    : { right: "50%", width: `${pct}%` }
-                }
-              />
-            </div>
-            <span
-              className={cn(
-                "w-12 shrink-0 text-right tabular-nums",
-                raises ? "text-[var(--color-error)]" : "text-[var(--color-success)]",
-              )}
-            >
-              {raises ? "+" : ""}
-              {d.contribution.toFixed(2)}
-            </span>
-          </div>
-        );
-      })}
-    </div>
+              >
+                {raises ? "+" : "−"}
+                {Math.abs(d.contribution).toFixed(2)}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
   );
 }

--- a/packages/ui/src/owners/owner-profile.tsx
+++ b/packages/ui/src/owners/owner-profile.tsx
@@ -1,601 +1,642 @@
-"use client";
-
-import { useMemo } from "react";
-import {
-  Flame,
-  ShieldAlert,
-  Trash2,
-  GitCommit,
-  Calendar,
-  Users,
-  Folder,
-  TrendingUp,
-  Bot,
-} from "lucide-react";
+import * as React from "react";
 import type {
   OwnerProfile,
   OwnerFileEntry,
   OwnerModuleRollup,
   OwnerCoAuthor,
 } from "@repowise-dev/types/owners";
-import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
-import { Badge } from "../ui/badge";
+import { PageLede } from "../shared/page-lede";
+import { OverviewSection, SectionLink } from "../overview/section";
+import { ReadsColumn, type ReadItem } from "../overview/reads-column";
+import { StatRibbon, type RibbonStat } from "../stats/stat-ribbon";
 import { EmptyState } from "../shared/empty-state";
-import {
-  ResponsiveTable,
-  type ResponsiveColumn,
-} from "../shared/responsive-table";
-import { cn } from "../lib/cn";
-import { truncatePath, formatRelativeTimeOrNull } from "../lib/format";
-import { AgentTierBar } from "../git/agent-tier-bar";
+import { rampStep } from "../lib/ramp";
+import { formatCompact, formatRelativeTimeOrNull } from "../lib/format";
 import { OwnerAvatar } from "./owner-avatar";
 
-const dateFormatter = new Intl.DateTimeFormat(undefined, {
-  year: "numeric",
-  month: "short",
-  day: "numeric",
-});
-
-function fmtDate(iso: string | null): string {
-  if (!iso) return "—";
-  const t = new Date(iso);
-  return Number.isNaN(t.getTime()) ? "—" : dateFormatter.format(t);
-}
-
-function fmtCompact(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return n.toLocaleString();
-}
-
-const timeAgo = (iso: string | null) => formatRelativeTimeOrNull(iso, "never");
+/**
+ * The contributor profile, rebuilt on the section style.
+ *
+ * It was nine bordered containers at near-identical weight — a header card, a
+ * four-tile risk strip, and five more cards in a 2 + 1 grid — so the page had
+ * nothing to lead with and no way to say which of the nine mattered.
+ *
+ * Three things drove the rewrite, all of them measured against a real index
+ * before being changed rather than after:
+ *
+ * 1. **Every marker fired on nearly every row.** The hotspot flame hit 80% /
+ *    70% / 55% of the top files for the three contributors with real history;
+ *    the churn pill's red band hit 80% / 85% / 55%; the bus-factor scale's
+ *    green band had no members at all. A badge most rows carry says nothing.
+ *    The one marker left is hotspot *and* sole owner *and* ≥90% of the file's
+ *    commits, which lands on 25% / 25% / 15% and names a single thing: a
+ *    high-churn file this person alone maintains.
+ *
+ * 2. **Colour was doing work it is not allowed to do.** Lines added rendered
+ *    green and lines deleted red, as though deleting code were an error; churn
+ *    percentile and bus factor got the health triad for what are plain counts.
+ *    Green / amber / red belong to health bands. What is left uses the accent
+ *    ramp, where position carries magnitude.
+ *
+ * 3. **The figures restated each other.** Modules was a headline tile *and* a
+ *    section; co-authors was a headline tile *and* a section. Each figure in
+ *    this file now appears exactly once, in the place that can explain it:
+ *    sole ownership in the lede, the three secondary reads in the column beside
+ *    it, five volume figures in the ribbon, and the rest inside the section
+ *    that owns the subject.
+ *
+ * Server-renderable: no state, no handlers, `hrefFor*` instead of `onSelect*`.
+ * Every row is then a real URL that survives a middle-click, and the page above
+ * it stops needing a client boundary.
+ */
 
 export interface OwnerProfileViewProps {
   owner: OwnerProfile;
-  onSelectFile?: (filePath: string) => void;
-  onSelectModule?: (modulePath: string) => void;
-  onSelectCoAuthor?: (coAuthor: OwnerCoAuthor) => void;
-  /** Optional renderer for the embedded blast-radius / activity preview. */
-  rightRail?: React.ReactNode;
+  /** `/repos/{id}` — the prefix for every drill-in on this page. */
+  base: string;
+  hrefForFile?: ((filePath: string) => string) | undefined;
+  hrefForModule?: ((modulePath: string) => string) | undefined;
+  hrefForCoAuthor?: ((coAuthor: OwnerCoAuthor) => string) | undefined;
+  LinkComponent?: React.ElementType | undefined;
 }
 
 /**
- * Engineering-leader contributor profile. All data comes from the
- * /api/repos/{id}/owners/{key} endpoint — no client-side aggregation.
+ * A break opportunity after each path separator.
  *
- * Layout:
- *  - Header: avatar, headline metrics, time-on-codebase line
- *  - Risk strip: silos / bus-factor / dead-code / hotspots, color-coded
- *  - Two-column body: top files + modules (left), co-authors + categories (right)
+ * Without it a 72-character path in a narrow column breaks mid-identifier and
+ * wraps to ten lines; with it, it breaks between directories and wraps to two.
+ * `<wbr>` rather than a zero-width space so the path is still clean when it is
+ * copied out of the page.
  */
-export function OwnerProfileView({
-  owner,
-  onSelectFile,
-  onSelectModule,
-  onSelectCoAuthor,
-  rightRail,
-}: OwnerProfileViewProps) {
-  const tenureDays = useMemo(() => {
-    if (!owner.first_commit_at) return null;
-    const start = new Date(owner.first_commit_at).getTime();
-    if (Number.isNaN(start)) return null;
-    return Math.max(0, Math.floor((Date.now() - start) / 86_400_000));
-  }, [owner.first_commit_at]);
-
-  const categories = useMemo(
-    () =>
-      Object.entries(owner.commit_categories || {})
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, 6),
-    [owner.commit_categories],
-  );
-  const categoryTotal = categories.reduce((s, [, n]) => s + n, 0) || 1;
-
+function PathText({ path }: { path: string }) {
+  const segments = path.split("/");
   return (
-    <div className="space-y-6">
-      {/* ---------- Header ---------- */}
-      <Card>
-        <CardContent className="p-5">
-          <div className="flex flex-wrap items-start gap-5">
-            <OwnerAvatar name={owner.name} email={owner.email} size="lg" />
-            <div className="flex-1 min-w-0">
-              <h1 className="flex flex-wrap items-center gap-2 text-2xl font-bold text-[var(--color-text-primary)]">
-                {owner.name}
-                {tenureDays !== null && tenureDays < 90 && (
-                  <Badge variant="outline" className="text-[10px] font-medium">
-                    new to this repo
-                  </Badge>
-                )}
-              </h1>
-              {owner.email && (
-                <a
-                  href={`mailto:${owner.email}`}
-                  className="text-sm text-[var(--color-text-secondary)] hover:underline"
-                >
-                  {owner.email}
-                </a>
-              )}
-              <p className="mt-2 text-xs text-[var(--color-text-tertiary)]">
-                <Calendar className="inline h-3 w-3 mr-1" />
-                {tenureDays !== null
-                  ? `${tenureDays.toLocaleString()} days on this repo`
-                  : "tenure unknown"}{" "}
-                · first commit {fmtDate(owner.first_commit_at)} · last touched{" "}
-                {timeAgo(owner.last_commit_at)}
-              </p>
-            </div>
-          </div>
-
-          <div className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-6">
-            <Headline label="Files owned" value={owner.files_owned} />
-            <Headline label="Modules" value={owner.modules.length} />
-            <Headline
-              label="Commits / 90d"
-              value={owner.commit_count_90d}
-              icon={<GitCommit className="h-3.5 w-3.5" />}
-            />
-            <Headline
-              label="Lines added (est)"
-              value={fmtCompact(owner.lines_added_90d_est)}
-              tone="add"
-            />
-            <Headline
-              label="Lines deleted (est)"
-              value={fmtCompact(owner.lines_deleted_90d_est)}
-              tone="del"
-            />
-            <Headline label="Co-authors" value={owner.co_authors.length} />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* ---------- Risk strip ---------- */}
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <RiskTile
-          icon={<Users className="h-4 w-4 text-[var(--color-warning)]" />}
-          label="Silo modules"
-          value={owner.silo_modules}
-          help="modules where this person owns >80% of files"
-          tone={owner.silo_modules > 0 ? "warn" : "ok"}
-        />
-        <RiskTile
-          icon={<ShieldAlert className="h-4 w-4 text-[var(--color-error)]" />}
-          label="Bus-factor risk"
-          value={owner.bus_factor_risk_files}
-          help="files with bus_factor ≤ 1 that they own"
-          tone={owner.bus_factor_risk_files > 0 ? "danger" : "ok"}
-        />
-        <RiskTile
-          icon={<Flame className="h-4 w-4 text-[var(--color-warning)]" />}
-          label="Hotspots owned"
-          value={owner.hotspots_owned}
-          help="high-churn files where they are primary owner"
-          tone={owner.hotspots_owned > 0 ? "warn" : "ok"}
-        />
-        <RiskTile
-          icon={<Trash2 className="h-4 w-4 text-[var(--color-text-tertiary)]" />}
-          label="Dead-code burden"
-          value={`${owner.dead_code_files_owned} files · ${fmtCompact(owner.dead_code_lines_owned)} lines`}
-          help="dead code findings whose primary owner is this person"
-          tone={owner.dead_code_files_owned > 0 ? "muted" : "ok"}
-        />
-      </div>
-
-      {/* ---------- Body ---------- */}
-      <div className="grid gap-4 lg:grid-cols-3">
-        <div className="space-y-4 lg:col-span-2">
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm flex items-center gap-1.5">
-                <Folder className="h-4 w-4" /> Modules
-              </CardTitle>
-              <p className="text-xs text-[var(--color-text-tertiary)]">
-                Where this person spends their time. Bars show their share of the module.
-              </p>
-            </CardHeader>
-            <CardContent className="pt-0 space-y-1.5">
-              {owner.modules.slice(0, 12).map((m) => (
-                <ModuleRow key={m.module_path} mod={m} onClick={() => onSelectModule?.(m.module_path)} />
-              ))}
-              {owner.modules.length > 12 && (
-                <p className="px-2 pt-1 text-[10px] text-[var(--color-text-tertiary)]">
-                  +{owner.modules.length - 12} more modules not shown
-                </p>
-              )}
-              {owner.modules.length === 0 && (
-                <EmptyState
-                  className="p-6"
-                  title="No module attribution yet"
-                  description="Module ownership appears after the next git sync."
-                />
-              )}
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm flex items-center gap-1.5">
-                <TrendingUp className="h-4 w-4" /> Top files
-              </CardTitle>
-              <p className="text-xs text-[var(--color-text-tertiary)]">
-                Files this person touches most, ordered by attributed commit count.
-              </p>
-            </CardHeader>
-            <CardContent className="pt-0">
-              <FileTable files={owner.top_files} onSelectFile={onSelectFile} />
-              {(owner.files_touched_total ?? 0) > Math.min(owner.top_files.length, 20) && (
-                <p className="pt-2 text-[10px] text-[var(--color-text-tertiary)]">
-                  +{(owner.files_touched_total ?? 0) - Math.min(owner.top_files.length, 20)}{" "}
-                  more files touched, not shown
-                </p>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-
-        <div className="space-y-4">
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm flex items-center gap-1.5">
-                <Users className="h-4 w-4" /> Co-authors
-              </CardTitle>
-              <p className="text-xs text-[var(--color-text-tertiary)]">
-                People who edit the same files. Strong overlap = natural reviewer.
-              </p>
-              {owner.co_authors.filter((c) => c.co_change_strength >= 0.3).length > 0 && (
-                <p className="text-[10px] text-[var(--color-text-secondary)]">
-                  Would review well for this person&apos;s changes:{" "}
-                  {owner.co_authors
-                    .filter((c) => c.co_change_strength >= 0.3)
-                    .slice(0, 2)
-                    .map((c) => c.name)
-                    .join(", ")}
-                </p>
-              )}
-            </CardHeader>
-            <CardContent className="pt-0 space-y-1.5">
-              {owner.co_authors.slice(0, 10).map((c) => (
-                <button
-                  key={c.email ?? c.name}
-                  onClick={() => onSelectCoAuthor?.(c)}
-                  className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs hover:bg-[var(--color-bg-elevated)]"
-                >
-                  <OwnerAvatar name={c.name} email={c.email} size="sm" />
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate font-medium text-[var(--color-text-primary)]">
-                      {c.name}
-                    </div>
-                    <div className="text-[10px] text-[var(--color-text-tertiary)]">
-                      {c.shared_files} shared {c.shared_files === 1 ? "file" : "files"} ·{" "}
-                      {(c.co_change_strength * 100).toFixed(0)}% overlap
-                    </div>
-                  </div>
-                  <div className="h-1 w-12 overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
-                    <div
-                      className="h-full bg-[var(--color-accent-primary)]"
-                      style={{ width: `${Math.min(100, c.co_change_strength * 100)}%` }}
-                    />
-                  </div>
-                </button>
-              ))}
-              {(owner.co_authors_total ?? owner.co_authors.length) >
-                Math.min(owner.co_authors.length, 10) && (
-                <p className="px-2 pt-1 text-[10px] text-[var(--color-text-tertiary)]">
-                  +
-                  {(owner.co_authors_total ?? owner.co_authors.length) -
-                    Math.min(owner.co_authors.length, 10)}{" "}
-                  more co-authors not shown
-                </p>
-              )}
-              {owner.co_authors.length === 0 && (
-                <EmptyState
-                  className="p-6"
-                  title="No co-authors detected"
-                  description="Nobody else edits the files this person owns."
-                />
-              )}
-            </CardContent>
-          </Card>
-
-          {owner.agent_collab && owner.agent_collab.agent_commit_count > 0 && (
-            <Card>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm flex items-center gap-1.5">
-                  <Bot className="h-4 w-4" /> Agent collaboration
-                </CardTitle>
-                <p className="text-xs text-[var(--color-text-tertiary)]">
-                  Coding-agent activity on the files this person owns.
-                </p>
-              </CardHeader>
-              <CardContent className="pt-0 space-y-2 text-xs">
-                <div className="flex items-center justify-between">
-                  <span className="text-[var(--color-text-secondary)]">
-                    Agent-attributed commits
-                  </span>
-                  <span className="tabular-nums font-medium text-[var(--color-text-primary)]">
-                    {owner.agent_collab.agent_commit_count}
-                    {owner.agent_collab.agent_share_pct != null &&
-                      ` (${Math.round(owner.agent_collab.agent_share_pct)}%)`}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-[var(--color-text-secondary)]">
-                    Owned files with agent commits
-                  </span>
-                  <span className="tabular-nums font-medium text-[var(--color-text-primary)]">
-                    {owner.agent_collab.files_with_agent_commits}
-                  </span>
-                </div>
-                {Object.keys(owner.agent_collab.tier_counts).length > 0 && (
-                  <div className="pt-1">
-                    <AgentTierBar tierCounts={owner.agent_collab.tier_counts} />
-                  </div>
-                )}
-              </CardContent>
-            </Card>
+    <span className="font-mono text-xs text-[var(--color-text-primary)] transition-colors group-hover:text-[var(--color-accent-primary)] [overflow-wrap:anywhere]">
+      {segments.map((seg, i) => (
+        <React.Fragment key={i}>
+          {i > 0 && (
+            <>
+              /<wbr />
+            </>
           )}
-
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm">Commit mix</CardTitle>
-              <p className="text-xs text-[var(--color-text-tertiary)]">
-                Classification of commits across files this person touches.
-              </p>
-            </CardHeader>
-            <CardContent className="pt-0">
-              {categories.length === 0 ? (
-                <EmptyState
-                  className="p-6"
-                  title="No category data"
-                  description="Commit classification runs during indexing."
-                />
-              ) : (
-                <div className="space-y-2">
-                  {categories.map(([cat, n]) => (
-                    <div key={cat}>
-                      <div className="flex items-center justify-between text-xs">
-                        <span className="capitalize text-[var(--color-text-secondary)]">
-                          {cat}
-                        </span>
-                        <span className="tabular-nums text-[var(--color-text-tertiary)]">
-                          {n}
-                        </span>
-                      </div>
-                      <div className="mt-1 h-1 overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
-                        <div
-                          className={cn("h-full", categoryColor(cat))}
-                          style={{ width: `${(n / categoryTotal) * 100}%` }}
-                        />
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          {rightRail}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Building blocks
-// ---------------------------------------------------------------------------
-
-function Headline({
-  label,
-  value,
-  tone,
-  icon,
-}: {
-  label: string;
-  value: string | number;
-  tone?: "add" | "del";
-  icon?: React.ReactNode;
-}) {
-  const color =
-    tone === "add"
-      ? "text-[var(--color-success)]"
-      : tone === "del"
-        ? "text-[var(--color-error)]"
-        : "text-[var(--color-text-primary)]";
-  return (
-    <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] px-3 py-2">
-      <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider text-[var(--color-text-tertiary)]">
-        {icon}
-        {label}
-      </div>
-      <div className={`mt-1 text-xl font-bold tabular-nums ${color}`}>{value}</div>
-    </div>
-  );
-}
-
-function RiskTile({
-  icon,
-  label,
-  value,
-  help,
-  tone,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  value: number | string;
-  help: string;
-  tone: "ok" | "warn" | "danger" | "muted";
-}) {
-  const border =
-    tone === "danger"
-      ? "border-[var(--color-error)]/40 bg-[var(--color-error)]/5"
-      : tone === "warn"
-        ? "border-[var(--color-warning)]/40 bg-[var(--color-warning)]/5"
-        : tone === "muted"
-          ? "border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]"
-          : "border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]";
-  return (
-    <div className={cn("rounded-lg border p-3", border)}>
-      <div className="flex items-center gap-1.5 text-xs uppercase tracking-wider text-[var(--color-text-tertiary)]">
-        {icon}
-        {label}
-      </div>
-      <div className="mt-1.5 text-lg font-semibold text-[var(--color-text-primary)]">
-        {value}
-      </div>
-      <p className="mt-1 text-[10px] text-[var(--color-text-tertiary)]">{help}</p>
-    </div>
-  );
-}
-
-function ModuleRow({
-  mod,
-  onClick,
-}: {
-  mod: OwnerModuleRollup;
-  onClick: () => void;
-}) {
-  const share = Math.min(100, Math.max(0, mod.dominant_pct * 100));
-  return (
-    <button
-      onClick={onClick}
-      className="group flex w-full items-center gap-3 rounded-md px-2 py-1.5 hover:bg-[var(--color-bg-elevated)]"
-    >
-      <span className="flex-1 truncate text-left text-xs font-medium text-[var(--color-text-primary)]">
-        {mod.module_path}
-      </span>
-      {mod.hotspot_count > 0 && (
-        <Badge variant="outdated" className="text-[10px]">
-          <Flame className="mr-0.5 h-3 w-3" />
-          {mod.hotspot_count}
-        </Badge>
-      )}
-      <span className="w-12 text-right text-[10px] tabular-nums text-[var(--color-text-tertiary)]">
-        {mod.file_count} files
-      </span>
-      <div className="h-1.5 w-24 overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
-        <div
-          className={cn(
-            "h-full",
-            share > 80 ? "bg-[var(--color-warning)]" : "bg-[var(--color-accent-primary)]",
-          )}
-          style={{ width: `${share}%` }}
-        />
-      </div>
-      <span className="w-10 text-right text-[10px] tabular-nums text-[var(--color-text-tertiary)]">
-        {share.toFixed(0)}%
-      </span>
-    </button>
-  );
-}
-
-const FILE_COLUMNS: ResponsiveColumn<OwnerFileEntry>[] = [
-  {
-    key: "file_path",
-    header: "File",
-    priority: 1,
-    cellClassName: "max-w-[320px]",
-    render: (f) => (
-      <span className="flex items-center gap-1.5 truncate font-mono text-xs text-[var(--color-text-primary)]">
-        {f.is_hotspot && <Flame className="h-3 w-3 shrink-0 text-[var(--color-warning)]" />}
-        {truncatePath(f.file_path, 48)}
-      </span>
-    ),
-  },
-  {
-    key: "commit_count_90d",
-    header: "Commits / 90d",
-    mobileLabel: "Commits",
-    align: "right",
-    priority: 2,
-    cellClassName: "tabular-nums",
-    render: (f) => f.commit_count_90d,
-  },
-  {
-    key: "churn",
-    header: "Churn",
-    align: "right",
-    priority: 2,
-    cellClassName: "tabular-nums",
-    render: (f) => <ChurnPill value={f.churn_percentile} />,
-  },
-  {
-    key: "bus",
-    header: "Bus",
-    align: "right",
-    priority: 3,
-    cellClassName: "tabular-nums",
-    render: (f) => <BusBadge bf={f.bus_factor} />,
-  },
-  {
-    key: "touched",
-    header: "Touched",
-    align: "right",
-    priority: 3,
-    cellClassName: "text-[10px] text-[var(--color-text-tertiary)]",
-    render: (f) => timeAgo(f.last_commit_at),
-  },
-];
-
-function FileTable({
-  files,
-  onSelectFile,
-}: {
-  files: OwnerFileEntry[];
-  onSelectFile?: ((path: string) => void) | undefined;
-}) {
-  return (
-    <ResponsiveTable
-      columns={FILE_COLUMNS}
-      rows={files.slice(0, 20)}
-      rowKey={(f) => f.file_path}
-      onRowClick={onSelectFile ? (f) => onSelectFile(f.file_path) : undefined}
-      bare
-      empty={
-        <EmptyState
-          className="p-6"
-          title="No file attribution"
-          description="File-level ownership appears after the next git sync."
-        />
-      }
-    />
-  );
-}
-
-function ChurnPill({ value }: { value: number }) {
-  const v = Math.round(value);
-  const color =
-    v >= 80
-      ? "bg-[var(--color-error)]/20 text-[var(--color-error)]"
-      : v >= 50
-        ? "bg-[var(--color-warning)]/20 text-[var(--color-warning)]"
-        : "bg-[var(--color-bg-inset)] text-[var(--color-text-tertiary)]";
-  return (
-    <span className={cn("inline-block rounded px-1.5 py-0.5 text-[10px] tabular-nums", color)}>
-      {v}
+          {seg}
+        </React.Fragment>
+      ))}
     </span>
   );
 }
 
-function BusBadge({ bf }: { bf: number }) {
-  const color =
-    bf <= 1
-      ? "text-[var(--color-error)]"
-      : bf === 2
-        ? "text-[var(--color-warning)]"
-        : "text-[var(--color-success)]";
-  return <span className={cn("font-semibold", color)}>{bf}</span>;
+/**
+ * The only marker on the file table.
+ *
+ * Sole ownership on its own marks 80% of this contributor's files, and a
+ * hotspot flag 80% again, so either alone marks nothing. The conjunction — a
+ * high-churn file, no second author, and this person wrote at least 90% of its
+ * commits — lands on a quarter of rows at most and describes one specific
+ * situation worth acting on.
+ */
+function isSoleCarried(f: OwnerFileEntry): boolean {
+  return f.is_hotspot && f.bus_factor <= 1 && (f.primary_owner_commit_pct ?? 0) >= 0.9;
 }
 
-function categoryColor(category: string): string {
-  const map: Record<string, string> = {
-    feat: "bg-[var(--color-success)]",
-    fix: "bg-[var(--color-error)]",
-    refactor: "bg-[var(--color-accent-secondary)]",
-    docs: "bg-[var(--color-info)]",
-    test: "bg-[var(--color-accent-primary)]",
-    chore: "bg-[var(--color-text-tertiary)]",
-    perf: "bg-[var(--color-warning)]",
-  };
-  return map[category] ?? "bg-[var(--color-accent-primary)]";
+const pct = (part: number, whole: number): number =>
+  whole > 0 ? Math.round((part / whole) * 100) : 0;
+
+export function OwnerProfileView({
+  owner,
+  base,
+  hrefForFile,
+  hrefForModule,
+  hrefForCoAuthor,
+  LinkComponent,
+}: OwnerProfileViewProps) {
+  const solePct = pct(owner.bus_factor_risk_files, owner.files_owned);
+  const filesShown = owner.top_files.slice(0, 20);
+  const soleCarried = filesShown.filter(isSoleCarried).length;
+
+  // Every read here is a figure that appears nowhere else on the page, and
+  // every one is a link: this column doubles as navigation for someone who
+  // opened the profile for one specific thing.
+  const reads: ReadItem[] = [];
+  if (owner.dead_code_files_owned > 0) {
+    reads.push({
+      key: "dead",
+      label: "Dead code owned",
+      value: owner.dead_code_files_owned.toLocaleString(),
+      unit: "files",
+      why: `${owner.dead_code_lines_owned.toLocaleString()} unreachable lines still attributed here. Usually the cheapest thing on this page to act on.`,
+      href: `${base}/dead-code`,
+    });
+  }
+  if (owner.silo_modules > 0) {
+    reads.push({
+      key: "silos",
+      label: "Silo directories",
+      value: owner.silo_modules.toLocaleString(),
+      unit: owner.silo_modules === 1 ? "directory" : "directories",
+      why: "Top-level directories where this person owns more than 80% of the files, so a review has nobody obvious to route to.",
+      href: `${base}/ownership`,
+    });
+  }
+  if (owner.agent_collab && owner.agent_collab.agent_commit_count > 0) {
+    const a = owner.agent_collab;
+    reads.push({
+      key: "agent",
+      label: "Agent-assisted",
+      value: a.agent_commit_count.toLocaleString(),
+      unit: "commits",
+      why:
+        (a.agent_share_pct != null
+          ? `${a.agent_share_pct.toFixed(2)}% of the commits on their owned files carry a coding-agent trailer. `
+          : "Read from commit trailers, so it counts what was declared. ") +
+        `${a.files_with_agent_commits.toLocaleString()} owned ${a.files_with_agent_commits === 1 ? "file has" : "files have"} one.`,
+      href: `${base}/commits`,
+    });
+  }
+
+  // Volume figures, none of which appear in the lede, the reads column or a
+  // section below. The two line counts are the payload's `_est` fields, so an
+  // exact six-digit figure would claim a precision the number does not have.
+  const ribbon: RibbonStat[] = [
+    { label: "Commits, 90d", value: owner.commit_count_90d.toLocaleString() },
+    {
+      label: "Lines added",
+      value: formatCompact(owner.lines_added_90d_est),
+      hint: "Estimated from commit stats over the last 90 days",
+    },
+    {
+      label: "Lines removed",
+      value: formatCompact(owner.lines_deleted_90d_est),
+      hint: "Estimated from commit stats over the last 90 days",
+    },
+    {
+      label: "Files touched",
+      value: (owner.files_touched_total ?? owner.top_files.length).toLocaleString(),
+      hint: "Files with at least one commit attributed to this person",
+    },
+    {
+      label: "High-churn owned",
+      value: owner.hotspots_owned.toLocaleString(),
+      hint: "Owned files that are also in the repo's high-churn band",
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-6 sm:gap-8">
+      <section className="grid grid-cols-1 items-start gap-6 lg:grid-cols-[minmax(0,1fr)_300px] lg:gap-10">
+        <PageLede
+          label="Sole-owned files"
+          value={owner.bus_factor_risk_files.toLocaleString()}
+          unit={`of ${owner.files_owned.toLocaleString()} owned`}
+          action={
+            <SectionLink href={`${base}/owners`} LinkComponent={LinkComponent}>
+              All contributors
+            </SectionLink>
+          }
+        >
+          <p>
+            {owner.bus_factor_risk_files > 0 ? (
+              <>
+                <strong className="font-semibold text-[var(--color-text-primary)]">
+                  {owner.bus_factor_risk_files.toLocaleString()} files
+                </strong>{" "}
+                where this person wrote most of the surviving lines and nobody
+                else has committed, which is {solePct}% of everything they own.
+                Ownership follows the surviving lines rather than the last
+                commit, so this is knowledge held rather than activity logged.
+              </>
+            ) : (
+              <>
+                Every one of the{" "}
+                {owner.files_owned.toLocaleString()} files this person owns has a
+                second author. Ownership follows the surviving lines rather than
+                the last commit, so this is knowledge held rather than activity
+                logged.
+              </>
+            )}
+          </p>
+        </PageLede>
+        <ReadsColumn items={reads} LinkComponent={LinkComponent} />
+      </section>
+
+      <StatRibbon stats={ribbon} />
+
+      <OwnershipFootprint
+        modules={owner.modules}
+        base={base}
+        hrefForModule={hrefForModule}
+        LinkComponent={LinkComponent}
+      />
+
+      <OverviewSection
+        title="Files they carry"
+        description={`The ${filesShown.length} ${filesShown.length === 1 ? "file" : "files"} with the most commits attributed to this person, of ${(owner.files_touched_total ?? owner.top_files.length).toLocaleString()} touched. Churn is a percentile against every file in the repo. A dot marks a high-churn file they alone maintain and wrote at least 90% of the commits for${soleCarried > 0 ? `: ${soleCarried} of these ${filesShown.length}` : ", and none of these qualify"}.`}
+      >
+        <OwnerFileTable
+          files={filesShown}
+          hrefForFile={hrefForFile}
+          LinkComponent={LinkComponent}
+        />
+      </OverviewSection>
+
+      <WorkingRelationships
+        coAuthors={owner.co_authors}
+        total={owner.co_authors_total ?? owner.co_authors.length}
+        hrefForCoAuthor={hrefForCoAuthor}
+        LinkComponent={LinkComponent}
+      />
+
+      <CommitMix categories={owner.commit_categories} />
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Where the ownership sits, as one stacked bar rather than a row of bars.
+ *
+ * The endpoint only attributes top-level directories, so this list is two to
+ * four entries on a real repo — this one has `packages`, `tests`, `scripts`
+ * and `docker`. Four rows each carrying a label, a count, a track and a
+ * percentage is more chrome than four numbers can pay for, and it invites the
+ * reader to compare bars that are all measuring different denominators. One
+ * bar shows the split, and the key carries the share.
+ *
+ * The ramp, not a hue per directory: these are ordered shares of one whole, so
+ * position is the encoding. Five unrelated colours for five directories is the
+ * language-donut anti-pattern.
+ */
+function OwnershipFootprint({
+  modules,
+  base,
+  hrefForModule,
+  LinkComponent,
+}: {
+  modules: OwnerModuleRollup[];
+  base: string;
+  hrefForModule?: ((modulePath: string) => string) | undefined;
+  LinkComponent?: React.ElementType | undefined;
+}) {
+  const A = LinkComponent ?? "a";
+  const ordered = [...modules].sort((a, b) => b.file_count - a.file_count);
+  const total = ordered.reduce((sum, m) => sum + m.file_count, 0);
+
+  return (
+    <OverviewSection
+      title="Where the ownership sits"
+      description="Share is the fraction of each directory's files where this person wrote most of the surviving lines. Only top-level directories are attributed, so this is a coarse map rather than a per-module one."
+      action={
+        <SectionLink href={`${base}/ownership`} LinkComponent={LinkComponent}>
+          Ownership
+        </SectionLink>
+      }
+    >
+      {total === 0 ? (
+        <EmptyState
+          className="p-6"
+          title="No directory attribution yet"
+          description="Ownership by directory appears after the next git sync."
+        />
+      ) : (
+        <>
+          <div className="flex h-2 w-full overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
+            {ordered.map((m, i) => (
+              <span
+                key={m.module_path}
+                title={`${m.module_path}: ${m.file_count.toLocaleString()} owned files`}
+                className="h-full"
+                style={{
+                  width: `${(m.file_count / total) * 100}%`,
+                  background: rampStep(i),
+                }}
+              />
+            ))}
+          </div>
+          <ul className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:gap-x-6 sm:gap-y-2">
+            {ordered.map((m, i) => {
+              const href = hrefForModule?.(m.module_path);
+              const label = (
+                <>
+                  <span
+                    aria-hidden
+                    className="h-2 w-2 shrink-0 rounded-[2px]"
+                    style={{ background: rampStep(i) }}
+                  />
+                  <span className="font-mono text-xs text-[var(--color-text-primary)] transition-colors group-hover:text-[var(--color-accent-primary)] [overflow-wrap:anywhere]">
+                    {m.module_path}
+                  </span>
+                  <span className="text-xs tabular-nums text-[var(--color-text-tertiary)]">
+                    {m.file_count.toLocaleString()}{" "}
+                    {m.file_count === 1 ? "file" : "files"} ·{" "}
+                    {Math.round(m.dominant_pct * 100)}% theirs
+                  </span>
+                </>
+              );
+              return (
+                <li key={m.module_path} className="min-w-0">
+                  {href ? (
+                    <A href={href} className="group flex items-center gap-2 no-underline">
+                      {label}
+                    </A>
+                  ) : (
+                    <span className="flex items-center gap-2">{label}</span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </OverviewSection>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The file table.
+ *
+ * Hand-rolled rather than `ResponsiveTable` for the same reason `OwnerTable`
+ * is: that primitive is a client component, and nothing here needs one.
+ *
+ * Below `sm` it stops being a table. Five columns cannot share 390px without
+ * starving the primary one, and the primary one is a file path that may not be
+ * truncated — so the path takes the full width and the four figures collapse
+ * into a single meta line beneath it.
+ */
+function OwnerFileTable({
+  files,
+  hrefForFile,
+  LinkComponent,
+}: {
+  files: OwnerFileEntry[];
+  hrefForFile?: ((filePath: string) => string) | undefined;
+  LinkComponent?: React.ElementType | undefined;
+}) {
+  const A = LinkComponent ?? "a";
+
+  if (files.length === 0) {
+    return (
+      <EmptyState
+        className="p-6"
+        title="No file attribution yet"
+        description="File-level ownership appears after the next git sync."
+      />
+    );
+  }
+
+  const headCls =
+    "border-b border-[var(--color-border-default)] pb-2 font-mono text-[10px] font-normal uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]";
+  const numCls = "whitespace-nowrap py-2.5 pl-3 text-right align-top tabular-nums max-sm:hidden";
+
+  return (
+    <div className="-mx-[var(--page-pad)] overflow-x-auto px-[var(--page-pad)] sm:mx-0 sm:px-0">
+      <table className="w-full border-collapse text-[13.5px]">
+        <thead className="max-sm:hidden">
+          <tr>
+            <th scope="col" className={`${headCls} pr-3 text-left`}>
+              File
+            </th>
+            <th scope="col" className={`${headCls} whitespace-nowrap pl-3 text-right`}>
+              Commits 90d
+            </th>
+            <th
+              scope="col"
+              title="Percentile rank of this file's change frequency against every file in the repo"
+              className={`${headCls} cursor-help whitespace-nowrap pl-3 text-right`}
+            >
+              Churn
+            </th>
+            <th
+              scope="col"
+              title="Share of this file's commits written by this person"
+              className={`${headCls} cursor-help whitespace-nowrap pl-3 text-right`}
+            >
+              Their commits
+            </th>
+            <th scope="col" className={`${headCls} whitespace-nowrap pl-3 text-right`}>
+              Touched
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {files.map((f) => {
+            const href = hrefForFile?.(f.file_path);
+            const ownPct =
+              f.primary_owner_commit_pct != null
+                ? `${Math.round(f.primary_owner_commit_pct * 100)}%`
+                : "—";
+            const touched = formatRelativeTimeOrNull(f.last_commit_at) ?? "—";
+            return (
+              <tr
+                key={f.file_path}
+                className="border-b border-[var(--color-border-default)] hover:bg-[var(--color-bg-elevated)] max-sm:block"
+              >
+                <td className="py-2.5 pr-3 align-top max-sm:block max-sm:pr-0">
+                  {href ? (
+                    <A href={href} className="group no-underline">
+                      <PathText path={f.file_path} />
+                    </A>
+                  ) : (
+                    <PathText path={f.file_path} />
+                  )}
+                  {isSoleCarried(f) && (
+                    <span
+                      title="High-churn file this person alone maintains"
+                      className="ml-1.5 inline-block h-[5px] w-[5px] shrink-0 rounded-full bg-[var(--color-warning)] align-middle"
+                    />
+                  )}
+                  {/* The four figures as one line, below `sm` only. Reads as a
+                      sentence rather than as a table row that lost its header. */}
+                  <span className="mt-1 hidden text-[11.5px] tabular-nums text-[var(--color-text-tertiary)] max-sm:block">
+                    {f.commit_count_90d.toLocaleString()} commits in 90d · churn{" "}
+                    {Math.round(f.churn_percentile)} · {ownPct} of its commits ·
+                    touched {touched}
+                  </span>
+                </td>
+                <td className={numCls}>{f.commit_count_90d.toLocaleString()}</td>
+                <td className={`${numCls} text-[var(--color-text-tertiary)]`}>
+                  {Math.round(f.churn_percentile)}
+                </td>
+                <td className={`${numCls} text-[var(--color-text-tertiary)]`}>{ownPct}</td>
+                <td className={`${numCls} text-[var(--color-text-tertiary)]`}>{touched}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Who else works in the same files.
+ *
+ * A list of ten was the wrong shape for this data. Overlap on a real repo is
+ * one partner and then a cliff — 15.8%, then 1.6%, 1.2%, 1.0%, 0.8% — so rows
+ * two through ten are people who once touched the same file, presented at the
+ * same weight as the person who actually shares the work. The lead partner is
+ * the answer to the question the section exists for (who reviews this), and
+ * the tail is honestly reported as a count rather than padded out into rows.
+ */
+function WorkingRelationships({
+  coAuthors,
+  total,
+  hrefForCoAuthor,
+  LinkComponent,
+}: {
+  coAuthors: OwnerCoAuthor[];
+  total: number;
+  hrefForCoAuthor?: ((coAuthor: OwnerCoAuthor) => string) | undefined;
+  LinkComponent?: React.ElementType | undefined;
+}) {
+  const A = LinkComponent ?? "a";
+  const [lead, second] = [...coAuthors].sort(
+    (a, b) => b.co_change_strength - a.co_change_strength,
+  );
+
+  return (
+    <OverviewSection
+      title="Who else works here"
+      description="Contributors editing the same files. Overlap is the share of this person's files the other has also committed to, so it reads as how much of their work is genuinely shared."
+    >
+      {!lead ? (
+        <EmptyState
+          className="p-6"
+          title="Nobody else has touched these files"
+          description="Co-authorship appears once a second contributor commits to a file this person owns."
+        />
+      ) : (
+        <div className="flex flex-col gap-3">
+          <LeadPartner
+            coAuthor={lead}
+            href={hrefForCoAuthor?.(lead)}
+            LinkComponent={A}
+          />
+          <p className="max-w-[62ch] text-xs leading-relaxed text-[var(--color-text-tertiary)] [text-wrap:pretty]">
+            {total <= 1 ? (
+              <>No other contributor shares a file with this person.</>
+            ) : second ? (
+              <>
+                The next closest of {(total - 1).toLocaleString()} other
+                contributors overlaps on{" "}
+                {(second.co_change_strength * 100).toFixed(1)}%, so there is one
+                natural reviewer here rather than a shortlist.
+              </>
+            ) : (
+              <>
+                {(total - 1).toLocaleString()} other contributors share at least
+                one file.
+              </>
+            )}
+          </p>
+        </div>
+      )}
+    </OverviewSection>
+  );
+}
+
+function LeadPartner({
+  coAuthor,
+  href,
+  LinkComponent,
+}: {
+  coAuthor: OwnerCoAuthor;
+  href: string | undefined;
+  LinkComponent: React.ElementType;
+}) {
+  const A = LinkComponent;
+  const body = (
+    <>
+      <OwnerAvatar name={coAuthor.name} email={coAuthor.email} size="md" />
+      <span className="min-w-0">
+        {/* No truncation: the name is the primary column here and there is room
+            for it. */}
+        <span className="block font-medium text-[var(--color-text-primary)] transition-colors group-hover:text-[var(--color-accent-primary)] [text-wrap:pretty]">
+          {coAuthor.name || coAuthor.email || "unknown"}
+        </span>
+        <span className="block text-xs tabular-nums text-[var(--color-text-tertiary)]">
+          {coAuthor.shared_files.toLocaleString()} shared{" "}
+          {coAuthor.shared_files === 1 ? "file" : "files"} ·{" "}
+          {(coAuthor.co_change_strength * 100).toFixed(1)}% of this person&apos;s
+          work overlaps theirs
+        </span>
+      </span>
+    </>
+  );
+
+  return href ? (
+    <A
+      href={href}
+      className="group flex w-fit items-center gap-3 no-underline"
+    >
+      {body}
+    </A>
+  ) : (
+    <span className="flex items-center gap-3">{body}</span>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Commit mix, down the accent ramp.
+ *
+ * The colour map this replaced keyed on `feat`, `docs`, `test`, `chore` and
+ * `perf`. The endpoint returns `feature`, `fix`, `refactor` and `dependency`,
+ * so four of the five colours were unreachable and the largest category fell
+ * through to the default — a palette that had never once rendered as designed.
+ * Ordered shares of one whole want the ramp, where position is the magnitude,
+ * not a hue per category.
+ *
+ * Zero-count categories are dropped rather than rendered as an empty track:
+ * the endpoint returns the full key set, so a contributor who has never
+ * refactored was getting a labelled bar with nothing in it.
+ */
+function CommitMix({ categories }: { categories: Record<string, number> }) {
+  const entries = Object.entries(categories ?? {})
+    .filter(([, n]) => n > 0)
+    .sort((a, b) => b[1] - a[1]);
+  const total = entries.reduce((sum, [, n]) => sum + n, 0);
+
+  return (
+    <OverviewSection
+      title="What they commit"
+      description={
+        total > 0
+          ? `${total.toLocaleString()} commits classified from the subject line, across every file this person has touched.`
+          : "Commits are classified from the subject line during indexing."
+      }
+    >
+      {entries.length === 0 ? (
+        <EmptyState
+          className="p-6"
+          title="No classified commits yet"
+          description="Commit classification runs during indexing and fills this in on the next sync."
+        />
+      ) : (
+        <dl className="flex max-w-[420px] flex-col gap-3">
+          {entries.map(([category, n], i) => (
+            <div key={category}>
+              <div className="flex items-baseline justify-between gap-3 text-xs">
+                <dt className="capitalize text-[var(--color-text-secondary)]">{category}</dt>
+                <dd className="tabular-nums text-[var(--color-text-tertiary)]">
+                  {n.toLocaleString()} · {pct(n, total)}%
+                </dd>
+              </div>
+              <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-[var(--color-bg-inset)]">
+                <span
+                  className="block h-full"
+                  style={{ width: `${(n / total) * 100}%`, background: rampStep(i) }}
+                />
+              </div>
+            </div>
+          ))}
+        </dl>
+      )}
+    </OverviewSection>
+  );
 }

--- a/packages/ui/src/shared/page-lede.tsx
+++ b/packages/ui/src/shared/page-lede.tsx
@@ -17,6 +17,13 @@ export interface PageLedeProps {
   /** Trailing unit, quiet and small: "out of 10", "of 5,485 files". */
   unit?: string | undefined;
   band?: PageLedeBand | undefined;
+  /**
+   * An already-styled marker to sit on the figure's baseline, for callers whose
+   * band has its own component. Use instead of `band`, not as well: a
+   * `PriorityBadge` inside the chip would be two pieces of chrome around one
+   * word.
+   */
+  badge?: React.ReactNode;
   /** The sentence that makes the figure mean something. Load-bearing. */
   children: React.ReactNode;
   /** Optional jump into the page that owns the subject. */
@@ -42,6 +49,7 @@ export function PageLede({
   valueColor,
   unit,
   band,
+  badge,
   children,
   action,
 }: PageLedeProps) {
@@ -78,6 +86,7 @@ export function PageLede({
             {band.label}
           </span>
         )}
+        {badge}
       </div>
 
       <div className="mt-3.5 max-w-[54ch] text-[13px] leading-relaxed text-[var(--color-text-secondary)] [text-wrap:pretty]">

--- a/packages/web/src/app/repos/[id]/commits/page.tsx
+++ b/packages/web/src/app/repos/[id]/commits/page.tsx
@@ -122,7 +122,7 @@ export default async function CommitsPage({
         <CommitDistribution stats={stats} recent={recent?.items ?? []} />
       </OverviewSection>
 
-      <CommitDetailSheet repoId={id} />
+      <CommitDetailSheet repoId={id} reviewCut={stats?.high_cut} />
     </PageShell>
   );
 }

--- a/packages/web/src/app/repos/[id]/owners/[owner]/page.tsx
+++ b/packages/web/src/app/repos/[id]/owners/[owner]/page.tsx
@@ -1,69 +1,83 @@
-"use client";
-
-import { useParams, useRouter } from "next/navigation";
-import useSWR from "swr";
+import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowLeft, Users } from "lucide-react";
+import { Users } from "lucide-react";
+import { PageShell } from "@repowise-dev/ui/shared/page-shell";
+import { OwnerAvatar } from "@repowise-dev/ui/owners/owner-avatar";
 import { OwnerProfileView } from "@repowise-dev/ui/owners/owner-profile";
-import { fileEntityPath } from "@repowise-dev/ui/shared/entity";
-import { Skeleton } from "@repowise-dev/ui/ui/skeleton";
 import { EmptyState } from "@repowise-dev/ui/shared/empty-state";
+import { fileEntityPath } from "@repowise-dev/ui/shared/entity";
+import { formatDate, formatRelativeTimeOrNull } from "@repowise-dev/ui/lib/format";
 import { getOwnerProfile } from "@/lib/api/owners";
-import type { OwnerProfileResponse } from "@/lib/api/types";
 
-export default function OwnerProfilePage() {
-  const { id, owner } = useParams<{ id: string; owner: string }>();
-  const router = useRouter();
+export const metadata: Metadata = { title: "Contributor" };
+
+/**
+ * A server component, where this was a client component behind one SWR wave.
+ * The profile is a single fetch and nothing on the page is interactive, so the
+ * whole thing arrives in the initial HTML instead of after a skeleton.
+ *
+ * Drill-ins are hrefs rather than `router.push` handlers, which is what lets
+ * the page render on the server at all, and gives every file and contributor a
+ * URL that survives a middle-click.
+ */
+export default async function OwnerProfilePage({
+  params,
+}: {
+  params: Promise<{ id: string; owner: string }>;
+}) {
+  const { id, owner } = await params;
+  const base = `/repos/${id}`;
   const ownerKey = decodeURIComponent(owner);
 
-  const { data, isLoading, error } = useSWR<OwnerProfileResponse>(
-    `owner:${id}:${ownerKey}`,
-    () => getOwnerProfile(id, ownerKey),
-    { revalidateOnFocus: false },
-  );
+  const profile = await getOwnerProfile(id, ownerKey).catch(() => null);
 
-  return (
-    <div className="p-4 sm:p-6 space-y-4 max-w-[1600px]">
-      <div className="flex items-center justify-between">
-        <Link
-          href={`/repos/${id}/owners`}
-          className="inline-flex items-center gap-1 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)]"
-        >
-          <ArrowLeft className="h-3 w-3" /> All contributors
-        </Link>
-      </div>
-
-      {isLoading && (
-        <div className="space-y-4">
-          <Skeleton className="h-32 w-full" />
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <Skeleton key={i} className="h-24" />
-            ))}
-          </div>
-          <Skeleton className="h-96 w-full" />
-        </div>
-      )}
-
-      {error && (
+  if (!profile) {
+    return (
+      <PageShell
+        icon={<Users className="h-5 w-5 text-[var(--color-accent-primary)]" />}
+        title="Contributor"
+      >
         <EmptyState
           icon={<Users className="h-6 w-6" />}
-          title="Contributor not found"
-          description="The requested profile doesn't exist in this repository's git history yet."
+          title="No profile for this contributor"
+          description="Nobody by this name or address appears in the indexed git history. They may have committed under a different address, or the history may not have been synced yet."
         />
-      )}
+      </PageShell>
+    );
+  }
 
-      {data && (
-        <OwnerProfileView
-          owner={data}
-          onSelectFile={(path) => router.push(fileEntityPath(`/repos/${id}`, path))}
-          onSelectModule={(mod) => router.push(`/repos/${id}/modules/${encodeURIComponent(mod)}`)}
-          onSelectCoAuthor={(c) => {
-            const k = c.email ?? `name:${c.name}`;
-            router.push(`/repos/${id}/owners/${encodeURIComponent(k)}`);
-          }}
-        />
-      )}
-    </div>
+  const displayName = profile.name || profile.email || "unknown";
+  const lastTouched = formatRelativeTimeOrNull(profile.last_commit_at);
+
+  // Tenure as a sentence rather than a "new to this repo" badge. That badge
+  // fired on anyone who joined after the repo's first 90 days, which on a young
+  // repo is most people, and a marker that common marks nothing. A span of
+  // dates says the same thing without dressing it as a verdict.
+  const tenure = [
+    profile.first_commit_at
+      ? `Committing here since ${formatDate(profile.first_commit_at)}`
+      : null,
+    lastTouched ? `last touched ${lastTouched}` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return (
+    <PageShell
+      icon={<OwnerAvatar name={profile.name} email={profile.email} size="md" />}
+      title={displayName}
+      {...(tenure ? { description: tenure } : {})}
+    >
+      <OwnerProfileView
+        owner={profile}
+        base={base}
+        hrefForFile={(path) => fileEntityPath(base, path)}
+        hrefForModule={(mod) => `${base}/modules/${encodeURIComponent(mod)}`}
+        hrefForCoAuthor={(c) =>
+          `${base}/owners/${encodeURIComponent(c.email ?? `name:${c.name}`)}`
+        }
+        LinkComponent={Link}
+      />
+    </PageShell>
   );
 }

--- a/packages/web/src/components/commits/commit-detail-sheet.tsx
+++ b/packages/web/src/components/commits/commit-detail-sheet.tsx
@@ -22,7 +22,16 @@ import { getCommit } from "@/lib/api/git";
  * also what makes the deep link work — entity links from Overview and the file
  * pages land here with the sheet already open, and it survives a refresh.
  */
-export function CommitDetailSheet({ repoId }: { repoId: string }) {
+export function CommitDetailSheet({
+  repoId,
+  reviewCut,
+}: {
+  repoId: string;
+  /** `CommitStats.high_cut` — the raw score at this repo's review line. The
+   *  page already has it, and without it the card can only state a commit's
+   *  score with nothing to measure it against. */
+  reviewCut?: number | null | undefined;
+}) {
   const [selectedSha, setSelectedSha] = useQueryState("commit");
   const [promptOpen, setPromptOpen] = useState(false);
 
@@ -56,7 +65,7 @@ export function CommitDetailSheet({ repoId }: { repoId: string }) {
                     onClick={() => setPromptOpen(true)}
                   />
                 </div>
-                <CommitDetailCard commit={detail} />
+                <CommitDetailCard commit={detail} reviewCut={reviewCut} />
               </>
             )}
           </div>

--- a/packages/web/src/components/commits/commit-distribution.tsx
+++ b/packages/web/src/components/commits/commit-distribution.tsx
@@ -2,20 +2,16 @@
 
 import { useQueryState } from "nuqs";
 import type { CommitResponse, CommitStats } from "@/lib/api/types";
-import { CommitRiskHistogram } from "@repowise-dev/ui/commits/commit-risk-histogram";
-import { CommitRiskScatter } from "@repowise-dev/ui/commits/commit-risk-scatter";
+import { CommitDistribution as CommitDistributionView } from "@repowise-dev/ui/commits/commit-distribution";
 
 /**
- * The two views of how the score behaves here.
+ * The app's wiring for the shared distribution charts: everything this file
+ * still owns is the decision that "open this commit" means writing `?commit=`
+ * for the detail sheet to read. The headings, the prose and the charts moved to
+ * `@repowise-dev/ui/commits` so a second surface cannot end up with its own
+ * copy of the explanation.
  *
- * They stay a pair. The histogram says where the tercile cuts fall, the
- * scatter says what commit shape lands you above them, and neither answers the
- * question alone — showing one leaves a half-width chart beside dead space,
- * which is the empty state the old collapsible produced whenever a repo
- * predated the histogram aggregate.
- *
- * A client island only because both charts hover, and because clicking a dot
- * writes `?commit=` for the detail sheet to pick up.
+ * A client island only because of that query-param write.
  */
 export function CommitDistribution({
   stats,
@@ -26,38 +22,11 @@ export function CommitDistribution({
 }) {
   const [, setSelectedSha] = useQueryState("commit");
 
-  const hasHistogram = (stats?.risk_histogram?.length ?? 0) > 0;
-  if (!hasHistogram || !stats || recent.length === 0) return null;
-
   return (
-    <div className="grid grid-cols-1 gap-7 lg:grid-cols-2 lg:gap-10">
-      <div className="flex flex-col gap-2">
-        <h3 className="text-[13px] font-semibold text-[var(--color-text-primary)]">
-          Score distribution
-        </h3>
-        <p className="max-w-[62ch] text-xs leading-relaxed text-[var(--color-text-tertiary)]">
-          Every scored commit, binned on the raw 0 to 10 score rather than the
-          percentile. Percentile ranks are uniform by construction, so that axis
-          has no shape to draw. The dashed lines are the tercile cuts behind each
-          row&apos;s priority pill.
-        </p>
-        <CommitRiskHistogram stats={stats} />
-      </div>
-      <div className="flex flex-col gap-2">
-        <h3 className="text-[13px] font-semibold text-[var(--color-text-primary)]">
-          Size against diffusion
-        </h3>
-        <p className="max-w-[62ch] text-xs leading-relaxed text-[var(--color-text-tertiary)]">
-          The {recent.length.toLocaleString()} most recent commits, on their own
-          recency sample rather than the feed above: that defaults to risk-sorted,
-          so reusing it would plot only the top tercile and call it the spread.
-          Big and scattered is what the model penalises. Click a dot to open it.
-        </p>
-        <CommitRiskScatter
-          commits={recent}
-          onSelect={(sha) => void setSelectedSha(sha)}
-        />
-      </div>
-    </div>
+    <CommitDistributionView
+      stats={stats}
+      recent={recent}
+      onSelect={(sha) => void setSelectedSha(sha)}
+    />
   );
 }


### PR DESCRIPTION
Ports the contributor profile (`/repos/[id]/owners/[owner]`) and the commit
detail sheet onto the section style, and moves `CommitDistribution` into the
shared package.

## Contributor profile

Nine bordered containers at near-identical weight, so the page had nothing to
lead with and no way to say which of the nine mattered. It now leads with sole
ownership and a sentence, three secondary reads beside it, five volume figures
in a ribbon, and one section per subject.

**Every marker was counted against a real index before being kept or cut.**
Firing rates below are over the top 20 files for the three contributors with
enough history to have a profile:

| Marker | Fired on | Verdict |
|---|---|---|
| Hotspot flame | 80% / 70% / 55% | cut |
| Churn pill, red at >= 80 | 80% / 85% / 55% | colour cut |
| Bus factor, red / amber / green | green band has no members | colour cut |
| Lines added green, deleted red | always | colour cut |
| Risk strip tinted | all four tiles, top contributor | cut |
| *New:* hotspot AND sole owner AND >= 90% of its commits | 25% / 25% / 15% | kept |

Two bugs found on the way:

- The commit-mix palette keys on `feat` / `docs` / `test` / `chore` / `perf`.
  The endpoint returns `feature` / `fix` / `refactor` / `dependency`, so four of
  five colours were unreachable and the largest category fell through to the
  default. It had never once rendered as designed.
- Zero-count categories rendered as labelled bars with nothing in them, because
  the endpoint returns the full key set.

Figures are now disjoint. Modules and co-authors were each a headline tile *and*
a section; each figure now appears once, in the place that can explain it.

The page is a server component, and drill-ins are hrefs rather than
`router.push`, so every file and contributor has a URL that survives a
middle-click. First load drops to 4.78 kB / 144 kB.

## Commit detail sheet

The percentile was stated four times over: a 24px figure, a priority pill,
"Riskier than 100% of this repo's commits", and a summary paragraph restating
the box directly above it. `ordinal(Math.round(99.94))` also rendered "100th
percentile", which claims a commit is riskier than itself.

It now leads with the raw score against this repo's own review line. The queue
this sheet opens from already carries a percentile column per row, so repeating
it spends the largest figure on the page on something the reader just clicked
past. Rank was considered and rejected as unbuildable: the raw score is rounded
to one decimal before ranking, so 886 commits share 86 distinct percentiles and
"the 1st riskiest of 886" would be a computed guess printed as a measurement.

Driver rows name the measured value instead of the baseline comparison. "More
files than baseline" carries -1.12 and renders green, so on three rows out of
seven the words and the colour disagreed. The stat ribbon above them is gone
entirely: it listed lines, files, dirs, subsystems, entropy and author
experience, which is exactly the model's feature set, so it restated the table
beneath it without adding what any measurement did to the score. It was also
overflowing, since it sized to the viewport rather than to the 560px drawer.

Also fixes a review-cut sentence that named the moderate/high boundary as the
floor of whichever band the commit was in, which was wrong for every moderate
and low commit.

## Portability

`CommitDistribution` moves to `@repowise-dev/ui/commits`. It carried two
headings and two explanatory paragraphs, so it was content rather than data
wiring, and any second surface showing these charts would have had to copy the
prose. It takes `stats`, `recent` and `onSelect`; the app wrapper keeps only the
decision that "open this commit" means writing `?commit=`. No platform flag.

`PageLede` gains a `badge` slot for callers whose band already has its own
component.

## Verification

Type-check on both packages, the full `packages/ui` suite, the contrast gates,
`check-shared-imports`, and a production build. Checked in a browser in light
and dark at 1440 and at 390, where the file table stops being a table: five
columns cannot share 390px without starving a path that may not be truncated,
so the path takes the full width and the figures collapse to one line beneath
it. Paths carry a break opportunity after each separator, so they wrap between
directories rather than mid-identifier.

`workspace/dsm-matrix.test.tsx` flakes under load and is pre-existing; it passes
in isolation and is untouched here.
