### PR TITLE
feat(bench): score answer retrieval against a set that refuses to load broken

### DIFF
--- a/repowise_bench/__init__.py
+++ b/repowise_bench/__init__.py
@@ -1,0 +1,6 @@
+"""Benchmark and evaluation harnesses for repowise.
+
+This package is deliberately outside the three published wheel roots
+(``packages/core``, ``packages/cli``, ``packages/server``), so it is importable
+in development and in tests but never ships to users.
+"""

--- a/repowise_bench/eval/__init__.py
+++ b/repowise_bench/eval/__init__.py
@@ -1,0 +1,7 @@
+"""Evaluation harness for the answer tool.
+
+Two question sets drive it: a retrieval set scored without a model
+(recall@k, MRR) and a gold set scored by a judge. This module holds the parts
+that need neither an index nor a network: loading a question set and the
+scoring maths.
+"""

--- a/repowise_bench/eval/question_set.py
+++ b/repowise_bench/eval/question_set.py
@@ -1,0 +1,120 @@
+"""Loading the retrieval question set.
+
+The set is JSONL - one question per line - so a diff shows exactly which
+questions a change added or reworded, which a single JSON array would not.
+
+Every validation here raises. None of it warns and continues. A question set
+that loses a question, or reads a mistyped key as "this question expects
+nothing", still produces a score, and that score is worse than no score at all
+because it looks like a measurement.
+
+Line format::
+
+    {"id": "q001", "question": "Where is X?", "expected_page_ids": ["file:a.py"]}
+
+``tags`` is the one optional key. Blank lines and ``#`` comment lines are
+skipped.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REQUIRED_KEYS = frozenset({"id", "question", "expected_page_ids"})
+OPTIONAL_KEYS = frozenset({"tags"})
+
+
+class QuestionSetError(ValueError):
+    """A question-set file is missing, empty, or malformed."""
+
+
+@dataclass(frozen=True)
+class RetrievalQuestion:
+    """One question and the page ids a correct retrieval must surface."""
+
+    id: str
+    question: str
+    expected_page_ids: frozenset[str]
+    tags: frozenset[str] = field(default_factory=frozenset)
+
+
+def _fail(path: Path, line_number: int, problem: str) -> QuestionSetError:
+    return QuestionSetError(f"{path}, line {line_number}: {problem}")
+
+
+def _read_string_list(path: Path, line_number: int, raw: object, key: str) -> frozenset[str]:
+    if not isinstance(raw, list) or not raw:
+        raise _fail(path, line_number, f"{key} must be a non-empty list of strings")
+    for entry in raw:
+        if not isinstance(entry, str) or not entry.strip():
+            raise _fail(path, line_number, f"{key} must contain only non-empty strings")
+    return frozenset(entry.strip() for entry in raw)
+
+
+def _parse_line(path: Path, line_number: int, text: str) -> RetrievalQuestion:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise _fail(path, line_number, f"is not valid JSON ({exc.msg})") from exc
+
+    if not isinstance(payload, dict):
+        raise _fail(path, line_number, "must be a JSON object")
+
+    keys = set(payload)
+    if missing := REQUIRED_KEYS - keys:
+        raise _fail(path, line_number, f"missing required key(s): {', '.join(sorted(missing))}")
+    if unknown := keys - REQUIRED_KEYS - OPTIONAL_KEYS:
+        raise _fail(path, line_number, f"unknown key(s): {', '.join(sorted(unknown))}")
+
+    for key in ("id", "question"):
+        value = payload[key]
+        if not isinstance(value, str) or not value.strip():
+            raise _fail(path, line_number, f"{key} must be a non-empty string")
+
+    tags = (
+        _read_string_list(path, line_number, payload["tags"], "tags")
+        if "tags" in payload
+        else frozenset()
+    )
+
+    return RetrievalQuestion(
+        id=payload["id"].strip(),
+        question=payload["question"].strip(),
+        expected_page_ids=_read_string_list(
+            path, line_number, payload["expected_page_ids"], "expected_page_ids"
+        ),
+        tags=tags,
+    )
+
+
+def load_retrieval_questions(path: str | Path) -> list[RetrievalQuestion]:
+    """Read and validate a JSONL retrieval question set, preserving file order.
+
+    Raises ``QuestionSetError`` on anything that would make a run's score
+    unreliable: a missing file, a file with no questions, a line that does not
+    parse, a missing or blank field, an unknown key, or a duplicate question id.
+    """
+    path = Path(path)
+    if not path.is_file():
+        raise QuestionSetError(f"question set does not exist: {path}")
+
+    questions: list[RetrievalQuestion] = []
+    seen_ids: set[str] = set()
+
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        text = raw_line.strip()
+        if not text or text.startswith("#"):
+            continue
+
+        question = _parse_line(path, line_number, text)
+        if question.id in seen_ids:
+            raise _fail(path, line_number, f"duplicate question id: {question.id}")
+        seen_ids.add(question.id)
+        questions.append(question)
+
+    if not questions:
+        raise QuestionSetError(f"question set contains no questions: {path}")
+
+    return questions

--- a/repowise_bench/eval/scoring.py
+++ b/repowise_bench/eval/scoring.py
@@ -1,0 +1,111 @@
+"""Retrieval scoring: recall@k and mean reciprocal rank.
+
+No model, no index, no network. Given the page ids a retrieval returned and the
+page ids that should have been returned, these functions say how well it did.
+
+Two rules the maths depends on, both enforced here rather than assumed:
+
+* **Duplicate page ids are collapsed before ranking.** A page returned twice is
+  one result at its first position. Without this a retrieval that repeats one
+  page five times would fill the top-5 window and read as a legitimate miss.
+* **A question with no expected pages is an error, not a zero.** Silently
+  scoring it zero would let a malformed question set drag the average down with
+  no sign that anything was wrong.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+class ScoringError(ValueError):
+    """A scoring input is malformed - bad k, no expected pages, no questions."""
+
+
+@dataclass(frozen=True)
+class RetrievalScores:
+    """Aggregate scores over a whole question set."""
+
+    n_questions: int
+    recall_at_k: float
+    mrr: float
+    k: int
+    n_empty_results: int
+    """Questions whose retrieval returned nothing. These score zero; the count
+    separates 'retrieval found the wrong pages' from 'retrieval found nothing'."""
+
+
+def _rank_order(retrieved: Iterable[str]) -> list[str]:
+    """Collapse duplicates, keeping each page id at its first position."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for page_id in retrieved:
+        if page_id in seen:
+            continue
+        seen.add(page_id)
+        ordered.append(page_id)
+    return ordered
+
+
+def _check_expected(expected: set[str]) -> None:
+    if not expected:
+        raise ScoringError("cannot score a question with no expected pages")
+
+
+def recall_at_k(retrieved: Sequence[str], expected: set[str], k: int) -> float:
+    """Fraction of the expected pages that appear in the first ``k`` results.
+
+    Returns a value in [0, 1]. A result list shorter than ``k`` is not padded -
+    two results containing the single expected page still score 1.0.
+    """
+    if k < 1:
+        raise ScoringError(f"k must be >= 1, got {k}")
+    _check_expected(expected)
+
+    window = set(_rank_order(retrieved)[:k])
+    return len(window & expected) / len(expected)
+
+
+def reciprocal_rank(retrieved: Sequence[str], expected: set[str]) -> float:
+    """``1 / rank`` of the first expected page, or 0.0 if none was retrieved."""
+    _check_expected(expected)
+
+    for position, page_id in enumerate(_rank_order(retrieved), start=1):
+        if page_id in expected:
+            return 1.0 / position
+    return 0.0
+
+
+def score_retrieval(
+    results: Mapping[str, tuple[Sequence[str], set[str]]],
+    k: int,
+) -> RetrievalScores:
+    """Aggregate per-question scores into a mean recall@k and MRR.
+
+    ``results`` maps a question id to ``(retrieved page ids, expected page ids)``.
+    """
+    if not results:
+        raise ScoringError("cannot score a run with no questions")
+
+    recalls: list[float] = []
+    reciprocal_ranks: list[float] = []
+    n_empty = 0
+
+    for question_id, (retrieved, expected) in results.items():
+        if not retrieved:
+            n_empty += 1
+            logger.warning("retrieval returned no pages for question %s", question_id)
+        recalls.append(recall_at_k(retrieved, expected, k=k))
+        reciprocal_ranks.append(reciprocal_rank(retrieved, expected))
+
+    return RetrievalScores(
+        n_questions=len(results),
+        recall_at_k=sum(recalls) / len(recalls),
+        mrr=sum(reciprocal_ranks) / len(reciprocal_ranks),
+        k=k,
+        n_empty_results=n_empty,
+    )

--- a/tests/unit/bench/test_eval_scoring.py
+++ b/tests/unit/bench/test_eval_scoring.py
@@ -1,0 +1,109 @@
+"""Scoring maths for the answer retrieval eval.
+
+Every expected value in this file is computed by hand in the docstring or a
+comment. If an assertion here needs a calculator, the test is wrong.
+"""
+
+import pytest
+
+from repowise_bench.eval.scoring import (
+    RetrievalScores,
+    ScoringError,
+    recall_at_k,
+    reciprocal_rank,
+    score_retrieval,
+)
+
+
+class TestRecallAtK:
+    def test_one_of_two_expected_inside_top_five(self):
+        """Expected pages sit at ranks 2 and 7 of 10 → 1 of 2 inside top-5 → 0.5."""
+        retrieved = [f"p{i}" for i in range(1, 11)]
+        assert recall_at_k(retrieved, {"p2", "p7"}, k=5) == 0.5
+
+    def test_all_expected_inside_top_k(self):
+        assert recall_at_k(["a", "b", "c"], {"a", "c"}, k=5) == 1.0
+
+    def test_none_expected_retrieved(self):
+        assert recall_at_k(["a", "b", "c"], {"z"}, k=5) == 0.0
+
+    def test_hit_below_the_cut_does_not_count(self):
+        """The only expected page is at rank 6, so recall@5 is 0 even though it was found."""
+        retrieved = [f"p{i}" for i in range(1, 11)]
+        assert recall_at_k(retrieved, {"p6"}, k=5) == 0.0
+
+    def test_short_result_list_is_not_padded(self):
+        """Two results, one expected and present → 1.0, not 1/5."""
+        assert recall_at_k(["a", "b"], {"b"}, k=5) == 1.0
+
+    def test_duplicate_retrieved_ids_do_not_consume_the_window(self):
+        """A page repeated at ranks 1-5 must not push p6 out of the top-5 window."""
+        retrieved = ["dup", "dup", "dup", "dup", "dup", "p6"]
+        assert recall_at_k(retrieved, {"p6"}, k=5) == 1.0
+
+    def test_empty_expected_set_raises(self):
+        with pytest.raises(ScoringError, match="no expected pages"):
+            recall_at_k(["a"], set(), k=5)
+
+    def test_non_positive_k_raises(self):
+        with pytest.raises(ScoringError, match="k must be >= 1"):
+            recall_at_k(["a"], {"a"}, k=0)
+
+
+class TestReciprocalRank:
+    def test_first_expected_at_rank_two(self):
+        """Ranks 2 and 7 are expected; the first is rank 2 → 1/2."""
+        retrieved = [f"p{i}" for i in range(1, 11)]
+        assert reciprocal_rank(retrieved, {"p2", "p7"}) == 0.5
+
+    def test_first_expected_at_rank_one(self):
+        assert reciprocal_rank(["a", "b"], {"a"}) == 1.0
+
+    def test_first_expected_at_rank_four(self):
+        assert reciprocal_rank(["a", "b", "c", "d"], {"d"}) == 0.25
+
+    def test_no_expected_retrieved_scores_zero(self):
+        assert reciprocal_rank(["a", "b"], {"z"}) == 0.0
+
+    def test_duplicates_do_not_shift_the_rank(self):
+        """'dup' occupying ranks 1-2 means the real hit is rank 2, not rank 3."""
+        assert reciprocal_rank(["dup", "dup", "hit"], {"hit"}) == 0.5
+
+    def test_empty_expected_set_raises(self):
+        with pytest.raises(ScoringError, match="no expected pages"):
+            reciprocal_rank(["a"], set())
+
+
+class TestScoreRetrieval:
+    def test_aggregate_is_the_mean_over_questions(self):
+        """
+        q1: expected p1, retrieved at rank 1 → recall@5 = 1.0, RR = 1.0
+        q2: expected p9, retrieved at rank 9 → recall@5 = 0.0, RR = 1/9
+        mean recall@5 = (1.0 + 0.0) / 2       = 0.5
+        mean MRR      = (1.0 + 0.111...) / 2  = 0.5555...
+        """
+        scores = score_retrieval(
+            {
+                "q1": (["p1", "p2"], {"p1"}),
+                "q2": ([f"p{i}" for i in range(1, 11)], {"p9"}),
+            },
+            k=5,
+        )
+        assert scores == RetrievalScores(
+            n_questions=2,
+            recall_at_k=0.5,
+            mrr=pytest.approx(0.5555555, abs=1e-6),
+            k=5,
+            n_empty_results=0,
+        )
+
+    def test_empty_result_list_scores_zero_and_is_counted(self):
+        """A retrieval that returned nothing is a zero, not a skip - the count proves it."""
+        scores = score_retrieval({"q1": ([], {"p1"})}, k=5)
+        assert scores.recall_at_k == 0.0
+        assert scores.mrr == 0.0
+        assert scores.n_empty_results == 1
+
+    def test_no_questions_raises(self):
+        with pytest.raises(ScoringError, match="no questions"):
+            score_retrieval({}, k=5)

--- a/tests/unit/bench/test_question_set.py
+++ b/tests/unit/bench/test_question_set.py
@@ -1,0 +1,114 @@
+"""Loading a retrieval question set.
+
+The point of every test here is that a malformed file stops the run. A question
+set that silently drops a question, or reads a typo'd key as "no expectations",
+produces a score that looks fine and means nothing.
+"""
+
+import pytest
+
+from repowise_bench.eval.question_set import (
+    QuestionSetError,
+    RetrievalQuestion,
+    load_retrieval_questions,
+)
+
+GOOD_LINE = '{"id": "q001", "question": "Where is the cache invalidated?", '
+GOOD_LINE += '"expected_page_ids": ["file:a.py"]}'
+
+
+def write_set(tmp_path, text):
+    path = tmp_path / "questions.jsonl"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class TestLoadsAValidSet:
+    def test_parses_every_field(self, tmp_path):
+        path = write_set(tmp_path, GOOD_LINE)
+        assert load_retrieval_questions(path) == [
+            RetrievalQuestion(
+                id="q001",
+                question="Where is the cache invalidated?",
+                expected_page_ids=frozenset({"file:a.py"}),
+                tags=frozenset(),
+            )
+        ]
+
+    def test_keeps_file_order(self, tmp_path):
+        lines = "\n".join(
+            f'{{"id": "q00{i}", "question": "q{i}?", "expected_page_ids": ["p{i}"]}}'
+            for i in (1, 2, 3)
+        )
+        assert [q.id for q in load_retrieval_questions(write_set(tmp_path, lines))] == [
+            "q001",
+            "q002",
+            "q003",
+        ]
+
+    def test_blank_lines_and_comments_are_skipped(self, tmp_path):
+        path = write_set(tmp_path, f"# retrieval set\n\n{GOOD_LINE}\n\n")
+        assert len(load_retrieval_questions(path)) == 1
+
+    def test_tags_are_optional_and_read_when_present(self, tmp_path):
+        line = (
+            '{"id": "q001", "question": "Where?", "expected_page_ids": ["p1"], '
+            '"tags": ["where", "hard"]}'
+        )
+        (question,) = load_retrieval_questions(write_set(tmp_path, line))
+        assert question.tags == frozenset({"where", "hard"})
+
+
+class TestMalformedSetRaises:
+    def test_missing_file(self, tmp_path):
+        with pytest.raises(QuestionSetError, match="does not exist"):
+            load_retrieval_questions(tmp_path / "nope.jsonl")
+
+    def test_file_with_no_questions(self, tmp_path):
+        with pytest.raises(QuestionSetError, match="no questions"):
+            load_retrieval_questions(write_set(tmp_path, "# only a comment\n"))
+
+    def test_unparseable_json_names_the_line(self, tmp_path):
+        path = write_set(tmp_path, f"{GOOD_LINE}\n{{not json\n")
+        with pytest.raises(QuestionSetError, match="line 2"):
+            load_retrieval_questions(path)
+
+    def test_line_that_is_not_an_object(self, tmp_path):
+        with pytest.raises(QuestionSetError, match="line 1"):
+            load_retrieval_questions(write_set(tmp_path, '["q001"]'))
+
+    @pytest.mark.parametrize("field", ["id", "question", "expected_page_ids"])
+    def test_missing_required_field(self, tmp_path, field):
+        line = '{"id": "q001", "question": "Where?", "expected_page_ids": ["p1"]}'.replace(
+            f'"{field}"', '"unused"'
+        )
+        with pytest.raises(QuestionSetError):
+            load_retrieval_questions(write_set(tmp_path, line))
+
+    def test_empty_expected_page_ids_is_not_a_valid_expectation(self, tmp_path):
+        line = '{"id": "q001", "question": "Where?", "expected_page_ids": []}'
+        with pytest.raises(QuestionSetError, match="expected_page_ids"):
+            load_retrieval_questions(write_set(tmp_path, line))
+
+    def test_blank_question_text(self, tmp_path):
+        line = '{"id": "q001", "question": "   ", "expected_page_ids": ["p1"]}'
+        with pytest.raises(QuestionSetError, match="question"):
+            load_retrieval_questions(write_set(tmp_path, line))
+
+    def test_expected_page_ids_must_be_a_list_of_strings(self, tmp_path):
+        line = '{"id": "q001", "question": "Where?", "expected_page_ids": [3]}'
+        with pytest.raises(QuestionSetError, match="expected_page_ids"):
+            load_retrieval_questions(write_set(tmp_path, line))
+
+    def test_duplicate_id_raises(self, tmp_path):
+        with pytest.raises(QuestionSetError, match="duplicate"):
+            load_retrieval_questions(write_set(tmp_path, f"{GOOD_LINE}\n{GOOD_LINE}"))
+
+    def test_unknown_key_raises_so_a_typo_cannot_be_read_as_no_expectation(self, tmp_path):
+        """`expected_page_id` (singular) must not parse as a question with no expectations."""
+        line = (
+            '{"id": "q001", "question": "Where?", "expected_page_ids": ["p1"], '
+            '"expected_page_id": "p2"}'
+        )
+        with pytest.raises(QuestionSetError, match="unknown"):
+            load_retrieval_questions(write_set(tmp_path, line))


### PR DESCRIPTION
## Why

The two question sets that measure the answer tool live nowhere in this repository. They survive only as numbers in old commit messages. That makes every retrieval change unfalsifiable — there is no way to show a change helped without re-deriving the measurement by hand each time, and no way for a reviewer to check the claim.

This PR is the part of the harness that needs **no index and no network**, so it can be tested properly and land on its own. The runner and the question sets follow in separate PRs.

## Where it lives

`repowise_bench/` sits at the repo root, outside the three published wheel roots (`packages/core`, `packages/cli`, `packages/server`), so it is importable in development and under pytest but never ships to users. `pythonpath = ["."]` already makes it importable; tests live in `tests/unit/bench/` because that is what CI collects.

## What it does

**Scoring** — `recall_at_k`, `reciprocal_rank`, and an aggregate `score_retrieval`. Two things it enforces rather than assumes:

- **Duplicate page ids collapse to their first position before ranking.** A retrieval that returns the same page five times would otherwise fill the top-5 window, and a page sitting at rank 6 would read as an honest miss.
- **A question with no expected pages raises.** Scoring it zero would let a malformed set drag the average down with nothing to show that it had.

`RetrievalScores` also carries `n_empty_results`, separating "retrieval found the wrong pages" from "retrieval found nothing at all". The two have different causes and the mean hides the difference.

**The loader** raises on every malformed input: a missing file, a file with no questions, a line that does not parse, a blank or missing field, a duplicate question id, and any unknown key.

That last one is the one that matters. Writing `expected_page_id` instead of `expected_page_ids` must not parse as a question that expects nothing — the run would still finish and still print a score, and the score would be wrong in the direction that looks like good news.

The set is JSONL rather than one JSON array so a diff shows exactly which questions a change added or reworded.

## Tests

33 tests, failing before the modules existed and passing after. Every expected value is hand-computed in a comment or docstring — if an assertion needs a calculator, the test is wrong.

Gates: `pytest tests/unit/bench` 33 passed · `ruff check` clean · `ruff format --check` clean · `mypy repowise_bench` clean.