### PR TITLE
docs: remove obsolete Anthropic Message Batches / --no-batch

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -15,7 +15,7 @@ For per-package detail (installation, full API reference, all CLI flags, file ma
 | Package | README | What it covers |
 |---------|--------|----------------|
 | `packages/core` | [`packages/core/README.md`](../../packages/core/README.md) | Ingestion, generation, persistence, providers — all key classes with code examples |
-| `packages/cli` | [`packages/cli/README.md`](../../packages/cli/README.md) | All 10 CLI commands with every flag documented |
+| `packages/cli` | [`packages/cli/README.md`](../../packages/cli/README.md) | CLI entrypoints and flags; full surface in [`CLI_REFERENCE.md`](../reference/CLI_REFERENCE.md) |
 | `packages/server` | [`packages/server/README.md`](../../packages/server/README.md) | All REST API endpoints, 11 MCP tools, webhook setup, scheduler jobs |
 | `packages/web` | [`packages/web/README.md`](../../packages/web/README.md) | Every frontend file with purpose — API client, hooks, components, pages |
 
@@ -354,25 +354,18 @@ reduces the refill rate. This is transparent to all callers.
 Default limits are configured per provider in `.repowise/config.yaml` and can be
 adjusted for users with higher API tiers.
 
-### 4.2 Batch Mode (Init Only)
-
-For `repowise init`, the Anthropic provider supports the Message Batches API:
-instead of firing concurrent streaming requests, all file-page generation requests
-for a given level are submitted as a single batch, which is ~50% cheaper and
-processes asynchronously (typically within 1 hour).
-
-Batch mode is enabled by default for `repowise init` when using the Anthropic
-provider. Pass `--no-batch` to use streaming instead (faster wall-clock time,
-higher cost).
-
-### 4.3 Prompt Caching
+### 4.2 Prompt Caching
 
 For Anthropic: the `ContextAssembler` marks the system prompt + shared repository
 context with cache-control breakpoints. Across the hundreds of file-page generation
 calls during a large init, this shared prefix is only billed once. Cost reduction
 on large repos is typically 60–90%.
 
-### 4.4 Adding a Provider
+> **Note:** An older Anthropic Message Batches / `--no-batch` init path is no
+> longer part of the product. Init uses concurrent streaming requests under the
+> rate limiter; there is no `batch_mode` config key and no `--no-batch` flag.
+
+### 4.3 Adding a Provider
 
 Implement `LLMProvider`, add an entry to `LANGUAGE_CONFIGS` in `providers/registry.py`,
 and add a section to `.repowise/config.yaml`. See [Section 12](#12-adding-a-new-llm-provider).
@@ -1629,7 +1622,6 @@ model: claude-sonnet-4-5    # passed through to the provider
 embedding_provider: anthropic
 embedding_model: voyage-3
 
-batch_mode: auto             # auto | always | never
 prompt_caching: true
 
 anthropic:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -57,11 +57,10 @@ repowise init [PATH] [OPTIONS]
 |--------|---------|-------------|
 | `--provider` | `anthropic` | LLM provider: `anthropic`, `openai`, `ollama`, `litellm` |
 | `--model` | provider default | Model identifier (e.g., `claude-opus-4-6`, `gpt-4o`) |
-| `--concurrency` | `5` | Max simultaneous LLM calls |
+| `--concurrency` | `10` | Max simultaneous LLM calls |
 | `--skip-tests` | off | Skip test files during generation |
 | `--resume` | off | Resume an interrupted init job from last checkpoint |
 | `--dry-run` | off | Show generation plan and cost estimate without calling the LLM |
-| `--no-batch` | off | Disable Anthropic batch API (faster wall-clock time, higher cost) |
 
 ```bash
 # Current directory, Anthropic (default)
@@ -80,9 +79,9 @@ repowise init --dry-run
 repowise init --resume
 ```
 
-**Batch API:** When using the Anthropic provider, `repowise init` uses the Message Batches API by default, which reduces cost by ~50%. Pass `--no-batch` to use streaming instead (returns results immediately, costs more).
-
 **Prompt caching:** The Anthropic provider caches the shared system prompt and repository context across all generation calls. On large repos, this typically cuts cost by 60–90%.
+
+See [`docs/reference/CLI_REFERENCE.md`](../../docs/reference/CLI_REFERENCE.md) for the full current `init` flag set (`--prose` / `--no-prose`, `--index-only`, etc.).
 
 ---
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -64,7 +64,7 @@ AST parsing uses [tree-sitter](https://tree-sitter.github.io/) with one `.scm` q
 
 | Provider | Name | Notes |
 |----------|------|-------|
-| Anthropic | `anthropic` | Prompt caching and Message Batches API (50% cost reduction on init) |
+| Anthropic | `anthropic` | Prompt caching on shared system/repo context (large-init cost reduction) |
 | OpenAI | `openai` | Any OpenAI-compatible endpoint |
 | Ollama | `ollama` | Fully offline, no API key required |
 | LiteLLM | `litellm` | 100+ providers through one interface (optional dependency) |


### PR DESCRIPTION
## Summary
- Remove \`--no-batch\` / Message Batches claims from \`packages/cli/README.md\` and \`packages/core/README.md\`.
- Delete ARCHITECTURE §4.2 Batch Mode and the appendix \`batch_mode\` config key; keep prompt-caching as the real Anthropic cost control.
- Point the CLI package blurb at \`CLI_REFERENCE.md\` instead of \"All 10 CLI commands\".
- Align the documented \`--concurrency\` default with \`CLI_REFERENCE.md\` (\`10\`).

## Why
\`init_cmd\` has no \`--no-batch\`; \`CLI_REFERENCE.md\` / \`CONFIG.md\` have no \`batch_mode\`. The docs were advertising a removed feature. Not tied to any open issue.

## Test plan
- [x] \`rg 'no-batch|Message Batches|batch_mode'\` on the touched files only finds the explicit \"no longer part of the product\" note
- [x] Spot-check \`repowise init --help\` has no \`--no-batch\`