### PR TITLE
fix(architecture): stop the graph blaming the backend mid-load, and quiet its chrome

### DIFF
--- a/packages/ui/__tests__/graph/graph-flow.test.tsx
+++ b/packages/ui/__tests__/graph/graph-flow.test.tsx
@@ -59,29 +59,33 @@ describe("GraphFlow shell", () => {
     expect(screen.getByText("No graph data")).toBeTruthy();
   });
 
+  // Uses "language" as the controlled value because it is the one that is not
+  // the default. This was "risk" until that lens was removed for painting
+  // `pagerank * 3` through unreachable thresholds; the assertion is about
+  // control flow, not about which lens, so it survives the swap unchanged.
   it("reflects a controlled colorMode and reports changes without self-updating", () => {
     const onColorModeChange = vi.fn();
     render(
       <GraphFlow
         {...baseProps}
-        colorMode="risk"
+        colorMode="language"
         onColorModeChange={onColorModeChange}
       />,
     );
 
-    // Controlled value wins: Risk is active, Community (the default) is not.
-    expect(screen.getByRole("button", { name: "Risk" }).getAttribute("aria-pressed")).toBe("true");
+    // Controlled value wins: Language is active, Community (the default) is not.
+    expect(screen.getByRole("button", { name: "Language" }).getAttribute("aria-pressed")).toBe("true");
     expect(
       screen.getByRole("button", { name: "Community" }).getAttribute("aria-pressed"),
     ).toBe("false");
 
     // Clicking another mode reports out but does NOT change the displayed mode —
     // the host owns the value and hasn't pushed a new prop yet.
-    fireEvent.click(screen.getByRole("button", { name: "Language" }));
-    expect(onColorModeChange).toHaveBeenCalledWith("language");
-    expect(screen.getByRole("button", { name: "Risk" }).getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(screen.getByRole("button", { name: "Community" }));
+    expect(onColorModeChange).toHaveBeenCalledWith("community");
+    expect(screen.getByRole("button", { name: "Language" }).getAttribute("aria-pressed")).toBe("true");
     expect(
-      screen.getByRole("button", { name: "Language" }).getAttribute("aria-pressed"),
+      screen.getByRole("button", { name: "Community" }).getAttribute("aria-pressed"),
     ).toBe("false");
   });
 
@@ -92,8 +96,8 @@ describe("GraphFlow shell", () => {
       screen.getByRole("button", { name: "Language" }).getAttribute("aria-pressed"),
     ).toBe("true");
 
-    fireEvent.click(screen.getByRole("button", { name: "Risk" }));
-    expect(screen.getByRole("button", { name: "Risk" }).getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(screen.getByRole("button", { name: "Community" }));
+    expect(screen.getByRole("button", { name: "Community" }).getAttribute("aria-pressed")).toBe("true");
     expect(
       screen.getByRole("button", { name: "Language" }).getAttribute("aria-pressed"),
     ).toBe("false");

--- a/packages/ui/src/graph/graph-flow.tsx
+++ b/packages/ui/src/graph/graph-flow.tsx
@@ -224,8 +224,9 @@ export function GraphFlow(props: GraphFlowProps) {
 
   // The dependency graph follows the global app theme rather than a separate
   // local toggle. Sigma needs a concrete "light"/"dark" (never "system"), so
-  // resolve it; the in-graph Sun/Moon control flips the global theme below.
-  const { resolvedTheme, setTheme } = useTheme();
+  // resolve it. The toolbar used to carry its own Sun/Moon that just called
+  // `setTheme` — a duplicate of the app's header toggle — and it is gone.
+  const { resolvedTheme } = useTheme();
   const graphTheme: GraphTheme = resolvedTheme === "dark" ? "dark" : "light";
 
   const [egoDepth, setEgoDepth] = useState(0);
@@ -678,6 +679,15 @@ export function GraphFlow(props: GraphFlowProps) {
     !!fileGraphData &&
     fileGraphData.nodes.length >= ASYNC_BUILD_THRESHOLD;
 
+  // `isBuildingGraph` is only raised *inside* the effect below, which React
+  // runs after it has already painted. So on the commit where an async build
+  // first becomes necessary — the fetch has landed, the build has not started
+  // — every loading flag reads false while `sigmaGraph` is still null, and the
+  // canvas paints its "No graph data" empty state for a frame. Deriving the
+  // wait during render closes the gap: any repo above ASYNC_BUILD_THRESHOLD
+  // (1,000 nodes) hit this on every full / dead / hot load.
+  const isAwaitingAsyncBuild = needsAsyncBuild && !asyncSigmaGraph;
+
   useEffect(() => {
     if (!needsAsyncBuild || !fileGraphData) {
       setAsyncSigmaGraph(null);
@@ -1091,14 +1101,6 @@ export function GraphFlow(props: GraphFlowProps) {
     setLayoutNotice(null);
   }, [sigmaGraph]);
 
-  const handleGraphThemeChange = useCallback(
-    (theme: GraphTheme) => {
-      // Drive the global theme; the graph re-reads it via resolvedTheme.
-      setTheme(theme);
-    },
-    [setTheme],
-  );
-
   const handleSignalToggle = useCallback((signal: Signal) => {
     setActiveSignals((prev) => {
       const next = new Set(prev);
@@ -1205,12 +1207,32 @@ export function GraphFlow(props: GraphFlowProps) {
     setCtxMenu(null);
   }, [ctxMenu, setCtxMenu]);
 
-  if (isLoading || (isBuildingGraph && !sigmaGraph))
+  if (isLoading || isAwaitingAsyncBuild || (isBuildingGraph && !sigmaGraph))
     return <Skeleton className="h-full w-full rounded-lg" />;
+
+  // What the top-left status panel has to say, if anything. It is one bordered
+  // panel now, so it must not render when every row inside it is empty — an
+  // empty box is worse than the four separate chips it replaced.
+  const showOverlayCounts =
+    !!sigmaGraph && sigmaGraph.order > 0 && (isDeadView || isHotView);
+  const hasCanvasStatus =
+    (isEgoActive && !!selectedNodeId) ||
+    (isModuleView && isDrilledDown) ||
+    (isModuleView && !isDrilledDown && hasExpandedModules) ||
+    (isModuleView && hasExpandedModules && !fullGraph && isLoadingFullGraph) ||
+    (isModuleView && !isDrilledDown && !hasExpandedModules && !moduleHintDismissed) ||
+    (showOverlayCounts && !!overlayStats);
 
   return (
     <GraphProvider value={ctxValue}>
-      <div className="relative w-full h-full" style={{ touchAction: "none", ...(graphTheme === "dark" ? { background: "var(--color-bg-inset)" } : {}) }} aria-label="Dependency graph">
+      {/* The canvas is what the reader came for, so it sits on the page plane
+          rather than below it (rule 8). Dark mode used to paint
+          `--color-bg-inset`, which the July ramp move dropped to #0a0a0b — a
+          full step darker than the #0e0e0f page around it, so the graph read
+          as a hole cut in the app. Light mode never painted anything and has
+          always looked right; this makes dark do what light already did. Same
+          call the knowledge-graph canvas made in `zoom/theme.ts`. */}
+      <div className="relative w-full h-full" style={{ touchAction: "none", ...(graphTheme === "dark" ? { background: "var(--color-bg-root)" } : {}) }} aria-label="Dependency graph">
         {sigmaGraph && sigmaGraph.order > 0 ? (
           <SigmaCanvas
             ref={sigmaRef}
@@ -1247,18 +1269,24 @@ export function GraphFlow(props: GraphFlowProps) {
               title={overlayEmptyState?.title ?? "No graph data"}
               description={
                 overlayEmptyState?.description ??
-                "Check that the backend is running and this repo has been indexed."
+                "This scope came back with nothing to draw. Try another scope, or re-index the repo if it was added recently."
               }
             />
           </div>
         ) : null}
 
-        {/* Ego indicator / breadcrumb / overlay counts (stacked top-left) */}
-        <div className="absolute top-3 left-3 z-10 flex flex-col items-start gap-1.5">
+        {/* Canvas status, top-left. One panel with hairline rows, matching the
+            toolbar, the legend and the zoom controls — this corner could
+            otherwise stack four independently-bordered, independently-shadowed
+            chips (breadcrumb, expanded-modules, loading, tip, overlay counts)
+            over the diagram at once. Rendered only when it has something to
+            say, so an idle canvas carries no chrome here at all (rule 10). */}
+        {hasCanvasStatus && (
+        <div className={`absolute top-3 left-3 z-10 flex flex-col items-stretch overflow-hidden ${canvasPanelClass}`}>
         {isEgoActive && selectedNodeId ? (
           <div>
-            <div className="flex items-center gap-2 rounded-lg border border-[var(--color-accent-graph)]/30 bg-[var(--color-bg-elevated)]/90 backdrop-blur-sm px-2.5 py-1.5 shadow-lg shadow-black/20">
-              <span className="text-[10px] text-[var(--color-accent-graph)]">
+            <div className={canvasRowClass}>
+              <span className="text-[10px] text-[var(--color-accent-primary)]">
                 Showing {egoVisibleCount} nodes within {egoDepth} hop{egoDepth === 1 ? "" : "s"} of{" "}
                 <span className="font-mono font-medium">{selectedNodeId.split("/").pop()}</span>
               </span>
@@ -1272,7 +1300,7 @@ export function GraphFlow(props: GraphFlowProps) {
           </div>
         ) : isModuleView && isDrilledDown ? (
           <div>
-            <div className="flex items-center gap-1 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/90 backdrop-blur-sm px-2.5 py-1.5 shadow-lg shadow-black/20">
+            <div className={canvasRowClass}>
               <button
                 onClick={() => handleBreadcrumbClick(-1)}
                 className="flex items-center gap-1 text-xs text-[var(--color-text-tertiary)] hover:text-[var(--color-accent-graph)] transition-colors"
@@ -1306,13 +1334,13 @@ export function GraphFlow(props: GraphFlowProps) {
 
         {/* Expanded-modules chip: count + collapse-all. */}
         {isModuleView && !isDrilledDown && hasExpandedModules && (
-          <div className="flex items-center gap-2 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/90 backdrop-blur-sm px-2.5 py-1.5 shadow-sm">
+          <div className={canvasRowClass}>
             <span className="text-[10px] text-[var(--color-text-secondary)]">
               {expandedModules.size} module{expandedModules.size === 1 ? "" : "s"} expanded
             </span>
             <button
               onClick={collapseAll}
-              className="text-[10px] font-medium text-[var(--color-accent-graph)] hover:underline"
+              className="text-[10px] font-medium text-[var(--color-accent-primary)] hover:underline"
             >
               Collapse all
             </button>
@@ -1322,18 +1350,16 @@ export function GraphFlow(props: GraphFlowProps) {
         {/* Expansion needs the file-level graph — surface the fetch instead of
             letting the double-click look like it silently did nothing. */}
         {isModuleView && hasExpandedModules && !fullGraph && isLoadingFullGraph && (
-          <div
-            role="status"
-            aria-live="polite"
-            className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/90 backdrop-blur-sm px-2.5 py-1.5 shadow-sm text-[10px] text-[var(--color-text-secondary)]"
-          >
-            Loading files for expanded module…
+          <div role="status" aria-live="polite" className={canvasRowClass}>
+            <span className="text-[10px] text-[var(--color-text-secondary)]">
+              Loading files for expanded module…
+            </span>
           </div>
         )}
 
         {/* One-time interaction hint for the modules scope. */}
         {isModuleView && !isDrilledDown && !hasExpandedModules && !moduleHintDismissed && (
-          <div className="flex items-center gap-2 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/90 backdrop-blur-sm px-2.5 py-1.5 shadow-sm">
+          <div className={canvasRowClass}>
             <span className="text-[10px] text-[var(--color-text-secondary)]">
               Tip: double-click a module to see its files
             </span>
@@ -1351,8 +1377,8 @@ export function GraphFlow(props: GraphFlowProps) {
             totals come from the backend when it provides them; without totals
             we still report the in-view count so the overlay never reads as
             silently doing nothing. */}
-        {sigmaGraph && sigmaGraph.order > 0 && overlayStats && (isDeadView || isHotView) && (
-          <div className="flex flex-col items-start gap-1">
+        {showOverlayCounts && overlayStats && (
+          <>
             {isDeadView && (
               <OverlayCountChip
                 kind="dead"
@@ -1367,9 +1393,10 @@ export function GraphFlow(props: GraphFlowProps) {
                 total={hotTotal}
               />
             )}
-          </div>
+          </>
         )}
         </div>
+        )}
 
         {/* Layout-skipped notice: the hierarchical toggle must never look
             active while silently doing nothing. */}
@@ -1428,8 +1455,6 @@ export function GraphFlow(props: GraphFlowProps) {
             onSearchKeyDown={handleSearchKeyDown}
             layoutMode={layoutMode}
             onLayoutModeChange={handleLayoutModeChange}
-            graphTheme={graphTheme}
-            onGraphThemeChange={handleGraphThemeChange}
             onToggleHelp={handleToggleShortcutHelp}
             availableScopes={availableScopes}
             showExternals={showExternals}
@@ -1594,6 +1619,18 @@ export function GraphFlow(props: GraphFlowProps) {
   );
 }
 
+/**
+ * Chrome for the top-left status panel. Shares the toolbar / legend / zoom
+ * treatment so every corner of the canvas reads as one system: one border, one
+ * shadow, one blur, and hairline dividers instead of gaps between boxes.
+ */
+const canvasPanelClass =
+  "rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/85 shadow-sm backdrop-blur-sm";
+
+/** One row inside that panel. `first:border-t-0` keeps the top edge clean. */
+const canvasRowClass =
+  "flex items-center gap-2 border-t border-[var(--color-border-default)] px-2.5 py-1.5 first:border-t-0";
+
 /** Small status chip captioning a dead/hot view: "12 of 37 dead files in
  *  view" when the backend supplies repo-wide totals, or just the in-view
  *  count when it doesn't. */
@@ -1616,11 +1653,8 @@ function OverlayCountChip({
     text = `${inView} ${noun} in view`;
   }
   return (
-    <div
-      role="status"
-      className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/90 backdrop-blur-sm px-2.5 py-1.5 shadow-sm text-[10px] text-[var(--color-text-secondary)]"
-    >
-      {text}
+    <div role="status" className={canvasRowClass}>
+      <span className="text-[10px] text-[var(--color-text-secondary)]">{text}</span>
     </div>
   );
 }

--- a/packages/ui/src/graph/graph-legend.tsx
+++ b/packages/ui/src/graph/graph-legend.tsx
@@ -17,6 +17,76 @@ const LANGUAGE_LEGEND = [
   { lang: "other", color: LANGUAGE_COLORS.other, label: "Other" },
 ];
 
+/**
+ * Legend chrome, shared by the constellation and the file/module readings.
+ *
+ * Sleeker than what it replaced: one hairline instead of three (the header
+ * rule, the section rule and the per-block rules all did the same job), a
+ * single 6px gutter instead of nested 10px padding, and rows that are flush
+ * hit targets rather than text with negative margins hung off it. The old box
+ * spent about a third of its height on borders and uppercase section labels
+ * describing two or three entries each — rule 3's "if a section's label is a
+ * large fraction of its content, it wants merging".
+ */
+const shellClass =
+  "overflow-hidden rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/85 text-xs shadow-sm backdrop-blur-sm";
+
+const headerClass =
+  "flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-text-primary)]";
+
+const countClass = "font-mono text-[10px] tabular-nums tracking-[0.04em]";
+
+const rowClass =
+  "flex w-full items-center gap-2 rounded px-1.5 py-1 text-left text-[11px] text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-wash-hover)] hover:text-[var(--color-text-primary)]";
+
+/** Section label inside the key. Mono micro-label, no rule above it. */
+const groupClass =
+  "px-1.5 pt-1.5 pb-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]";
+
+function Chevron({ expanded }: { expanded: boolean }) {
+  const Icon = expanded ? ChevronDown : ChevronUp;
+  return <Icon className="h-3 w-3 shrink-0 text-[var(--color-text-tertiary)]" />;
+}
+
+// `color` is optional because LANGUAGE_COLORS is an index signature — an
+// unknown language resolves to undefined and the swatch just renders empty.
+function Swatch({ color }: { color: string | undefined }) {
+  return (
+    <span
+      className="h-2 w-2 shrink-0 rounded-full"
+      style={{ background: color }}
+    />
+  );
+}
+
+/** A toggleable swatch. Same 8px mark as `Swatch` so a filterable row and a
+ *  static one line up on the same optical grid; unchecked reads as an outline
+ *  rather than a different shape. */
+function SwatchToggle({
+  color,
+  checked,
+  label,
+  onToggle,
+}: {
+  color: string;
+  checked: boolean;
+  label: string;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onToggle();
+      }}
+      className="h-4 w-4 shrink-0 rounded-full border sm:h-2 sm:w-2"
+      style={{ borderColor: color, background: checked ? color : "transparent" }}
+      aria-label={label}
+      aria-pressed={checked}
+    />
+  );
+}
+
 interface GraphLegendProps {
   nodeCount: number;
   edgeCount: number;
@@ -54,7 +124,11 @@ export const GraphLegend = memo(function GraphLegend({
   constellationEntries,
   onConstellationHubClick,
 }: GraphLegendProps) {
-  const [expanded, setExpanded] = useState(false);
+  // Open by default. Every node on the canvas is painted from this key, so
+  // collapsing it ships a field of coloured circles with no way to read them
+  // until the reader thinks to click a counter. The key is the cheapest thing
+  // on screen and the only one that makes the rest mean anything.
+  const [expanded, setExpanded] = useState(true);
   const communityFamily = useCommunityFamilies();
   const edgeColors = edgeColorsForTheme(graphTheme);
   const isConstellation = viewMode === "architecture";
@@ -65,27 +139,17 @@ export const GraphLegend = memo(function GraphLegend({
     const entries = allEntries.slice(0, 12);
     const overflow = allEntries.length - entries.length;
     return (
-      <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)]/80 backdrop-blur-sm text-xs shadow-sm min-w-[160px] max-w-[220px]">
-        <button
-          onClick={() => setExpanded((s) => !s)}
-          className="flex items-center justify-between w-full px-2.5 py-2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
-        >
-          <span className="font-medium tabular-nums">
+      <div className={shellClass}>
+        <button onClick={() => setExpanded((s) => !s)} className={headerClass}>
+          <span className={countClass}>
             {allEntries.length} communit{allEntries.length === 1 ? "y" : "ies"}
           </span>
-          {expanded ? (
-            <ChevronDown className="w-3 h-3 shrink-0 ml-1.5" />
-          ) : (
-            <ChevronUp className="w-3 h-3 shrink-0 ml-1.5" />
-          )}
+          <Chevron expanded={expanded} />
         </button>
         {expanded && (
-          <div className="px-2.5 pb-2.5 space-y-1 border-t border-[var(--color-border-default)] pt-2">
-            <p className="text-[10px] text-[var(--color-text-tertiary)] uppercase tracking-wider font-medium">
-              Communities
-            </p>
+          <div className="space-y-px px-1.5 pb-1.5">
             {entries.length === 0 && (
-              <p className="text-[10px] text-[var(--color-text-tertiary)]">
+              <p className="px-1.5 py-1 text-[11px] text-[var(--color-text-tertiary)]">
                 No communities detected
               </p>
             )}
@@ -95,24 +159,22 @@ export const GraphLegend = memo(function GraphLegend({
                 <button
                   key={e.communityId}
                   onClick={() => onConstellationHubClick?.(e.communityId)}
-                  className="flex items-center gap-2 w-full text-left text-[var(--color-text-tertiary)] rounded px-1 -mx-1 hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)] transition-colors"
+                  className={rowClass}
                 >
-                  <span
-                    className="w-2.5 h-2.5 rounded-full shrink-0"
-                    style={{ background: color }}
-                  />
-                  <span className="truncate flex-1">{e.label}</span>
-                  <span className="tabular-nums text-[10px] shrink-0">{e.memberCount}</span>
+                  <Swatch color={color} />
+                  <span className="min-w-0 flex-1 truncate">{e.label}</span>
+                  <span className="shrink-0 tabular-nums text-[10px] text-[var(--color-text-tertiary)]">
+                    {e.memberCount}
+                  </span>
                 </button>
               );
             })}
             {overflow > 0 && (
-              <p className="text-[10px] text-[var(--color-text-tertiary)]">
-                +{overflow} smaller communit{overflow === 1 ? "y" : "ies"} not
-                listed
+              <p className="px-1.5 pt-1 text-[10px] text-[var(--color-text-tertiary)]">
+                +{overflow} smaller not listed
               </p>
             )}
-            <p className="text-[10px] text-[var(--color-text-tertiary)] pt-1.5 border-t border-[var(--color-border-default)]">
+            <p className="px-1.5 pt-1.5 text-[10px] text-[var(--color-text-tertiary)]">
               Inner ring = entry surface
             </p>
           </div>
@@ -122,35 +184,28 @@ export const GraphLegend = memo(function GraphLegend({
   }
 
   return (
-    <div className="rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-overlay)]/80 backdrop-blur-sm text-xs shadow-sm min-w-[120px] max-w-[150px]">
-      <button
-        onClick={() => setExpanded((s) => !s)}
-        className="flex items-center justify-between w-full px-2.5 py-2 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] transition-colors"
-      >
-        <span className="font-medium tabular-nums">
+    <div className={`${shellClass} min-w-[148px] max-w-[190px]`}>
+      <button onClick={() => setExpanded((s) => !s)} className={headerClass}>
+        <span className={countClass}>
           {nodeCount} nodes &middot; {edgeCount} edges
         </span>
-        {expanded ? (
-          <ChevronDown className="w-3 h-3 shrink-0 ml-1.5" />
-        ) : (
-          <ChevronUp className="w-3 h-3 shrink-0 ml-1.5" />
-        )}
+        <Chevron expanded={expanded} />
       </button>
 
       {expanded && (
-        <div className="px-2.5 pb-2.5 space-y-1.5 border-t border-[var(--color-border-default)] pt-2">
-          <p className="text-[10px] text-[var(--color-text-tertiary)] uppercase tracking-wider font-medium">
-            {colorMode === "language" ? "Language" : colorMode === "community" ? "Community" : "Risk"}
+        <div className="space-y-px px-1.5 pb-1.5">
+          <p className={groupClass}>
+            {colorMode === "language" ? "Language" : "Community"}
           </p>
 
           {colorMode === "language" &&
             LANGUAGE_LEGEND.map((l) => (
-              <div key={l.lang} className="flex items-center gap-2 text-[var(--color-text-tertiary)]">
-                <span
-                  className="w-2 h-2 rounded-full shrink-0"
-                  style={{ background: l.color }}
-                />
-                <span>{l.label}</span>
+              <div
+                key={l.lang}
+                className="flex items-center gap-2 px-1.5 py-0.5 text-[11px] text-[var(--color-text-secondary)]"
+              >
+                <Swatch color={l.color} />
+                <span className="truncate">{l.label}</span>
               </div>
             ))}
 
@@ -166,43 +221,29 @@ export const GraphLegend = memo(function GraphLegend({
                 {onToggleAllCommunities && entries && (
                   <button
                     onClick={() => onToggleAllCommunities(!allSelected)}
-                    className="text-[10px] text-[var(--color-accent-graph)] hover:underline mb-0.5"
+                    className="px-1.5 pb-0.5 text-[10px] font-medium text-[var(--color-accent-primary)] hover:underline"
                   >
-                    {allSelected ? "Deselect All" : "Select All"}
+                    {allSelected ? "Deselect all" : "Select all"}
                   </button>
                 )}
                 {entries
-                  ? entries.map(([cid, label], i) => {
+                  ? entries.map(([cid, label]) => {
                       const color = communityFamily(cid).hub;
                       const checked = !activeCommunities || activeCommunities.has(cid);
                       return (
-                        <div
-                          key={cid}
-                          className={`flex items-center gap-2 text-[var(--color-text-tertiary)]${
-                            onCommunityClick
-                              ? " cursor-pointer rounded px-1 -mx-1 hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-text-primary)] transition-colors"
-                              : ""
-                          }`}
-                        >
-                          {onCommunityToggle && (
-                            <button
-                              onClick={(e) => { e.stopPropagation(); onCommunityToggle(cid); }}
-                              className="shrink-0 w-4 h-4 sm:w-[10px] sm:h-[10px] rounded-sm border"
-                              style={{
-                                borderColor: color,
-                                background: checked ? color : "transparent",
-                              }}
-                              aria-label={`Toggle community ${label}`}
+                        <div key={cid} className={rowClass}>
+                          {onCommunityToggle ? (
+                            <SwatchToggle
+                              color={color}
+                              checked={checked}
+                              label={`Toggle community ${label}`}
+                              onToggle={() => onCommunityToggle(cid)}
                             />
-                          )}
-                          {!onCommunityToggle && (
-                            <span
-                              className="w-2 h-2 rounded-full shrink-0"
-                              style={{ background: color }}
-                            />
+                          ) : (
+                            <Swatch color={color} />
                           )}
                           <span
-                            className="truncate"
+                            className="min-w-0 flex-1 truncate"
                             onClick={() => onCommunityClick?.(cid)}
                           >
                             {label}
@@ -211,40 +252,21 @@ export const GraphLegend = memo(function GraphLegend({
                       );
                     })
                   : Array.from({ length: 6 }, (_, i) => (
-                      <div key={i} className="flex items-center gap-2 text-[var(--color-text-tertiary)]">
-                        <span
-                          className="w-2 h-2 rounded-full shrink-0"
-                          style={{ background: communityFamily(i).hub }}
-                        />
-                        <span>Community {i + 1}</span>
+                      <div
+                        key={i}
+                        className="flex items-center gap-2 px-1.5 py-0.5 text-[11px] text-[var(--color-text-secondary)]"
+                      >
+                        <Swatch color={communityFamily(i).hub} />
+                        <span className="truncate">Community {i + 1}</span>
                       </div>
                     ))}
               </>
             );
           })()}
 
-          {colorMode === "risk" && (
-            <>
-              <div className="flex items-center gap-2 text-[var(--color-text-tertiary)]">
-                <span className="w-2 h-2 rounded-full shrink-0 bg-[var(--color-risk-low)]" />
-                <span>Low risk</span>
-              </div>
-              <div className="flex items-center gap-2 text-[var(--color-text-tertiary)]">
-                <span className="w-2 h-2 rounded-full shrink-0 bg-[var(--color-risk-medium)]" />
-                <span>Medium risk</span>
-              </div>
-              <div className="flex items-center gap-2 text-[var(--color-text-tertiary)]">
-                <span className="w-2 h-2 rounded-full shrink-0 bg-[var(--color-risk-high)]" />
-                <span>High risk</span>
-              </div>
-            </>
-          )}
-
           {onEdgeTypeToggle && visibleEdgeTypes && (
             <>
-              <p className="text-[10px] text-[var(--color-text-tertiary)] uppercase tracking-wider font-medium pt-1.5 border-t border-[var(--color-border-default)] mt-1.5">
-                Edges
-              </p>
+              <p className={groupClass}>Edges</p>
               {([
                 { type: "import", label: "Imports", color: edgeColors.import },
                 { type: "crossCommunity", label: "Cross-community", color: edgeColors.crossCommunity },
@@ -254,17 +276,16 @@ export const GraphLegend = memo(function GraphLegend({
               ] as const).map((et) => {
                 const checked = visibleEdgeTypes.has(et.type);
                 return (
-                  <div key={et.type} className="flex items-center gap-2 text-[var(--color-text-tertiary)]">
-                    <button
-                      onClick={() => onEdgeTypeToggle(et.type)}
-                      className="shrink-0 w-4 h-4 sm:w-[10px] sm:h-[10px] rounded-sm border"
-                      style={{
-                        borderColor: et.color,
-                        background: checked ? et.color : "transparent",
-                      }}
-                      aria-label={`Toggle ${et.label} edges`}
+                  <div key={et.type} className={rowClass}>
+                    <SwatchToggle
+                      color={et.color}
+                      checked={checked}
+                      label={`Toggle ${et.label} edges`}
+                      onToggle={() => onEdgeTypeToggle(et.type)}
                     />
-                    <span className={checked ? "" : "line-through opacity-50"}>
+                    <span
+                      className={`min-w-0 flex-1 truncate ${checked ? "" : "opacity-45"}`}
+                    >
                       {et.label}
                     </span>
                   </div>
@@ -274,7 +295,7 @@ export const GraphLegend = memo(function GraphLegend({
           )}
 
           {viewMode !== "module" && viewMode !== "full" && (
-            <p className="text-[10px] text-[var(--color-text-tertiary)] pt-1 border-t border-[var(--color-border-default)]">
+            <p className="px-1.5 pt-1.5 text-[10px] text-[var(--color-text-tertiary)]">
               {viewMode === "dead" && "Showing unreachable files"}
               {viewMode === "hotfiles" && "Most-committed files (30d)"}
               {viewMode === "unified" && "Unified: community + risk signals"}

--- a/packages/ui/src/graph/graph-toolbar.tsx
+++ b/packages/ui/src/graph/graph-toolbar.tsx
@@ -3,7 +3,6 @@
 import {
   Palette,
   Network,
-  Shield,
   EyeOff,
   Maximize,
   Route,
@@ -17,8 +16,6 @@ import {
   X,
   GitBranch,
   Waypoints,
-  Sun,
-  Moon,
   SlidersHorizontal,
   HelpCircle,
   Package,
@@ -26,7 +23,23 @@ import {
 import { memo, useState } from "react";
 import { Button } from "../ui/button";
 
-export type ColorMode = "language" | "community" | "risk";
+/**
+ * No "risk" member. There was one, and it painted `pagerank * 3` through
+ * green/amber/red thresholds of 0.3 and 0.7 (`sigma/use-sigma.ts`). PageRank is
+ * a probability distribution summing to 1 across every node, so on any repo
+ * above roughly ten files nothing can reach 0.233 — the highest value in this
+ * codebase's own index is 0.036, which is 0.108 after the ×3. The lens was
+ * green by construction, on every repo, always.
+ *
+ * It was also spending the green/amber/red band vocabulary that rule 2
+ * reserves for real health readouts, on centrality — so a reader who learned
+ * those colours from Code Health was being taught the opposite thing here.
+ *
+ * The product does have a real defect-risk score, but `graph_nodes` carries no
+ * health column, so an honest lens needs the payload to gain one first. Until
+ * then this ships two lenses that both encode something true.
+ */
+export type ColorMode = "language" | "community";
 export type ViewMode = "module" | "full" | "architecture" | "dead" | "hotfiles" | "unified";
 export type LayoutMode = "hierarchical" | "force" | "radial";
 export type GraphTheme = "light" | "dark";
@@ -92,8 +105,6 @@ interface GraphToolbarProps {
   onSearchKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   layoutMode: LayoutMode;
   onLayoutModeChange: (mode: LayoutMode) => void;
-  graphTheme: GraphTheme;
-  onGraphThemeChange: (theme: GraphTheme) => void;
   /** Opens the keyboard-shortcut help overlay (also bound to `?`). */
   onToggleHelp?: () => void;
   /** Which scopes the scope cluster offers. Defaults to all three; the Explore
@@ -128,7 +139,6 @@ const NODE_FILTERS: { id: Overlay | "all"; icon?: typeof Skull; label: string; h
 const COLOR_MODES: { id: ColorMode; icon: typeof Palette; label: string }[] = [
   { id: "language", icon: Palette, label: "Language" },
   { id: "community", icon: Network, label: "Community" },
-  { id: "risk", icon: Shield, label: "Risk" },
 ];
 
 const LAYOUT_MODES: { id: LayoutMode; icon: typeof GitBranch; label: string }[] = [
@@ -143,6 +153,31 @@ const RADIAL_LAYOUT: { id: LayoutMode; icon: typeof GitFork; label: string } = {
   icon: GitFork,
   label: "Radial",
 };
+
+/**
+ * One panel, not four.
+ *
+ * Scope, node filter, the layout/colour/action row and search each used to be
+ * their own rounded box with its own border, its own `shadow-sm` and its own
+ * `backdrop-blur-sm`, stacked down the same edge with 6px of canvas showing
+ * between them. Four frames and four shadows for one control surface, over a
+ * diagram the reader is trying to look past (rule 13). They are now one shell
+ * with hairline dividers, sharing the legend's chrome so the two corners of
+ * the canvas read as the same system.
+ */
+const panelClass =
+  "overflow-hidden rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/85 shadow-sm backdrop-blur-sm";
+
+/** A divider row inside the panel. The first group omits the top hairline. */
+const groupClass =
+  "flex items-center gap-0.5 p-1 border-t border-[var(--color-border-default)] first:border-t-0";
+
+const itemActiveClass =
+  "bg-[var(--color-accent-primary)]/15 text-[var(--color-accent-primary)]";
+const itemIdleClass =
+  "text-[var(--color-text-tertiary)] hover:bg-[var(--color-bg-wash-hover)] hover:text-[var(--color-text-secondary)]";
+const itemClass =
+  "flex items-center gap-1.5 rounded-md px-2 py-2 text-[10px] font-medium transition-colors sm:py-1";
 
 export const GraphToolbar = memo(function GraphToolbar({
   viewMode,
@@ -164,8 +199,6 @@ export const GraphToolbar = memo(function GraphToolbar({
   onSearchKeyDown,
   layoutMode,
   onLayoutModeChange,
-  graphTheme,
-  onGraphThemeChange,
   onToggleHelp,
   availableScopes,
   showExternals,
@@ -223,10 +256,11 @@ export const GraphToolbar = memo(function GraphToolbar({
         Controls
       </button>
 
+      <div className={panelClass}>
       {/* Scope (mutually exclusive). Hidden when only one scope is offered —
           the surface is locked (e.g. the Communities lens). */}
       {scopes.length > 1 && (
-      <div className={`${clusterVisibility} gap-0.5 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/90 backdrop-blur-sm p-1 shadow-sm`}>
+      <div className={`${clusterVisibility} ${groupClass}`}>
         {scopes.map((m) => {
           const Icon = m.icon;
           const isActive = activeScope === m.id;
@@ -234,11 +268,7 @@ export const GraphToolbar = memo(function GraphToolbar({
             <button
               key={m.id}
               onClick={() => setScope(m.id)}
-              className={`flex items-center gap-1.5 px-2 py-2 sm:py-1.5 rounded-md text-[10px] font-medium transition-all ${
-                isActive
-                  ? "bg-[var(--color-accent-primary)]/15 text-[var(--color-accent-primary)]"
-                  : "text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-overlay)]"
-              }`}
+              className={`${itemClass} ${isActive ? itemActiveClass : itemIdleClass}`}
               title={m.hint}
               aria-label={m.label}
               aria-pressed={isActive}
@@ -256,7 +286,7 @@ export const GraphToolbar = memo(function GraphToolbar({
       <div
         role="radiogroup"
         aria-label="Node filter"
-        className={`${clusterVisibility} gap-0.5 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/90 backdrop-blur-sm p-1 shadow-sm`}
+        className={`${clusterVisibility} ${groupClass}`}
       >
         {NODE_FILTERS.map((f) => {
           const Icon = f.icon;
@@ -265,11 +295,7 @@ export const GraphToolbar = memo(function GraphToolbar({
             <button
               key={f.id}
               onClick={() => setNodeFilter(f.id)}
-              className={`flex items-center gap-1 px-2 py-2 sm:py-1 rounded-md text-[10px] font-medium transition-all ${
-                isActive
-                  ? "bg-[var(--color-accent-graph)]/15 text-[var(--color-accent-graph)]"
-                  : "text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-overlay)]"
-              }`}
+              className={`${itemClass} ${isActive ? itemActiveClass : itemIdleClass}`}
               title={f.hint}
               aria-label={f.label}
               role="radio"
@@ -283,9 +309,8 @@ export const GraphToolbar = memo(function GraphToolbar({
       </div>
       )}
 
-      {/* Layout · color · actions collapse into one floating group so the
-          canvas isn't fenced in by a row of separate shadowed pills. */}
-      <div className={`${clusterVisibility} items-center gap-1 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/90 backdrop-blur-sm p-1 shadow-sm`}>
+      {/* Layout · colour · actions. */}
+      <div className={`${clusterVisibility} ${groupClass}`}>
         <div className="flex gap-0.5">
           {isConstellation ? (
             // Constellation is locked to the radial layout; show a single
@@ -293,7 +318,7 @@ export const GraphToolbar = memo(function GraphToolbar({
             <button
               key={RADIAL_LAYOUT.id}
               disabled
-              className="flex items-center gap-1 px-2 py-1 rounded-md text-[10px] font-medium bg-[var(--color-accent-graph)]/15 text-[var(--color-accent-graph)] cursor-default"
+              className={`${itemClass} ${itemActiveClass} cursor-default`}
               title={`${RADIAL_LAYOUT.label} (fixed for Communities)`}
               aria-label={RADIAL_LAYOUT.label}
               aria-pressed
@@ -308,11 +333,7 @@ export const GraphToolbar = memo(function GraphToolbar({
                 <button
                   key={m.id}
                   onClick={() => onLayoutModeChange(m.id)}
-                  className={`flex items-center gap-1 px-2 py-2 sm:py-1 rounded-md text-[10px] font-medium transition-all ${
-                    isActive
-                      ? "bg-[var(--color-accent-graph)]/15 text-[var(--color-accent-graph)]"
-                      : "text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-overlay)]"
-                  }`}
+                  className={`${itemClass} ${isActive ? itemActiveClass : itemIdleClass}`}
                   title={m.label}
                   aria-label={m.label}
                   aria-pressed={isActive}
@@ -324,7 +345,18 @@ export const GraphToolbar = memo(function GraphToolbar({
           )}
         </div>
 
-        <div className="flex gap-0.5 border-l border-[var(--color-border-default)] pl-1">
+        {/* Colour-by. This control decides what every circle on the canvas
+            means, and it used to be three unlabelled icons — a palette, a
+            network and a shield — so there was no way to know whether you were
+            looking at languages, communities or risk without hovering each
+            one. Worse, Risk paints green/amber/red and Community paints
+            families that include green, amber and red: same marks, two
+            vocabularies, switched by a mystery glyph. The active mode now
+            always carries its word. */}
+        <div className="flex items-center gap-0.5 border-l border-[var(--color-border-default)] pl-1">
+          <span className="hidden pl-1 pr-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)] lg:inline">
+            Colour
+          </span>
           {COLOR_MODES.map((m) => {
             const Icon = m.icon;
             const isActive = colorMode === m.id;
@@ -332,33 +364,23 @@ export const GraphToolbar = memo(function GraphToolbar({
               <button
                 key={m.id}
                 onClick={() => onColorModeChange(m.id)}
-                className={`flex items-center gap-1 px-2 py-2 sm:py-1 rounded-md text-[10px] font-medium transition-all ${
-                  isActive
-                    ? "bg-[var(--color-accent-graph)]/15 text-[var(--color-accent-graph)]"
-                    : "text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-overlay)]"
-                }`}
+                className={`${itemClass} ${isActive ? itemActiveClass : itemIdleClass}`}
                 title={m.label}
                 aria-label={m.label}
                 aria-pressed={isActive}
               >
                 <Icon className="w-3 h-3" />
+                {isActive && <span>{m.label}</span>}
               </button>
             );
           })}
         </div>
 
+        {/* No theme control here. It set the *global* theme, so it did exactly
+            what the app's own toggle in the header does, a few hundred pixels
+            away — two controls, one effect, and this one buried in a row of a
+            dozen unlabelled icons. */}
         <div className="flex gap-0.5 border-l border-[var(--color-border-default)] pl-1">
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() => onGraphThemeChange(graphTheme === "light" ? "dark" : "light")}
-            className={`h-8 w-8 sm:h-7 sm:w-7 p-0 ${graphTheme === "dark" ? "text-[var(--color-accent-graph)]" : "text-[var(--color-text-tertiary)]"}`}
-            title={graphTheme === "dark" ? "Light graph theme" : "Dark graph theme"}
-            aria-label={graphTheme === "dark" ? "Light graph theme" : "Dark graph theme"}
-            aria-pressed={graphTheme === "dark"}
-          >
-            {graphTheme === "dark" ? <Sun className="w-3.5 h-3.5" /> : <Moon className="w-3.5 h-3.5" />}
-          </Button>
           {/* Path finder / execution flows operate on file-level nodes and
               don't apply to the community constellation — hidden there. */}
           {!isConstellation && pathFinderAvailable && (
@@ -366,7 +388,7 @@ export const GraphToolbar = memo(function GraphToolbar({
             size="sm"
             variant="ghost"
             onClick={onTogglePathFinder}
-            className={`h-8 w-8 sm:h-7 sm:w-7 p-0 ${showPathFinder ? "text-[var(--color-accent-graph)]" : "text-[var(--color-text-tertiary)]"}`}
+            className={`h-8 w-8 sm:h-7 sm:w-7 p-0 ${showPathFinder ? "text-[var(--color-accent-primary)]" : "text-[var(--color-text-tertiary)]"}`}
             title="Find dependency path"
             aria-label="Find dependency path"
             aria-pressed={showPathFinder}
@@ -379,7 +401,7 @@ export const GraphToolbar = memo(function GraphToolbar({
             size="sm"
             variant="ghost"
             onClick={onToggleFlows}
-            className={`h-8 w-8 sm:h-7 sm:w-7 p-0 ${showFlows ? "text-[var(--color-accent-graph)]" : "text-[var(--color-text-tertiary)]"}`}
+            className={`h-8 w-8 sm:h-7 sm:w-7 p-0 ${showFlows ? "text-[var(--color-accent-primary)]" : "text-[var(--color-text-tertiary)]"}`}
             title="Execution flows"
             aria-label="Execution flows"
             aria-pressed={showFlows}
@@ -392,7 +414,7 @@ export const GraphToolbar = memo(function GraphToolbar({
             size="sm"
             variant="ghost"
             onClick={() => onShowExternalsChange(!showExternals)}
-            className={`h-8 w-8 sm:h-7 sm:w-7 p-0 ${showExternals ? "text-[var(--color-accent-graph)]" : "text-[var(--color-text-tertiary)]"}`}
+            className={`h-8 w-8 sm:h-7 sm:w-7 p-0 ${showExternals ? "text-[var(--color-accent-primary)]" : "text-[var(--color-text-tertiary)]"}`}
             title={
               showExternals
                 ? `Hide ${externalCount} external dependencies`
@@ -413,7 +435,7 @@ export const GraphToolbar = memo(function GraphToolbar({
             size="sm"
             variant="ghost"
             onClick={() => onHideTestsChange(!hideTests)}
-            className={`h-8 w-8 sm:h-7 sm:w-7 p-0 ${hideTests ? "text-[var(--color-accent-graph)]" : "text-[var(--color-text-tertiary)]"}`}
+            className={`h-8 w-8 sm:h-7 sm:w-7 p-0 ${hideTests ? "text-[var(--color-accent-primary)]" : "text-[var(--color-text-tertiary)]"}`}
             title={hideTests ? "Show test files" : "Hide test files"}
             aria-label={hideTests ? "Show test files" : "Hide test files"}
             aria-pressed={hideTests}
@@ -446,33 +468,34 @@ export const GraphToolbar = memo(function GraphToolbar({
         </div>
       </div>
 
-      <div className="relative">
-        <div className="flex items-center gap-1 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/90 backdrop-blur-sm px-2 py-1 shadow-sm">
-          <Search className="w-3 h-3 text-[var(--color-text-tertiary)] shrink-0" />
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => onSearchChange(e.target.value)}
-            onKeyDown={onSearchKeyDown}
-            placeholder="Search nodes…"
-            aria-label="Search graph nodes"
-            className="bg-transparent text-xs text-[var(--color-text-primary)] placeholder:text-[var(--color-text-tertiary)] outline-none w-28 lg:w-40"
-          />
-          {searchQuery && searchMatchCount != null && searchTotalCount != null && (
-            <span className="text-[10px] text-[var(--color-text-tertiary)] tabular-nums whitespace-nowrap">
-              {searchMatchCount} / {searchTotalCount}
-            </span>
-          )}
-          {searchQuery && (
-            <button
-              onClick={() => onSearchChange("")}
-              aria-label="Clear search"
-              className="text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)]"
-            >
-              <X className="w-3 h-3" />
-            </button>
-          )}
-        </div>
+      {/* Search stays visible at every width — it is the one control that
+          still works when the rest of the cluster is collapsed on a phone. */}
+      <div className="flex items-center gap-1.5 border-t border-[var(--color-border-default)] px-2 py-1.5">
+        <Search className="h-3 w-3 shrink-0 text-[var(--color-text-tertiary)]" />
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          onKeyDown={onSearchKeyDown}
+          placeholder="Search nodes…"
+          aria-label="Search graph nodes"
+          className="w-28 bg-transparent text-xs text-[var(--color-text-primary)] outline-none placeholder:text-[var(--color-text-tertiary)] lg:w-40"
+        />
+        {searchQuery && searchMatchCount != null && searchTotalCount != null && (
+          <span className="whitespace-nowrap font-mono text-[10px] tabular-nums text-[var(--color-text-tertiary)]">
+            {searchMatchCount}/{searchTotalCount}
+          </span>
+        )}
+        {searchQuery && (
+          <button
+            onClick={() => onSearchChange("")}
+            aria-label="Clear search"
+            className="text-[var(--color-text-tertiary)] hover:text-[var(--color-text-primary)]"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </div>
       </div>
     </div>
   );

--- a/packages/ui/src/graph/graph-truncation-banner.tsx
+++ b/packages/ui/src/graph/graph-truncation-banner.tsx
@@ -1,15 +1,19 @@
 "use client";
 
 /**
- * GraphTruncationBanner — shown when the server capped the full-graph
- * response to top-N by PageRank. Communicates the cap to the user and offers
- * a stepped "load more" escape hatch (one page of importance at a time).
+ * GraphTruncationBanner — states the bound when the server capped the
+ * full-graph response to top-N by PageRank, and offers a stepped "load more"
+ * escape hatch (one page of importance at a time).
+ *
+ * A cap is normal on any large repo, not a fault, so this reads as a status
+ * line rather than a warning: no amber fill, no alert glyph, no border box. It
+ * used to spend all three on a message that fires on every big-repo load, and
+ * sat directly above the canvas it was describing. Rule 10 — a marker means
+ * there is something to do.
  *
  * Lives in `packages/ui` so the hosted frontend can reuse it.
  */
 
-import { AlertTriangle } from "lucide-react";
-import { Button } from "../ui/button";
 import { cn } from "../lib/cn";
 import { formatNumber } from "../lib/format";
 
@@ -29,6 +33,9 @@ export interface GraphTruncationBannerProps {
   className?: string;
 }
 
+const linkClass =
+  "shrink-0 font-medium text-[var(--color-accent-primary)] hover:underline";
+
 export function GraphTruncationBanner({
   shown,
   total,
@@ -46,42 +53,36 @@ export function GraphTruncationBanner({
       role="status"
       aria-live="polite"
       className={cn(
-        "flex items-center gap-3 rounded-lg border border-[var(--color-warning)]/40 bg-[var(--color-warning)]/10 px-3 py-2 text-[12px] text-[var(--color-text-primary)]",
+        "flex flex-wrap items-baseline gap-x-3 gap-y-1 text-[12px] text-[var(--color-text-secondary)]",
         className,
       )}
     >
-      <AlertTriangle className="h-4 w-4 shrink-0 text-[var(--color-warning)]" />
       <p className="min-w-0 flex-1">
-        Showing <span className="font-semibold tabular-nums">{formatNumber(shown)}</span> of{" "}
-        <span className="font-semibold tabular-nums">{formatNumber(total)}</span> by importance.
-        {slowHint && canLoadMore && (
-          <span className="ml-1 text-[var(--color-text-secondary)]">
-            Loading more may be slow.
-          </span>
-        )}
+        Showing the{" "}
+        <span className="font-medium tabular-nums text-[var(--color-text-primary)]">
+          {formatNumber(shown)}
+        </span>{" "}
+        most-connected files of{" "}
+        <span className="font-medium tabular-nums text-[var(--color-text-primary)]">
+          {formatNumber(total)}
+        </span>
+        .
+        {slowHint && canLoadMore && " Loading more will be slower."}
       </p>
-      <div className="flex shrink-0 items-center gap-2">
-        {onSwitchToArchitecture && (
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onSwitchToArchitecture}
-            className="h-7 px-2 text-xs font-medium text-[var(--color-warning)] hover:bg-[var(--color-warning)]/15 hover:text-[var(--color-warning)]"
-          >
-            Switch to Architecture
-          </Button>
-        )}
-        {onLoadMore && canLoadMore && (
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() => onLoadMore(nextLimit)}
-            className="h-7 px-2 text-xs font-medium text-[var(--color-warning)] hover:bg-[var(--color-warning)]/15 hover:text-[var(--color-warning)]"
-          >
-            Load {formatNumber(Math.min(LOAD_MORE_STEP, nextLimit - limit))} more
-          </Button>
-        )}
-      </div>
+      {onSwitchToArchitecture && (
+        <button type="button" onClick={onSwitchToArchitecture} className={linkClass}>
+          See all of them grouped
+        </button>
+      )}
+      {onLoadMore && canLoadMore && (
+        <button
+          type="button"
+          onClick={() => onLoadMore(nextLimit)}
+          className={linkClass}
+        >
+          Load {formatNumber(Math.min(LOAD_MORE_STEP, nextLimit - limit))} more
+        </button>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/graph/sigma/sigma-canvas.tsx
+++ b/packages/ui/src/graph/sigma/sigma-canvas.tsx
@@ -213,7 +213,7 @@ export const SigmaCanvas = forwardRef<SigmaCanvasHandle, SigmaCanvasProps>(
           // For the constellation, paint the dark canvas on the wrapper and keep
           // the sigma container transparent so the depth-ring underlay shows.
           hasDepthRings && props.graphTheme === "dark"
-            ? { background: "var(--color-bg-canvas)" }
+            ? { background: "var(--color-bg-root)" }
             : undefined
         }
       >
@@ -224,9 +224,14 @@ export const SigmaCanvas = forwardRef<SigmaCanvasHandle, SigmaCanvasProps>(
           ref={containerCallback}
           className="w-full h-full relative z-[1]"
           style={{
+            // `--color-bg-canvas` aliases `--color-bg-inset`, which the July
+            // ramp move took to #0a0a0b — darker than the page. The canvas is
+            // the subject, so it takes the page plane (rule 8), matching the
+            // knowledge-graph canvas. Light mode is unchanged: it was already
+            // transparent, which is why only dark looked wrong.
             background:
               !hasDepthRings && props.graphTheme === "dark"
-                ? "var(--color-bg-canvas)"
+                ? "var(--color-bg-root)"
                 : "transparent",
             cursor: "grab",
           }}
@@ -242,7 +247,6 @@ export const SigmaCanvas = forwardRef<SigmaCanvasHandle, SigmaCanvasProps>(
           }
           isLayoutRunning={props.layoutMode === "force" ? isLayoutRunning : isElkComputing}
           onToggleLayout={props.layoutMode === "force" ? toggleLayout : undefined}
-          graphTheme={props.graphTheme}
         />
         <SigmaMinimap sigma={sigma} graphTheme={props.graphTheme} />
       </div>

--- a/packages/ui/src/graph/sigma/sigma-controls.tsx
+++ b/packages/ui/src/graph/sigma/sigma-controls.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ZoomIn, ZoomOut, Maximize, Focus, Play, Pause } from "lucide-react";
-import { Button } from "../../ui/button";
 
 interface SigmaControlsProps {
   onZoomIn: () => void;
@@ -10,7 +9,6 @@ interface SigmaControlsProps {
   onFocusSelected?: (() => void) | undefined;
   isLayoutRunning: boolean;
   onToggleLayout?: (() => void) | undefined;
-  graphTheme: "light" | "dark";
 }
 
 export function SigmaControls({
@@ -20,78 +18,84 @@ export function SigmaControls({
   onFocusSelected,
   isLayoutRunning,
   onToggleLayout,
-  graphTheme,
 }: SigmaControlsProps) {
-  const isDark = graphTheme === "dark";
-  const btnClass = isDark
-    ? "h-7 w-7 p-0 border-white/10 bg-[#1a1a2e] text-white/60 hover:bg-[#252540] hover:text-white shadow-lg shadow-black/40"
-    : "h-7 w-7 p-0 border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-overlay)] hover:text-[var(--color-text-primary)] shadow-lg shadow-black/20";
+  // One panel with hairline dividers, matching the toolbar and the legend, so
+  // all three corners of the canvas read as the same system. Each button used
+  // to be its own bordered, `shadow-lg` pill; five of them stacked down the
+  // right edge was five frames and five shadows for one control.
+  //
+  // Dark mode also painted a hardcoded `#1a1a2e` navy that belongs to no
+  // palette in this app — the same class of drift as `--color-bg-glass`, and
+  // it survived for the same reason: it only ever renders on top of a diagram,
+  // where a plane one step off reads as deliberate.
+  const btnClass =
+    "flex h-7 w-7 items-center justify-center rounded-md text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-wash-hover)] hover:text-[var(--color-text-primary)]";
 
   return (
-    <div className="absolute bottom-3 right-3 z-10 flex flex-col gap-1">
-      <Button
-        size="sm"
-        variant="outline"
-        onClick={onZoomIn}
-        className={btnClass}
-        title="Zoom in"
-        aria-label="Zoom in"
-      >
-        <ZoomIn className="w-3.5 h-3.5" />
-      </Button>
-      <Button
-        size="sm"
-        variant="outline"
-        onClick={onZoomOut}
-        className={btnClass}
-        title="Zoom out"
-        aria-label="Zoom out"
-      >
-        <ZoomOut className="w-3.5 h-3.5" />
-      </Button>
-      <Button
-        size="sm"
-        variant="outline"
-        onClick={onFitView}
-        className={btnClass}
-        title="Fit view"
-        aria-label="Fit view"
-      >
-        <Maximize className="w-3.5 h-3.5" />
-      </Button>
-      {onFocusSelected && (
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={onFocusSelected}
-          className={btnClass}
-          title="Focus selected"
-          aria-label="Focus selected"
-        >
-          <Focus className="w-3.5 h-3.5" />
-        </Button>
-      )}
-      {onToggleLayout && (
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={onToggleLayout}
-          className={btnClass}
-          title={isLayoutRunning ? "Stop layout" : "Run layout"}
-          aria-label={isLayoutRunning ? "Stop layout" : "Run layout"}
-        >
-          {isLayoutRunning ? (
-            <Pause className="w-3.5 h-3.5" />
-          ) : (
-            <Play className="w-3.5 h-3.5" />
-          )}
-        </Button>
-      )}
+    <div className="absolute bottom-3 right-3 z-10 flex flex-col items-end gap-1.5">
       {isLayoutRunning && (
-        <div className="text-[10px] text-center text-[var(--color-accent-graph)] animate-pulse whitespace-nowrap">
-          Layout optimizing...
+        <div className="animate-pulse whitespace-nowrap rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/85 px-2 py-1 text-[10px] text-[var(--color-accent-primary)] shadow-sm backdrop-blur-sm">
+          Arranging…
         </div>
       )}
+      <div className="flex flex-col overflow-hidden rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]/85 p-1 shadow-sm backdrop-blur-sm">
+        <button
+          type="button"
+          onClick={onZoomIn}
+          className={btnClass}
+          title="Zoom in"
+          aria-label="Zoom in"
+        >
+          <ZoomIn className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={onZoomOut}
+          className={btnClass}
+          title="Zoom out"
+          aria-label="Zoom out"
+        >
+          <ZoomOut className="h-3.5 w-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={onFitView}
+          className={btnClass}
+          title="Fit view"
+          aria-label="Fit view"
+        >
+          <Maximize className="h-3.5 w-3.5" />
+        </button>
+        {onFocusSelected && (
+          <button
+            type="button"
+            onClick={onFocusSelected}
+            className={btnClass}
+            title="Focus selected"
+            aria-label="Focus selected"
+          >
+            <Focus className="h-3.5 w-3.5" />
+          </button>
+        )}
+        {onToggleLayout && (
+          <button
+            type="button"
+            onClick={onToggleLayout}
+            className={`${btnClass} mt-1 border-t border-[var(--color-border-default)] pt-1 ${
+              isLayoutRunning ? "text-[var(--color-accent-primary)]" : ""
+            }`}
+            title={isLayoutRunning ? "Stop arranging" : "Re-arrange nodes"}
+            aria-label={isLayoutRunning ? "Stop arranging" : "Re-arrange nodes"}
+            aria-pressed={isLayoutRunning}
+          >
+            {isLayoutRunning ? (
+              <Pause className="h-3.5 w-3.5" />
+            ) : (
+              <Play className="h-3.5 w-3.5" />
+            )}
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/graph/sigma/use-sigma.ts
+++ b/packages/ui/src/graph/sigma/use-sigma.ts
@@ -447,14 +447,17 @@ export function useSigmaRenderer(options: UseSigmaOptions): UseSigmaReturn {
             attrs.nodeType === "module"
               ? getCommunityFamily(attrs.communityId).hub
               : languageColor(attrs.language || "other");
-        } else if (cm === "community") {
-          // Modules (centroids) get the hub hue; files use the softer satellite
-          // tint so leaves recede behind their community's anchor.
+        } else {
+          // Community. Modules (centroids) get the hub hue; files use the
+          // softer satellite tint so leaves recede behind their anchor.
+          //
+          // A third branch used to paint a "risk" lens from `pagerank * 3`
+          // against thresholds of 0.3 and 0.7. PageRank sums to 1 across the
+          // graph, so those thresholds are unreachable on any real repo and
+          // the lens rendered entirely green. See the `ColorMode` docstring in
+          // `graph-toolbar.tsx` for why it is gone rather than re-tuned.
           const family = getCommunityFamily(attrs.communityId);
           color = attrs.nodeType === "module" ? family.hub : family.satellite;
-        } else {
-          const risk = attrs.pagerank * 3;
-          color = risk > 0.7 ? viz.risk.high : risk > 0.3 ? viz.risk.medium : viz.risk.low;
         }
         if (attrs.isDead) color = desaturateColor(color, 0.6);
         if (attrs.isHotspot) color = tintColor(color, viz.hotspot, 0.4);

--- a/packages/ui/src/graph/use-graph-keyboard-shortcuts.ts
+++ b/packages/ui/src/graph/use-graph-keyboard-shortcuts.ts
@@ -70,9 +70,8 @@ export function useGraphKeyboardShortcuts(opts: GraphKeyboardShortcutOptions): v
         case "2":
           setColorMode("community");
           break;
-        case "3":
-          setColorMode("risk");
-          break;
+        // No "3". It bound the risk lens, which is gone — see the `ColorMode`
+        // docstring in `graph-toolbar.tsx`.
         case "/":
           e.preventDefault();
           document

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -74,7 +74,20 @@ export default async function RootLayout({
                 <Sidebar repos={repos} workspace={workspace} />
                 <div className="flex flex-1 flex-col min-w-0 overflow-hidden">
                   <MobileNav repos={repos} workspace={workspace} />
-                  <main id="main-content" className="flex-1 overflow-auto min-w-0">
+                  {/* A flex column, so anything a route layout stacks above
+                      the page (repo breadcrumb, reindex hint, active-job
+                      banner) is subtracted from the page's own height rather
+                      than added to it. `PageTransition` used to take `h-full`
+                      = 100% of this element, which ignored those bands: the
+                      page then overflowed by exactly their combined height and
+                      `main` scrolled. Invisible on a document page, but a
+                      full-bleed canvas pushed its bottom-anchored chrome — the
+                      graph legend, the zoom controls — below the fold, where
+                      it could not be clicked. */}
+                  <main
+                    id="main-content"
+                    className="flex flex-1 flex-col overflow-auto min-w-0"
+                  >
                     {children}
                   </main>
                 </div>

--- a/packages/web/src/components/architecture/graph-view.tsx
+++ b/packages/web/src/components/architecture/graph-view.tsx
@@ -12,9 +12,11 @@ import { getGraph } from "@/lib/api/graph";
 import type { GraphExportResponse } from "@/lib/api/types";
 
 type ViewMode = "module" | "full" | "architecture" | "dead" | "hotfiles" | "unified";
-type ColorMode = "language" | "community" | "risk";
+type ColorMode = "language" | "community";
 
-const VALID_COLOR_MODES = new Set<ColorMode>(["language", "community", "risk"]);
+// `?colorMode=risk` links predate the removal of that lens; an unlisted value
+// falls through to the "community" default rather than erroring.
+const VALID_COLOR_MODES = new Set<ColorMode>(["language", "community"]);
 
 const VALID_VIEW_MODES = new Set<ViewMode>([
   "module",
@@ -144,11 +146,15 @@ export function GraphView({
 
   return (
     <GraphCanvasShell
-      title={isMap ? "Communities" : "Dependency Explorer"}
+      // No title. The tab above already says "Communities" / "Explore", and a
+      // heading that repeats the control you just clicked spends a band of
+      // chrome saying nothing — this page carried three of them above the
+      // canvas. What is left is the one line that adds something the tab
+      // cannot: what to do with the thing you are looking at.
       description={
         isMap
-          ? "Detected communities and how they connect — double-click a hub to blossom it"
-          : "Explore dependencies, overlays and trace paths between files"
+          ? "Each circle is a detected community, sized by how much code it holds. Double-click one to open it up."
+          : "Every file and how it depends on the others. Pick two files to trace a path between them."
       }
       banner={
         // Shown only when the current scope renders the capped full graph and

--- a/packages/web/src/components/layout/page-transition.tsx
+++ b/packages/web/src/components/layout/page-transition.tsx
@@ -19,7 +19,12 @@ export function PageTransition({ children }: PageTransitionProps) {
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -4 }}
         transition={{ duration: 0.15, ease: "easeOut" }}
-        className="h-full"
+        // `flex-1`, not `h-full`. `main` is a flex column, so this claims the
+        // space left over after the route layout's banners instead of 100% of
+        // `main` regardless of them. Deliberately no `min-h-0`: the default
+        // `min-height: auto` keeps a page taller than the viewport able to
+        // grow and scroll `main`, which is what every document page relies on.
+        className="flex-1"
       >
         {children}
       </motion.div>


### PR DESCRIPTION
Four bugs on the Architecture graph page, and a pass over the chrome sitting on top of the canvas. Measured against this repo's own index (31,381 nodes, 1,500-node capped export).

## The canvas reported an error on every large load

It painted **"No graph data. Check that the backend is running and this repo has been indexed."** for a frame on each load, which is an alarming thing to show someone whose backend is fine.

`isBuildingGraph` is only raised *inside* an effect, and React runs effects after it has already painted. So on the commit where the fetch lands but the build has not started, every loading flag reads false while the graph is still null. The async build path kicks in at 1,000 nodes and this repo loads 1,500, so it fired every time. The wait is now derived during render, which closes the gap. The empty state that remains no longer blames the backend for what is usually just an empty scope.

## Dark mode painted the canvas below the page

`--color-bg-canvas` aliases `--color-bg-inset`, which the July ramp move took to `#0a0a0b`, a full step darker than the `#0e0e0f` page around it. The graph read as a hole cut in the app. Light mode never painted a ground at all, which is exactly why only dark looked wrong. Both sit on the page plane now, matching the call `zoom/theme.ts` already made for the knowledge graph.

## Bottom-anchored canvas chrome was below the fold

`main` was a plain block and `PageTransition` took `h-full`, so a page claimed 100% of `main` regardless of the breadcrumb and banner rows the repo layout stacks above it. The page therefore overflowed by exactly their combined height. Invisible on a document page; on a full-bleed canvas it pushed the legend and the zoom controls off-screen, where they could not be clicked. `main` is a flex column now and `PageTransition` claims the leftover space. Deliberately no `min-h-0`, so a page taller than the viewport still grows and scrolls.

This one is in the app shell, so it is worth a second pair of eyes: it touches every route, though the intent is that only pages with banners above them move at all.

## The Risk lens could never be anything but green

```js
const risk = attrs.pagerank * 3;
color = risk > 0.7 ? high : risk > 0.3 ? medium : low;
```

PageRank is a probability distribution summing to 1 across every node, so on any repo above roughly ten files nothing can reach 0.233. Measured here:

| | |
|---|---|
| Highest pagerank in the repo | 0.0359 |
| That value after the ×3 | 0.108 |
| Amber threshold | 0.3 |
| Nodes that can reach amber or red | **0** |

It was also spending the green/amber/red band vocabulary on centrality, so a reader who learned those colours from Code Health was being taught the opposite thing here. `graph_nodes` carries no health column, so an honest lens needs the payload to gain one first. Removed rather than re-tuned. `?colorMode=risk` links fall through to the default instead of breaking.

## Chrome

The toolbar was four separately bordered, shadowed and blurred boxes stacked down one edge; the zoom controls were five; the top-left status area could stack four more. Roughly ten floating frames over a diagram the reader is trying to look past. They are now three panels with hairline dividers sharing one treatment, and the status panel renders nothing when it has nothing to say.

Also in this pass:

- Dropped a graph theme toggle that called `setTheme` globally, so it did exactly what the app's header toggle does a few hundred pixels away.
- Dropped a page title that repeated the tab directly above it.
- The legend opens by default. It was shipping a field of coloured circles with no way to read them until you thought to click a counter.
- Colour-by shows the name of the active lens. It was three unlabelled icons deciding what every circle on screen means.
- The truncation banner reads as a status line, not an amber warning. A cap is normal on a large repo. It also names what it is counting ("the 1,500 most-connected files of 31,381") and no longer offers "Switch to Architecture", a scope name that appears nowhere in the tab list.
- Removed a hardcoded `#1a1a2e` in the zoom controls that belongs to no palette in this app. Same drift class as `--color-bg-glass`, and it survived for the same reason: it only ever renders on top of a diagram.

## Checks

`packages/ui` and `packages/web` both typecheck. Full `packages/ui` suite passes, 972/972.

Two tests used `"risk"` purely as a value that was not the default; they now use `"language"`, which keeps what they were actually asserting.

Note for whoever picks this up: `__tests__/zoom/node-signals.test.ts` has a `descendant_count` type error that is already on `main` and is not touched here.

## Deliberately not in this PR

- Perf. A separate audit found the minimap redrawing every node on every frame, ~3,000 synchronous `getComputedStyle` calls per graph load, and 89% of downloaded edges being hidden on first paint. Own PR.
- `THEME_COLORS` in `use-sigma.ts` is a hardcoded mirror of the canvas background that has drifted from the tokens, which is why dimmed nodes never fully recede. Own PR, alongside hub labels failing contrast on 10 of 12 hues in light mode.
- The Modules scope and the tab structure. Modules draws nine top-level directories where one holds 69% of the files, and the same scope axis is currently controlled both by page tabs and by in-canvas pills. That is a real refactor and deserves its own run.
