### PR TITLE
fix(server): un-shadow hidden test in test_mcp_workspace (F811)

### DIFF
--- a/tests/unit/server/test_mcp_workspace.py
+++ b/tests/unit/server/test_mcp_workspace.py
@@ -302,7 +302,7 @@ async def test_get_health_resolves_alias_different_from_repo_name(workspace_mcp)
 
 
 @pytest.mark.asyncio
-async def test_generate_refactoring_code_resolves_alias_different_from_repo_name(workspace_mcp):
+async def test_generate_refactoring_code_unknown_id_returns_error(workspace_mcp):
     from repowise.server.mcp_server import generate_refactoring_code
 
     result = await generate_refactoring_code(suggestion_id="does-not-exist", repo="frontend")


### PR DESCRIPTION
## Summary

- Renames the test function at line 305 in `tests/unit/server/test_mcp_workspace.py` to `test_generate_refactoring_code_unknown_id_returns_error` to fix Ruff `F811` (`redefined-while-unused`).
- **Root Cause:** Line 305 previously shared the exact same function signature as line 319 (`test_generate_refactoring_code_resolves_alias_different_from_repo_name`). In Python, the second definition overwrote the first in the module namespace, causing the line 305 test to be shadowed and completely skipped during test runs.
- Un-shadowing line 305 restores the test so pytest discovers and executes both test cases independently.

## Related Issues

Refs #1130

## Test Plan

- [x] Tests pass (`uv run pytest tests/unit/server/test_mcp_workspace.py`) — collected 29 items (up from 28) and all 29 passed cleanly.
- [x] Lint passes (`uv run ruff check tests/unit/server/test_mcp_workspace.py --select F811`)

## Checklist

- [x] My code follows the project's code style
- [ ] I have added tests for new functionality
- [x] All existing tests still pass
- [ ] I have updated documentation if needed
