### PR TITLE
fix(mcp): report an empty completion instead of shipping a blank answer

### DIFF
--- a/packages/server/src/repowise/server/mcp_server/tool_answer/synthesis.py
+++ b/packages/server/src/repowise/server/mcp_server/tool_answer/synthesis.py
@@ -280,6 +280,32 @@ def _synthesis_failure_note(exc: BaseException, provider, timeout_s: float, time
     )
 
 
+def _empty_completion_note(provider, response) -> str:
+    """Note for a call that succeeded and returned no text.
+
+    Measured against a local reasoning model on ollama: it spent all 1024
+    tokens thinking and emitted an empty content block. The call did not fail,
+    so nothing marked it degraded, and get_answer shipped a blank answer as a
+    normal result. That is the same silent empty answer #1119 was reported as,
+    reached from the other side.
+    """
+    who = (
+        f"provider={getattr(provider, 'provider_name', None) or '?'}, "
+        f"model={getattr(provider, 'model_name', None) or '?'}"
+    )
+    if getattr(response, "stop_reason", None) == "max_tokens":
+        return (
+            f"DEGRADED: the model used its entire {_SYNTHESIS_MAX_TOKENS}-token "
+            f"budget without emitting an answer ({who}). Reasoning models spend "
+            "that budget on hidden thinking; try a non-reasoning model for "
+            "synthesis. Read the listed files to answer meanwhile."
+        )
+    return (
+        f"DEGRADED: the model returned an empty completion ({who}). "
+        "Read the listed files to answer."
+    )
+
+
 async def synthesize(provider, system_prompt: str, user_prompt: str) -> tuple[str, str | None]:
     """Run one synthesis call. Returns ``(answer_text, failure_note)``.
 
@@ -320,7 +346,8 @@ async def synthesize(provider, system_prompt: str, user_prompt: str) -> tuple[st
         timed_out = True
         response, failure = None, exc
     if failure is None:
-        return (getattr(response, "content", None) or "").strip(), None
+        text = (getattr(response, "content", None) or "").strip()
+        return (text, None) if text else ("", _empty_completion_note(provider, response))
 
     _log.warning(
         "get_answer LLM call failed (provider=%s, model=%s, budget=%.1fs, timed_out=%s): %s",

--- a/tests/unit/server/mcp/test_answer_synthesis_timeout.py
+++ b/tests/unit/server/mcp/test_answer_synthesis_timeout.py
@@ -323,14 +323,46 @@ async def test_a_non_timeout_failure_is_not_reported_as_a_budget_overrun():
     assert _TIMEOUT_ENV not in note
 
 
-async def test_an_empty_completion_is_not_mistaken_for_a_failure():
+async def test_an_empty_completion_is_reported_rather_than_shipped_blank():
+    """A call can succeed and still produce nothing usable.
+
+    Measured on ollama: a local reasoning model spent all 1024 tokens on hidden
+    thinking and returned an empty content block. Nothing raised, so this used
+    to reach the agent as an ordinary answer that happened to be blank.
+    """
+
     class _Empty(_SlowProvider):
         async def generate(self, **kwargs):
-            return SimpleNamespace(content=None)
+            return SimpleNamespace(content=None, stop_reason=None)
 
     answer, note = await synthesize(_Empty(duration=0, budget=30.0), "sys", "user")
     assert answer == ""
-    assert note is None
+    assert note is not None
+    assert "empty completion" in note
+    assert "slowprov" in note
+
+
+async def test_a_reasoning_model_that_burned_its_budget_is_named_as_such():
+    """ "Empty" and "spent 1024 tokens thinking" need different remedies."""
+
+    class _AllThinking(_SlowProvider):
+        async def generate(self, **kwargs):
+            return SimpleNamespace(content="", stop_reason="max_tokens")
+
+    answer, note = await synthesize(_AllThinking(duration=0, budget=30.0), "sys", "user")
+    assert answer == ""
+    assert str(_SYNTHESIS_MAX_TOKENS) in note
+    assert "reasoning" in note.lower()
+
+
+async def test_whitespace_only_completion_counts_as_empty():
+    class _Blank(_SlowProvider):
+        async def generate(self, **kwargs):
+            return SimpleNamespace(content="   \n  ", stop_reason="end_turn")
+
+    answer, note = await synthesize(_Blank(duration=0, budget=30.0), "sys", "user")
+    assert answer == ""
+    assert note is not None
 
 
 # --- the degraded payload both failure modes share -------------------------


### PR DESCRIPTION
Follow-up to #1124. Refs #1119.

Found by running the reported configuration for real rather than reasoning about it: ollama with a small local model on Windows. A local reasoning model spent its entire 1024-token budget on hidden thinking and returned an empty content block.

```
ollama.generate.done  input_tokens=2143 output_tokens=1024
   50.4s  OK  answer=0 chars
```

Nothing raised, so synthesis counted as a success. `get_answer` then carried straight on with `answer_text = ""`: citations fell back to the top two retrieval paths, quotes came out empty, and the payload shipped `answer: ""` as an ordinary result with no `degraded` marker and nothing to explain it.

That is the same silent blank answer #1119 was reported as, reached from the other side. The reporter's config has `reasoning: auto` on a local model, so it is reachable for them today, and for anyone else pointing synthesis at a reasoning model.

## What changed

`synthesize()` treats an empty or whitespace-only completion as a failure and says which kind it is:

- Hit `max_tokens` with no text: the note explains that reasoning models spend that budget on hidden thinking and suggests a non-reasoning model, because raising a timeout cannot help.
- Empty for any other reason: reported plainly, naming the provider and model.

Both route through the existing degraded payload, so the response is marked and carries the retrieval hits, same as every other synthesis-less path.

## Note on the test that changed

#1124 shipped `test_an_empty_completion_is_not_mistaken_for_a_failure`, which asserted the old behavior. I wrote that test from an assumption about what an empty completion meant, and measuring it showed the assumption was wrong: an empty completion is not a benign success, it is the exact failure the issue was filed about. It is replaced by three tests covering the plain-empty, burned-the-budget, and whitespace-only cases.

## Testing

915 passing across `tests/unit/server/mcp` and `tests/unit/test_providers`, plus verification against live ollama: the empty case now returns the degraded note instead of a blank answer, and a normal model still answers unchanged.
