### PR TITLE
docs(website): sync language list with 16 AST languages

### DIFF
--- a/website/concepts.md
+++ b/website/concepts.md
@@ -65,7 +65,7 @@ From this, repowise builds a **dependency graph** using NetworkX. Nodes are file
 
 **Why it matters for you:** The dependency graph powers risk analysis, cascade detection, and architecture diagrams. When you ask "what does this module affect?", the answer comes from this layer.
 
-**Supported languages:** Python, TypeScript, JavaScript, Go, Rust, Java, C, C++, Kotlin, Ruby, C#, Swift, Scala, PHP. 14 languages with full AST support.
+**Supported languages:** Python, TypeScript, JavaScript, Go, Rust, Java, C, C++, Kotlin, Ruby, C#, Swift, Scala, PHP, Dart, Shell. **16 languages** parsed to a full AST (11 at the Full tier with code-health markers). See [Language Support](https://github.com/repowise-dev/repowise/blob/main/docs/layers/LANGUAGE_SUPPORT.md).
 
 ---
 

--- a/website/index.md
+++ b/website/index.md
@@ -26,7 +26,7 @@ repowise generates and maintains a structured wiki for any codebase. It tracks c
 | **Decision intelligence** | Captures *why* code is structured the way it is |
 | **MCP server** | 10 tools for AI assistants (Claude Code, Codex, Cursor, Windsurf, Cline) |
 | **Web dashboard** | Browse wiki, search, and explore architecture diagrams |
-| **Multi-language** | Python, TypeScript, JavaScript, Go, Rust, Java, C/C++, Kotlin, Ruby, C#, Swift, Scala, PHP |
+| **Multi-language** | 16 AST languages (11 Full tier): Python, TypeScript, JavaScript, Go, Rust, Java, C/C++, Kotlin, Ruby, C#, Swift, Scala, PHP, Dart, Shell |
 
 ---
 


### PR DESCRIPTION
## Summary
- Update \`website/index.md\` and \`website/concepts.md\` to match \`docs/layers/LANGUAGE_SUPPORT.md\`: **16 AST languages** (11 Full tier), including **Dart** and **Shell**.
- Drop the stale \"14 languages with full AST support\" claim.

## Why
Root README and LANGUAGE_SUPPORT already list 16; the public website pages were still advertising the pre-Dart/Shell set. Not tied to any open issue.

## Test plan
- [x] Diff website lists against \`docs/layers/LANGUAGE_SUPPORT.md\` tiers
- [x] Confirm no invented languages beyond the shipped matrix