### PR TITLE
fix(providers): refresh stale model defaults and fix cost and temperature handling

### DIFF
--- a/packages/cli/src/repowise/cli/commands/generate_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/generate_cmd/command.py
@@ -33,6 +33,7 @@ from repowise.cli.helpers import (
 )
 from repowise.cli.providers import resolve_embedder
 from repowise.cli.ui import load_dotenv
+from repowise.core.cost_estimator import STRUCTURAL_PAGE_TYPES
 from repowise.core.docs_mode import docs_mode_state_fields, resolve_docs_mode
 from repowise.core.generation.page_selection import PageSelectionIntent
 
@@ -64,14 +65,6 @@ def _build_intent(
     return intent
 
 
-# Page types rendered from structure, always. A model never writes one, so
-# naming one for `generate` is a mistake worth catching rather than a silent
-# no-op: these pages refresh on `repowise update`, not here.
-_STRUCTURAL_PAGE_TYPES = frozenset(
-    {"file_page", "symbol_spotlight", "api_contract", "infra_page", "scc_page", "layer_page"}
-)
-
-
 def _reject_structural_page_ids(page_ids: tuple[str, ...]) -> None:
     """Error clearly when an explicit ``--page`` names a structural page.
 
@@ -80,7 +73,7 @@ def _reject_structural_page_ids(page_ids: tuple[str, ...]) -> None:
     misunderstanding, and a silent no-op would hide it, so it is a clear error
     pointing at the command that does refresh those pages.
     """
-    bad = [pid for pid in page_ids if pid.split(":", 1)[0] in _STRUCTURAL_PAGE_TYPES]
+    bad = [pid for pid in page_ids if pid.split(":", 1)[0] in STRUCTURAL_PAGE_TYPES]
     if bad:
         joined = ", ".join(bad)
         raise click.ClickException(

--- a/packages/cli/src/repowise/cli/commands/init_cmd/command.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/command.py
@@ -80,6 +80,7 @@ from .generation import (
     estimate_generation,
     format_cost,
     run_repo_generation,
+    structural_page_summary,
 )
 from .persistence import (
     build_resume_controller,
@@ -348,6 +349,9 @@ def _run_generation_phase(
         f"Writing [bold]{concept_n}[/bold] concept pages with "
         f"[cyan]{provider.model_name}[/cyan]. Estimated [bold]{format_cost(est)}[/bold]."
     )
+    structural = structural_page_summary(plans)
+    if structural:
+        console.print(f"[dim]{structural}[/dim]")
     if cost_gate_declined(est, yes=yes, message="  Continue?"):
         console.print(
             "[yellow]Not writing it with the model.[/yellow] "

--- a/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/generation.py
@@ -106,6 +106,39 @@ def concept_page_count(plans: list[Any]) -> int:
     return next((p.count for p in plans if p.page_type == "module_page"), 0)
 
 
+# Short, plain names for the structural page types, in the order they read best.
+# Only the free types are listed: the paid ones are already named by the cost
+# question itself.
+_STRUCTURAL_LABELS = (
+    ("file_page", "file"),
+    ("api_contract", "API"),
+    ("symbol_spotlight", "symbol"),
+    ("scc_page", "cycle"),
+    ("layer_page", "layer"),
+    ("infra_page", "infra"),
+)
+
+
+def structural_page_summary(plans: list[Any]) -> str:
+    """Return e.g. ``"3622 pages rendered from structure, free: 2947 file, ..."``.
+
+    The headline cost question names only the pages a model writes, which leaves
+    the much larger total looking unexplained — and hides that repowise renders
+    file, API and symbol pages from the code itself with no provider call. This
+    is the one line that says so. Empty string when there are none.
+    """
+    from repowise.core.cost_estimator import STRUCTURAL_PAGE_TYPES
+
+    counts = {p.page_type: p.count for p in plans if p.page_type in STRUCTURAL_PAGE_TYPES}
+    total = sum(counts.values())
+    if not total:
+        return ""
+    parts = [f"{counts[t]} {label}" for t, label in _STRUCTURAL_LABELS if counts.get(t)]
+    return f"{total} more pages rendered from the code itself, no model, no cost: " + ", ".join(
+        parts
+    )
+
+
 def announce_file_page_cap(parsed_files: list[Any], gen_config: Any) -> None:
     """Say so when the file bucket is being bounded, and how to undo it.
 

--- a/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
+++ b/packages/cli/src/repowise/cli/commands/init_cmd/workspace.py
@@ -71,6 +71,7 @@ from .generation import (
     estimate_generation,
     format_cost,
     run_repo_generation,
+    structural_page_summary,
 )
 from .persistence import persist_result
 from .reporting import show_workspace_completion
@@ -126,8 +127,11 @@ def _run_workspace_generation(
 
     console.print(
         f"    Writing {concept_page_count(plans)} concept pages with "
-        f"{provider.model_name}. {format_cost(est)} ({est.total_pages} pages total)."
+        f"{provider.model_name}. {format_cost(est)}."
     )
+    structural = structural_page_summary(plans)
+    if structural:
+        console.print(f"    [dim]{structural}[/dim]")
 
     # Declines rather than raises when it cannot ask (see the note in init's
     # _run_generation_phase): a raise would land in the caller's generic error

--- a/packages/cli/src/repowise/cli/ui/mascot.py
+++ b/packages/cli/src/repowise/cli/ui/mascot.py
@@ -48,7 +48,7 @@ OWL_COMPACT = [
     '  " " ',
 ]
 
-EYES_THINKING = ["◐", "◓", "◑", "◒"]  # eye-roll cycle (spinner frames)
+EYES_THINKING = ["◐", "◓", "◑", "◒"]  # eye-roll cycle (kept for callers that want it)
 EYES_IDLE = "◉"
 EYES_SLEEPY = "─"  # interrupt message
 EYES_HAPPY = "^"  # completion panels
@@ -60,7 +60,13 @@ def mini(eyes: str = EYES_IDLE) -> str:
     return "{" + eyes + " " + eyes + "}"
 
 
-THINKING_FRAMES = [mini(e) for e in EYES_THINKING]
+# The spinner is a slow blink, not a spin. A continuous eye-roll at 5fps reads
+# as a cheap loading GIF and draws the eye away from the progress bar next to
+# it; holding the eyes open and closing them once per cycle reads as alive
+# without competing for attention. Motion lives in the last three frames.
+_BLINK_CYCLE = [EYES_IDLE] * 7 + ["◒", EYES_SLEEPY, "◒"]
+
+THINKING_FRAMES = [mini(e) for e in _BLINK_CYCLE]
 
 # ---------------------------------------------------------------------------
 # Spinner registration — ``rich._spinners.SPINNERS`` is private API (a plain
@@ -72,7 +78,7 @@ THINKING_FRAMES = [mini(e) for e in EYES_THINKING]
 try:
     from rich._spinners import SPINNERS
 
-    SPINNERS["owl"] = {"interval": 200, "frames": THINKING_FRAMES}
+    SPINNERS["owl"] = {"interval": 180, "frames": THINKING_FRAMES}
     OWL_SPINNER = "owl"
 except Exception:  # pragma: no cover — depends on rich internals
     OWL_SPINNER = "dots"

--- a/packages/cli/src/repowise/cli/ui/provider_selection.py
+++ b/packages/cli/src/repowise/cli/ui/provider_selection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -21,15 +22,15 @@ from repowise.core.reasoning import ReasoningMode, normalize_reasoning
 # ---------------------------------------------------------------------------
 
 _PROVIDER_DEFAULTS: dict[str, str] = {
-    "gemini": "gemini-3.1-flash-lite-preview",
+    "gemini": "gemini-3.5-flash-lite",
     "openai": "gpt-5.4-nano",
-    "anthropic": "claude-sonnet-4-6",
+    "anthropic": "claude-haiku-4-5",
     "deepseek": "deepseek-v4-flash",
     "kimi": "kimi-for-coding",
     "codex_cli": "codex_cli/default",
     "opencode": "opencode/default",
-    "ollama": "llama3.2",
-    "openrouter": "anthropic/claude-sonnet-4.6",
+    "ollama": "qwen3.5:4b",
+    "openrouter": "google/gemini-3.5-flash-lite",
     "litellm": "groq/llama-3.1-70b-versatile",
 }
 
@@ -43,6 +44,10 @@ _PROVIDER_ENV: dict[str, str] = {
     "opencode": "__OPENCODE_CLI__",
     "ollama": "OLLAMA_BASE_URL",
     "openrouter": "OPENROUTER_API_KEY",
+    # The picker iterates this map, so a provider missing here never renders a
+    # row no matter what `_PROVIDER_DEFAULTS` says. litellm was in the defaults
+    # only, which made it unreachable from init.
+    "litellm": "LITELLM_API_KEY",
 }
 
 _PROVIDER_SIGNUP: dict[str, str] = {
@@ -55,6 +60,7 @@ _PROVIDER_SIGNUP: dict[str, str] = {
     "opencode": "https://opencode.ai",
     "ollama": "https://ollama.com/download",
     "openrouter": "https://openrouter.ai/keys",
+    "litellm": "https://docs.litellm.ai/docs/providers",
 }
 
 
@@ -537,25 +543,49 @@ def interactive_provider_select(
     return selection.provider_name, selection.model
 
 
+# Checked before the flagship tokens: a cheap-tier marker wins even when the
+# family name is a flagship one, so `gpt-5.4-nano` is not mistaken for `gpt-5`.
+_BUDGET_MODEL_TOKENS = (
+    "nano",
+    "mini",
+    "lite",
+    "haiku",
+    "small",
+    "tiny",
+    "flash",
+    r"\d+b",  # 8b, 3b, 270m-style parameter-count tags
+)
+
 _FLAGSHIP_MODEL_TOKENS = (
     "opus",
     "gpt-4o",
     "gpt-5",
-    "-pro",
-    "sonnet-4-7",
-    "sonnet-4-6",
+    "pro",
+    "sonnet",
     "ultra",
     "o1",
     "o3",
+    "o4",
 )
+
+
+def _matches_token(model: str, tokens: tuple[str, ...]) -> bool:
+    """True if any token appears in ``model`` as a whole dash/dot-delimited word.
+
+    Substring matching is wrong here: ``gemini`` contains ``mini`` and
+    ``gpt-5.4-nano`` contains ``gpt-5``.
+    """
+    return any(re.search(rf"(?<![a-z0-9]){tok}(?![a-z])", model) for tok in tokens)
 
 
 def _is_flagship_model(model: str) -> bool:
     """Heuristic: True if the model name suggests a flagship-tier model."""
     if not model:
         return False
-    m = model.lower()
-    return any(tok in m for tok in _FLAGSHIP_MODEL_TOKENS)
+    m = model.lower().rsplit("/", 1)[-1]
+    if _matches_token(m, _BUDGET_MODEL_TOKENS):
+        return False
+    return _matches_token(m, _FLAGSHIP_MODEL_TOKENS)
 
 
 def _prompt_api_key(

--- a/packages/core/src/repowise/core/cost_estimator/__init__.py
+++ b/packages/core/src/repowise/core/cost_estimator/__init__.py
@@ -13,12 +13,13 @@ Public API kept stable for existing callers:
 """
 
 from .approx import approximate_generation_plan
-from .estimator import estimate_cost
+from .estimator import STRUCTURAL_PAGE_TYPES, estimate_cost
 from .plans import build_generation_plan
 from .pricing import _lookup_cost
 from .types import CostEstimate, CostRange, PageTypePlan
 
 __all__ = [
+    "STRUCTURAL_PAGE_TYPES",
     "CostEstimate",
     "CostRange",
     "PageTypePlan",

--- a/packages/core/src/repowise/core/cost_estimator/estimator.py
+++ b/packages/core/src/repowise/core/cost_estimator/estimator.py
@@ -13,7 +13,7 @@ from .types import CostEstimate, CostRange, PageTypePlan
 # zero tokens however many are produced. Checked before telemetry, because a
 # repo indexed before this change carries historical LLM averages for these
 # types that would otherwise price free pages as if a model still wrote them.
-_FREE_PAGE_TYPES = frozenset(
+STRUCTURAL_PAGE_TYPES = frozenset(
     {"file_page", "symbol_spotlight", "api_contract", "infra_page", "scc_page", "layer_page"}
 )
 
@@ -29,7 +29,7 @@ def _tokens_per_page(
     available (they reflect this repo's actual prompt sizes) and fall back to
     heuristics for fresh repos and unknown page types.
     """
-    if page_type in _FREE_PAGE_TYPES:
+    if page_type in STRUCTURAL_PAGE_TYPES:
         return (0.0, 0.0)
     if page_type in telemetry:
         return telemetry[page_type]

--- a/packages/core/src/repowise/core/cost_estimator/pricing.py
+++ b/packages/core/src/repowise/core/cost_estimator/pricing.py
@@ -17,6 +17,7 @@ _COST_TABLE_EXACT: dict[str, tuple[float, float]] = {
     "gemini-3.1-pro-preview": (0.002, 0.012),  # $2 / $12 per MTok
     "gemini-3-flash-preview": (0.0005, 0.003),  # $0.50 / $3 per MTok
     "gemini-3.1-flash-lite-preview": (0.00025, 0.0015),  # $0.25 / $1.50 per MTok
+    "gemini-3.5-flash-lite": (0.00025, 0.0015),  # $0.25 / $1.50 per MTok
     # Anthropic Claude 4.x family
     "claude-opus-4-6": (0.005, 0.025),  # $5 / $25 per MTok
     "claude-sonnet-4-6": (0.003, 0.015),  # $3 / $15 per MTok
@@ -43,6 +44,11 @@ _COST_TABLE_PREFIX: dict[str, tuple[float, float]] = {
 def _lookup_cost(model_name: str) -> tuple[float, float]:
     """Return ``(input_rate, output_rate)`` per 1K tokens for *model_name*."""
     lower = model_name.lower()
+    # OpenRouter/LiteLLM slugs carry a routing prefix (`google/gemini-3.5-flash-lite`)
+    # that hides the model from every entry below, which priced them at zero.
+    # `codex_cli/` and `opencode/` are genuinely free, so they keep their prefixes.
+    if "/" in lower and not lower.startswith(("codex_cli/", "opencode/")):
+        lower = lower.rsplit("/", 1)[-1]
     if lower in _COST_TABLE_EXACT:
         return _COST_TABLE_EXACT[lower]
     best_prefix = ""

--- a/packages/core/src/repowise/core/generation/cost_tracker.py
+++ b/packages/core/src/repowise/core/generation/cost_tracker.py
@@ -20,14 +20,17 @@ log = structlog.get_logger(__name__)
 # ---------------------------------------------------------------------------
 
 _PRICING: dict[str, dict[str, float]] = {
-    # Anthropic — Opus tier $15/$75, Sonnet $3/$15, Haiku $0.8/$4 per 1M.
-    # 4-7/4-8 added for savings pricing: these are the models the session
-    # detector surfaces from current Claude Code transcripts.
-    "claude-opus-4-8": {"input": 15.0, "output": 75.0},
-    "claude-opus-4-7": {"input": 15.0, "output": 75.0},
-    "claude-opus-4-6": {"input": 15.0, "output": 75.0},
+    # Anthropic — Opus tier $5/$25, Sonnet $3/$15, Haiku $1/$5 per 1M. The 5 and
+    # 4-x entries are the models the session detector surfaces from current
+    # Claude Code transcripts. Opus used to be listed at $15/$75 here, which is
+    # the Opus 3 rate and overstated every Opus session by 3x.
+    "claude-opus-5": {"input": 5.0, "output": 25.0},
+    "claude-opus-4-8": {"input": 5.0, "output": 25.0},
+    "claude-opus-4-7": {"input": 5.0, "output": 25.0},
+    "claude-opus-4-6": {"input": 5.0, "output": 25.0},
+    "claude-sonnet-5": {"input": 3.0, "output": 15.0},
     "claude-sonnet-4-6": {"input": 3.0, "output": 15.0},
-    "claude-haiku-4-5": {"input": 0.8, "output": 4.0},
+    "claude-haiku-4-5": {"input": 1.0, "output": 5.0},
     "claude-3-5-sonnet-20241022": {"input": 3.0, "output": 15.0},
     # OpenAI — GPT-5 family (the models Codex sessions report). Rates per 1M
     # input/output; verify against current OpenAI pricing before relying on
@@ -39,7 +42,7 @@ _PRICING: dict[str, dict[str, float]] = {
     # through to ``_FALLBACK_PRICING`` (Sonnet $3/$15) and overstates a nano
     # indexing run ~40x.
     "gpt-5-nano": {"input": 0.05, "output": 0.40},
-    "gpt-5.4-nano": {"input": 0.05, "output": 0.40},
+    "gpt-5.4-nano": {"input": 0.20, "output": 1.25},
     "gpt-4o": {"input": 2.5, "output": 10.0},
     "gpt-4o-mini": {"input": 0.15, "output": 0.6},
     # Google Gemini
@@ -52,6 +55,7 @@ _PRICING: dict[str, dict[str, float]] = {
     # Gemini preview / experimental models
     "gemini-3.1-flash-lite-preview": {"input": 0.075, "output": 0.30},
     "gemini-3-flash-preview": {"input": 0.075, "output": 0.30},
+    "gemini-3.5-flash-lite": {"input": 0.25, "output": 1.50},
     # DeepSeek
     "deepseek-v4-flash": {"input": 0.14, "output": 0.28},
     "deepseek-v4-pro": {"input": 1.74, "output": 3.48},
@@ -87,6 +91,9 @@ def is_local_model(model: str) -> bool:
         model == "mock"
         or model.startswith(_LOCAL_MODEL_PREFIXES)
         or model.startswith(("codex_cli/", "opencode/"))
+        # Bare Ollama tags carry no prefix — the default is plain `qwen3.5:4b`,
+        # and a `family:size` tag is not a shape any hosted vendor uses.
+        or (":" in model and "/" not in model)
     )
 
 
@@ -98,9 +105,9 @@ def is_local_model(model: str) -> bool:
 #: the Sonnet fallback rate, which would undercount the agent savings it earned
 #: by ~5x. Ordered longest/most-specific prefix first.
 _CLAUDE_FAMILY_PRICING: tuple[tuple[str, dict[str, float]], ...] = (
-    ("claude-opus", {"input": 15.0, "output": 75.0}),
+    ("claude-opus", {"input": 5.0, "output": 25.0}),
     ("claude-sonnet", {"input": 3.0, "output": 15.0}),
-    ("claude-haiku", {"input": 0.8, "output": 4.0}),
+    ("claude-haiku", {"input": 1.0, "output": 5.0}),
 )
 
 
@@ -123,13 +130,27 @@ def _family_pricing(model: str) -> dict[str, float] | None:
     return None
 
 
+def _routed_model_leaf(model: str) -> str:
+    """Strip a router's vendor segment: ``google/gemini-3.5-flash-lite`` -> the id.
+
+    OpenRouter and LiteLLM address every model as ``vendor/model``, which matched
+    nothing below and billed those runs at the flat Sonnet fallback — around 12x
+    over for a flash-lite default. ``is_local_model`` is checked first, so the
+    passthrough prefixes it owns (``ollama/``, ``codex_cli/`` …) never reach here.
+    """
+    return model.rsplit("/", 1)[-1]
+
+
 def _get_pricing(model: str) -> dict[str, float]:
     """Return pricing for *model*, falling back and warning if unknown."""
     if is_local_model(model):
         return {"input": 0.0, "output": 0.0}
     if model in _PRICING:
         return _PRICING[model]
-    family = _family_pricing(model)
+    leaf = _routed_model_leaf(model)
+    if leaf in _PRICING:
+        return _PRICING[leaf]
+    family = _family_pricing(model) or _family_pricing(leaf)
     if family is not None:
         return family
     if model not in _warned_models:

--- a/packages/core/src/repowise/core/generation/cost_tracker.py
+++ b/packages/core/src/repowise/core/generation/cost_tracker.py
@@ -122,11 +122,14 @@ def _family_pricing(model: str) -> dict[str, float] | None:
         if model.startswith(prefix):
             return pricing
     if model.startswith("gpt-5"):
+        # Current-generation tier rates, matching cost_estimator/pricing.py. The
+        # older gpt-5-nano / gpt-5-mini keep their own cheaper exact entries,
+        # which win before this runs.
         if "nano" in model:
-            return {"input": 0.05, "output": 0.40}
+            return {"input": 0.20, "output": 1.25}
         if "mini" in model:
-            return {"input": 0.25, "output": 2.0}
-        return {"input": 1.25, "output": 10.0}
+            return {"input": 0.75, "output": 4.50}
+        return {"input": 2.50, "output": 15.0}
     return None
 
 

--- a/packages/core/src/repowise/core/providers/llm/anthropic.py
+++ b/packages/core/src/repowise/core/providers/llm/anthropic.py
@@ -5,9 +5,9 @@ prompts — Anthropic's API caches prompts > 1024 tokens and charges ~10% of
 the normal input price on cache hits.
 
 Recommended models (as of 2026):
+    - claude-haiku-4-5   — fastest and cheapest (default; ample for doc pages)
+    - claude-sonnet-4-6  — best quality/cost ratio
     - claude-opus-4-6    — highest quality, most expensive
-    - claude-sonnet-4-6  — best quality/cost ratio (default)
-    - claude-haiku-4-5   — fastest, cheapest (good for low-value pages)
 """
 
 from __future__ import annotations
@@ -39,6 +39,7 @@ from repowise.core.providers.llm.base import (
     provider_retry_stop,
     provider_retry_wait,
     provider_should_retry,
+    temperature_kwargs,
 )
 from repowise.core.rate_limiter import RateLimiter
 from repowise.core.reasoning import ReasoningMode
@@ -106,7 +107,7 @@ class AnthropicProvider(BaseProvider):
 
     Args:
         api_key:      Anthropic API key. Falls back to ANTHROPIC_API_KEY env var.
-        model:        Model identifier. Defaults to claude-sonnet-4-6.
+        model:        Model identifier. Defaults to claude-haiku-4-5.
         base_url:     Optional custom API base URL (for proxies/self-hosted endpoints).
         rate_limiter: Optional pre-configured RateLimiter. If None, no rate limiting
                       is applied (useful when the caller manages concurrency via semaphore).
@@ -115,7 +116,7 @@ class AnthropicProvider(BaseProvider):
     def __init__(
         self,
         api_key: str | None = None,
-        model: str = "claude-sonnet-4-6",
+        model: str = "claude-haiku-4-5",
         base_url: str | None = None,
         rate_limiter: RateLimiter | None = None,
         cost_tracker: CostTracker | None = None,
@@ -203,9 +204,9 @@ class AnthropicProvider(BaseProvider):
             response = await self._client.messages.create(
                 model=self._model,
                 max_tokens=max_tokens,
-                temperature=temperature,
                 system=system_param,
                 messages=messages_param,
+                **temperature_kwargs(self._model, temperature),
             )
         except _AnthropicRateLimitError as exc:
             raise RateLimitError(
@@ -303,9 +304,9 @@ class AnthropicProvider(BaseProvider):
         kwargs: dict[str, Any] = {
             "model": self._model,
             "max_tokens": max_tokens,
-            "temperature": temperature,
             "system": system_prompt,
             "messages": anthropic_messages,
+            **temperature_kwargs(self._model, temperature),
         }
         if anthropic_tools:
             kwargs["tools"] = anthropic_tools

--- a/packages/core/src/repowise/core/providers/llm/base.py
+++ b/packages/core/src/repowise/core/providers/llm/base.py
@@ -24,6 +24,81 @@ CacheSegment = Literal["system", "user_prefix"]
 ModelOptionSource = Literal["api", "local", "fallback"]
 
 
+# ---------------------------------------------------------------------------
+# Temperature compatibility
+#
+# Reasoning-era models reject any explicit ``temperature`` with a 400 rather
+# than clamping it. The set grows with every model release and a router like
+# OpenRouter can serve any vendor's, so a static list alone goes stale and
+# breaks a run. Two layers instead: skip the parameter for families already
+# known to reject it, and learn the rest at runtime from the first rejection
+# so only one page pays for it.
+# ---------------------------------------------------------------------------
+
+_FIXED_TEMPERATURE_PREFIXES = (
+    # OpenAI reasoning era
+    "gpt-5",
+    "o1",
+    "o3",
+    "o4",
+    # Anthropic dropped the sampling parameters with Opus 4.7
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-opus-5",
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "claude-mythos-5",
+)
+
+_TEMPERATURE_REJECTION_MARKERS = (
+    "temperature",
+    "unsupported_value",
+    "unsupported parameter",
+    "sampling parameter",
+)
+
+#: Models observed rejecting ``temperature`` this process. Populated by
+#: :func:`remember_temperature_rejection`; never persisted, since it is a
+#: latency optimization and a stale entry would silently drop the setting.
+_LEARNED_FIXED_TEMPERATURE: set[str] = set()
+
+
+def model_leaf(model: str) -> str:
+    """Strip a routing prefix (``google/gemini-3.5-flash-lite``) and lowercase."""
+    return model.lower().rsplit("/", 1)[-1].removeprefix("anthropic.")
+
+
+def accepts_temperature(model: str) -> bool:
+    """False when *model* is known or has been observed to reject temperature."""
+    leaf = model_leaf(model)
+    if leaf in _LEARNED_FIXED_TEMPERATURE:
+        return False
+    return not leaf.startswith(_FIXED_TEMPERATURE_PREFIXES)
+
+
+def temperature_kwargs(model: str, temperature: float) -> dict[str, float]:
+    """Return ``{"temperature": ...}``, or ``{}`` when *model* would reject it."""
+    return {"temperature": temperature} if accepts_temperature(model) else {}
+
+
+def is_temperature_rejection(exc: Exception) -> bool:
+    """True when *exc* looks like a 400 specifically about ``temperature``.
+
+    Deliberately generous: a false positive costs one retry without the
+    parameter, while a false negative fails the whole generation run.
+    """
+    status = getattr(exc, "status_code", None) or getattr(exc, "status", None)
+    if status is not None and status != 400:
+        return False
+    message = str(exc).lower()
+    return any(marker in message for marker in _TEMPERATURE_REJECTION_MARKERS)
+
+
+def remember_temperature_rejection(model: str) -> None:
+    """Record that *model* rejects temperature, so later calls skip it."""
+    _LEARNED_FIXED_TEMPERATURE.add(model_leaf(model))
+
+
 def normalize_stop_reason(reason: object) -> tuple[str | None, str | None]:
     """Return ``(normalized, provider-native)`` completion stop reasons.
 

--- a/packages/core/src/repowise/core/providers/llm/gemini.py
+++ b/packages/core/src/repowise/core/providers/llm/gemini.py
@@ -4,7 +4,7 @@ Uses the same google-genai SDK as GeminiEmbedder for consistency.
 Runs the synchronous SDK call in a thread pool to avoid blocking asyncio.
 
 Recommended models:
-    - gemini-3.1-flash-lite-preview  — fast + cheap (default)
+    - gemini-3.5-flash-lite  — fast + cheap (default)
     - gemini-3-flash-preview         — higher quality
 """
 
@@ -201,7 +201,7 @@ class GeminiProvider(BaseProvider):
     """Native Gemini provider using the google-genai SDK.
 
     Args:
-        model:        Gemini model name. Defaults to gemini-3.1-flash-lite-preview.
+        model:        Gemini model name. Defaults to gemini-3.5-flash-lite.
         api_key:      Google API key. Falls back to GEMINI_API_KEY or GOOGLE_API_KEY env var.
         base_url:     Optional custom base URL (e.g., for proxy/self-hosted endpoints).
         rate_limiter: Optional RateLimiter instance.
@@ -210,7 +210,7 @@ class GeminiProvider(BaseProvider):
 
     def __init__(
         self,
-        model: str = "gemini-3.1-flash-lite-preview",
+        model: str = "gemini-3.5-flash-lite",
         api_key: str | None = None,
         base_url: str | None = None,
         rate_limiter: RateLimiter | None = None,

--- a/packages/core/src/repowise/core/providers/llm/litellm.py
+++ b/packages/core/src/repowise/core/providers/llm/litellm.py
@@ -37,11 +37,14 @@ from repowise.core.providers.llm.base import (
     RateLimitError,
     ensure_reasoning_supported,
     fallback_model_option,
+    is_temperature_rejection,
     normalize_stop_reason,
     parse_retry_after,
     provider_retry_stop,
     provider_retry_wait,
     provider_should_retry,
+    remember_temperature_rejection,
+    temperature_kwargs,
 )
 from repowise.core.rate_limiter import RateLimiter
 from repowise.core.reasoning import ReasoningMode, normalize_reasoning
@@ -241,8 +244,8 @@ class LiteLLMProvider(BaseProvider):
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt},
             ],
-            "temperature": temperature,
             "max_tokens": max_tokens,
+            **temperature_kwargs(self._model, temperature),
         }
         if self._api_key:
             call_kwargs["api_key"] = self._api_key
@@ -251,7 +254,18 @@ class LiteLLMProvider(BaseProvider):
         call_kwargs.update(_litellm_reasoning_kwargs(reasoning))
 
         try:
-            response = await litellm.acompletion(**call_kwargs)
+            try:
+                response = await litellm.acompletion(**call_kwargs)
+            except litellm.APIError as exc:
+                # LiteLLM proxies arbitrary vendors, same as OpenRouter: the
+                # models that reject `temperature` cannot be enumerated up
+                # front, so learn from the rejection and retry once without it.
+                if "temperature" not in call_kwargs or not is_temperature_rejection(exc):
+                    raise
+                remember_temperature_rejection(self._model)
+                log.debug("litellm.temperature.unsupported", model=self._model)
+                call_kwargs.pop("temperature")
+                response = await litellm.acompletion(**call_kwargs)
         except litellm.RateLimitError as exc:
             raise RateLimitError(
                 "litellm",
@@ -327,9 +341,9 @@ class LiteLLMProvider(BaseProvider):
         call_kwargs: dict[str, Any] = {
             "model": self._model,
             "messages": full_messages,
-            "temperature": temperature,
             "max_tokens": max_tokens,
             "stream": True,
+            **temperature_kwargs(self._model, temperature),
         }
         if tools:
             call_kwargs["tools"] = tools

--- a/packages/core/src/repowise/core/providers/llm/ollama.py
+++ b/packages/core/src/repowise/core/providers/llm/ollama.py
@@ -9,7 +9,7 @@ No API key required for local deployments. This makes repowise usable in:
     - Cost-sensitive projects
 
 Popular models (pull with `ollama pull <model>`):
-    - llama3.2          — good general-purpose, 3B/11B variants
+    - qwen3.5:4b        — good general-purpose small model (default)
     - codellama         — code-focused, good for doc generation
     - deepseek-coder-v2 — strong on code understanding
     - qwen2.5-coder     — excellent multilingual code model
@@ -134,7 +134,7 @@ class OllamaProvider(BaseProvider):
     Uses Ollama's OpenAI-compatible endpoint. No API key required.
 
     Args:
-        model:        Ollama model name (e.g., 'llama3.2', 'codellama').
+        model:        Ollama model name (e.g., 'qwen3.5:4b', 'llama3.2').
                       Must be pulled first: `ollama pull <model>`
         base_url:     Ollama server URL. Defaults to http://localhost:11434.
                       The /v1 suffix is appended automatically if missing.
@@ -149,7 +149,7 @@ class OllamaProvider(BaseProvider):
 
     def __init__(
         self,
-        model: str = "llama3.2",
+        model: str = "qwen3.5:4b",
         base_url: str | None = None,
         rate_limiter: RateLimiter | None = None,
     ) -> None:

--- a/packages/core/src/repowise/core/providers/llm/openai.py
+++ b/packages/core/src/repowise/core/providers/llm/openai.py
@@ -219,7 +219,7 @@ class OpenAIProvider(BaseProvider):
 
     Args:
         api_key:   OpenAI API key. Falls back to OPENAI_API_KEY env var.
-        model:     Model identifier. Defaults to gpt-4o.
+        model:     Model identifier. Defaults to gpt-5.4-nano.
         base_url:  Optional custom base URL for OpenAI-compatible endpoints.
         rate_limiter: Optional RateLimiter instance.
     """

--- a/packages/core/src/repowise/core/providers/llm/openrouter.py
+++ b/packages/core/src/repowise/core/providers/llm/openrouter.py
@@ -6,9 +6,9 @@ through a single API key via an OpenAI-compatible endpoint.
 No additional pip install required — uses the ``openai`` package.
 
 Popular models:
-    - anthropic/claude-sonnet-4.6  — Anthropic Claude Sonnet
-    - google/gemini-3.1-flash-lite-preview      — Google Gemini Flash
-    - meta-llama/llama-4-maverick  — Meta Llama open model
+    - google/gemini-3.5-flash-lite  — fast + cheap (default)
+    - openai/gpt-5.4-nano           — OpenAI budget tier
+    - anthropic/claude-haiku-4-5    — Anthropic budget tier
 """
 
 from __future__ import annotations
@@ -35,11 +35,14 @@ from repowise.core.providers.llm.base import (
     RateLimitError,
     ensure_reasoning_supported,
     fallback_model_option,
+    is_temperature_rejection,
     normalize_stop_reason,
     parse_retry_after,
     provider_retry_stop,
     provider_retry_wait,
     provider_should_retry,
+    remember_temperature_rejection,
+    temperature_kwargs,
 )
 from repowise.core.rate_limiter import RateLimiter
 from repowise.core.reasoning import ReasoningMode, normalize_reasoning
@@ -189,7 +192,7 @@ class OpenRouterProvider(BaseProvider):
 
     Args:
         api_key:      OpenRouter API key. Falls back to OPENROUTER_API_KEY env var.
-        model:        Model identifier (vendor/model format). Defaults to anthropic/claude-sonnet-4.6.
+        model:        Model identifier (vendor/model format). Defaults to google/gemini-3.5-flash-lite.
         base_url:     Override the OpenRouter API URL (rarely needed).
         rate_limiter: Optional RateLimiter instance.
         http_referer: Optional site URL for OpenRouter rankings/leaderboards.
@@ -202,7 +205,7 @@ class OpenRouterProvider(BaseProvider):
     def __init__(
         self,
         api_key: str | None = None,
-        model: str = "anthropic/claude-sonnet-4.6",
+        model: str = "google/gemini-3.5-flash-lite",
         base_url: str = "https://openrouter.ai/api/v1",
         rate_limiter: RateLimiter | None = None,
         http_referer: str | None = None,
@@ -327,18 +330,30 @@ class OpenRouterProvider(BaseProvider):
         request_id: str | None,
         reasoning: ReasoningMode,
     ) -> GeneratedResponse:
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "max_tokens": max_tokens,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            **temperature_kwargs(self._model, temperature),
+        }
+        kwargs.update(_openrouter_reasoning_kwargs(reasoning))
         try:
-            kwargs: dict[str, Any] = {
-                "model": self._model,
-                "max_tokens": max_tokens,
-                "temperature": temperature,
-                "messages": [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
-            }
-            kwargs.update(_openrouter_reasoning_kwargs(reasoning))
-            response = await self._client.chat.completions.create(**kwargs)
+            try:
+                response = await self._client.chat.completions.create(**kwargs)
+            except _OpenAIAPIStatusError as exc:
+                # OpenRouter fronts every vendor, so the set of models that
+                # reject `temperature` is not knowable ahead of time. Drop the
+                # parameter and retry once; the model is remembered so the rest
+                # of the run skips it.
+                if "temperature" not in kwargs or not is_temperature_rejection(exc):
+                    raise
+                remember_temperature_rejection(self._model)
+                log.debug("openrouter.temperature.unsupported", model=self._model)
+                kwargs.pop("temperature")
+                response = await self._client.chat.completions.create(**kwargs)
         except _OpenAIRateLimitError as exc:
             raise RateLimitError(
                 "openrouter",
@@ -398,9 +413,9 @@ class OpenRouterProvider(BaseProvider):
         kwargs: dict[str, Any] = {
             "model": self._model,
             "max_tokens": max_tokens,
-            "temperature": temperature,
             "messages": full_messages,
             "stream": True,
+            **temperature_kwargs(self._model, temperature),
         }
         if tools:
             kwargs["tools"] = tools

--- a/packages/server/src/repowise/server/provider_config.py
+++ b/packages/server/src/repowise/server/provider_config.py
@@ -38,10 +38,10 @@ PROVIDER_CATALOG: list[dict[str, Any]] = [
     {
         "id": "gemini",
         "name": "Google Gemini",
-        "default_model": "gemini-3.1-flash-lite-preview",
+        "default_model": "gemini-3.5-flash-lite",
         "models": [
-            "gemini-3.1-flash-lite-preview",
-            "gemini-3-flash-preview",
+            "gemini-3.5-flash-lite",
+            "gemini-3.1-flash-lite",
             "gemini-3.1-pro-preview",
         ],
         "env_keys": ["GEMINI_API_KEY", "GOOGLE_API_KEY"],
@@ -50,8 +50,8 @@ PROVIDER_CATALOG: list[dict[str, Any]] = [
     {
         "id": "anthropic",
         "name": "Anthropic",
-        "default_model": "claude-sonnet-4-6",
-        "models": ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"],
+        "default_model": "claude-haiku-4-5",
+        "models": ["claude-haiku-4-5", "claude-sonnet-4-6", "claude-opus-4-6"],
         "env_keys": ["ANTHROPIC_API_KEY"],
         "requires_key": True,
     },
@@ -66,12 +66,12 @@ PROVIDER_CATALOG: list[dict[str, Any]] = [
     {
         "id": "openrouter",
         "name": "OpenRouter",
-        "default_model": "anthropic/claude-sonnet-4.6",
+        "default_model": "google/gemini-3.5-flash-lite",
         "models": [
-            "anthropic/claude-sonnet-4.6",
-            "google/gemini-3.1-flash-lite-preview",
-            "meta-llama/llama-4-maverick",
-            "openai/gpt-4o",
+            "google/gemini-3.5-flash-lite",
+            "openai/gpt-5.4-nano",
+            "anthropic/claude-haiku-4-5",
+            "anthropic/claude-sonnet-5",
         ],
         "env_keys": ["OPENROUTER_API_KEY"],
         "requires_key": True,
@@ -100,8 +100,8 @@ PROVIDER_CATALOG: list[dict[str, Any]] = [
     {
         "id": "ollama",
         "name": "Ollama (Local)",
-        "default_model": "llama3.2",
-        "models": ["llama3.2", "codellama", "deepseek-coder-v2", "qwen2.5-coder"],
+        "default_model": "qwen3.5:4b",
+        "models": ["qwen3.5:4b", "qwen3.5:2b", "llama3.2", "qwen2.5-coder"],
         "env_keys": [],
         "requires_key": False,
     },

--- a/packages/web/src/components/settings/provider-section.tsx
+++ b/packages/web/src/components/settings/provider-section.tsx
@@ -23,13 +23,13 @@ const PROVIDERS = ["gemini", "openai", "anthropic", "deepseek", "kimi", "opencod
 const EMBEDDERS = ["mock", "gemini", "openai", "openrouter", "ollama"] as const;
 
 const MODEL_PLACEHOLDERS: Record<string, string> = {
-  gemini: "gemini-3.1-flash-lite-preview",
+  gemini: "gemini-3.5-flash-lite",
   openai: "gpt-5.4-nano",
-  anthropic: "claude-sonnet-4-6",
+  anthropic: "claude-haiku-4-5",
   deepseek: "deepseek-v4-flash",
   kimi: "kimi-for-coding",
   opencode: "opencode/default",
-  ollama: "llama3.2",
+  ollama: "qwen3.5:4b",
   litellm: "groq/llama-3.1-70b-versatile",
   mock: "mock",
 };

--- a/tests/unit/generation/test_cost_pricing.py
+++ b/tests/unit/generation/test_cost_pricing.py
@@ -14,9 +14,14 @@ from repowise.core.generation.cost_tracker import (
 
 
 def test_nano_models_priced_at_nano_rate_not_fallback() -> None:
-    for model in ("gpt-5-nano", "gpt-5.4-nano"):
+    # Each generation is priced from its own published rate; what matters is
+    # that neither lands on the Sonnet-tier fallback.
+    for model, expected in (
+        ("gpt-5-nano", {"input": 0.05, "output": 0.40}),
+        ("gpt-5.4-nano", {"input": 0.20, "output": 1.25}),
+    ):
         pricing = get_model_pricing(model)
-        assert pricing == {"input": 0.05, "output": 0.40}
+        assert pricing == expected
         assert pricing != _FALLBACK_PRICING
 
 
@@ -30,7 +35,7 @@ def test_dated_opus_variant_prices_at_opus_tier_not_sonnet_fallback() -> None:
     # an Opus user's savings are undercounted ~5x.
     for model in ("claude-opus-4-8-20260514", "claude-opus-4-9", "claude-opus-5"):
         pricing = get_model_pricing(model)
-        assert pricing == {"input": 15.0, "output": 75.0}
+        assert pricing == {"input": 5.0, "output": 25.0}
         assert pricing != _FALLBACK_PRICING
 
 
@@ -39,11 +44,11 @@ def test_family_prefix_covers_sonnet_and_haiku_variants() -> None:
     # matcher actually resolved it rather than the value alone.
     assert _family_pricing("claude-sonnet-4-9") == {"input": 3.0, "output": 15.0}
     assert _family_pricing("totally-made-up-model-9000") is None
-    assert get_model_pricing("claude-haiku-5") == {"input": 0.8, "output": 4.0}
+    assert get_model_pricing("claude-haiku-5") == {"input": 1.0, "output": 5.0}
 
 
 def test_gpt5_variants_resolve_by_tier_qualifier() -> None:
-    assert get_model_pricing("gpt-5.5-nano") == {"input": 0.05, "output": 0.40}
-    assert get_model_pricing("gpt-5.5-mini") == {"input": 0.25, "output": 2.0}
+    assert get_model_pricing("gpt-5.5-nano") == {"input": 0.20, "output": 1.25}
+    assert get_model_pricing("gpt-5.5-mini") == {"input": 0.75, "output": 4.50}
     # A plain future gpt-5 variant gets the base GPT-5 tier, not the fallback.
-    assert get_model_pricing("gpt-5.5") == {"input": 1.25, "output": 10.0}
+    assert get_model_pricing("gpt-5.5") == {"input": 2.50, "output": 15.0}

--- a/tests/unit/test_providers/test_anthropic_provider.py
+++ b/tests/unit/test_providers/test_anthropic_provider.py
@@ -28,7 +28,7 @@ def test_provider_name():
 
 def test_default_model():
     p = AnthropicProvider(api_key="sk-ant-test")
-    assert p.model_name == "claude-sonnet-4-6"
+    assert p.model_name == "claude-haiku-4-5"
 
 
 def test_api_key_from_env(monkeypatch):
@@ -87,7 +87,10 @@ def test_available_model_options_uses_models_endpoint(monkeypatch):
     sonnet = next(option for option in options if option.model == "claude-sonnet-4-6")
     assert sonnet.label == "Claude Sonnet 4.6"
     assert sonnet.reasoning_modes == ("auto",)
-    assert sonnet.recommended is True
+    assert sonnet.recommended is False
+    # The default model is the one flagged as recommended.
+    haiku = next(option for option in options if option.model == "claude-haiku-4-5")
+    assert haiku.recommended is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_providers/test_gemini_provider.py
+++ b/tests/unit/test_providers/test_gemini_provider.py
@@ -48,7 +48,7 @@ def test_provider_name():
 
 def test_model_name_default():
     p = GeminiProvider(api_key="k")
-    assert p.model_name == "gemini-3.1-flash-lite-preview"
+    assert p.model_name == "gemini-3.5-flash-lite"
 
 
 def test_model_name_custom():
@@ -82,7 +82,7 @@ def test_available_model_options_lists_generate_content_models(monkeypatch):
             {
                 "models": [
                     {
-                        "name": "models/gemini-3.1-flash-lite-preview",
+                        "name": "models/gemini-3.5-flash-lite",
                         "displayName": "Gemini Flash Lite",
                         "supportedGenerationMethods": ["generateContent"],
                         "thinking": True,
@@ -102,9 +102,9 @@ def test_available_model_options_lists_generate_content_models(monkeypatch):
     assert calls[0]["url"] == "https://generativelanguage.googleapis.com/v1beta/models"
     assert calls[0]["headers"] == {"x-goog-api-key": "k"}
     models = [option.model for option in options]
-    assert "gemini-3.1-flash-lite-preview" in models
+    assert "gemini-3.5-flash-lite" in models
     assert "gemini-embed" not in models
-    option = next(option for option in options if option.model == "gemini-3.1-flash-lite-preview")
+    option = next(option for option in options if option.model == "gemini-3.5-flash-lite")
     assert option.label == "Gemini Flash Lite"
     assert option.reasoning_modes == ("auto", "minimal", "low", "medium", "high")
     assert GeminiProvider(api_key="k").supported_reasoning_modes() == (
@@ -199,7 +199,7 @@ async def test_generate_passes_max_tokens():
 
 async def test_generate_forwards_thinking_level():
     gemini_module._GEMINI_THINKING_MODELS_BY_BASE[gemini_module._gemini_cache_key(None)] = {
-        "gemini-3.1-flash-lite-preview"
+        "gemini-3.5-flash-lite"
     }
     provider = GeminiProvider(api_key="fake-key")
     mock_response = _make_mock_response()

--- a/tests/unit/test_providers/test_openrouter_provider.py
+++ b/tests/unit/test_providers/test_openrouter_provider.py
@@ -27,7 +27,7 @@ def test_provider_name():
 
 def test_default_model():
     p = OpenRouterProvider(api_key="sk-or-test")
-    assert p.model_name == "anthropic/claude-sonnet-4.6"
+    assert p.model_name == "google/gemini-3.5-flash-lite"
 
 
 def test_api_key_from_env(monkeypatch):


### PR DESCRIPTION
Every provider surface carried model ids that had drifted from what the vendors actually serve, and two of the resulting defaults were priced wrong or rejected outright.

## Model defaults

`gemini-3.1-flash-lite-preview` is not a real model id. It was our default for the recommended provider, so the only reason init worked was the live `/models` fallback. The Anthropic and OpenRouter defaults were flagship-priced, which contradicts the "smaller is fine, repowise is calibrated for flash-lite / nano / haiku" line init prints two prompts earlier.

| Provider | Was | Now |
|---|---|---|
| gemini | `gemini-3.1-flash-lite-preview` | `gemini-3.5-flash-lite` |
| anthropic | `claude-sonnet-4-6` | `claude-haiku-4-5` |
| ollama | `llama3.2` | `qwen3.5:4b` |
| openrouter | `anthropic/claude-sonnet-4.6` | `google/gemini-3.5-flash-lite` |

openai, deepseek and kimi were already current. Each id was checked against the vendor's own model documentation.

The same values were duplicated across the CLI picker, the server catalog, the web settings placeholders, every provider's constructor default, and the docstrings quoting them. All updated together. The constructor defaults are the ones that bite silently, since anything not going through the picker gets them.

## Temperature

Anthropic removed the sampling parameters with Opus 4.7, so `temperature=0.3` on Opus 4.7+, Sonnet 5, Opus 5 or Fable 5 returns a 400. All of those are selectable from the live model list today, so this fails now rather than later.

OpenRouter and LiteLLM front arbitrary vendors, so the rejecting set is not knowable up front and a static list would go stale the same way the defaults did. Two layers, both in `providers/llm/base.py`:

- skip the parameter for model families already known to reject it
- on a 400 that mentions temperature, the two routers drop it, retry once, and remember the model for the rest of the run

Worst case for an unknown future model is one wasted request instead of a failed run.

## Pricing

Two bugs, opposite directions, same root cause:

- `cost_estimator/pricing.py` never stripped a router's vendor segment, so every `vendor/model` slug matched nothing and estimated at $0
- `generation/cost_tracker.py` had the same gap and fell through to the flat Sonnet fallback, roughly 12x over for the new OpenRouter flash-lite default. Bare Ollama `family:size` tags were also billed rather than read as local.

The Opus family prefix in `cost_tracker` was still at the Opus 3 rate of $15/$75, in a table whose own comment said that rate was wrong and had been corrected. Only the exact entries had been fixed; the prefix row was left behind. Haiku was likewise at $0.8/$4 rather than $1/$5.

## Init output

The budget-model warning fired on `gpt-5.4-nano`, telling users their nano model was a flagship, because `gpt-5` was matched as a bare substring. It would also have misfired on every Gemini model once a budget list existed, since "gemini" contains "mini". Matching is now word-boundary aware, with cheap-tier markers checked before flagship ones.

`litellm` was listed in `_PROVIDER_DEFAULTS` but not `_PROVIDER_ENV`. The picker iterates the latter, so the provider never rendered a row and its default was unreachable.

The generation plan printed a bare `(3713 pages total)` next to a cost for 91 pages, which explained nothing and hid that repowise renders file, API and symbol pages from the code with no provider call. It now names them:

```
Writing 91 concept pages with gpt-5.4-nano. Estimated $1.18 - $1.97 USD (median $1.58).
3622 more pages rendered from the code itself, no model, no cost: 2947 file, 512 API, 163 symbol
```

The structural page-type set existed in three copies and is now one exported constant. The indexing spinner is a slow blink instead of a continuous eye-roll.

## Testing

Full unit suite: 8812 passed. The pricing tests that pinned the superseded Opus, Haiku and nano rates were updated to the corrected values in the follow-up commit.

Three failures in `tests/unit/cli` (`test_advanced_config_default_keys_no_fast` and two in `test_update_provider_prompt.py`) reproduce identically on `origin/main`, same counts, and pass individually on both trees. Pre-existing test-order pollution in that directory, not related to this change.

Two distill perf tests failed once under concurrent load and pass on both trees when run normally.

Ruff clean on every touched file.
