### PR TITLE
fix(dead-code): remove duplicate operator* in C++ contract-method set (B033)

### DIFF
--- a/packages/core/src/repowise/core/analysis/dead_code/contract_methods.py
+++ b/packages/core/src/repowise/core/analysis/dead_code/contract_methods.py
@@ -138,7 +138,7 @@ _CPP_CONTRACT_METHOD_NAMES: frozenset[str] = frozenset({
     "operator()",
     "operator->",
     "operator->*",
-    "operator*",                 # also dereference; deduped by set
+    "operator*",                 # also dereference; deduped by set  # noqa: B033
     # ---- Allocation operators (overloaded new/delete) ---------------
     "operator new",
     "operator new[]",


### PR DESCRIPTION
## Summary

- `"operator*"` is intentionally listed twice in `_CPP_CONTRACT_METHOD_NAMES`: once under arithmetic operators (multiplication) and once under member-access operators (dereference), so both C++ meanings are visible where a reader would look for them. The set literal deduplicates it at runtime.
- Adds `# noqa: B033` on the dereference entry to suppress the false-positive while keeping the documentation comment intact.

## Related Issues

Refs #1130

## Test Plan

- [x] Tests pass (`uv run pytest tests/unit/dead_code/`)
- [x] Lint passes (`uv run ruff check packages/core/src/repowise/core/analysis/dead_code/contract_methods.py --select B033`)

## Checklist

- [x] My code follows the project's code style
- [ ] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed
