### PR TITLE
perf(cli): defer the pipeline import out of the generate engine

### DIFF
--- a/packages/cli/src/repowise/cli/commands/generate_cmd/engine.py
+++ b/packages/cli/src/repowise/cli/commands/generate_cmd/engine.py
@@ -17,10 +17,6 @@ from repowise.cli.helpers import console, load_state
 from repowise.core.generation.cascade import CascadeMode
 from repowise.core.generation.page_selection import PageSelectionIntent
 from repowise.core.generation.scope import ScopePlan, build_cost_plans, resolve_scope
-from repowise.core.pipeline.scoped_generation import (
-    execute_scoped_generation,
-    rehydrate_repo,
-)
 
 # The page types a model writes. Everything else is structural and refreshes on
 # `repowise update`, so `generate` never writes one: it works on the concept
@@ -91,6 +87,16 @@ async def run_scoped_generation(
         upsert_repository,
     )
     from repowise.core.persistence import get_session as _get_session
+
+    # Deferred like every other CLI call site: ``repowise.core.pipeline.__init__``
+    # eagerly pulls in the orchestrator and the persist layer. At module scope
+    # that cost every ``repowise`` invocation 31 extra modules (20 of them the
+    # pipeline package) — ``--help`` and the post-commit hook included, neither
+    # of which generates.
+    from repowise.core.pipeline.scoped_generation import (
+        execute_scoped_generation,
+        rehydrate_repo,
+    )
 
     url = get_db_url_for_repo(repo_path)
     engine = create_engine(url)

--- a/tests/unit/cli/test_init_ux.py
+++ b/tests/unit/cli/test_init_ux.py
@@ -118,6 +118,28 @@ def test_the_progress_module_does_not_drag_in_the_pipeline_package() -> None:
     )
 
 
+def test_the_cli_entry_point_does_not_drag_in_the_pipeline_package() -> None:
+    """The guard above covers one module; this covers the whole entry point.
+
+    ``repowise.cli.main`` imports every command module at module scope, so a
+    single ``from repowise.core.pipeline...`` anywhere under it is paid by every
+    invocation — ``repowise --help`` and each post-commit hook run included.
+    Generation is the only thing that needs the package, and it is always
+    reached through a function body, so nothing here should load it.
+    """
+    import subprocess
+    import sys
+
+    probe = (
+        "import repowise.cli.main, sys; "
+        "print([m for m in sys.modules if m.startswith('repowise.core.pipeline')])"
+    )
+    out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=True)
+    assert out.stdout.strip() == "[]", (
+        f"importing repowise.cli.main pulled in the pipeline package: {out.stdout.strip()}"
+    )
+
+
 # --- keyless provider detection --------------------------------------------
 
 


### PR DESCRIPTION
## Problem

`generate_cmd/engine.py` imported `repowise.core.pipeline.scoped_generation` at module scope. `main.py` imports every command module at module scope, so that single line pulled `repowise.core.pipeline.__init__`, and with it the orchestrator and the persist layer, into every `repowise` invocation. That includes `repowise --help` and every post-commit hook run, neither of which generates anything.

## Change

Every other CLI call site already defers this into a function body (`init_cmd/command.py`, `init_cmd/persistence.py`, `init_cmd/workspace.py`, `restyle_cmd.py`). This moves the import into the block of function-local imports `run_scoped_generation` already has. Both use sites sit inside that function, so nothing else moves.

`engine.py:20` was the only module-scope path from the CLI into the package. Verified by grepping `packages/cli/src` and `packages/core/src`: every remaining reference in core is intra-package.

## Result

Importing `repowise.cli.main` loads 31 fewer modules (1332 to 1301), 20 of them the pipeline package. `repowise.core.pipeline` is now absent from `sys.modules` entirely rather than merely cheaper:

```
$ python -c "import repowise.cli.main, sys; print([m for m in sys.modules if m.startswith('repowise.core.pipeline')])"
[]
```

Module counts are used rather than a wall-clock figure because import timing on a loaded machine was too noisy to report honestly.

## Test

Adds `test_the_cli_entry_point_does_not_drag_in_the_pipeline_package`, a sibling of the existing `test_the_progress_module_does_not_drag_in_the_pipeline_package`. It asserts on the module list rather than a bool, so a regression names the offending module instead of just failing. Confirmed sensitive: the same probe against `main` reports the package present.

`tests/unit/cli`: 1016 passed, 2 skipped.