### PR TITLE
release: v0.37.0 — the UI release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "repowise",
       "source": "./plugins/claude-code",
       "description": "Codebase intelligence for Claude Code. Indexes your repo into five layers (Graph, Git, Docs, Decisions, Code Health) and gives Claude deep understanding of architecture, ownership, hotspots, decisions, and defect risk — fewer greps, fewer file reads, lower cost per query.",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "category": "productivity",
       "keywords": [
         "codebase",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.37.0] — 2026-07-29
+
+The release where the web UI got taken apart and put back together. Fourteen surfaces moved onto one design language: sections and hairlines instead of a grid of near-identical bordered cards, a sentence above every figure saying what the figure means, and a header row plus a key row on the pages whose canvas is the page. Overview, Docs, Commits, Contributors, Code Health, Coverage, Dead code, Chat, Settings, Decisions, Stats, Files, Refactoring, Knowledge Graph and Architecture all changed shape. The Architecture and Knowledge Graph canvases also got their marks named and their per-frame cost cut, and the docs page stopped downloading 38 MB of page bodies to draw a tree. Away from the UI there is a Structurizr DSL export, a first-run pass over interactive `init`, refreshed provider model defaults, and three MCP response fixes.
+
+### Added
+- **A Structurizr DSL export.** `repowise export --format structurizr` and `GET /api/graph/{id}/c4/structurizr` emit a [Structurizr DSL](https://docs.structurizr.com/dsl) model of the repository, with a download button on the Knowledge Graph page. `--standalone` wraps the model in a `workspace` block so the file opens on structurizr.com as-is, and `--components` includes the component level. Built on a new typed node-id module so ids carry their kind instead of being parsed by convention. (#1143, #1144)
+- **`repowise init --no-editor-setup`** skips global MCP and hook registration, for CI, agents and throwaway installs that should not rewrite `~/.claude/settings.json`. `REPOWISE_SKIP_EDITOR_SETUP=1` is the same switch. (#1086)
+- **`fields=summary` on `GET /api/pages`**, which drops `content` and `metadata` and returns a `content_chars` count in their place. `fields=full` remains the default, so existing callers are unaffected. (#1120)
+- **A key row on the Knowledge Graph.** The arrows, the role dot and the health dot were three kinds of mark the surface never explained. All three are named now, the two dots no longer collide on colour, and a mislabelled verb in the backend map is corrected. (#1145)
+- **`--verbose` and richer failure reporting on `init`.** A run that generated some pages and failed others said it succeeded; it now names the failures and points at `--resume`. (#1094, #1098)
+
+### Changed
+- **The web UI runs on one design language.** Cards at uniform weight are gone from Overview, Docs, Commits and Contributors, the contributor profile and commit detail, Code Health, Coverage, Dead code, Chat, Settings and Decisions. Sections and hairlines carry the hierarchy, a lede sentence carries the meaning of the number under it, and the dark surface ramp starts lower so reading columns sit on the base plane instead of in a trench between two lighter walls. (#1114, #1118, #1121, #1125, #1129, #1132, #1134)
+- **The Architecture page steers one axis from one control.** Scope used to live in both the tab strip and a floating pill cluster, with "Communities" appearing twice on one screen. Tabs are datasets now (Map, Coupling, Packages, Symbols) and scope is a single labelled control in the section header. (#1146, #1150)
+- **The Refactoring page leads with what the pile is.** The priority-by-effort quadrant plotted 120 of 1,819 plans, because 89% of plans rate small effort and the X axis was one column. It is replaced with charts whose axes actually spread, under a sentence that says what the plans are. (#1151)
+- **The Files page opens on the map.** The treemap is the subject, so it goes first, with the four figures riding in the sentence beneath it rather than in a strip of equal-weight stat boxes above. (#1152)
+- **The Stats page shows what no other page shows,** and the coding-rhythm punch card is reworked: marginal totals, a colour scale that means something, and no dead gutter on a wide viewport. On this repo the old chart made 853 commits look idle because every cell it could draw capped in the low tens. (#1091, #1096)
+- **Provider model defaults refreshed.** Several shipped model ids had drifted from what the vendors serve, including a default for the recommended provider that was not a real id and only worked via the live `/models` fallback. The Anthropic and OpenRouter defaults were flagship-priced, contradicting the calibration guidance. Cost and temperature handling is corrected alongside. (#1137)
+- **A first-run pass over interactive `init`.** A read-only walkthrough found 52 places where the terminal was confusing, contradictory or invisible; 49 are applied, plus five defects found reviewing the result. Phase reporting is one system now rather than two glued together. (#1139)
+- **Documentation generation enforces completion** and filters the file dependency context it passes to the model. (#1010, #1011)
+- **Python lint is gated in CI.** Ruff is configured to match how the repo is actually written, 508 accumulated violations are cleared, and lint runs on every PR. Types and UI tests do too. (#1101, #1161)
+
+### Fixed
+- **The docs page loaded every page's body to draw a tree.** Opening `/repos/[id]/docs` on this repo meant twelve sequential round trips and 38.6 MB across 5,485 pages, none of whose text the tree renders. The four things that read bodies off that list are each served directly now. (#1120)
+- **The architecture graph spent seconds arriving and kept paying per frame.** The minimap redrew every node on `afterRender`; `getComputedStyle` ran 3,022 times on the mount colour pass and again on every theme flip; ELK wrote 3,000 graphology events for one position update. Measured on this repo's capped export (1,500 nodes, 4,107 edges), those are 0, 36, 12 and 1. Dimming also blended toward the wrong colour. (#1149)
+- **The graph stopped blaming the backend mid-load.** An error state rendered while data was still arriving. (#1146)
+- **`get_health` dropped targets it could not resolve** and repeated itself, so an agent could not tell "not indexed" from "no findings". Nothing about scoring changed; this is the MCP response surface. (#1142)
+- **`get_answer` synthesis was capped at a flat 30 seconds,** a budget sized for a remote API. Providers that shell out to a coding-agent CLI or drive a local model need 40 to 120 seconds for one turn, and those are exactly the providers `init` offers users with no API key. The budget is per provider now. (#1119, #1124)
+- **`get_answer` reports an empty completion** instead of shipping a blank answer as if it were one. (#1126)
+- **A `--resume` run deleted pages it had just protected.** Pages skipped because they already existed were absent from the produced set, which is what the stale sweep treats as deleted. (#1089, #1097)
+- **A page whose provider call failed is kept** rather than dropped from the wiki. (#1104)
+- **The augment hook is silent when its console script is missing** instead of printing an error into every agent turn. (#1141)
+- **`repowise --help` no longer imports the generation pipeline.** One module-scope import in the generate engine pulled the orchestrator and persist layer into every invocation, including post-commit hooks. (#1140)
+- **Malformed `.gitignore` patterns are tolerated** rather than failing ingestion. (#1095)
+- **Command palette answers a single keypress.** It used to need two. (#1157)
+- **Nav links land where their label says.** (#1158)
+- **The docs reader** shows one breadcrumb, computes its height correctly, and wraps long backlinks. (#1156)
+- **Dead code:** the default `min_confidence` floor aligns with `RISK_CAP_CONFIDENCE`, and the zombie-package detector reads git metadata with `dict.get()` instead of assuming the key. (#1084, #1087, #1128)
+- **Coupling keeps `?focus=` in sync with the pinned file.** (#1088)
+- **Pages parented to the repo root use the stored concept tree.** (#1081, #1085)
+- **Server jobs fail explicitly on an unknown execution mode** rather than silently. (#881, #911)
+
+### Documentation
+- **Contributors are onboarded through repowise itself,** and the README badge row is trimmed. (#1110)
+- **Website pages resynced with the shipped surface:** the MCP pages match the live default tool set, the language list matches the 16 AST languages, and the obsolete Anthropic Message Batches / `--no-batch` material is gone. (#1122, #1135, #1136)
+- **New walkthroughs** for `distill` / `expand` / saved output, the security scan, health coverage, and OpenCode provider setup. (#1020, #1021, #1109, #1123)
+- **The commercial page acknowledges the OSS full-history secret scan.** (#1105)
+- **Plugin:** Claude Code and Codex skills and commands updated for the `--no-editor-setup` flag, the dead-code confidence floor, the `get_health` response shape and the augment hook change.
+
+### Internal
+- **One home for "is this path a test?"** The last inline test-path checks in core and the server are converted to the shared rules, and `.mts` / `.cts` tests are classified correctly in `coverage_gradient` and `move_method`. (#1103, #1111, #1112, #1113, #1115)
+- **CLI test coverage** for `repowise decision list/show/confirm/dismiss/health` and the `security scan` stub. (#1108, #1138)
+
+---
+
 ## [0.36.0] — 2026-07-25
 
 A smaller release that settles what 0.35.0 started. Wikis on very large repositories now bound their own file-page volume by default instead of emitting one page per file, `distill` learns a real shell lexer and gains install and infra command families, and a run of contributor fixes lands across serve, the job scheduler and dead code.

--- a/packages/cli/src/repowise/cli/__init__.py
+++ b/packages/cli/src/repowise/cli/__init__.py
@@ -16,4 +16,4 @@ from repowise.cli._stdio import _ensure_utf8_stdio
 # is already UTF-8.
 _ensure_utf8_stdio()
 
-__version__ = "0.36.0"
+__version__ = "0.37.0"

--- a/packages/core/src/repowise/core/__init__.py
+++ b/packages/core/src/repowise/core/__init__.py
@@ -6,4 +6,4 @@ generation engine. This is the heart of repowise — all other packages depend o
 Namespace package: repowise.core is part of the repowise namespace.
 """
 
-__version__ = "0.36.0"
+__version__ = "0.37.0"

--- a/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
+++ b/packages/core/src/repowise/core/upgrade/_data/CHANGELOG.md
@@ -9,6 +9,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.37.0] — 2026-07-29
+
+The release where the web UI got taken apart and put back together. Fourteen surfaces moved onto one design language: sections and hairlines instead of a grid of near-identical bordered cards, a sentence above every figure saying what the figure means, and a header row plus a key row on the pages whose canvas is the page. Overview, Docs, Commits, Contributors, Code Health, Coverage, Dead code, Chat, Settings, Decisions, Stats, Files, Refactoring, Knowledge Graph and Architecture all changed shape. The Architecture and Knowledge Graph canvases also got their marks named and their per-frame cost cut, and the docs page stopped downloading 38 MB of page bodies to draw a tree. Away from the UI there is a Structurizr DSL export, a first-run pass over interactive `init`, refreshed provider model defaults, and three MCP response fixes.
+
+### Added
+- **A Structurizr DSL export.** `repowise export --format structurizr` and `GET /api/graph/{id}/c4/structurizr` emit a [Structurizr DSL](https://docs.structurizr.com/dsl) model of the repository, with a download button on the Knowledge Graph page. `--standalone` wraps the model in a `workspace` block so the file opens on structurizr.com as-is, and `--components` includes the component level. Built on a new typed node-id module so ids carry their kind instead of being parsed by convention. (#1143, #1144)
+- **`repowise init --no-editor-setup`** skips global MCP and hook registration, for CI, agents and throwaway installs that should not rewrite `~/.claude/settings.json`. `REPOWISE_SKIP_EDITOR_SETUP=1` is the same switch. (#1086)
+- **`fields=summary` on `GET /api/pages`**, which drops `content` and `metadata` and returns a `content_chars` count in their place. `fields=full` remains the default, so existing callers are unaffected. (#1120)
+- **A key row on the Knowledge Graph.** The arrows, the role dot and the health dot were three kinds of mark the surface never explained. All three are named now, the two dots no longer collide on colour, and a mislabelled verb in the backend map is corrected. (#1145)
+- **`--verbose` and richer failure reporting on `init`.** A run that generated some pages and failed others said it succeeded; it now names the failures and points at `--resume`. (#1094, #1098)
+
+### Changed
+- **The web UI runs on one design language.** Cards at uniform weight are gone from Overview, Docs, Commits and Contributors, the contributor profile and commit detail, Code Health, Coverage, Dead code, Chat, Settings and Decisions. Sections and hairlines carry the hierarchy, a lede sentence carries the meaning of the number under it, and the dark surface ramp starts lower so reading columns sit on the base plane instead of in a trench between two lighter walls. (#1114, #1118, #1121, #1125, #1129, #1132, #1134)
+- **The Architecture page steers one axis from one control.** Scope used to live in both the tab strip and a floating pill cluster, with "Communities" appearing twice on one screen. Tabs are datasets now (Map, Coupling, Packages, Symbols) and scope is a single labelled control in the section header. (#1146, #1150)
+- **The Refactoring page leads with what the pile is.** The priority-by-effort quadrant plotted 120 of 1,819 plans, because 89% of plans rate small effort and the X axis was one column. It is replaced with charts whose axes actually spread, under a sentence that says what the plans are. (#1151)
+- **The Files page opens on the map.** The treemap is the subject, so it goes first, with the four figures riding in the sentence beneath it rather than in a strip of equal-weight stat boxes above. (#1152)
+- **The Stats page shows what no other page shows,** and the coding-rhythm punch card is reworked: marginal totals, a colour scale that means something, and no dead gutter on a wide viewport. On this repo the old chart made 853 commits look idle because every cell it could draw capped in the low tens. (#1091, #1096)
+- **Provider model defaults refreshed.** Several shipped model ids had drifted from what the vendors serve, including a default for the recommended provider that was not a real id and only worked via the live `/models` fallback. The Anthropic and OpenRouter defaults were flagship-priced, contradicting the calibration guidance. Cost and temperature handling is corrected alongside. (#1137)
+- **A first-run pass over interactive `init`.** A read-only walkthrough found 52 places where the terminal was confusing, contradictory or invisible; 49 are applied, plus five defects found reviewing the result. Phase reporting is one system now rather than two glued together. (#1139)
+- **Documentation generation enforces completion** and filters the file dependency context it passes to the model. (#1010, #1011)
+- **Python lint is gated in CI.** Ruff is configured to match how the repo is actually written, 508 accumulated violations are cleared, and lint runs on every PR. Types and UI tests do too. (#1101, #1161)
+
+### Fixed
+- **The docs page loaded every page's body to draw a tree.** Opening `/repos/[id]/docs` on this repo meant twelve sequential round trips and 38.6 MB across 5,485 pages, none of whose text the tree renders. The four things that read bodies off that list are each served directly now. (#1120)
+- **The architecture graph spent seconds arriving and kept paying per frame.** The minimap redrew every node on `afterRender`; `getComputedStyle` ran 3,022 times on the mount colour pass and again on every theme flip; ELK wrote 3,000 graphology events for one position update. Measured on this repo's capped export (1,500 nodes, 4,107 edges), those are 0, 36, 12 and 1. Dimming also blended toward the wrong colour. (#1149)
+- **The graph stopped blaming the backend mid-load.** An error state rendered while data was still arriving. (#1146)
+- **`get_health` dropped targets it could not resolve** and repeated itself, so an agent could not tell "not indexed" from "no findings". Nothing about scoring changed; this is the MCP response surface. (#1142)
+- **`get_answer` synthesis was capped at a flat 30 seconds,** a budget sized for a remote API. Providers that shell out to a coding-agent CLI or drive a local model need 40 to 120 seconds for one turn, and those are exactly the providers `init` offers users with no API key. The budget is per provider now. (#1119, #1124)
+- **`get_answer` reports an empty completion** instead of shipping a blank answer as if it were one. (#1126)
+- **A `--resume` run deleted pages it had just protected.** Pages skipped because they already existed were absent from the produced set, which is what the stale sweep treats as deleted. (#1089, #1097)
+- **A page whose provider call failed is kept** rather than dropped from the wiki. (#1104)
+- **The augment hook is silent when its console script is missing** instead of printing an error into every agent turn. (#1141)
+- **`repowise --help` no longer imports the generation pipeline.** One module-scope import in the generate engine pulled the orchestrator and persist layer into every invocation, including post-commit hooks. (#1140)
+- **Malformed `.gitignore` patterns are tolerated** rather than failing ingestion. (#1095)
+- **Command palette answers a single keypress.** It used to need two. (#1157)
+- **Nav links land where their label says.** (#1158)
+- **The docs reader** shows one breadcrumb, computes its height correctly, and wraps long backlinks. (#1156)
+- **Dead code:** the default `min_confidence` floor aligns with `RISK_CAP_CONFIDENCE`, and the zombie-package detector reads git metadata with `dict.get()` instead of assuming the key. (#1084, #1087, #1128)
+- **Coupling keeps `?focus=` in sync with the pinned file.** (#1088)
+- **Pages parented to the repo root use the stored concept tree.** (#1081, #1085)
+- **Server jobs fail explicitly on an unknown execution mode** rather than silently. (#881, #911)
+
+### Documentation
+- **Contributors are onboarded through repowise itself,** and the README badge row is trimmed. (#1110)
+- **Website pages resynced with the shipped surface:** the MCP pages match the live default tool set, the language list matches the 16 AST languages, and the obsolete Anthropic Message Batches / `--no-batch` material is gone. (#1122, #1135, #1136)
+- **New walkthroughs** for `distill` / `expand` / saved output, the security scan, health coverage, and OpenCode provider setup. (#1020, #1021, #1109, #1123)
+- **The commercial page acknowledges the OSS full-history secret scan.** (#1105)
+- **Plugin:** Claude Code and Codex skills and commands updated for the `--no-editor-setup` flag, the dead-code confidence floor, the `get_health` response shape and the augment hook change.
+
+### Internal
+- **One home for "is this path a test?"** The last inline test-path checks in core and the server are converted to the shared rules, and `.mts` / `.cts` tests are classified correctly in `coverage_gradient` and `move_method`. (#1103, #1111, #1112, #1113, #1115)
+- **CLI test coverage** for `repowise decision list/show/confirm/dismiss/health` and the `security scan` stub. (#1108, #1138)
+
+---
+
 ## [0.36.0] — 2026-07-25
 
 A smaller release that settles what 0.35.0 started. Wikis on very large repositories now bound their own file-page volume by default instead of emitting one page per file, `distill` learns a real shell lexer and gains install and infra command families, and a run of contributor fixes lands across serve, the job scheduler and dead code.

--- a/packages/server/src/repowise/server/__init__.py
+++ b/packages/server/src/repowise/server/__init__.py
@@ -7,4 +7,4 @@ Provides:
     - Background job scheduler (APScheduler)
 """
 
-__version__ = "0.36.0"
+__version__ = "0.37.0"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "repowise",
   "displayName": "Repowise",
   "description": "Know what your change breaks before you push. Health signals, architecture maps, and refactoring plans in your editor, and the same intelligence for your AI agent via MCP. Local and free.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "publisher": "repowise-dev",
   "license": "AGPL-3.0-or-later",
   "homepage": "https://www.repowise.dev",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "repowise",
   "description": "Codebase intelligence for Claude Code. Indexes your codebase into five layers (Graph, Git, Docs, Decisions, Code Health) and exposes them through ten task-shaped MCP tools — so Claude understands architecture, ownership, hotspots, why code is built the way it is, and where the defect risk lives.",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "author": {
     "name": "Repowise",
     "email": "hello@repowise.dev",

--- a/plugins/claude-code/CHANGELOG.md
+++ b/plugins/claude-code/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to the Repowise Claude Code plugin are documented here.
 
+## 0.37.0
+
+### Added
+- `/repowise:init` documents `--no-editor-setup` (and the matching
+  `REPOWISE_SKIP_EDITOR_SETUP=1`), which skips global MCP and hook
+  registration. The codebase-exploration skill points at it for scratch
+  clones, fixtures and worktrees (#1086).
+
+### Changed
+- Version bump to track the repowise 0.37.0 release.
+- The augment hook command in `hooks/hooks.json` guards on the console script
+  being present, so a shell that cannot find `repowise-augment` stays silent
+  instead of reporting a failure on every matched tool call (#1141).
+- `/repowise:dead-code` re-synced with the CLI's `--min-confidence` default,
+  now anchored to `RISK_CAP_CONFIDENCE` (#1087).
+- The code-health skill reflects the `get_health` response surface: targets
+  that cannot be resolved are reported rather than dropped, and the response
+  no longer repeats itself (#1142).
+- `DEVELOPER.md` covers the no-editor-setup path.
+
+## 0.36.0
+
+### Changed
+- Version bump to track the repowise 0.36.0 release.
+- `/repowise:health` dropped `--safe-only`, which never did anything on
+  `health`. The flag remains live on `dead-code` (#1027).
+
 ## 0.35.0
 
 ### Changed

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Repowise codebase intelligence for Codex.",
   "author": {
     "name": "Repowise",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "repowise"
-version = "0.36.0"
+version = "0.37.0"
 description = "The codebase intelligence layer for your AI coding agent — dependency graph, git history, dead code, decisions, and code health, exposed over MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -3054,7 +3054,7 @@ wheels = [
 
 [[package]]
 name = "repowise"
-version = "0.36.0"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bumps to 0.37.0 and writes the changelog. 61 commits since v0.36.0.

## What this release is

The web UI got taken apart and put back together. Fourteen surfaces moved onto one design language: sections and hairlines instead of a grid of near-identical bordered cards, a sentence above every figure saying what the figure means, and a header row plus a key row on the pages whose canvas is the page. Overview, Docs, Commits, Contributors, Code Health, Coverage, Dead code, Chat, Settings, Decisions, Stats, Files, Refactoring, Knowledge Graph and Architecture all changed shape.

Alongside that, the Architecture and Knowledge Graph canvases got their marks named and their per-frame cost cut, and the docs page stopped downloading 38.6 MB of page bodies to draw a tree.

Away from the UI: a Structurizr DSL export, a first-run pass over interactive `init`, refreshed provider model defaults, three MCP response fixes, and ruff gated in CI.

## What's in the diff

- Version bump across the four Python constants, `uv.lock`, and both plugin manifests.
- `plugins/codex` to 0.4.0 — it shipped skill changes this cycle.
- `packages/vscode` to 0.7.0. 25 `packages/ui` commits have landed since `vscode-v0.6.0`, every one of them in a subpath the webviews import (`health`, `graph`, `docs`, `refactoring`, `c4`, `lib/format`, `shared`, `ui`, `wiki`). The published VSIX has been bundling stale UI, and on a release whose subject is the UI that is the wrong thing to ship. Publishing it is a separate `vscode-v0.7.0` tag after this merges.
- `docs/CHANGELOG.md` and its bundled copy under `core/upgrade/_data/`.
- `plugins/claude-code/CHANGELOG.md` gets its 0.37.0 entry, plus the 0.36.0 entry that was never written.

`STORE_FORMAT_VERSION` and `PARSER_SCHEMA_VERSION` are unchanged. Nothing this cycle persists a shape an older store needs to react to; the only `persist.py` change is sweep logic.

## Test plan

- [x] Drift grep clean — no `0.36.0` left in the version files, `uv.lock` self-entry moved
- [x] `uv lock` run explicitly, lockfile committed
- [x] `uv build --wheel` — 79 command modules, 18 `.scm` queries, 34 `.j2` templates present
- [x] `npm ci && npm run build --workspace packages/web` — 62 routes, standalone `server.js` at the expected nested path, workspace-package code present in compiled chunks
- [x] Wheel installs into a clean venv and reports `0.37.0`
- [x] `tests/unit/upgrade/test_bundled_changelog_sync.py` passes
- [x] `ruff check .` passes
- [x] Plugin MCP tool references match the live `list_tools()` surface
- [x] `hooks/hooks.json` matcher and command identical to `claude_config.py`
- [x] `dead-code.md` `--min-confidence` default matches `RISK_CAP_CONFIDENCE`
- [ ] CI green on this PR
- [ ] Tag `v0.37.0` on `main` after merge, watch `publish.yml`
- [ ] Post-release: release assets, PyPI version, web tarball structure
- [ ] Final gate: install `repowise==0.37.0` from PyPI into a throwaway venv and cold-index `test-repos/microdot`
- [ ] Optional: `vscode-v0.7.0` tag once the extension's own checklist passes
