### PR TITLE
fix(zoom): repair the node fixture that is failing type-check on main

### DIFF
--- a/packages/ui/__tests__/zoom/node-signals.test.ts
+++ b/packages/ui/__tests__/zoom/node-signals.test.ts
@@ -1,33 +1,55 @@
 import { describe, it, expect } from "vitest";
 import { hasRole, healthBandLabel, nodeRoles } from "../../src/zoom/node-signals";
-import type { ZoomNode } from "../../src/zoom/types";
+import type { ZoomMetrics, ZoomNode } from "../../src/zoom/types";
 
-function node(over: Partial<ZoomNode> = {}): ZoomNode {
+const METRICS: ZoomMetrics = {
+  file_count: 0,
+  descendant_count: 0,
+  hotspot_count: 0,
+  entry_point_count: 0,
+  on_flow_count: 0,
+  dead_count: 0,
+};
+
+/**
+ * `metrics` merges rather than replaces, so a fixture names only the counts its
+ * assertion is about. Requiring all six meant every new field in `ZoomMetrics`
+ * broke every fixture that set any of them, which is what happened to
+ * `descendant_count`.
+ *
+ * The return is not cast. The `as ZoomNode` that used to sit here accepted an
+ * object that did not describe a `ZoomNode` at all: `metrics` was missing
+ * `descendant_count`, `summary` was null against a `string`, `importance` and
+ * `sibling_rank` were absent, and `rect` is not a field (the node's box is
+ * `layout`). Only the one override call site ever errored, and only in the
+ * type-check job, which does not run on pull requests.
+ */
+function node(
+  over: Omit<Partial<ZoomNode>, "metrics"> & { metrics?: Partial<ZoomMetrics> } = {},
+): ZoomNode {
+  const { metrics, ...rest } = over;
   return {
     id: "n",
     parent_id: null,
+    level: 0,
     kind: "file",
     name: "n",
     path: "n",
-    language: null,
-    summary: null,
     children: [],
-    rect: { x: 0, y: 0, w: 1, h: 1 },
-    metrics: {
-      file_count: 0,
-      hotspot_count: 0,
-      entry_point_count: 0,
-      on_flow_count: 0,
-      dead_count: 0,
-    },
+    importance: 0,
+    sibling_rank: 0,
+    layout: null,
+    summary: "",
+    language: null,
     health_score: null,
     is_entry_point: false,
     is_hotspot: false,
     is_dead: false,
     is_test: false,
     on_flow: false,
-    ...over,
-  } as ZoomNode;
+    ...rest,
+    metrics: { ...METRICS, ...metrics },
+  };
 }
 
 describe("nodeRoles", () => {
@@ -46,13 +68,7 @@ describe("nodeRoles", () => {
   it("inherits a role from the subtree, matching what the card's dot tests", () => {
     const container = node({
       kind: "folder",
-      metrics: {
-        file_count: 9,
-        hotspot_count: 2,
-        entry_point_count: 0,
-        on_flow_count: 0,
-        dead_count: 0,
-      },
+      metrics: { file_count: 9, hotspot_count: 2 },
     });
     expect(nodeRoles(container)).toEqual(["Hotspot"]);
     expect(hasRole(container)).toBe(true);


### PR DESCRIPTION
`main` is red. The "Publish internal prereleases / Publish to GitHub Packages" job fails at `Type-check + test`:

```
__tests__/zoom/node-signals.test.ts(49,7): error TS2741:
Property 'descendant_count' is missing in type
'{ file_count: number; hotspot_count: number; entry_point_count: number;
   on_flow_count: number; dead_count: number; }'
but required in type 'ZoomMetrics'.
```

`ZoomMetrics` has required `descendant_count` since #918. The fixture added with the node-signals tests in #1145 omits it.

## Why it got through

That job runs on push, not on pull requests, and vitest does not type-check. So #1145 was green on every check that actually ran against it, and the first thing to notice was main.

## Why one missing field went unnoticed inside the file

The fixture helper ended in `as ZoomNode`. That cast was hiding four separate departures from the type, not one:

| Written | Actual type |
|---|---|
| `metrics` without `descendant_count` | required since #918 |
| `summary: null` | `string` |
| `importance`, `sibling_rank` absent | both required |
| `rect: { x, y, w, h }` | not a field on `ZoomNode`; its box is `layout` |

Only the single call site passing a `metrics` override ever produced an error, because `Partial<ZoomNode>` still demands a *complete* `ZoomMetrics`. The cast swallowed the rest.

So this drops the cast and makes the object describe a real `ZoomNode`, and lets `metrics` merge rather than replace, so a fixture names only the counts its assertion is about. Requiring all six is what turned one new field into a broken build.

No assertion changed. The folder fixture still sets `file_count: 9` and `hotspot_count: 2`; the other four counts now come from the shared default instead of being restated.

## Checks

The four commands that job runs, in order:

```
npm run type-check --workspace @repowise-dev/types    clean
npm run type-check --workspace @repowise-dev/ui       clean
npm run test --workspace @repowise-dev/types          86/86, no type errors
npm run test --workspace @repowise-dev/ui             972/972
```

Rebased onto main after #1146 merged and re-run there.

## Worth a separate decision

The underlying hole is that `type-check` only runs on push. Adding it to the PR workflow would have caught this before merge and will catch the next one. That is a CI policy change rather than a bug fix, so it is deliberately not in this PR.
